### PR TITLE
Add more dependencies to opam

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -21,6 +21,9 @@ via the opam OCaml packages manager.
 
   4. Install Jasmin dependencies:
 
+
+          $> opam repo add coq-released https://coq.inria.fr/opam/released
+          $> opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev
           $> opam install --deps-only jasmin
 
 Opam can be easily installed from source or via your packages manager:

--- a/compiler/opam
+++ b/compiler/opam
@@ -21,4 +21,7 @@ depends: [
   "zarith"
   "ocamlbuild"
   "ocamlfind"
+  "coq" {>= "8.6"}
+  "coq-mathcomp-ssreflect"
+  "coq-mathcomp-algebra"
 ]


### PR DESCRIPTION
- add the repo addresses for coq-released  and coq-extra-dev
- add dependencies to `coq`, `coq-mathcomp-ssreflect` and `coq-mathcomp-algebra` so they are also installed by `opam install --deps-only jasmin`

**Note:** Jasmin also compiles with `coq.8.7`