### PR TITLE
Tag assignments to inline variables as inline

### DIFF
--- a/compiler/examples/test_add.mil
+++ b/compiler/examples/test_add.mil
@@ -1,4 +1,4 @@
-export fn test1() -> inline int {
+fn test1() -> inline int {
 
   inline int i;
   inline int j;
@@ -12,7 +12,7 @@ export fn test1() -> inline int {
   return j;
 }
 
-export fn test2() -> inline u64 {
+fn test2() -> inline u64 {
 
   inline int i;
   inline u64 j;
@@ -31,10 +31,11 @@ export fn test3() -> reg u64 {
 
   reg u64 i;
   reg u64 j;
+  inline int tmp;
 
-
-  j = 0;
-  i = 0;
+  tmp = test1();
+  j = tmp;
+  i = test2();
   while (j <= 12) {
     j = j + i;
     i += 1;

--- a/compiler/src/typing.ml
+++ b/compiler/src/typing.ml
@@ -788,7 +788,12 @@ let rec tt_instr (env : Env.env) (pi : S.pinstr) : unit P.pinstr =
       let _, flv, vty = tt_lvalue env lv in
       let e, ety = tt_expr ~mode:`AllVar env pe in
       let e = vty |> omap_dfl (cast (L.loc pe) e ety) e in
-      cassgn_for (flv ety) AT_none e
+      let v = flv ety in
+      let tg =
+        P.(match v with
+            | Lvar v -> (match kind_i v with Inline -> AT_inline | _ -> AT_none)
+            | _ -> AT_none) in
+      cassgn_for v tg e
 
     | PIAssign(ls, `Raw, pe, None) ->
       (* Try to match addc, subc, mulu *)


### PR DESCRIPTION
Currently the `test_add` example fails.

Constant-propagation only considers assignments that are introduced by the compiler. It ignores the assignments to inline variables that are written by the programmer.

This patch makes source-level assignments to inline variable eligible to constant-propagation.