### PR TITLE
add gitignore in examples/gimli

### DIFF
--- a/compiler/examples/gimli/.gitignore
+++ b/compiler/examples/gimli/.gitignore
@@ -1,0 +1,4 @@
+test
+test.out
+testv
+testv.out


### PR DESCRIPTION
do not display generated file by `make`