### PR TITLE
Add missing dependency to default.nix

### DIFF
--- a/compiler/default.nix
+++ b/compiler/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "jasmin-0";
   src = ./.;
   buildInputs = [ mpfr ppl ]
-  ++ (with ocamlPackages; [ ocaml findlib ocamlbuild apron batteries menhir zarith ])
+  ++ (with ocamlPackages; [ ocaml findlib ocamlbuild apron batteries menhir zarith yojson])
   ;
 
   installPhase = ''


### PR DESCRIPTION
default.nix is missing a dependency 'yojson' to successfully build the compiler via make in the nix-shell