### PR TITLE
New AVX2 instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ DESTDIR  ?=
 PREFIX   ?= /usr/local
 BINDIR   := $(PREFIX)/bin
 LIBDIR   := $(PREFIX)/lib
-INSTALL  ?= install
-
+ifeq ($(UNAME_S),Darwin)
+  INSTALL  ?= ginstall
+else
+  INSTALL  ?= install
+endif
 # --------------------------------------------------------------------
 .PHONY: all build check clean dist distcheck
 

--- a/compiler/tests/success/pext.jazz
+++ b/compiler/tests/success/pext.jazz
@@ -1,0 +1,21 @@
+export
+fn test_pext32(reg u64 tmp)
+{
+  reg u32 a b c;
+
+  a = 0xFF;
+  b = 0x02;
+  c = #PEXT_32(a, b);
+  (u32)[tmp] = c;
+}
+
+export
+fn test_pext64(reg u64 tmp)
+{
+  reg u64 a b c;
+    
+  a = 0xFF;
+  b = 0x02;
+  c = #PEXT_64(a, b);
+  (u64)[tmp] = c;
+}

--- a/compiler/tests/success/pocnt.jazz
+++ b/compiler/tests/success/pocnt.jazz
@@ -1,0 +1,11 @@
+export
+fn test_popcnt16(){
+}
+
+export
+fn test_popcnt32(){
+}
+
+export
+fn test_popcnt64(){
+}

--- a/compiler/tests/success/popcnt.jazz
+++ b/compiler/tests/success/popcnt.jazz
@@ -1,0 +1,32 @@
+export
+fn test_popcnt16(reg u64 rp){
+  reg bool zf;
+  reg u16 t;
+
+  t = 0x01;
+  
+  _, _, _, _, zf, t = #POPCNT_16(t);
+  (u16)[rp] = t;
+}
+
+export
+fn test_popcnt32(reg u64 rp){
+  reg bool zf;
+  reg u32 t;
+
+  t = 0x01;
+  
+  _, _, _, _, zf, t = #POPCNT_32(t);
+  (u32)[rp] = t;
+}
+
+export
+fn test_popcnt64(reg u64 rp){
+  reg bool zf;
+  reg u64 t;
+
+  t = 0x01;
+  
+  _, _, _, _, zf, t = #POPCNT_64(t);
+  [rp] = t;
+}

--- a/compiler/tests/success/rdtsc.jazz
+++ b/compiler/tests/success/rdtsc.jazz
@@ -1,0 +1,38 @@
+export
+fn test_rdtsc32(reg u64 x) {
+  reg u32 a b;
+
+  b, a = #RDTSC_32();
+  (u32)[x] = a;
+  (u32)[x+4] = b;
+}
+
+export
+fn test_rdtsc64(reg u64 x) {
+  reg u64 a b;
+
+  b, a = #RDTSC_64();
+  [x] = a;
+  [x+8] = b;
+}
+
+export
+fn test_rdtscp32(reg u64 x) {
+  reg u32 a b c;
+
+  b, a, c = #RDTSCP_32();
+  (u32)[x] = a;
+  (u32)[x+4] = b;
+  (u32)[x+8] = c;
+}
+
+export
+fn test_rdtscp64(reg u64 x) {
+  reg u64 a b c;
+
+  b, a, c = #RDTSCP_64();
+  [x] = a;
+  [x+8] = b;
+  [x+16] = c;
+}
+

--- a/compiler/tests/success/vmovhpd.jazz
+++ b/compiler/tests/success/vmovhpd.jazz
@@ -1,0 +1,7 @@
+export
+fn test_vmovhpd(reg u64 tmp) {
+  reg u128 x;
+
+  x = #set0_128();
+  (u64) [tmp] = #VMOVHPD(x);
+}

--- a/compiler/tests/success/vmovlpd.jazz
+++ b/compiler/tests/success/vmovlpd.jazz
@@ -1,0 +1,7 @@
+export
+fn test_vmovlpd(reg u64 tmp) {
+  reg u128 x;
+
+  x = #set0_128();
+  (u64) [tmp] = #VMOVLPD(x);
+}

--- a/compiler/tests/success/vpcmpgt.jazz
+++ b/compiler/tests/success/vpcmpgt.jazz
@@ -5,13 +5,14 @@ fn test_vpcmpgt(reg u64 tmp) {
 
   y = #set0_256();
   x = #set0_256();
-  z = #VPCMPGT_16u16(x, y);
+  z = #VPCMPGT_32u8(x, y);
   (u256)[tmp] = z;
 
   i = #set0_128();
   j = #set0_128();
-  k = #VPCMPGT_4u32(i, j);
+  k = #VPCMPGT_8u16(i, j);
   (u128)[tmp + 32] = k;
 
   z = #VPCMPGT_8u32(x, y);
+  (u256)[tmp + 48] = z;
 }

--- a/compiler/tests/success/vpcmpgt.jazz
+++ b/compiler/tests/success/vpcmpgt.jazz
@@ -1,5 +1,5 @@
 export
-fn test_pcmpgt(reg u64 tmp) {
+fn test_vpcmpgt(reg u64 tmp) {
   reg u256 x y z;
   reg u128 i j k;
 
@@ -10,8 +10,8 @@ fn test_pcmpgt(reg u64 tmp) {
 
   i = #set0_128();
   j = #set0_128();
-  z = #VPCMPGT_4u32(i, j);
+  k = #VPCMPGT_4u32(i, j);
   (u128)[tmp + 32] = k;
 
-  (u256)[tmp + 48] = #VPCMPGT_8u32(x, y);
+  z = #VPCMPGT_8u32(x, y);
 }

--- a/compiler/tests/success/vpcmpgt.jazz
+++ b/compiler/tests/success/vpcmpgt.jazz
@@ -1,0 +1,17 @@
+export
+fn test_pcmpgt(reg u64 tmp) {
+  reg u256 x y z;
+  reg u128 i j k;
+
+  y = #set0_256();
+  x = #set0_256();
+  z = #VPCMPGT_16u16(x, y);
+  (u256)[tmp] = z;
+
+  i = #set0_128();
+  j = #set0_128();
+  z = #VPCMPGT_4u32(i, j);
+  (u128)[tmp + 32] = k;
+
+  (u256)[tmp + 48] = #VPCMPGT_8u32(x, y);
+}

--- a/compiler/tests/success/vpermd.jazz
+++ b/compiler/tests/success/vpermd.jazz
@@ -1,0 +1,12 @@
+export
+fn test_vpermd(reg u64 tmp)
+{
+  reg u256 t0 t1;
+
+  t0 = #set0_256();
+  t1 = #set0_256();
+
+  t0 = #VPERMD_256(t0, t1);
+  (u256)[tmp] = t0;
+  (u256)[tmp + 32] = #VPERMD_256(t0, t1);
+}

--- a/compiler/tests/success/vpermd.jazz
+++ b/compiler/tests/success/vpermd.jazz
@@ -8,5 +8,4 @@ fn test_vpermd(reg u64 tmp)
 
   t0 = #VPERMD_256(t0, t1);
   (u256)[tmp] = t0;
-  (u256)[tmp + 32] = #VPERMD_256(t0, t1);
 }

--- a/compiler/tests/success/vpmaddubsw.jazz
+++ b/compiler/tests/success/vpmaddubsw.jazz
@@ -1,0 +1,15 @@
+export
+fn test_pmaddubsw(reg u64 rp) {
+  reg u256 f0 f1 f2;
+  reg u128 t0 t1 t2;
+
+  f0 = #set0_256();
+  f1 = #set0_256();
+  f2 = #VPMADDUBSW_256(f0, f1);
+  (u256)[rp] = f2;
+
+  t0 = #set0_128();
+  t1 = #set0_128();
+  t2 = #VPMADDUBSW_128(t0, t1);
+  (u128) [rp + 32] = t2;
+}

--- a/compiler/tests/success/vpmaddwd.jazz
+++ b/compiler/tests/success/vpmaddwd.jazz
@@ -1,15 +1,15 @@
 export
-fn test_pmaddubsw(reg u64 rp) {
+fn test_pmaddwd(reg u64 rp) {
   reg u256 f0 f1 f2;
   reg u128 t0 t1 t2;
 
   f0 = #set0_256();
   f1 = #set0_256();
-  f2 = #VPMADDUBSW_256(f0, f1);
+  f2 = #VPMADDWD_256(f0, f1);
   (u256)[rp] = f2;
 
   t0 = #set0_128();
   t1 = #set0_128();
-  t2 = #VPMADDUBSW_128(t0, t1);
+  t2 = #VPMADDWD_128(t0, t1);
   (u128)[rp + 32] = t2;
 }

--- a/compiler/tests/success/vpmovmskb.jazz
+++ b/compiler/tests/success/vpmovmskb.jazz
@@ -1,0 +1,19 @@
+export
+fn test_pmovmskb(reg u64 tmp) {
+  reg u32 a;
+  reg u64 b;
+  reg u128 x;
+  reg u256 y;
+
+  x = #set0_128();
+  y = #set0_256();
+  a = #VPMOVMSKB_u128u32(x);
+  (u32) [tmp] = a;
+  b = #VPMOVMSKB_u128u64(x);
+  [tmp] = b;
+  a = #VPMOVMSKB_u256u32(y);
+  (u32) [tmp] = a;
+  b = #VPMOVMSKB_u256u64(y);
+  [tmp] = b;
+}
+

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -165,6 +165,7 @@ Variant asm_op : Type :=
 | VPMOVMSKB of wsize & wsize (* sorce size (U128/256) & dest. size (U32/64) *)
 | VPERMD     `(wsize)
 | VPCMPGT    `(velem) `(wsize)
+| POPCNT     `(wsize)
 .
 
 
@@ -856,6 +857,12 @@ Definition x86_VPCMPGT ve sz (v1 v2: word sz): ex_tpl(w_ty sz) :=
   Let _ := check_size_8_32 ve in
   Let _ := check_size_128_256 sz in
   ok (wrepr sz 0).
+
+(* FIXME *)
+Definition x86_POPCNT sz (v: word sz): ex_tpl (b5w_ty sz) :=
+  Let _ := check_size_16_64 sz in
+  let r := (wrepr sz 0) in (* FIXME! *)
+  ok (:: Some false, Some false, Some false, Some false, Some (ZF_of_word v) & r).
 
 (* ----------------------------------------------------------------------------- *)
 Coercion F f := ADImplicit (IArflag f).
@@ -1586,7 +1593,6 @@ Definition Ox86_VPERMD_instr :=
                 ,("VPERMD"%string, PrimP U256 VPERMD)
   ).
 
-Print VE32.
 Definition Ox86_VPCMPGT_instr :=
   (fun (ve: velem) sz => mk_instr
                   (pp_ve_sz "VPCMPGT"%string ve sz)
@@ -1604,6 +1610,9 @@ Definition Ox86_VPCMPGT_instr :=
                   (pp_viname "vpcmpgt" ve sz)
                 ,("VPCMPGT"%string, PrimV VPCMPGT)
   ).
+
+Definition Ox86_POPCNT_instr :=
+  mk_instr_w_b5w "POPCNT" x86_POPCNT msb_dfl [:: E 1] [:: E 0] 2 (fun _ => [::r_rm]) no_imm (primP POPCNT) (pp_iname "popcnt").
 
 Definition instr_desc o : instr_desc_t :=
   match o with
@@ -1709,6 +1718,7 @@ Definition instr_desc o : instr_desc_t :=
   | VPMOVMSKB ssz dsz  => Ox86_PMOVMSKB_instr.1 ssz dsz
   | VPERMD sz          => Ox86_VPERMD_instr.1 sz
   | VPCMPGT ve sz      => Ox86_VPCMPGT_instr.1 ve sz
+  | POPCNT sz          => Ox86_POPCNT_instr.1 sz
   end.
 
 (* -------------------------------------------------------------------- *)
@@ -1817,6 +1827,7 @@ Definition prim_string :=
    Ox86_PMOVMSKB_instr.2
    Ox86_VPERMD_instr.2
    Ox86_VPCMPGT_instr.2
+   Ox86_POPCNT_instr.2
  ].
   
   

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -166,6 +166,7 @@ Variant asm_op : Type :=
 | VPERMD     `(wsize)
 | VPCMPGT    `(velem) `(wsize)
 | POPCNT     `(wsize)
+| PEXT       `(wsize)
 .
 
 
@@ -863,6 +864,11 @@ Definition x86_POPCNT sz (v: word sz): ex_tpl (b5w_ty sz) :=
   Let _ := check_size_16_64 sz in
   let r := (wrepr sz 0) in (* FIXME! *)
   ok (:: Some false, Some false, Some false, Some false, Some (ZF_of_word v) & r).
+
+(* FIXME *)
+Definition x86_PEXT sz (v1 v2: word sz): ex_tpl (w_ty sz) :=
+  Let _ := check_size_32_64 sz in
+  ok (wrepr sz 0).
 
 (* ----------------------------------------------------------------------------- *)
 Coercion F f := ADImplicit (IArflag f).
@@ -1614,6 +1620,9 @@ Definition Ox86_VPCMPGT_instr :=
 Definition Ox86_POPCNT_instr :=
   mk_instr_w_b5w "POPCNT" x86_POPCNT msb_dfl [:: E 1] [:: E 0] 2 (fun _ => [::r_rm]) no_imm (primP POPCNT) (pp_iname "popcnt").
 
+Definition Ox86_PEXT_instr :=
+  mk_instr_w2_w_120 "PEXT" x86_PEXT (fun _ => [:: [:: r; r; rm true]]) no_imm (primP PEXT) (pp_iname "pext").
+
 Definition instr_desc o : instr_desc_t :=
   match o with
   | MOV sz             => Ox86_MOV_instr.1 sz
@@ -1719,6 +1728,7 @@ Definition instr_desc o : instr_desc_t :=
   | VPERMD sz          => Ox86_VPERMD_instr.1 sz
   | VPCMPGT ve sz      => Ox86_VPCMPGT_instr.1 ve sz
   | POPCNT sz          => Ox86_POPCNT_instr.1 sz
+  | PEXT sz            => Ox86_PEXT_instr.1 sz
   end.
 
 (* -------------------------------------------------------------------- *)
@@ -1828,6 +1838,7 @@ Definition prim_string :=
    Ox86_VPERMD_instr.2
    Ox86_VPCMPGT_instr.2
    Ox86_POPCNT_instr.2
+   Ox86_PEXT_instr.2
  ].
   
   

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -1595,7 +1595,7 @@ Definition Ox86_VPERMD_instr :=
                   sz
                   (no_imm sz)
                   [::]
-                  (pp_iname "vpermd" sz)
+                  (pp_name "vpermd" sz)
                 ,("VPERMD"%string, PrimP U256 VPERMD)
   ).
 
@@ -1618,10 +1618,10 @@ Definition Ox86_VPCMPGT_instr :=
   ).
 
 Definition Ox86_POPCNT_instr :=
-  mk_instr_w_b5w "POPCNT" x86_POPCNT msb_dfl [:: E 1] [:: E 0] 2 (fun _ => [::r_rm]) no_imm (primP POPCNT) (pp_iname "popcnt").
+  mk_instr_w_b5w "POPCNT" x86_POPCNT msb_dfl [:: E 1] [:: E 0] 2 (fun _ => [::r_rm]) no_imm (primP POPCNT) (pp_name "popcnt").
 
 Definition Ox86_PEXT_instr :=
-  mk_instr_w2_w_120 "PEXT" x86_PEXT (fun _ => [:: [:: r; r; rm true]]) no_imm (primP PEXT) (pp_iname "pext").
+  mk_instr_w2_w_120 "PEXT" x86_PEXT (fun _ => [:: [:: r; r; rm true]]) no_imm (primP PEXT) (pp_name "pext").
 
 Definition instr_desc o : instr_desc_t :=
   match o with

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -855,26 +855,23 @@ Definition x86_VPERMD sz (v1 v2: word sz): ex_tpl(w_ty sz) :=
   Let _ := check_size_256 sz in
   ok (@vpermd sz v1 v2).
 
-(* FIXME *)
 Definition x86_VPCMPGT ve sz (v1 v2: word sz): ex_tpl(w_ty sz) :=
   Let _ := check_size_8_32 ve in
   Let _ := check_size_128_256 sz in
-  ok (wrepr sz 0).
+  ok (@vpcmpgt ve sz v1 v2).
 
-(* FIXME *)
 Definition x86_POPCNT sz (v: word sz): ex_tpl (b5w_ty sz) :=
   Let _ := check_size_16_64 sz in
-  let r := (wrepr sz 0) in (* FIXME! *)
+  let r := (@popcnt sz v) in
   ok (:: Some false, Some false, Some false, Some false, Some (ZF_of_word v) & r).
 
-(* FIXME *)
 Definition x86_PEXT sz (v1 v2: word sz): ex_tpl (w_ty sz) :=
-  Let _ := check_size_32_64 sz in
-  ok (wrepr sz 0).
+  let _ := check_size_32_64 sz in
+  ok (@pextr sz v1 v2).
 
 Definition x86_VPMADDUBSW sz (v v1: word sz) : ex_tpl (w_ty sz) :=
   Let _ := check_size_128_256 sz in
-  ok (@pmaddubsw sz v v2).
+  ok (@pmaddubsw sz v v1).
 
 Definition x86_VPMADDWD sz (v v1: word sz) : ex_tpl (w_ty sz) :=
   Let _ := check_size_128_256 sz in
@@ -1886,13 +1883,12 @@ Definition prim_string :=
    Ox86_VAESKEYGENASSIST_instr.2;
    Ox86_RDTSC_instr.2;
    Ox86_RDTSCP_instr.2;
-   Ox86_PMOVMSKB_instr.2
-   Ox86_VPERMD_instr.2
-   Ox86_VPCMPGT_instr.2
-   Ox86_POPCNT_instr.2
-   Ox86_PEXT_instr.2
    Ox86_PMOVMSKB_instr.2;
-   Ox86_VPMADDUBSW_instr.2
-   Ox86_VPMADDWD_instr.2;
+   Ox86_VPERMD_instr.2;
+   Ox86_VPCMPGT_instr.2;
+   Ox86_POPCNT_instr.2;
+   Ox86_PEXT_instr.2;
+   Ox86_VPMADDUBSW_instr.2;
+   Ox86_VPMADDWD_instr.2
  ].
   

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -163,6 +163,7 @@ Variant asm_op : Type :=
 | RDTSC    of wsize
 | RDTSCP   of wsize
 | VPMOVMSKB of wsize & wsize (* sorce size (U128/256) & dest. size (U32/64) *)
+| VPERMD     `(wsize)
 .
 
 
@@ -844,6 +845,10 @@ Definition x86_VPMOVMSKB ssz dsz (v : word ssz): ex_tpl (w_ty dsz) :=
   Let _ := check_size_32_64 dsz in
   Let _ := check_size_128_256 ssz in
   ok (@pmovmskb ssz dsz v).
+
+Definition x86_VPERMD sz (v1 v2: word sz): ex_tpl(w_ty sz) :=
+  Let _ := check_size_256 sz in
+  ok (@vpermd sz v1 v2).
 
 (* ----------------------------------------------------------------------------- *)
 Coercion F f := ADImplicit (IArflag f).
@@ -1556,6 +1561,23 @@ Definition Ox86_PMOVMSKB_instr :=
    ,("VPMOVMSKB"%string, PrimX VPMOVMSKB) (* jasmin concrete syntax *)
   ).
 
+Definition Ox86_VPERMD_instr :=
+  (fun sz => mk_instr
+                  (pp_sz "VPERMD"%string sz)
+                  (w2_ty sz sz)
+                  (w_ty sz)
+                  [:: E 1; E 2]
+                  [:: E 0]
+                  MSB_CLEAR
+                  (@x86_VPERMD sz)
+                  (check_xmm_xmm_xmmm sz)
+                  3
+                  sz
+                  (no_imm sz)
+                  [::]
+                  (pp_iname "vpermd" sz)
+                ,("VPERMD"%string, PrimP U256 VPERMD)
+  ).
 
 Definition instr_desc o : instr_desc_t :=
   match o with
@@ -1659,6 +1681,7 @@ Definition instr_desc o : instr_desc_t :=
   | RDTSC sz           => Ox86_RDTSC_instr.1 sz
   | RDTSCP sz          => Ox86_RDTSCP_instr.1 sz
   | VPMOVMSKB ssz dsz  => Ox86_PMOVMSKB_instr.1 ssz dsz
+  | VPERMD sz          => Ox86_VPERMD_instr.1 sz
   end.
 
 (* -------------------------------------------------------------------- *)
@@ -1765,6 +1788,7 @@ Definition prim_string :=
    Ox86_RDTSC_instr.2;
    Ox86_RDTSCP_instr.2;
    Ox86_PMOVMSKB_instr.2
+   Ox86_VPERMD_instr.2
  ].
   
   

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1458,6 +1458,27 @@ Definition vpermd sz (w1 idx: word sz) : word sz :=
 Definition popcnt sz (w: word sz) :=
  wrepr sz (count id (w2t w)).
 
+(* TODO: cleanup *)
+Fixpoint add_pairs ve (v1: seq (word ve)) : seq (word ve) :=
+  match v1 with
+  | cons p1 (cons p2 v1') => (wrepr ve ((wunsigned p1) + (wunsigned p2))) :: (add_pairs v1')
+  | nil | cons _ _ => [::]
+  end.
+
+Definition pmadd1 ve (v1 v2: seq (word ve)): seq (word ve) :=
+  let tmp := map2 *%R  v1 v2 in
+  add_pairs tmp.
+
+Definition pmaddubsw sz (v1 v2: word sz) : word sz :=
+  let w1 := map (@zero_extend VE16 VE8) (split_vec VE8 v1) in
+  let w2 := map (@zero_extend VE16 VE8) (split_vec VE8 v2) in
+  make_vec sz (pmadd1 w1 w2).
+
+Definition pmaddwd sz (v1 v2: word sz) : word sz :=
+  let w1 := map (@zero_extend VE32 VE16) (split_vec VE16 v1) in
+  let w2 := map (@zero_extend VE32 VE16) (split_vec VE16 v2) in
+  make_vec sz (pmadd1 w1 w2).
+
 Definition vpcmpgt1 ve (e1 e2: word ve) : word ve :=
   if (wunsigned e1) >? (wunsigned e2) then (wshl 1 (wsize_size_minus_1 ve) - 1)%R
   else 0%R.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1455,6 +1455,9 @@ Definition vpermd sz (w1 idx: word sz) : word sz :=
   let i := split_vec U32 idx in
   make_vec sz (map (vpermd1 v) i).
 
+Definition popcnt sz (w: word sz) :=
+ wrepr sz (count id (w2t w)).
+
 Definition vpcmpgt1 ve (e1 e2: word ve) : word ve :=
   if (wunsigned e1) >? (wunsigned e2) then (wshl 1 (wsize_size_minus_1 ve) - 1)%R
   else 0%R.
@@ -1462,8 +1465,8 @@ Definition vpcmpgt1 ve (e1 e2: word ve) : word ve :=
 Definition vpcmpgt ve sz (w1 w2: word sz) : word sz :=
   lift2_vec ve (@vpcmpgt1 ve) sz w1 w2.
 
-(* FIXME *)
-Definition popcnt sz (w: word sz): word sz :=
-  let b := split_vec 1 w in
-  let b1 := map (fun b => if b == 1%R then 1%nat else 0%nat) b in
-  wrepr sz (List.fold_right plus 0%nat b1).
+Definition bits2z (l: seq bool) : Z :=
+ (\sum_(i < size l) 2%:R ^+ i * (nth false l i)%:R)%R.
+
+Definition pextr sz (w1 w2: word sz) :=
+ wrepr sz (bits2z (mask (w2t w2) (w2t w1))).

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1505,3 +1505,13 @@ Definition bits2z (l: seq bool) : Z :=
 
 Definition pextr sz (w1 w2: word sz) :=
  wrepr sz (bits2z (mask (w2t w2) (w2t w1))).
+
+Definition vmovlpd (w: u128): u64 :=
+  let v := split_vec U64 w in
+  let l64 := List.nth 1 v (wrepr U64 0) in
+  l64.
+
+Definition vmovhpd (w: u128): u64 :=
+  let v := split_vec U64 w in
+  let l64 := List.nth 0 v (wrepr U64 0) in
+  l64.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1459,9 +1459,23 @@ Definition popcnt sz (w: word sz) :=
  wrepr sz (count id (w2t w)).
 
 (* TODO: cleanup *)
+Definition saturated_signed (sz: wsize) (x: Z): Z :=
+ Z.max (wmin_signed sz) (Z.min (wmax_signed sz) x).
+
+Definition wrepr_saturated_signed (sz: wsize) (x: Z) : word sz :=
+ wrepr sz (saturated_signed sz x).
+
+(*
+Definition saturated_unsigned (sz: wsize) (x: Z): Z := 
+ Z.max 0%Z (Z.min (wmax_unsigned sz) x).
+
+Definition wrepr_saturated_unsigned (sz: wsize) (x: Z) : word sz :=
+ wrepr sz (saturated_unsigned sz x).
+*)
+
 Fixpoint add_pairs ve (v1: seq (word ve)) : seq (word ve) :=
   match v1 with
-  | cons p1 (cons p2 v1') => (wrepr ve ((wunsigned p1) + (wunsigned p2))) :: (add_pairs v1')
+  | cons p1 (cons p2 v1') => (wrepr_saturated_signed ve ((wunsigned p1) + (wunsigned p2))) :: (add_pairs v1')
   | nil | cons _ _ => [::]
   end.
 

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1454,3 +1454,10 @@ Definition vpermd sz (w1 idx: word sz) : word sz :=
   let v := split_vec U32 w1 in
   let i := split_vec U32 idx in
   make_vec sz (map (vpermd1 v) i).
+
+Definition vpcmpgt1 ve (e1 e2: word ve) : word ve :=
+  if (wunsigned e1) >? (wunsigned e2) then (wshl 1 (wsize_size_minus_1 ve) - 1)%R
+  else 0%R.
+
+Definition vpcmpgt ve sz (w1 w2: word sz) : word sz :=
+  lift2_vec ve (@vpcmpgt1 ve) sz w1 w2.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1461,3 +1461,9 @@ Definition vpcmpgt1 ve (e1 e2: word ve) : word ve :=
 
 Definition vpcmpgt ve sz (w1 w2: word sz) : word sz :=
   lift2_vec ve (@vpcmpgt1 ve) sz w1 w2.
+
+(* FIXME *)
+Definition popcnt sz (w: word sz): word sz :=
+  let b := split_vec 1 w in
+  let b1 := map (fun b => if b == 1%R then 1%nat else 0%nat) b in
+  wrepr sz (List.fold_right plus 0%nat b1).

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1440,3 +1440,7 @@ Proof.
   rewrite /align_word wsize_size_is_pow2 wand_align.
   lia.
 Qed.
+
+(* -------------------------------------------------------------------*)
+Definition pmovmskb (ssz dsz: wsize) (w : word ssz) : word dsz :=
+ wrepr dsz (t2w_def [tuple of map msb (split_vec U8 w)]).

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1442,5 +1442,15 @@ Proof.
 Qed.
 
 (* -------------------------------------------------------------------*)
+
 Definition pmovmskb (ssz dsz: wsize) (w : word ssz) : word dsz :=
- wrepr dsz (t2w_def [tuple of map msb (split_vec U8 w)]).
+  wrepr dsz (t2w_def [tuple of map msb (split_vec U8 w)]).
+
+Definition vpermd1 (v: seq u32) (idx: u32) :=
+  let off := wunsigned (wand idx (wshl 1 4 - 1)) in
+  (v`_(Z.to_nat off))%R.
+
+Definition vpermd sz (w1 idx: word sz) : word sz :=
+  let v := split_vec U32 w1 in
+  let i := split_vec U32 idx in
+  make_vec sz (map (vpermd1 v) i).

--- a/proofs/lang/wsize.v
+++ b/proofs/lang/wsize.v
@@ -155,6 +155,8 @@ Proof. by case s. Qed.
 
 (* -------------------------------------------------------------------- *)
 Definition check_size_8_64 sz := assert (sz ≤ U64)%CMP ErrType.
+Definition check_size_8_32 sz := assert ((U8 ≤ sz) && (sz ≤ U32))%CMP ErrType.
+(* Definition check_size_8_64 sz := assert ((U8 ≤ sz) && (sz ≤ U64))%CMP ErrType. *)
 Definition check_size_16_32 sz := assert ((U16 ≤ sz) && (sz ≤ U32))%CMP ErrType.
 Definition check_size_16_64 sz := assert ((U16 ≤ sz) && (sz ≤ U64))%CMP ErrType.
 Definition check_size_32_64 sz := assert ((U32 ≤ sz) && (sz ≤ U64))%CMP ErrType.

--- a/proofs/lang/wsize.v
+++ b/proofs/lang/wsize.v
@@ -161,6 +161,7 @@ Definition check_size_16_32 sz := assert ((U16 ≤ sz) && (sz ≤ U32))%CMP ErrT
 Definition check_size_16_64 sz := assert ((U16 ≤ sz) && (sz ≤ U64))%CMP ErrType.
 Definition check_size_32_64 sz := assert ((U32 ≤ sz) && (sz ≤ U64))%CMP ErrType.
 Definition check_size_128_256 sz := assert ((U128 ≤ sz) && (sz ≤ U256))%CMP ErrType.
+Definition check_size_256 sz := assert (sz == U256)%CMP ErrType.
 
 Lemma wsize_nle_u64_check_128_256 sz :
   (sz ≤ U64)%CMP = false →


### PR DESCRIPTION
- Add 10 new AVX2 instructions w/ Coq semantics and unit tests
**Notes**: The `VMOVLPD` and `VMOVHPD` instructions are only partially implemented (**i.e.** no support for memory to register operations)