### PR TITLE
Annotation mechanism for function signatures

### DIFF
--- a/compiler/examples/test_annot.jazz
+++ b/compiler/examples/test_annot.jazz
@@ -1,0 +1,56 @@
+// * Implementation of montgomery ladder for curve25519
+
+param int rem_p = 2; /* 2^(4*64) mod p      */
+
+// ** addition
+// ************************************************************************
+
+inline
+ fn add(@private reg u64[4] x, @public stack u64[4] ya) -> @private reg u64[4] {
+
+  reg u64[4] y;
+  reg u64 add0;
+  reg u64 add1;
+  reg bool cf;
+  inline int i;
+
+  for i = 0 to 4 {
+    y[i] = ya[i];
+    if   (i == 0) { cf, x[0] += y[0]; }
+    else         { cf, x[i] += y[i] + cf; }
+  }
+
+  add0 = 0;
+  add1 = rem_p;
+  add1 = add0 if !cf;
+
+  for i = 0 to 4 {
+    if (i == 0) {
+      cf, x[0] += add1;
+    } else {
+      cf, x[i] += add0 + cf;
+    }
+  }
+
+  add0 = add1 if cf;
+  x[0] += add0;
+
+  return x;
+}
+
+export fn eadd(reg u64 ad, @private reg u64 ax, reg u64 ay) {
+  reg   u64[4] x;
+  stack u64[4] y;
+  inline int i;
+  for i = 0 to 4 {
+    x[i] = [ax + 8*i];
+  }
+  for i = 0 to 4 {
+    y[i] = [ay + 8*i];
+  } 
+  x = add(x, y);
+  for i = 0 to 4 {
+    [ad + 8 * i] = x[i];
+  }
+
+}

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -77,6 +77,10 @@ let string_of_string0 s0 =
   let sz = Array.length s0 in
   String.init sz (fun i -> s0.(i))
 
+let cannot_of_annot l = List.map (fun (x,y) -> string0_of_string x, string0_of_string y) l
+
+let annot_of_cannot l = List.map (fun (x,y) -> string_of_string0 x, string_of_string0 y) l
+
 (* ------------------------------------------------------------------------ *)
 
 let cty_of_ty = function

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -7,6 +7,9 @@ type 'info coq_tbl
 val string0_of_string : string -> 'a (* coq string *)
 val string_of_string0 : 'a (* coq string *) -> string
 
+val cannot_of_annot : (string * string) list -> ('a * 'a) list (* 'a = coq string *)
+val annot_of_cannot : ('a * 'a) list -> (string * string) list (* 'a = coq string *)
+
 val bi_of_nat  : Datatypes.nat -> Bigint.zint
 val int_of_nat : Datatypes.nat -> int
 val nat_of_int : int -> Datatypes.nat
@@ -49,6 +52,8 @@ val cfun_of_fun : 'info coq_tbl -> funname -> BinNums.positive
 val fun_of_cfun : 'info coq_tbl -> BinNums.positive -> funname
 
 val get_iinfo   : 'info coq_tbl -> BinNums.positive -> (L.t * L.t list) * 'info
+
+val get_finfo   : 'info coq_tbl -> BinNums.positive -> L.t * f_annot * call_conv
 
 val cufdef_of_fdef : 'info coq_tbl -> 'info func -> BinNums.positive * Expr._ufundef
 val fdef_of_cufdef : 'info coq_tbl -> BinNums.positive * Expr._ufundef -> 'info func

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -50,6 +50,8 @@ let set_stop_after p () =
 let set_all_print () =
   print_list := poptions
 
+let private_annot = ref false
+
 let set_ec f =
   ec_list := f :: !ec_list
 
@@ -121,6 +123,7 @@ let options = [
     "-nowarning", Arg.Unit (nowarning), ": do no print warning";
     "--help-intrinsics", Arg.Set help_intrinsics, "List the set of intrinsic operators";
     "-pall"    , Arg.Unit set_all_print, "print program after each compilation steps";
+    "-print-private-annot", Arg.Set private_annot, "print private annotations of program signatures";
   ] @  List.map print_option poptions @ List.map stop_after_option poptions
 
 let usage_msg = "Usage : jasminc [option] filename"

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -221,6 +221,14 @@ let pp_arg fmt (sty, x) =
     pp_sto_ty sty
     pp_var x
 
+let pp_aarg fmt (_a,(sty, x)) =
+  F.fprintf
+    fmt
+    "%a %a"
+    pp_sto_ty sty
+    pp_var x
+
+
 let pp_args fmt (sty, xs) =
   F.fprintf
     fmt
@@ -306,14 +314,14 @@ let pp_funbody fmt { pdb_vars ; pdb_instr ; pdb_ret } =
         (pp_list ", " pp_var) ret;
   ) fmt pdb_ret
 
-let pp_fundef fmt { pdf_cc ; pdf_name ; pdf_args ; pdf_rty ; pdf_body } =
+let pp_fundef fmt {pdf_cc ; pdf_name ; pdf_args ; pdf_rty ; pdf_body } =
   F.fprintf
     fmt
     "%a%a %a(%a)%a %a"
     pp_cc pdf_cc
     kw "fn"
     dname (L.unloc pdf_name)
-    (pp_list ", " pp_arg) pdf_args
+    (pp_list ", " pp_aarg) pdf_args
     pp_rty pdf_rty
     (pp_inbraces 0 pp_funbody) pdf_body;
   F.fprintf fmt eol

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -322,7 +322,7 @@ let pp_fundef fmt {pdf_cc ; pdf_name ; pdf_args ; pdf_rty ; pdf_body } =
     kw "fn"
     dname (L.unloc pdf_name)
     (pp_list ", " pp_aarg) pdf_args
-    pp_rty pdf_rty
+    pp_rty (Utils.omap (List.map snd) pdf_rty)
     (pp_inbraces 0 pp_funbody) pdf_body;
   F.fprintf fmt eol
 

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -114,7 +114,6 @@ let signletter = ['s' 'u']
 let gensize = "1" | "2" | "4" | "8" | "16" | "32" | "64" | "128" 
 let vsize   = "2" | "4" | "8" | "16" | "32" 
 
-
 (* -------------------------------------------------------------------- *)
 rule main = parse
   | newline { Lexing.new_line lexbuf; main lexbuf }
@@ -136,6 +135,7 @@ rule main = parse
 
   | ident+ as s
       { odfl (NID s) (Hash.find_option keywords s) }
+  | "@" (ident+	as s) {ANNOT s}
 
   | (size as sw) (signletter as s)                { SWSIZE(mksizesign sw s)  }
   | (vsize as r) (signletter as s) (gensize as g) { SVSIZE(mkvsizesign r s g)}

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -409,7 +409,7 @@ let main () =
     let get_sig_annot fn =
       let _ , f_annot, _ = Conv.get_finfo tbl fn in
       (List.map Conv.cannot_of_annot (fst f_annot.sig_annot),
-       Conv.cannot_of_annot (snd f_annot.sig_annot))
+       (List.map Conv.cannot_of_annot (snd f_annot.sig_annot)))
     in
       
      (* TODO: update *)
@@ -538,10 +538,12 @@ let main () =
       if ! Glob_options.private_annot
       then
         Printer.(begin
-                    let l = Query.collect_ctt_signature get_sig_annot (Expr.to_uprog cprog) in
+                    let p = Expr.to_uprog cprog in
+                    let l = Query.collect_ctt_signature get_sig_annot p in
                     List.iter
-                      (fun (fn,(lb,b)) ->
-                        Format.printf "%s : %a -> %a\n" (Conv.fun_of_cfun tbl fn).fn_name (pp_list "->" pp_bool) lb   pp_bool b    ) l
+                      (fun (fn,(la,lr)) ->
+                        Format.printf "%s : %a->%a\n" (Conv.fun_of_cfun tbl fn).fn_name (pp_list "->" pp_bool) la
+                          (pp_list "*" pp_bool)  lr    ) l;
                   end) in
     
     begin match

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -78,6 +78,7 @@
 %token EXPORT
 %token ARRAYINIT
 %token <string> NID
+%token <string> ANNOT
 %token <Bigint.zint> INT
 %token <string> STRING
 
@@ -113,6 +114,7 @@ attribute:
 
 annotation:
   | SHARPLBRACKET a=separated_list(COMMA, attribute) RBRACKET { a }
+  | s = ANNOT {[s,""]} (* lightweigth annotation *)
 
 annotations:
   | a = list(annotation) { List.concat a }
@@ -356,6 +358,9 @@ storage:
 %inline pvardecl(S):
 | ty=stor_type vs=separated_nonempty_list(S, var) { (ty, vs) }
 
+%inline pargdecl(S):
+| a = annotations ty=stor_type vs=separated_nonempty_list(S, var) { (a, ty, vs) }
+
 pfunbody :
 | LBRACE
     vs = postfix(pvardecl(COMMA?), SEMICOLON)*
@@ -375,7 +380,7 @@ pfundef:
     cc=call_conv?
     FN
     name = ident
-    args = parens_tuple(pvardecl(empty))
+    args = parens_tuple(pargdecl(empty))
     rty  = prefix(RARROW, tuple(stor_type))?
     body = pfunbody
 
@@ -383,7 +388,7 @@ pfundef:
       pdf_cc   = cc;
       pdf_name = name;
       pdf_args = 
-        List.flatten (List.map (fun (str, ids) -> List.map (fun id -> (str, id)) ids) args);
+        List.flatten (List.map (fun (a, str, ids) -> List.map (fun id -> (a,(str, id))) ids) args);
       pdf_rty  = rty ;
       pdf_body = body; } }
 

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -375,13 +375,15 @@ call_conv :
 | EXPORT { `Export }
 | INLINE { `Inline }
 
+atype: a=annotations ty=stor_type {(a,ty)}
+
 pfundef:
 |  pdf_annot = annotations
     cc=call_conv?
     FN
     name = ident
     args = parens_tuple(pargdecl(empty))
-    rty  = prefix(RARROW, tuple(stor_type))?
+    rty  = prefix(RARROW, tuple(atype))?
     body = pfunbody
 
   { { pdf_annot;

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1459,7 +1459,7 @@ let ws_of_string =
             [U8;U16;U32;U64;U128;U256] in
   fun s -> List.assoc s l 
 
-let process_f_annot loc annot args_annot = 
+let process_f_annot loc annot args_annot ret_annot= 
   let open P in
   let do1 name mk_info = 
     match List.assoc name annot with
@@ -1489,7 +1489,7 @@ let process_f_annot loc annot args_annot =
     stack_allocation_size = do1 "stackallocsize" mk_stksize;
     stack_size = do1 "stacksize" mk_stksize;
     stack_align = do1 "stackalign" mk_stkalign;
-    sig_annot  = (args_annot,annot) (* Could remove the "known" attributes *)
+    sig_annot  = (args_annot,ret_annot) (* Could remove the "known" attributes *)
   }
 
 
@@ -1499,13 +1499,14 @@ let tt_fundef (env : Env.env) loc (pf : S.pfundef) : Env.env =
   let inret = odfl [] (omap (List.map L.unloc) pf.pdf_body.pdb_ret) in
   let dfl_mut x = List.mem x inret in
   let envb, args = tt_vardecls_push dfl_mut env (List.map snd pf.pdf_args) in
-  let rty  = odfl [] (omap (List.map (tt_type env |- snd)) pf.pdf_rty) in
+  let arty,rty = odfl ([],[]) (omap List.split pf.pdf_rty) in
+  let rty  = List.map (tt_type env |- snd) rty in
   let body, xret = tt_funbody envb pf.pdf_body in
   let f_cc = tt_call_conv loc args xret pf.pdf_cc in
   let args = List.map L.unloc args in
   let fdef =
     { P.f_loc   = loc;
-      P.f_annot = process_f_annot loc pf.pdf_annot (List.map fst pf.pdf_args);
+      P.f_annot = process_f_annot loc pf.pdf_annot (List.map fst pf.pdf_args) arty;
       P.f_cc    = f_cc;
       P.f_name  = P.F.mk (L.unloc pf.pdf_name);
       P.f_tyin  = List.map (fun { P.v_ty } -> v_ty) args;

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -178,7 +178,7 @@ type f_annot = {
     stack_allocation_size : B.zint option;
     stack_size    : B.zint option;
     stack_align   : wsize option;
-    sig_annot    : (annot list) * annot
+    sig_annot    : (annot list) * (annot list)
   }
 
 let f_annot_empty = {

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -171,11 +171,14 @@ type returnaddress_kind =
   | OnStack
   | OnReg
 
+type annot = (string * string) list
+
 type f_annot = { 
     retaddr_kind  : returnaddress_kind option;
     stack_allocation_size : B.zint option;
     stack_size    : B.zint option;
     stack_align   : wsize option;
+    sig_annot    : (annot list) * annot
   }
 
 let f_annot_empty = {
@@ -183,6 +186,7 @@ let f_annot_empty = {
     stack_allocation_size = None;
     stack_size    = None;
     stack_align   = None;
+    sig_annot    = ([],[])
   } 
     
 type ('len,'info) gfunc = {

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -155,9 +155,8 @@ type f_annot = {
     stack_size    : B.zint option;
     stack_align   : wsize option;
     (* [args_annot] gathers the annotations for the arguments 
-       and the function result.
-       [List.length (fst args_annot)] is the number of arguments. *)
-    sig_annot    : (annot list) * annot 
+       and the function results. *)
+    sig_annot    : (annot list) * (annot list)
   }
 
 

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -147,12 +147,19 @@ type returnaddress_kind =
   | OnStack
   | OnReg
 
+type annot = (string * string) list
+
 type f_annot = {
     retaddr_kind  : returnaddress_kind option;
     stack_allocation_size : B.zint option;
     stack_size    : B.zint option;
     stack_align   : wsize option;
+    (* [args_annot] gathers the annotations for the arguments 
+       and the function result.
+       [List.length (fst args_annot)] is the number of arguments. *)
+    sig_annot    : (annot list) * annot 
   }
+
 
 val f_annot_empty : f_annot
 

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -240,11 +240,13 @@ type pcall_conv = [
   | `Inline
 ]
 
+type annot = (string * string) list
+
 type pfundef = {
-  pdf_annot : (string * string) list;
+  pdf_annot : annot;
   pdf_cc   : pcall_conv option;
   pdf_name : pident;
-  pdf_args : (pstotype * pident) list;
+  pdf_args : (annot * (pstotype * pident)) list;
   pdf_rty  : pstotype list option;
   pdf_body : pfunbody;
 }

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -247,7 +247,7 @@ type pfundef = {
   pdf_cc   : pcall_conv option;
   pdf_name : pident;
   pdf_args : (annot * (pstotype * pident)) list;
-  pdf_rty  : pstotype list option;
+  pdf_rty  : (annot * pstotype) list option;
   pdf_body : pfunbody;
 }
 

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -39,6 +39,7 @@ compiler/makeReferenceArguments.v
 compiler/makeReferenceArguments_proof.v
 compiler/merge_varmaps.v
 compiler/merge_varmaps_proof.v
+compiler/query.v
 compiler/remove_globals.v
 compiler/remove_globals_proof.v
 compiler/stack_alloc.v

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -106,8 +106,9 @@ Record compiler_params := {
   is_reg_ptr       : var -> bool;
   is_ptr           : var -> bool;
   is_reg_array     : var -> bool;
-  get_sig_annot    : funname -> (list annot) * annot;
+  get_sig_annot    : instr_info -> (list annot) * (list annot);
 }.
+
 
 Definition var_alloc_prog cp (p: _uprog) : _uprog :=
   map_prog_name cp.(var_alloc_fd) p.

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -27,6 +27,7 @@ From mathcomp Require Import all_ssreflect all_algebra.
 Require Import x86_gen expr.
 Import ZArith.
 Require merge_varmaps.
+Require Import query.
 Require Import compiler_util allocation array_init inline dead_calls unrolling remove_globals
    constant_prop dead_code array_expansion lowering makeReferenceArguments stack_alloc linear tunneling x86_sem.
 Import Utf8.
@@ -105,6 +106,7 @@ Record compiler_params := {
   is_reg_ptr       : var -> bool;
   is_ptr           : var -> bool;
   is_reg_array     : var -> bool;
+  get_sig_annot    : funname -> (list annot) * annot;
 }.
 
 Definition var_alloc_prog cp (p: _uprog) : _uprog :=

--- a/proofs/compiler/query.v
+++ b/proofs/compiler/query.v
@@ -58,16 +58,16 @@ Definition match_pattern (p:pattern) (s:string)  : bool :=
   | PEQ s' => eqb s s'
   end.
 
-Fixpoint match_assoc (q:query) (a:assoc) : bool :=
+Definition match_attribute (p1 p2:pattern) (a:annot) : bool :=
+  List.existsb (fun '(x,v) => match_pattern p1 x && match_pattern p2 v) a.
+
+Fixpoint match_query (q:query) (a:annot) : bool :=
   match q with
   | QTRUE => true
-  | QATTR x v => match_pattern x a.1 &&   match_pattern v a.2
-  | QAND q1 q2 => (match_assoc q1 a) && (match_assoc q2 a)
-  | QOR q1 q2 => (match_assoc q1 a) || (match_assoc q2 a)
+  | QATTR x v => match_attribute x v a
+  | QAND q1 q2 => (match_query q1 a) && (match_query q2 a)
+  | QOR q1 q2 => (match_query q1 a) || (match_query q2 a)
   end.
-
-Definition match_query (q:query) (a:annot) : bool :=
-  List.existsb (match_assoc q) a.
 
 (** * Interface *)
 

--- a/proofs/compiler/query.v
+++ b/proofs/compiler/query.v
@@ -1,0 +1,89 @@
+(* ** License
+ * -----------------------------------------------------------------------
+ * Copyright 2016--2017 IMDEA Software Institute
+ * Copyright 2016--2017 Inria
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ----------------------------------------------------------------------- *)
+
+(* ** A query language to access attributes *)
+
+(* ** Imports and settings *)
+Require Import ZArith.
+From mathcomp Require Import all_ssreflect.
+Require Import expr compiler_util.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+(* ** Query language *)
+
+Definition assoc := (string * string)%type.
+
+Definition annot := list assoc.
+
+Inductive pattern : Type :=
+| PANY
+| PEQ (s: string).
+
+Inductive query :=
+| QTRUE
+| QATTR (a:pattern) (v:pattern)
+| QAND (a1 a2: query)
+| QOR (a1 a2: query).
+
+(* ** Interpretation *)
+
+Definition match_pattern (p:pattern) (s:string)  : bool :=
+  match p with
+  | PANY => true
+  | PEQ s' => eqb s s'
+  end.
+
+Fixpoint match_assoc (q:query) (a:assoc) : bool :=
+  match q with
+  | QTRUE => true
+  | QATTR x v => match_pattern x a.1 &&   match_pattern v a.2
+  | QAND q1 q2 => (match_assoc q1 a) && (match_assoc q2 a)
+  | QOR q1 q2 => (match_assoc q1 a) || (match_assoc q2 a)
+  end.
+
+Definition match_query (q:query) (a:annot) : bool :=
+  List.existsb (match_assoc q) a.
+
+(** * Interface *)
+
+Definition get_signature (q:query) (a : (list annot) * annot) :=
+  (List.map (match_query q) a.1 , match_query q a.2).
+
+(* Example *)
+
+Definition get_ctt_signature := get_signature (QATTR (PEQ "private") PANY).
+
+
+Section Section.
+
+  (* From compiler params *)
+  Variable get_annot_sig : funname -> (list annot) * annot.
+
+  Definition collect_ctt_signature (p:uprog) : seq (funname * ((seq bool) * bool)) :=
+      List.map (fun f => (f.1 , get_ctt_signature (get_annot_sig f.2.(f_iinfo)))) p.(expr.p_funcs).
+End Section.

--- a/proofs/compiler/query.v
+++ b/proofs/compiler/query.v
@@ -71,8 +71,8 @@ Fixpoint match_query (q:query) (a:annot) : bool :=
 
 (** * Interface *)
 
-Definition get_signature (q:query) (a : (list annot) * annot) :=
-  (List.map (match_query q) a.1 , match_query q a.2).
+Definition get_signature (q:query) (a : (list annot) * (list annot)) :=
+  (List.map (match_query q) a.1 , List.map (match_query q) a.2).
 
 (* Example *)
 
@@ -82,8 +82,8 @@ Definition get_ctt_signature := get_signature (QATTR (PEQ "private") PANY).
 Section Section.
 
   (* From compiler params *)
-  Variable get_annot_sig : funname -> (list annot) * annot.
+  Variable get_annot_sig : funname -> (list annot) * (list annot).
 
-  Definition collect_ctt_signature (p:uprog) : seq (funname * ((seq bool) * bool)) :=
+  Definition collect_ctt_signature (p:uprog) : seq (funname * ((seq bool) * (seq bool))) :=
       List.map (fun f => (f.1 , get_ctt_signature (get_annot_sig f.2.(f_iinfo)))) p.(expr.p_funcs).
 End Section.

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -42,6 +42,6 @@ Cd  "lang/ocaml".
 
 Extraction Blacklist String List Nat Utils Var Array.
 
-Separate Extraction utils expr sem x86_instr_decl compiler.
+Separate Extraction utils expr sem x86_instr_decl compiler query.
 
 Cd  "../..".


### PR DESCRIPTION
This is a preliminary experiment to annotate Jasmin function signatures.
- An annotation is either '#[ NID = STRING .... ]' or a shorter '@NID' (interpreted as parsing time as NID = "")
- Annotations can be attached to function arguments (used to be only attached to functions)
- The annotations are collected at 'Pretyping'  time and stored as an additional field 'sig_annot' of 'f_annot'.
-  On the Coq side, 'compiler_params.get_sig_annot' gives access to the annotation (using coq string)
-  'query.v` provides a simple query language. It is currently used to get which arguments are tagged "private"
- For testing purposes, it is currently available with the option -print-private-annot