### PR TITLE
Easycrypt semantics for x86 instructions

### DIFF
--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -255,6 +255,18 @@ op VPUNPCKH_4u64 (w1 w2: W256.t) =
   map2 VPUNPCKH_2u64 w1 w2.
 
 (* ------------------------------------------------------------------- *)
+op packus_4u32 (w: W256.t, off: int) : W64.t =
+  let pack = fun n =>
+  if (w \bits32 n) \slt W32.zero then W16.zero
+  else if (W32.of_int W16.max_uint) \sle (w \bits32 n) then (W16.of_int W16.max_uint)
+  else (w \bits16 (2*n))
+  in
+  pack4 [pack off; pack (off+1); pack (off+2); pack (off+3)].
+
+op VPACKUS_8u32 (w1 w2: W256.t) : W256.t =
+  pack4 [packus_4u32 w1 0; packus_4u32 w2 0; packus_4u32 w1 4; packus_4u32 w2 4].
+
+(* ------------------------------------------------------------------- *)
 op VPSLLDQ_128 (w1:W128.t) (w2:W8.t) =
   let n = to_uint w2 in
   let i = min n 16 in

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -186,6 +186,12 @@ op VPERMQ (w:W256.t) (i:W8.t) : W256.t =
   let choose = fun n => w \bits64 ((to_uint i %/ n) %% 4) in
   pack4 [choose 1; choose 4; choose 16; choose 64].
 
+op permd (v: W256.t) (i: W32.t) : W32.t =
+  v \bits32 (to_uint i %% 8).
+
+op VPERMD (w: W256.t) (i: W256.t) : W256.t =
+  map (permd w) i.
+
 op VEXTRACTI128 (w:W256.t) (i:W8.t) : W128.t =
   w \bits128 b2i i.[0].
 

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -306,6 +306,19 @@ op VPSRLV_4u64 (w1:W256.t) (w2:W256.t) =
   map2 srl w1 w2.
 
 (* ------------------------------------------------------------------- *)
+op VPBLENDW_128 (w1 w2: W128.t) (i: W8.t) : W128.t =
+  let choose = fun n =>
+    let w = if i.[n] then w2 else w1 in
+    w \bits16 n in
+  pack8 [choose 0; choose 1; choose 2; choose 3; choose 4; choose 5; choose 6; choose 7].
+
+op VPBLENDW_256 (w1 w2: W256.t) (i: W8.t) : W256.t =
+  let choose = fun n =>
+    let w = if i.[n] then w2 else w1 in
+    w \bits16 n in
+  pack16 [choose 0; choose 1; choose 2; choose 3; choose 4; choose 5; choose 6; choose 7;
+          choose 8; choose 9; choose 10; choose 11; choose 12; choose 13; choose 14; choose 15].
+
 op VPBLENDD_128 (w1 w2: W128.t) (i:W8.t) : W128.t =
   let choose = fun n =>
      let w = if i.[n] then w2 else w1 in

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -267,6 +267,19 @@ op VPACKUS_8u32 (w1 w2: W256.t) : W256.t =
   pack4 [packus_4u32 w1 0; packus_4u32 w2 0; packus_4u32 w1 4; packus_4u32 w2 4].
 
 (* ------------------------------------------------------------------- *)
+op VPMULH_8u16 (w1 w2: W128.t) : W128.t =
+  map2 (fun (x y:W16.t) => wmulhs x y) w1 w2.
+
+op VPMULH_16u16 (w1 w2: W256.t) : W256.t =
+  map2 (fun (x y:W16.t) => wmulhs x y) w1 w2.
+
+op VPMULL_8u16 (w1 w2: W128.t) : W128.t =
+  map2 (fun (x y:W16.t) => x * y) w1 w2.
+
+op VPMULL_16u16 (w1 w2: W256.t) : W256.t =
+  map2 (fun (x y:W16.t) => x * y) w1 w2.
+
+(* ------------------------------------------------------------------- *)
 op VPSLLDQ_128 (w1:W128.t) (w2:W8.t) =
   let n = to_uint w2 in
   let i = min n 16 in

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -333,6 +333,16 @@ op VPBLENDD_256 (w1 w2: W256.t) (i:W8.t) : W256.t =
 
 (* ------------------------------------------------------------------- *)
 
+op VPMOVMSKB_128 (v: W128.t) : W16.t =
+  let vb = w2bits v in
+  W16.bits2w (mkseq (fun i => nth false vb (8*i + 7)) 16).
+
+op VPMOVMSKB_256 (v: W256.t) : W32.t =
+  let vb = w2bits v in
+  W32.bits2w (mkseq (fun i => nth false vb (8*i + 7)) 32).
+
+(* ------------------------------------------------------------------- *)
+
 (* AES instruction *)
 
 abbrev [-printing] VAESDEC          = AESDEC.

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -2203,6 +2203,15 @@ abstract theory W_WS.
    op VPBROADCAST_'Ru'S (w: WS.t) =
      pack'R (map (fun i => w) (iota_ 0 r)).
 
+   op wucmp (cmp: int -> int -> bool) (x y: WS.t) : WS.t =
+     if cmp (to_uint x) (to_uint y) then (WS.of_int (-1)) else (WS.of_int 0).
+
+   op VPCMPGT_'Ru'S (w1 : WB.t) (w2: WB.t) =
+     map2 (wucmp Int.(<=)) w2 w1.
+
+   op VPCMPEQ_'Ru'S (w1 : WB.t) (w2: WB.t) =
+     map2 (wucmp (=)) w1 w2.
+
    (** TODO CHECKME : still x86 **)
    lemma x86_'Ru'S_rol_xor i w : 0 < i < sizeS =>
       VPSLL_'Ru'S w (W8.of_int i) +^ VPSRL_'Ru'S w (W8.of_int (sizeS - i)) =

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -1447,6 +1447,14 @@ op rflags_of_andn (w: t) =
   let ZF = ZF_of w in
   (OF, CF, SF, PF, ZF).
 
+op rflags_of_popcnt (w: t) =
+  let OF = false in
+  let CF = false in
+  let SF = false in
+  let PF = false in
+  let ZF = ZF_of w in
+  (OF, CF, SF, PF, ZF).
+
 op rflags_of_aluop_nocf_w (w : t) (vs : int) =
   let OF = to_sint w <> vs in
   let SF = SF_of w in
@@ -1617,6 +1625,11 @@ proof.
   + by apply negP => heq; apply hc0; rewrite -(to_uintK c) heq.
   rewrite to_uintB /= 1:uleE /=; smt (to_uint_cmp).
 qed.
+
+op POPCNT_XX (v: t) =
+  let vb = w2bits v in
+  let wcnt = of_int (count idfun vb) in
+  flags_w (rflags_of_popcnt wcnt) wcnt.
 
 end ALU.
 

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -1631,6 +1631,10 @@ op POPCNT_XX (v: t) =
   let wcnt = of_int (count idfun vb) in
   flags_w (rflags_of_popcnt wcnt) wcnt.
 
+op PEXT_XX (v m: t) =
+  let vbi = filter (fun i => m.[i]) (iota_ 0 size) in
+  bits2w (map (fun i => v.[i]) vbi).
+
 end ALU.
 
 end BitWord.


### PR DESCRIPTION
Add missing Easycrypt semantics for some of the new AVX2 and scalar instructions.