### PR TITLE
Proof of the new stack alloc pass

### DIFF
--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -62,7 +62,7 @@ let memory_analysis pp_comp_ferr ~debug tbl up =
   let cget_sao fn = get_sao (Conv.fun_of_cfun tbl fn) in
   
   let sp' = 
-    match Stack_alloc.alloc_prog crip gao.gao_data cglobs cget_sao up with
+    match Stack_alloc.alloc_prog false crip gao.gao_data cglobs cget_sao up with
     | Utils0.Ok sp -> sp 
     | Utils0.Error e ->
       Utils.hierror "compilation error %a@." (pp_comp_ferr tbl) e in
@@ -121,12 +121,11 @@ let memory_analysis pp_comp_ferr ~debug tbl up =
       let stk_size = 
         Bigint.add (Conv.bi_of_z csao.Stack_alloc.sao_size)
                    (Bigint.of_int extra_size) in
-      let ws = csao.Stack_alloc.sao_align in
       let stk_size = 
         match fd.f_cc with
-        | Export       -> Bigint.add stk_size (Bigint.of_int (size_of_ws ws - 1))
+        | Export       -> Bigint.add stk_size (Bigint.of_int (size_of_ws align - 1))
         | Subroutine _ -> 
-          Conv.bi_of_z (Memory_model.round_ws ws (Conv.z_of_bi stk_size))
+          Conv.bi_of_z (Memory_model.round_ws align (Conv.z_of_bi stk_size))
         | Internal -> assert false in
       Bigint.add max_stk stk_size in
     let saved_stack = 

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -44,6 +44,7 @@ compiler/remove_globals.v
 compiler/remove_globals_proof.v
 compiler/stack_alloc.v
 compiler/stack_alloc_proof.v
+compiler/stack_alloc_proof_2.v
 compiler/tunneling.v
 compiler/unrolling.v
 compiler/unrolling_proof.v

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -153,7 +153,7 @@ Section REMOVE_INIT.
     have ?:= Varr_inj1 (ok_inj heq); subst a1 => {heq}.
     rewrite WArray.castK.
     split; first by apply Z.le_refl.
-    move=> k w; rewrite (WArray.set_sub_get8 _ ht1) /=; case: ifP => ?.
+    move=> k w; rewrite (WArray.set_sub_get8 ht1) /=; case: ifP => ?.
     + by rewrite WArray.get_empty; case: ifP.
     by apply hu.
   Qed.

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -185,7 +185,7 @@ Definition compile_prog (entries subroutines : seq funname) (p: prog) :=
 
   let ao := cparams.(stackalloc) pl in
   Let ps :=
-     stack_alloc.alloc_prog
+     stack_alloc.alloc_prog true
        cparams.(global_static_data_symbol) ao.(ao_globals) ao.(ao_global_alloc)
        ao.(ao_stack_alloc) pl in
   let ps : sprog := cparams.(print_sprog) StackAllocation ps in

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -29,7 +29,7 @@ Require Import allocation inline_proof dead_calls_proof
                makeReferenceArguments_proof
                array_init_proof
                unrolling_proof constant_prop_proof dead_code_proof
-               array_expansion array_expansion_proof remove_globals_proof stack_alloc_proof
+               array_expansion array_expansion_proof remove_globals_proof stack_alloc_proof_2
                lowering_proof
                linear_proof
                merge_varmaps_proof

--- a/proofs/compiler/linear_proof.v
+++ b/proofs/compiler/linear_proof.v
@@ -858,12 +858,12 @@ Section PROOF.
     have hr2 := write_read8 Hw'' p1. move: Hr2. rewrite hr2 hr1 /=.
     case: ifP=> // _. by apply H1. 
   (* valid *)
-  + move=> p1 Hv. have Hv1 := (CoreMem.write_validw p1 U8 Hw).
-    have Hv2 := (CoreMem.write_validw p1 U8 Hw''). rewrite Hv2.
+  + move=> p1 Hv. have Hv1 := (CoreMem.write_validw_eq Hw).
+    have Hv2 := (CoreMem.write_validw_eq Hw''). rewrite Hv2.
     apply H2. by rewrite -Hv1.
   (* stack *)
-  move=> p1 H. have Hv1 := (CoreMem.write_validw p1 U8 Hw).
-  have Hv2 := (CoreMem.write_validw p1 U8 Hw''). rewrite Hv2.
+  move=> p1 H. have Hv1 := (CoreMem.write_validw_eq Hw).
+  have Hv2 := (CoreMem.write_validw_eq Hw''). rewrite Hv2.
   apply H3. have Hst := write_mem_stable Hw. case: Hst.
   by move=> -> -> _.
   Qed.
@@ -909,7 +909,7 @@ Section PROOF.
     move => /(_ w) [] m' ok_m'; exists m'; first exact: ok_m'.
     split.
     - move => x y ok_y.
-      rewrite (writeP_neq ok_m'); first exact: Hrm.
+      rewrite (CoreMem.writeP_neq ok_m'); first exact: Hrm.
       move => i j [] i_low i_hi; change (wsize_size U8) with 1%Z => j_range.
       have ? : j = 0%Z by lia.
       subst j => { j_range }.
@@ -920,7 +920,7 @@ Section PROOF.
       have := wunsigned_range a.
       generalize (wunsigned_range (top_stack m)).
       lia.
-    1-2: move => b; rewrite (CoreMem.write_validw _ _ ok_m').
+    1-2: move => b; rewrite (CoreMem.write_validw_eq ok_m').
     - exact/Hvm.
     exact/Hs.
   Qed.
@@ -1077,7 +1077,7 @@ Section PROOF.
       rewrite (value_uincl_word ev_ev' ok_ofs) /=.
       t_xrbindP => w' ok_w' tm' ok_tm' <-{t'} /=.
       move => ptr ptr_range /negP ptr_not_valid.
-      rewrite (writeP_neq ok_tm'); first reflexivity.
+      rewrite (CoreMem.writeP_neq ok_tm'); first reflexivity.
       apply: disjoint_range_U8 => i i_range ?; subst ptr.
       apply: ptr_not_valid.
       rewrite -valid8_validw.
@@ -1811,7 +1811,7 @@ Let vrsp : var := vid (string_of_register RSP).
       have := alloc_stackP ok_m.
       clear - ok_m ok_m1' ok_stk_sz z_pos z_bound sp_aligned => A a [] a_lo a_hi _.
       have top_range := ass_above_limit A.
-      rewrite (writeP_neq ok_m1'); first reflexivity.
+      rewrite (CoreMem.writeP_neq ok_m1'); first reflexivity.
       apply: disjoint_range_U8 => i i_range ? {ok_m1'}; subst a.
       move: a_lo {a_hi}.
       rewrite (top_stack_after_aligned_alloc _ sp_aligned) -/(stack_frame_allocation_size (f_extra fd')).
@@ -1874,7 +1874,7 @@ Let vrsp : var := vid (string_of_register RSP).
         case/and3P: ok_save_stack => /eqP sf_align_1 /eqP stk_sz_0 /eqP stk_extra_sz_0.
         have top_stack_preserved : top_stack m1' = top_stack (s1: mem).
         + rewrite (alloc_stack_top_stack ok_m1') sf_align_1.
-          rewrite Memory.top_stack_after_aligned_alloc.
+          rewrite top_stack_after_aligned_alloc.
           2: exact: is_align8.
           by rewrite stk_sz_0 stk_extra_sz_0 -addE add_0.
         have X' : vm_uincl (set_RSP m1' (kill_flags s1 rflags)) vm1.

--- a/proofs/compiler/merge_varmaps_proof.v
+++ b/proofs/compiler/merge_varmaps_proof.v
@@ -279,11 +279,11 @@ Section LEMMA.
     - have [ not_written_gd not_written_rsp ] := not_written_magic (mvp_not_written ok_W1).
       split.
       + by move: (mvp_not_written ok_W); rewrite write_c_cons; apply: disjoint_w; SvD.fsetdec.
-      + rewrite -(ss_top_stack (sem_I_stack_stable exec_i)) -(mvp_top_stack ok_W) (sem_I_not_written texec_i) //.
+      + rewrite -(ss_top_stack (sem_I_stack_stable_sprog exec_i)) -(mvp_top_stack ok_W) (sem_I_not_written texec_i) //.
         by SvD.fsetdec.
       + rewrite -(mvp_global_data ok_W) (sem_I_not_written texec_i) //.
         by SvD.fsetdec.
-      by rewrite -(ss_top_stack (sem_I_stack_stable exec_i)) (mvp_stack_aligned ok_W).
+      by rewrite -(ss_top_stack (sem_I_stack_stable_sprog exec_i)) (mvp_stack_aligned ok_W).
     have [t3 [kc texec_c hkc] sim3]:= hc _ _ _ _ ok_c ok_W2 sim2.
     exists t3 => //; exists (Sv.union ki kc); first by econstructor; eauto.
     rewrite write_c_cons; SvD.fsetdec.
@@ -489,11 +489,11 @@ Section LEMMA.
       split.
       + move: (mvp_not_written pre).
         by apply disjoint_w; rewrite write_i_while; SvD.fsetdec.
-      + rewrite -(ss_top_stack (sem_stack_stable sexec)) -(mvp_top_stack pre) (sem_not_written texec_c) //.
+      + rewrite -(ss_top_stack (sem_stack_stable_sprog sexec)) -(mvp_top_stack pre) (sem_not_written texec_c) //.
         by SvD.fsetdec.
       + rewrite -(sem_not_written texec_c); last SvD.fsetdec.
         exact: mvp_global_data pre1.
-      rewrite -(ss_top_stack (sem_stack_stable sexec)).
+      rewrite -(ss_top_stack (sem_stack_stable_sprog sexec)).
       exact: mvp_stack_aligned pre1.
     have [t3 [ k' texec_c' hk' ] sim3] := ih' _ _ _ _ check_c' pre2 sim2.
     case: (rec sz ii D1 O t3 checked).
@@ -501,10 +501,10 @@ Section LEMMA.
       split.
       + exact: mvp_not_written pre.
       + rewrite -(sem_not_written texec_c'); last SvD.fsetdec.
-        by rewrite (mvp_top_stack pre2) (ss_top_stack (sem_stack_stable sexec')).
+        by rewrite (mvp_top_stack pre2) (ss_top_stack (sem_stack_stable_sprog sexec')).
       + rewrite -(sem_not_written texec_c'); last SvD.fsetdec.
         by rewrite (mvp_global_data pre2).
-      rewrite -(ss_top_stack (sem_stack_stable sexec')).
+      rewrite -(ss_top_stack (sem_stack_stable_sprog sexec')).
       exact: mvp_stack_aligned pre2.
     - by apply: match_estateI sim3.
     move => t4 [ krec texec hkrec ] sim4.
@@ -783,8 +783,8 @@ Section LEMMA.
     have top_stack2 : top_stack (free_stack (emem s2)) = top_stack m.
     + have ok_alloc := Memory.alloc_stackP ok_m'.
       have ok_free := Memory.free_stackP (emem s2).
-      by rewrite {1}/top_stack ok_free.(fss_frames) ok_free.(fss_root) -(sem_stack_stable sexec).(ss_root)
-         -(sem_stack_stable sexec).(ss_frames) -(write_vars_emem ok_s1) ok_alloc.(ass_root) ok_alloc.(ass_frames).
+      by rewrite {1}/top_stack ok_free.(fss_frames) ok_free.(fss_root) -(sem_stack_stable_sprog sexec).(ss_root)
+         -(sem_stack_stable_sprog sexec).(ss_frames) -(write_vars_emem ok_s1) ok_alloc.(ass_root) ok_alloc.(ass_frames).
     have [ t2 [ k texec hk ] sim2 ] := ih _ _ _ t1' checked_body pre1 sim1.
     have [ tres ok_tres res_uincl ] : exists2 tres,
        mapM (λ x : var_i, get_var (set_RSP (free_stack (emem t2)) (evm t2)) x) (f_res fd) = ok tres
@@ -836,7 +836,7 @@ Section LEMMA.
           congr (ok (pword_of_word _)).
           rewrite -(mvm_mem sim2).
           move: ok_s1; rewrite (write_vars_lvals [::]) => /write_lvals_stack_stable /ss_top_stack ->.
-          by move/sem_stack_stable: sexec => /ss_top_stack.
+          by move/sem_stack_stable_sprog: sexec => /ss_top_stack.
         move/Sv.subset_spec: ok_wrf; rewrite /write_fd /= => ok_wrf.
         have [_]:= not_written_magic preserved_magic.
         by rewrite /vrsp /= /writefun_ra; SvD.fsetdec.

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -26,8 +26,9 @@
 (* ** Imports and settings *)
 From mathcomp Require Import all_ssreflect all_algebra.
 From CoqWord Require Import ssrZ.
-Require Import psem compiler_util constant_prop_proof.
+Require Import psem psem_facts compiler_util constant_prop_proof.
 Require Export psem stack_alloc.
+Require Import byteset.
 Require Import Psatz.
 Import Utf8.
 
@@ -40,190 +41,363 @@ Local Open Scope seq_scope.
 Local Open Scope Z_scope.
 
 Import Region.
-
 (* --------------------------------------------------------------------------- *)
-(*
-Definition size_of (t:stype) :=
-  match t with
-  | sword sz => wsize_size sz
-  | sarr n   => Zpos n
-  | _        => 1
-  end.
+
+(* Size of a value. *)
+Notation size_val v := (size_of (type_of_val v)).
+
+Lemma size_of_gt0 ty : 0 < size_of ty.
+Proof. by case: ty. Qed.
+
+Lemma size_slot_gt0 s : 0 < size_slot s.
+Proof. by apply size_of_gt0. Qed.
+
+Lemma size_of_le ty ty' : subtype ty ty' -> size_of ty <= size_of ty'.
+Proof.
+  case: ty => [||p|ws]; case:ty' => [||p'|ws'] //.
+  + by move=> /ZleP.
+  move=> /wsize_size_le.
+  by apply Z.divide_pos_le.
+Qed.
+
+(* TODO : move elsewhere *)
+(* but not clear where
+   Uptr is defined in memory_model, no stype there
+   stype is defined in type, no Uptr there
+*)
+Notation spointer := (sword Uptr) (only parsing).
 
 Section Section.
 
-Variables (pmap:pos_map) (stk_size glob_size:Z).
+Variables (pmap:pos_map) (glob_size:Z).
 Variables (rsp rip: pointer).
-(* FIXME: we should be more flexible on the alignment of rsp and rip *)
-Hypothesis (is_align_rsp: forall ws, is_align rsp ws) (is_align_rip: forall ws, is_align rip ws).
 
-Hypothesis (rsp_bound : wunsigned rsp + stk_size <= wbase Uptr)
-           (rip_bound : wunsigned rip + glob_size <= wbase Uptr).
+Variable (Slots : Sv.t).
+Variable (Addr : slot -> pointer).
+Variable (Writable : slot -> bool).
+Variable (Align : slot -> wsize).
 
-Hypothesis disj_rsp_rip :
-  0 < stk_size -> 0 < glob_size ->
-  wunsigned rsp + stk_size <= wunsigned rip \/ wunsigned rip + glob_size <= wunsigned rsp.
+(* Any pointer in a slot is valid. *)
+Definition slot_valid m := forall s p, Sv.In s Slots ->
+  between (Addr s) (size_slot s) p U8 -> validw m p U8.
 
-Lemma valid_align m p ws :
-  valid_pointer m p ws →
-  is_align p ws.
-Proof. by case/Memory.valid_pointerP. Qed.
+(* NOTE: disjoint_zrange already contains no_overflow conditions *)
+(* Slots are disjoint from the source memory [ms]. *)
+Definition disjoint_source ms :=
+  forall s p, Sv.In s Slots -> validw ms p U8 ->
+  disjoint_zrange (Addr s) (size_slot s) p (wsize_size U8).
 
-Hint Resolve is_align_no_overflow valid_align.
+(* Addresses of slots can be manipulated without risking overflows. *)
+Hypothesis addr_no_overflow : forall s, Sv.In s Slots ->
+  no_overflow (Addr s) (size_slot s).
 
-Definition global_pos x := 
-  omap (fun z => (z, vtype x)) (Mvar.get pmap.(globals) x).
+(* Two distinct slots, with at least one of them writable, are disjoint. *)
+Hypothesis disjoint_writable : forall s1 s2,
+  Sv.In s1 Slots -> Sv.In s2 Slots -> s1 <> s2 ->
+  Writable s1 ->
+  disjoint_zrange (Addr s1) (size_slot s1) (Addr s2) (size_slot s2).
 
-Definition local_pos x := 
-  match get_local pmap x with
-  | Some (Pstack z) => Some (z, vtype x)
-  | Some (Pstkptr z) => Some (z, sword Uptr)
-  | _ => None 
+(* The address [Addr s] of a slot [s] is aligned w.r.t. [Align s]. *)
+Hypothesis slot_align :
+  forall s, Sv.In s Slots -> is_align (Addr s) (Align s).
+
+(* Writable slots are disjoint from globals. *)
+Hypothesis writable_not_glob : forall s, Sv.In s Slots -> Writable s ->
+  0 < glob_size -> disjoint_zrange rip glob_size (Addr s) (size_slot s).
+
+(* All pointers valid in memory [m0] are valid in memory [m].
+   It is supposed to be applied with [m0] the initial target memory
+   and [m] the current target memory.
+*)
+Definition valid_incl m0 m :=
+  forall p, validw m0 p U8 -> validw m p U8.
+
+(* ms: current source memory
+   m0: initial target memory (just before the call to the current function)
+   m : current target memory
+
+   ms:
+                                                    --------------------
+                                                    |    mem source    |
+                                                    --------------------
+
+   m0:
+                       --------------- ------------ --------------------
+                       | other stack | |   glob   | |    mem source    |
+                       --------------- ------------ --------------------
+
+                                  ||
+                                  || function call
+                                  \/
+
+   m:
+   ------------------- --------------- ------------ --------------------
+   |   stack frame   | | other stack | |   glob   | |    mem source    |
+   ------------------- --------------- ------------ --------------------
+
+*)
+
+(* The memory zones that are not in a writable slot remain unchanged. *)
+Definition mem_unchanged ms m0 m :=
+  forall p, validw m0 p U8 -> ~ validw ms p U8 ->
+  (forall s, Sv.In s Slots -> Writable s -> disjoint_zrange (Addr s) (size_slot s) p (wsize_size U8)) ->
+  read m0 p U8 = read m p U8.
+
+Record wf_global g ofs ws := {
+  wfg_slot : Sv.In g Slots;
+  wfg_writable : ~ Writable g;
+  wfg_align : Align g = ws;
+  wfg_offset : Addr g = (rip + wrepr Uptr ofs)%R
+}.
+
+Definition wbase_ptr sc :=
+  if sc == Sglob then rip else rsp.
+
+Record wf_direct (x : var) (s : slot) ofs ws z sc := {
+  wfd_slot : Sv.In s Slots;
+  wfd_size : size_slot x <= z.(z_len);
+  wfd_zone : 0 <= z.(z_ofs) /\ z.(z_ofs) + z.(z_len) <= size_slot s;
+  wfd_writable : Writable s = (sc != Sglob);
+  wfd_align : Align s = ws;
+  wfd_offset : Addr s = (wbase_ptr sc + wrepr Uptr ofs)%R
+}.
+
+Record wf_regptr x xr := {
+  wfr_type : is_sarr (vtype x);
+  wfr_rtype : vtype xr = spointer;
+  wfr_not_vrip : xr <> pmap.(vrip);
+  wfr_not_vrsp : xr <> pmap.(vrsp);
+  wfr_new : Sv.In xr pmap.(vnew);
+  wfr_distinct : forall y yr,
+    get_local pmap y = Some (Pregptr yr) -> x <> y -> xr <> yr
+}.
+
+Record wf_stkptr (x : var) (s : slot) ofs ws z (xf : var) := {
+  wfs_slot : Sv.In s Slots;
+  wfs_type : is_sarr (vtype x);
+  wfs_size : wsize_size Uptr <= z.(z_len);
+  wfs_zone : 0 <= z.(z_ofs) /\ z.(z_ofs) + z.(z_len) <= size_slot s;
+  wfs_writable : Writable s;
+  wfs_align : Align s = ws;
+  wfs_align_ptr : (Uptr <= ws)%CMP;
+  wfs_offset_align : is_align (wrepr _ z.(z_ofs))%R Uptr;
+  wfs_offset : Addr s = (rsp + wrepr Uptr ofs)%R;
+  wfs_new : Sv.In xf pmap.(vnew);
+  wfs_distinct : forall y s' ofs' ws' z' yf,
+    get_local pmap y = Some (Pstkptr s' ofs' ws' z' yf) -> x <> y -> xf <> yf
+}.
+
+Definition wf_local x pk :=
+  match pk with
+  | Pdirect s ofs ws z sc => wf_direct x s ofs ws z sc
+  | Pregptr xr => wf_regptr x xr
+  | Pstkptr s ofs ws z xf => wf_stkptr x s ofs ws z xf
   end.
-
-Record wf_pos (get : var -> option (Z * stype)) size := {
-  wfg_ofs   : forall x ofs ty, get x = Some (ofs, ty) -> 
-             0 <= ofs /\ ofs + size_of ty <= size;
-  wfg_disj  : forall x y xofs yofs xty yty,
-             x <> y ->
-             get x = Some (xofs, xty) -> get y = Some (yofs, yty) ->
-             xofs + size_of xty <= yofs \/ yofs + size_of yty <= xofs;
-}.
-
-Class wf_regptr := {
-  wt_rip   : vtype pmap.(vrip) = sword Uptr;
-  wt_rsp   : vtype pmap.(vrsp) = sword Uptr;
-  wt_rptr  : forall x p, get_local pmap x = Some (Pregptr p) -> vtype p = sword Uptr;
-  wf_ptr   : forall x, (exists p, get_local pmap x = Some (Pregptr p)) \/
-                       (exists z, get_local pmap x = Some (Pstkptr z)) ->
-                       is_sarr (vtype x);
-  disj_ptr : forall x xp, 
-              get_local pmap x = Some (Pregptr xp) -> 
-              [/\ xp <> pmap.(vrip), xp <> pmap.(vrsp), Sv.In xp pmap.(vnew) &
-                  forall y yp, x <> y -> 
-                               get_local pmap y = Some (Pregptr yp) -> xp <> yp];
-}.
 
 Class wf_pmap := {
+  wt_rip     : vtype pmap.(vrip) = sword Uptr;
+  wt_rsp     : vtype pmap.(vrsp) = sword Uptr;
   rip_in_new : Sv.In pmap.(vrip) pmap.(vnew);
   rsp_in_new : Sv.In pmap.(vrsp) pmap.(vnew);
-  wt_regptr  :> wf_regptr;
-  wf_globals :> wf_pos global_pos glob_size;
-  wf_locals  :> wf_pos local_pos stk_size;
+  wf_globals : forall g ofs ws, Mvar.get pmap.(globals) g = Some (ofs, ws) -> wf_global g ofs ws;
+  wf_locals  : forall x pk, Mvar.get pmap.(locals) x = Some pk -> wf_local x pk;
+  wf_vnew    : forall x pk, Mvar.get pmap.(locals) x = Some pk -> ~ Sv.In x pmap.(vnew)
 }.
 
-Declare Instance wf_pmapI : wf_pmap.
-
-Definition valid_mp mp ty := 
-  exists x, 
-    subtype ty (vtype x) /\
-    if mp.(mp_s) == MSglob then get_global pmap x = ok mp.(mp_ofs)
-    else get_local pmap x = Some (Pstack mp.(mp_ofs)).
-
+(* Registers (not introduced by the compiler) hold the same value in [vm1] and [vm2] *)
 Definition eq_vm (vm1 vm2:vmap) := 
-  forall (x:var), get_local pmap x = None -> get_var vm1 x = get_var vm2 x.
+  forall (x:var),
+    Mvar.get pmap.(locals) x = None ->
+    ~ Sv.In x pmap.(vnew) ->
+    get_var vm1 x = get_var vm2 x.
 
-Definition wptr ms := 
-  if ms == MSglob then rip else rsp.
+(* Well-formedness of a [region]. *)
+Record wf_region (r : region) := {
+  wfr_slot     : Sv.In r.(r_slot) Slots;
+  wfr_writable : Writable r.(r_slot) = r.(r_writable);
+  wfr_align    : Align r.(r_slot) = r.(r_align);
+}.
 
-Definition wptr_size ms :=
-  if ms == MSstack then stk_size else glob_size.
+(* Well-formedness of a [zone]. *)
+Record wf_zone (z : zone) (ty : stype) (sl : slot) := {
+  wfz_len : size_of ty <= z.(z_len);
+    (* the zone is big enough to store a value of type [ty] *)
+  wfz_ofs : 0 <= z.(z_ofs) /\ z.(z_ofs) + z.(z_len) <= size_slot sl
+    (* the zone is a small enough to be in slot [sl] *)
+}.
 
-Definition disjoint_ptr m :=
-  forall w sz ms,
-    valid_pointer m w sz ->
-    ~ ( wunsigned (wptr ms) < wunsigned w + wsize_size sz /\ wunsigned w < wunsigned (wptr ms) + wptr_size ms).
+(* Well-formedness of a [sub_region]. *)
+Record wf_sub_region (sr : sub_region) ty := {
+  wfsr_region :> wf_region sr.(sr_region);
+  wfsr_zone   :> wf_zone sr.(sr_zone) ty sr.(sr_region).(r_slot)
+}.
 
-Definition mp_addr mp := 
-  (wptr mp.(mp_s) + wrepr _ mp.(mp_ofs))%R.
+Definition wfr_WF (rmap : region_map) :=
+  forall x sr,
+    Mvar.get rmap.(var_region) x = Some sr ->
+    wf_sub_region sr x.(vtype).
 
-Definition eq_mp_word (m2:mem) mp sz v := 
-  exists w:word sz, 
-    v = Vword w /\ read_mem m2 (mp_addr mp) sz = ok w.
-
-Definition eq_mp_array (m2:mem) mp s v := 
-  exists (a:WArray.array s),
-   v = Varr a /\
-   forall off, (0 <= off < Zpos s)%Z ->
-     forall v, WArray.get AAscale U8 a off = ok v ->
-     read_mem m2 (wptr mp.(mp_s) + (wrepr _ (off + mp.(mp_ofs)))) U8 = ok v.
-
-Definition eq_mp_val ty (m2:mem) mp v := 
-  match ty with
-  | sword ws => eq_mp_word m2 mp ws v
-  | sarr  s  => eq_mp_array m2 mp s v 
-  | _        => True
+(* TODO: should we raise another error in the Vword case ? Not really important *)
+(* This allows to read uniformly in words and arrays. *)
+Definition get_val_byte v off :=
+  match v with
+  | Vword ws w => if ((0 <=? off) && (off <? wsize_size ws)) then ok (LE.wread8 w off) else type_error
+  | Varr _ a => read a off U8
+  |_ => type_error
   end.
-  
+
+Definition sub_region_addr sr :=
+  (Addr sr.(sr_region).(r_slot) + wrepr _ sr.(sr_zone).(z_ofs))%R.
+
+Definition eq_sub_region_val_read (m2:mem) sr bytes v :=
+  forall off,
+     ByteSet.memi bytes (sr.(sr_zone).(z_ofs) + off) ->
+     forall w, get_val_byte v off = ok w ->
+     read m2 (sub_region_addr sr + wrepr _ off)%R U8 = ok w.
+
+Definition eq_sub_region_val ty m2 sr bytes v :=
+  eq_sub_region_val_read m2 sr bytes v /\
+  (* According to the psem semantics, a variable of type [sword ws] can store
+     a value of type [sword ws'] of shorter size (ws' <= ws).
+     But actually, this is used only for register variables.
+     For stack variables, we check in [alloc_lval] in stack_alloc.v that the
+     value has the same size as the variable, and we remember that fact here.
+  *)
+  (* Actually, it is handful to know that [ty] and [type_of_val v] are the same
+     even in the non-word cases.
+  *)
+  type_of_val v = ty.
+
 Variable (P: uprog) (ev: extra_val_t (progT := progUnit)).
 Notation gd := (p_globs P).
 
-Definition valid_pk pk mp (s2:estate) := 
-  match pk with
-  | Pstack z => mp = {| mp_s := MSstack; mp_ofs := z |}
-  | Pstkptr z => 
-    read_mem s2.(emem) (mp_addr {| mp_s := MSstack; mp_ofs := z |}) Uptr = ok (mp_addr mp)
-  | Pregptr p =>
-    get_var s2.(evm) p = ok (Vword (mp_addr mp))
-  end.
-   
-Definition check_gvalid rmap x := 
+(* TODO: could we have this in stack_alloc.v ?
+   -> could be used in check_valid/set_arr_word...
+   This could mean useless checks for globals, but maybe worth it
+   cf. check_vpk_word ?
+   Not clear : one advantage of using vpk is to avoid two calls to
+   pmap.(globals) and pmap.(locals)
+   Could pmap.(globlals) and pmap.(locals) directly return sub_regions ?
+*)
+Definition check_gvalid rmap x : option (sub_region * ByteSet.t) :=
   if is_glob x then 
-    omap (fun ofs => {| mp_s := MSglob; mp_ofs := ofs |}) (Mvar.get pmap.(globals) (gv x))
-  else 
-    match check_valid rmap (gv x) with
-    | Ok mp => Some mp
-    | _     => None 
+    omap (fun '(_, ws) =>
+      let sr := sub_region_glob x.(gv) ws in
+      let bytes := ByteSet.full (interval_of_zone sr.(sr_zone)) in
+      (sr, bytes)) (Mvar.get pmap.(globals) (gv x))
+  else
+    let sr := Mvar.get rmap.(var_region) x.(gv) in
+    match sr with
+    | Some sr =>
+      let bytes := get_var_bytes rmap.(region_var) sr.(sr_region) x.(gv) in
+      Some (sr, bytes)
+    | _ => None
     end.
 
-(* wfr_get_v_mp : 
-    forall x xs mp, Mmp.get rmap.(region_vars) mp = Some xs ->
-                    Sv.In x xs -> Mvar.get rmap.(var_region) x = Some mp;*)
-
-Definition wfr_VALID (rmap:regions) :=
-   forall x mp, Mvar.get rmap.(var_region) x = Some mp -> valid_mp mp (vtype x).
-
-Definition wfr_VAL (rmap:regions) (s1:estate) (s2:estate) :=
-  forall x mp v, check_gvalid rmap x = Some mp -> 
+Definition wfr_VAL (rmap:region_map) (s1:estate) (s2:estate) :=
+  forall x sr bytes v, check_gvalid rmap x = Some (sr, bytes) -> 
     get_gvar gd s1.(evm) x = ok v ->
-    eq_mp_val (vtype (gv x)) s2.(emem) mp v.
+    eq_sub_region_val x.(gv).(vtype) s2.(emem) sr bytes v.
 
-Definition wfr_PTR (rmap:regions) (s2:estate) :=
-  forall x mp, Mvar.get (var_region rmap) x = Some mp ->
-    exists pk, get_local pmap x = Some pk /\ valid_pk pk mp s2. 
+Definition valid_pk rmap (s2:estate) sr pk :=
+  match pk with
+  | Pdirect s ofs ws z sc =>
+    sr = sub_region_direct s ws sc z
+  | Pstkptr s ofs ws z f =>
+    check_stack_ptr rmap s ws z f ->
+    read s2.(emem) (sub_region_addr (sub_region_stkptr s ws z)) Uptr = ok (sub_region_addr sr)
+  | Pregptr p =>
+    get_var s2.(evm) p = ok (Vword (sub_region_addr sr))
+  end.
 
-Class wf_region (rmap:regions) (s1:estate) (s2:estate) := {  
-  wfr_valid_mp :  wfr_VALID rmap;
+Definition wfr_PTR (rmap:region_map) (s2:estate) :=
+  forall x sr, Mvar.get (var_region rmap) x = Some sr ->
+    exists pk, get_local pmap x = Some pk /\ valid_pk rmap s2 sr pk.
+
+Class wf_rmap (rmap:region_map) (s1:estate) (s2:estate) := {
+  wfr_wf  : wfr_WF rmap;
+    (* sub-regions in [rmap] are well-formed *)
   wfr_val : wfr_VAL rmap s1 s2;
+    (* [rmap] remembers for each relevant program variable which part of the target
+       memory contains the value that this variable has in the source. These pieces
+       of memory can be safely read without breaking semantics preservation.
+       The precision is at the byte-level. A byteset is attached to each variable.
+       If a byte is set in the byteset, then this byte holds the same value as
+       the corresponding byte in the source. If a byte is not set, then there
+       is no information.
+    *)
   wfr_ptr : wfr_PTR rmap s2;
+    (* a variable in [rmap] is also in [pmap] and there is a link between
+       the values associated to this variable in both maps *)
 }.
 
-Definition eq_glob (m1 m2:mem) := 
-  forall w sz, valid_pointer m1 w sz -> read_mem m1 w sz = read_mem m2 w sz.
+Definition eq_mem_source (m1 m2:mem) := 
+  forall w, validw m1 w U8 -> read m1 w U8 = read m2 w U8.
 
-Definition eq_not_mod (m0 m2:mem) := 
-  forall ofs, 
-     0 <= ofs < stk_size ->
-     (forall x xofs xty, 
-        local_pos x = Some(xofs, xty) -> 
-        xofs + size_of xty <= ofs \/ ofs + 1 <= xofs) ->
-     read_mem m0 (rsp + (wrepr _ ofs)) U8 = 
-     read_mem m2 (rsp + (wrepr _ ofs)) U8.
+Hypothesis wf_pmap0 : wf_pmap.
 
-Class valid_state (rmap:regions) (m0:mem) (s1:estate) (s2:estate) := {
-   vs_val_ptr : 
-      forall s w, (0 <= wunsigned w < wptr_size s) -> valid_pointer (emem s2) (wptr s + w) U8;
-   vs_disj      : disjoint_ptr (emem s1);
-   vs_rip       : get_var (evm s2) pmap.(vrip) = ok (Vword rip);
-   vs_rsp       : get_var (evm s2) pmap.(vrsp) = ok (Vword rsp);
-   vs_top_frame : ohead (frames (emem s2)) = Some (rsp, stk_size);
-   vs_eq_vm     : eq_vm s1.(evm) s2.(evm);
-   vs_wf_region :> wf_region rmap s1 s2;
-   vs_eq_mem    : eq_glob s1.(emem) s2.(emem);
-   vs_eq_not_mod: eq_not_mod m0 s2.(emem);
+(* FIXME: could we put [m0] as section variable? it should not be modified? *)
+(* [m0]: initial target memory (just before the call to the current function)
+   [s1]: current source estate
+   [s2]: current target estate
+*)
+Class valid_state (rmap : region_map) (m0 : mem) (s1 s2 : estate) := {
+  vs_slot_valid  : slot_valid s2.(emem);
+    (* slots are valid in the target *)
+  vs_disjoint    : disjoint_source s1.(emem);
+    (* slots are disjoint from the source memory *)
+  vs_valid_incl  : valid_incl s1.(emem) s2.(emem);
+    (* every valid memory cell in the source is valid in the target *)
+  vs_valid_incl2 : valid_incl m0 s2.(emem);
+    (* every valid memory cell before the call is valid during the call *)
+  vs_unchanged   : mem_unchanged s1.(emem) m0 s2.(emem);
+    (* stack memory (i.e. valid in the target before the call but not in the source)
+       disjoint from writable slots is unchanged between [m0] and [s2] *)
+  vs_rip         : get_var (evm s2) pmap.(vrip) = ok (Vword rip);
+    (* [vrip] stores address [rip] *)
+  vs_rsp         : get_var (evm s2) pmap.(vrsp) = ok (Vword rsp);
+    (* [vrsp] stores address [rsp] *)
+  vs_eq_vm       : eq_vm s1.(evm) s2.(evm);
+    (* registers already present in the source program store the same values
+       in the source and in the target *)
+  vs_wf_region   :> wf_rmap rmap s1 s2;
+    (* cf. [wf_rmap) definition *)
+  vs_eq_mem      : eq_mem_source s1.(emem) s2.(emem);
+    (* the memory that is already valid in the source is the same in the target *)
+  vs_glob_valid  : forall p, between rip glob_size p U8 -> validw m0 p U8;
+    (* globals are valid in the target before the call *)
+  vs_top_stack   : rsp = top_stack (emem s2);
+    (* [rsp] is the stack pointer, it points to the top of the stack *)
 }.
 
+(* We extend some predicates with the global case. *)
 (* -------------------------------------------------------------------------- *)
+
+Lemma sub_region_glob_wf x ofs ws :
+  wf_global x ofs ws ->
+  wf_sub_region (sub_region_glob x ws) x.(vtype).
+Proof.
+  move=> [*]; split.
+  + by split=> //; apply /idP.
+  by split=> /=; lia.
+Qed.
+
+Lemma check_gvalid_wf rmap x sr_bytes :
+  wfr_WF rmap ->
+  check_gvalid rmap x = Some sr_bytes ->
+  wf_sub_region sr_bytes.1 x.(gv).(vtype).
+Proof.
+  move=> hwfr.
+  rewrite /check_gvalid; case: (@idP (is_glob x)) => hg.
+  + by case heq: Mvar.get => [[??]|//] [<-] /=; apply (sub_region_glob_wf (wf_globals heq)).
+  by case heq: Mvar.get => // -[<-]; apply hwfr.
+Qed.
+
+Definition valid_vpk rv s2 x sr vpk :=
+  match vpk with
+  | VKglob (_, ws) => sr = sub_region_glob x ws
+  | VKptr pk => valid_pk rv s2 sr pk
+  end.
 
 Lemma get_globalP x z : get_global pmap x = ok z <-> Mvar.get pmap.(globals) x = Some z.
 Proof.
@@ -231,11 +405,399 @@ Proof.
   by move=> ?;split => -[->].
 Qed.
 
-Lemma get_gvar_glob gd x vm : is_glob x -> get_gvar gd vm x = sem.get_global gd (gv x).
-Proof. by rewrite /get_gvar /is_lvar /is_glob => /eqP ->. Qed.
+(* A variant of [wfr_PTR] for [gvar]. *)
+Lemma wfr_gptr rmap s1 s2 x sr bytes :
+  wf_rmap rmap s1 s2 ->
+  check_gvalid rmap x = Some (sr, bytes) ->
+  exists vpk, get_var_kind pmap x = ok (Some vpk)
+  /\ valid_vpk rmap s2 x.(gv) sr vpk.
+Proof.
+  move=> hrmap.
+  rewrite /check_gvalid /get_var_kind.
+  case: is_glob.
+  + case heq: Mvar.get => [[ofs ws]|//] /= [<- _].
+    have /get_globalP -> := heq.
+    by eexists.
+  case heq: Mvar.get => // [sr'] [<- _].
+  have /wfr_ptr [pk [-> hpk]] := heq.
+  by eexists.
+Qed.
 
-Lemma get_gvar_nglob gd x vm : ~~is_glob x -> get_gvar gd vm x = get_var vm (gv x).
-Proof. by rewrite /get_gvar /is_lvar /is_glob; case: (gs x). Qed.
+(* [wf_global] and [wf_direct] in a single predicate. *)
+Definition wf_vpk x vpk :=
+  match vpk with
+  | VKglob zws => wf_global x zws.1 zws.2
+  | VKptr pk => wf_local x pk
+  end.
+
+Lemma get_var_kind_wf x vpk :
+  get_var_kind pmap x = ok (Some vpk) ->
+  wf_vpk x.(gv) vpk.
+Proof.
+  rewrite /get_var_kind.
+  case: is_glob.
+  + by t_xrbindP=> -[ofs ws] /get_globalP /wf_globals ? <-.
+  case heq: get_local => [pk|//] [<-].
+  by apply wf_locals.
+Qed.
+
+(* Predicates about zone: zbetween_zone, disjoint_zones *)
+(* -------------------------------------------------------------------------- *)
+
+Definition zbetween_zone z1 z2 :=
+  (z1.(z_ofs) <=? z2.(z_ofs)) && (z2.(z_ofs) + z2.(z_len) <=? z1.(z_ofs) + z1.(z_len)).
+
+Lemma zbetween_zone_refl z : zbetween_zone z z.
+Proof. by rewrite /zbetween_zone !zify; lia. Qed.
+
+Lemma zbetween_zone_trans z1 z2 z3 :
+  zbetween_zone z1 z2 ->
+  zbetween_zone z2 z3 ->
+  zbetween_zone z1 z3.
+Proof. by rewrite /zbetween_zone !zify; lia. Qed.
+
+(* On the model of [between_byte]. *)
+Lemma zbetween_zone_byte z1 z2 i :
+  zbetween_zone z1 z2 ->
+  0 <= i /\ i < z2.(z_len) ->
+  zbetween_zone z1 (sub_zone_at_ofs z2 (Some i) (wsize_size U8)).
+Proof. by rewrite /zbetween_zone wsize8 !zify /=; lia. Qed.
+
+Lemma subset_interval_of_zone z1 z2 :
+  I.subset (interval_of_zone z1) (interval_of_zone z2) = zbetween_zone z2 z1.
+Proof.
+  rewrite /I.subset /interval_of_zone /zbetween_zone /=.
+  by apply /idP/idP; rewrite !zify; lia.
+Qed.
+
+Lemma memi_mem_U8 bytes z off :
+  ByteSet.memi bytes (z.(z_ofs) + off) =
+  ByteSet.mem bytes (interval_of_zone (sub_zone_at_ofs z (Some off) (wsize_size U8))).
+Proof.
+  apply /idP/idP.
+  + move=> hmem; apply /ByteSet.memP; move=> i.
+    rewrite /interval_of_zone /I.memi /= wsize8 !zify => hbound.
+    by have -> : i = z_ofs z + off by lia.
+  move=> /ByteSet.memP; apply.
+  by rewrite /interval_of_zone /I.memi /= wsize8 !zify; lia.
+Qed.
+
+Lemma disjoint_zones_sym z1 z2 : disjoint_zones z1 z2 = disjoint_zones z2 z1.
+Proof. by rewrite /disjoint_zones orbC. Qed.
+
+Lemma disjoint_zones_incl z1 z1' z2 z2' :
+  zbetween_zone z1 z1' ->
+  zbetween_zone z2 z2' ->
+  disjoint_zones z1 z2 ->
+  disjoint_zones z1' z2'.
+Proof. by rewrite /zbetween_zone /disjoint_zones !zify; lia. Qed.
+
+Lemma disjoint_zones_incl_l z1 z1' z2 :
+  zbetween_zone z1 z1' ->
+  disjoint_zones z1 z2 ->
+  disjoint_zones z1' z2.
+Proof. by move=> ?; apply disjoint_zones_incl => //; apply zbetween_zone_refl. Qed.
+
+Lemma disjoint_zones_incl_r z1 z2 z2' :
+  zbetween_zone z2 z2' ->
+  disjoint_zones z1 z2 ->
+  disjoint_zones z1 z2'.
+Proof. by move=> ?; apply disjoint_zones_incl => //; apply zbetween_zone_refl. Qed.
+
+Lemma disjoint_interval_of_zone z1 z2 :
+  I.disjoint (interval_of_zone z1) (interval_of_zone z2) =
+  disjoint_zones z1 z2.
+Proof. by rewrite /I.disjoint /disjoint_zones /= !zify. Qed.
+
+Lemma interval_of_zone_wf :
+  forall z, 0 < z.(z_len) -> I.wf (interval_of_zone z).
+Proof. by move=> z hlen; rewrite /I.wf /I.is_empty /= !zify; lia. Qed.
+
+Lemma mem_remove_interval_of_zone z1 z2 bytes :
+  0 < z1.(z_len) -> 0 < z2.(z_len) ->
+  ByteSet.mem (ByteSet.remove bytes (interval_of_zone z1)) (interval_of_zone z2) ->
+  ByteSet.mem bytes (interval_of_zone z2) /\ disjoint_zones z1 z2.
+Proof.
+  move=> hlt1 hlt2.
+  have hwf1 := interval_of_zone_wf hlt1.
+  have hwf2 := interval_of_zone_wf hlt2.
+  move=> /(mem_remove hwf1 hwf2).
+  by rewrite disjoint_interval_of_zone.
+Qed.
+
+Lemma disj_sub_regions_sym sr1 sr2 : disj_sub_regions sr1 sr2 = disj_sub_regions sr2 sr1.
+Proof. by rewrite /disj_sub_regions /region_same eq_sym disjoint_zones_sym. Qed.
+
+(* Lemmas about wf_zone *)
+(* -------------------------------------------------------------------------- *)
+
+Lemma sub_zone_at_ofs_compose z ofs1 ofs2 len1 len2 :
+  sub_zone_at_ofs (sub_zone_at_ofs z (Some ofs1) len1) (Some ofs2) len2 =
+  sub_zone_at_ofs z (Some (ofs1 + ofs2)) len2.
+Proof. by rewrite /= Z.add_assoc. Qed.
+
+Lemma wf_zone_len_gt0 z ty sl : wf_zone z ty sl -> 0 < z.(z_len).
+Proof. by move=> [? _]; have := size_of_gt0 ty; lia. Qed.
+
+Lemma zbetween_zone_sub_zone_at_ofs z ty sl ofs len :
+  wf_zone z ty sl ->
+  (forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + len <= size_of ty) ->
+  zbetween_zone z (sub_zone_at_ofs z ofs len).
+Proof.
+  move=> hwf.
+  case: ofs => [ofs|]; last by (move=> _; apply zbetween_zone_refl).
+  move=> /(_ _ refl_equal).
+  rewrite /zbetween_zone !zify /=.
+  by have := hwf.(wfz_len); lia.
+Qed.
+
+(* We use [sub_zone_at_ofs z (Some 0)] to manipulate sub-zones of [z].
+   Not sure if this a clean way to proceed.
+   This lemma is a special case of [zbetween_zone_sub_zone_at_ofs].
+*)
+Lemma zbetween_zone_sub_zone_at_ofs_0 z ty sl :
+  wf_zone z ty sl ->
+  zbetween_zone z (sub_zone_at_ofs z (Some 0) (size_of ty)).
+Proof.
+  move=> hwf.
+  apply: (zbetween_zone_sub_zone_at_ofs hwf).
+  by move=> _ [<-]; lia.
+Qed.
+
+Lemma zbetween_zone_sub_zone_at_ofs_option z i ofs len ty sl :
+  wf_zone z ty sl ->
+  0 <= i /\ i + len <= size_of ty ->
+  (ofs <> None -> ofs = Some i) ->
+  zbetween_zone (sub_zone_at_ofs z ofs len) (sub_zone_at_ofs z (Some i) len).
+Proof.
+  move=> hwf hi.
+  case: ofs => [ofs|].
+  + by move=> /(_ ltac:(discriminate)) [->]; apply zbetween_zone_refl.
+  move=> _.
+  apply (zbetween_zone_sub_zone_at_ofs hwf).
+  by move=> _ [<-].
+Qed.
+
+(* Lemmas about wf_sub_region *)
+(* -------------------------------------------------------------------------- *)
+
+(* The hypothesis [size_of ty2 <= size_of ty1] is enough, but this weakest
+   version is enough for our needs.
+*)
+Lemma wf_sub_region_subtype sr ty1 ty2 :
+  subtype ty2 ty1 ->
+  wf_sub_region sr ty1 ->
+  wf_sub_region sr ty2.
+Proof.
+  move=> hsub [hwf1 [hwf2 hwf3]]; split=> //; split=> //.
+  by move /size_of_le : hsub; lia.
+Qed.
+
+Definition stype_at_ofs (ofs : option Z) (ty ty' : stype) :=
+  if ofs is None then ty' else ty.
+
+Lemma sub_region_at_ofs_wf sr ty ofs ty2 :
+  wf_sub_region sr ty ->
+  (forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + size_of ty2 <= size_of ty) ->
+  wf_sub_region (sub_region_at_ofs sr ofs (size_of ty2)) (stype_at_ofs ofs ty2 ty).
+Proof.
+  move=> hwf hofs /=; split; first by apply hwf.(wfsr_region).
+  case: ofs hofs => [ofs|_] /=; last by apply hwf.
+  move=> /(_ _ refl_equal) ?.
+  split=> /=; first by auto with zarith.
+  have hlen := hwf.(wfz_len).
+  have hofs := hwf.(wfz_ofs).
+  by lia.
+Qed.
+
+Lemma sub_region_at_ofs_0_wf sr ty :
+  wf_sub_region sr ty ->
+  wf_sub_region (sub_region_at_ofs sr (Some 0) (size_of ty)) ty.
+Proof.
+  move=> hwf.
+  apply: (sub_region_at_ofs_wf hwf).
+  by move=> _ [<-]; lia.
+Qed.
+
+Lemma sub_region_at_ofs_wf_byte sr ty ofs :
+  wf_sub_region sr ty ->
+  0 <= ofs < size_of ty ->
+  wf_sub_region (sub_region_at_ofs sr (Some ofs) (wsize_size U8)) sword8.
+Proof.
+  move=> hwf hofs.
+  change (wsize_size U8) with (size_of sword8).
+  apply (sub_region_at_ofs_wf hwf (ofs:=Some ofs)).
+  by move=> _ [<-] /=; rewrite wsize8; lia.
+Qed.
+
+Lemma wunsigned_sub_region_addr sr ty :
+  wf_sub_region sr ty ->
+  wunsigned (sub_region_addr sr) = wunsigned (Addr sr.(sr_region).(r_slot)) + sr.(sr_zone).(z_ofs).
+Proof.
+  move=> hwf; apply wunsigned_add.
+  have hlen := wf_zone_len_gt0 hwf.
+  have hofs := wfz_ofs hwf.
+  have /ZleP hno := addr_no_overflow (wfr_slot hwf).
+  have ? := wunsigned_range (Addr (sr.(sr_region).(r_slot))).
+  by lia.
+Qed.
+
+Lemma zbetween_sub_region_addr sr ty :
+  wf_sub_region sr ty ->
+  zbetween (Addr sr.(sr_region).(r_slot)) (size_slot sr.(sr_region).(r_slot))
+    (sub_region_addr sr) (size_of ty).
+Proof.
+  move=> hwf; rewrite /zbetween !zify (wunsigned_sub_region_addr hwf).
+  have hofs := hwf.(wfz_ofs).
+  have hlen := hwf.(wfz_len).
+  by lia.
+Qed.
+
+Lemma sub_region_at_ofs_None sr len :
+  sub_region_at_ofs sr None len = sr.
+Proof. by case: sr. Qed.
+
+Lemma sub_region_addr_offset len sr ofs :
+  (sub_region_addr sr + wrepr _ ofs)%R =
+  sub_region_addr (sub_region_at_ofs sr (Some ofs) len).
+Proof. by rewrite /sub_region_addr wrepr_add GRing.addrA. Qed.
+
+Lemma no_overflow_sub_region_addr sr ty :
+  wf_sub_region sr ty ->
+  no_overflow (sub_region_addr sr) (size_of ty).
+Proof.
+  move=> hwf; apply (no_overflow_incl (zbetween_sub_region_addr hwf)).
+  by apply (addr_no_overflow hwf.(wfr_slot)).
+Qed.
+
+Lemma zbetween_sub_region_at_ofs sr ty ofs ws :
+  wf_sub_region sr ty ->
+  (∀ zofs : Z, ofs = Some zofs → 0 <= zofs ∧ zofs + wsize_size ws <= size_of ty) ->
+  zbetween (sub_region_addr sr) (size_of ty)
+           (sub_region_addr (sub_region_at_ofs sr ofs (wsize_size ws))) (size_of (stype_at_ofs ofs (sword ws) ty)).
+Proof.
+  move=> hwf hofs.
+  change (wsize_size ws) with (size_of (sword ws)) in hofs.
+  have hwf' := sub_region_at_ofs_wf hwf hofs.
+  rewrite /zbetween !zify.
+  rewrite (wunsigned_sub_region_addr hwf).
+  rewrite (wunsigned_sub_region_addr hwf').
+  case: ofs hofs {hwf'} => [ofs|] /=.
+  + by move=> /(_ _ refl_equal); lia.
+  by lia.
+Qed.
+
+Lemma zbetween_sub_region_at_ofs_option sr ofs ws i ty :
+  wf_sub_region sr ty ->
+  0 <= i /\ i + wsize_size ws <= size_of ty ->
+  (ofs <> None -> ofs = Some i) ->
+  zbetween (sub_region_addr (sub_region_at_ofs sr ofs (wsize_size ws))) (size_of (stype_at_ofs ofs (sword ws) ty))
+           (sub_region_addr sr + wrepr _ i) (wsize_size ws).
+Proof.
+  move=> hwf hi.
+  rewrite (sub_region_addr_offset (wsize_size ws)).
+  case: ofs => [ofs|] /=.
+  + by move=> /(_ ltac:(discriminate)) [->]; apply zbetween_refl.
+  move=> _; rewrite sub_region_at_ofs_None.
+  apply: (zbetween_sub_region_at_ofs hwf).
+  by move=> _ [<-].
+Qed.
+
+(* [valid_state]'s clauses deal about U8 only. We show extended versions valid
+   for any [ws].
+*)
+(* -------------------------------------------------------------------------- *)
+
+Lemma disjoint_source_word rmap m0 s1 s2 :
+  valid_state rmap m0 s1 s2 ->
+  forall s p ws,
+    Sv.In s Slots -> validw s1.(emem) p ws ->
+    disjoint_zrange (Addr s) (size_slot s) p (wsize_size ws).
+Proof.
+  move=> hvs s p ws hin /validwP [] /is_align_no_overflow hover hd.
+  apply disjoint_zrange_U8 => //.
+  + apply size_of_gt0.
+  by move=> k hk; apply vs_disjoint => //; apply hd.
+Qed.
+
+Lemma valid_incl_word rmap m0 s1 s2 p ws :
+  valid_state rmap m0 s1 s2 ->
+  validw s1.(emem) p ws ->
+  validw s2.(emem) p ws.
+Proof.
+  move=> hvs /validwP [hal hvalid].
+  apply /validwP; split=> //.
+  move=> k hk; apply vs_valid_incl.
+  by apply hvalid.
+Qed.
+
+Lemma eq_mem_source_word rmap m0 s1 s2 p ws :
+  valid_state rmap m0 s1 s2 ->
+  validw s1.(emem) p ws ->
+  read s1.(emem) p ws = read s2.(emem) p ws.
+Proof.
+  move=> hvs /validwP [hal hvalid].
+  apply eq_read.
+  by move=> k hk; apply vs_eq_mem; apply hvalid.
+Qed.
+
+(* [eq_sub_region_val_read] deals with 1-byte words. This lemma extends it to
+   words of arbitrary sizes.
+*)
+Lemma eq_sub_region_val_read_word sr ty s2 (v : value) bytes ofs ws i w :
+  wf_sub_region sr ty ->
+  eq_sub_region_val_read (emem s2) sr bytes v ->
+  ByteSet.mem bytes (interval_of_zone (sub_zone_at_ofs sr.(sr_zone) ofs (wsize_size ws))) ->
+  (ofs <> None -> ofs = Some i) ->
+  0 <= i /\ i + wsize_size ws <= size_of ty ->
+  (forall k, 0 <= k < wsize_size ws -> get_val_byte v (i + k) = ok (LE.wread8 w k)) ->
+  read (emem s2) (sub_region_addr sr + wrepr _ i)%R ws =
+    if is_align (sub_region_addr sr + wrepr _ i)%R ws then ok w else Error ErrAddrInvalid.
+Proof.
+  move=> hwf hread hmem hofs hbound hget.
+  apply read8_read.
+  move=> k hk.
+  rewrite addE -GRing.addrA -wrepr_add.
+  apply hread; last by apply hget.
+  rewrite memi_mem_U8; apply: mem_incl_r hmem; rewrite subset_interval_of_zone.
+  rewrite -(sub_zone_at_ofs_compose _ _ _ (wsize_size ws)).
+  apply: zbetween_zone_byte => //.
+  by apply (zbetween_zone_sub_zone_at_ofs_option hwf).
+Qed.
+
+Lemma get_val_byte_word ws (w : word ws) off :
+  0 <= off < wsize_size ws ->
+  get_val_byte (Vword w) off = ok (LE.wread8 w off).
+Proof. by rewrite /= -!zify => ->. Qed.
+
+Lemma get_val_byte_bound v off w :
+  get_val_byte v off = ok w -> 0 <= off /\ off < size_val v.
+Proof.
+  case: v => //.
+  + move=> len a /=.
+    by rewrite -get_read8 => /WArray.get_valid8 /WArray.in_boundP.
+  move=> ws w' /=.
+  by case: ifP => //; rewrite !zify.
+Qed.
+
+(* -------------------------------------------------------------------------- *)
+
+Lemma check_gvalid_lvar rmap (x : var_i) sr :
+  Mvar.get rmap.(var_region) x = Some sr ->
+  check_gvalid rmap (mk_lvar x) = Some (sr, get_var_bytes rmap sr.(sr_region) x).
+Proof. by rewrite /check_gvalid /= => ->. Qed.
+
+Lemma check_gvalid_writable rmap x sr bytes :
+  sr.(sr_region).(r_writable) ->
+  check_gvalid rmap x = Some (sr, bytes) ->
+  bytes = get_var_bytes rmap sr.(sr_region) x.(gv).
+Proof.
+  move=> hw.
+  rewrite /check_gvalid.
+  case: (@idP (is_glob x)) => hg.
+  + by case: Mvar.get => [[ws ofs]|//] /= [? _]; subst sr.
+  by case: Mvar.get => [_|//] [-> ?].
+Qed.
 
 Lemma cast_ptrP gd s e i : sem_pexpr gd s e >>= to_int = ok i ->
   sem_pexpr gd s (cast_ptr e) = ok (Vword (wrepr U64 i)).
@@ -265,185 +827,248 @@ Proof.
   rewrite /mk_ofs; case is_constP => /= [? [->] //| {e} e he] /=.
   rewrite /sem_sop2 /=.
   have [sz' [w [-> /= -> /=]]]:= cast_wordP he.
-  by rewrite !zero_extend_u wrepr_add wrepr_mul GRing.mulrC. 
+  by rewrite !zero_extend_u wrepr_add wrepr_mul GRing.mulrC.
 Qed.
 
-Lemma validr_valid_pointer (m1:mem) p ws : is_ok (validr m1 p ws) = valid_pointer m1 p ws.
-Proof.
-  case: (Memory.readV m1 p ws); rewrite Memory.readP /CoreMem.read.
-  + by move=> [w]; case: validr.
-  by case: validr => //= _ [];eauto.
-Qed.
-
-Lemma check_validP rmap x mp : 
-  check_valid rmap x = ok mp <->
-  (Mvar.get (var_region rmap) x = Some mp /\
-   exists xs,  Mmp.get (region_vars rmap) mp = Some xs /\ Sv.In x xs).
-Proof.
-  rewrite /check_valid.
-  case heq: Mvar.get => [mp' |]; last by intuition.
-  case heq1 : Mmp.get => [xs | /=]; last by split => // -[] [?]; subst mp'; rewrite heq1 => -[] ?[].
-  case: ifPn => /Sv_memP hin /=.
-  + split => [ [?] | [[?] ]]; subst mp' => //.
-    by split => //;exists xs.
-  by split => // -[] [?]; subst mp'; rewrite heq1 => -[xs'] [[<-]] /hin.
-Qed.
+Lemma mk_ofsiP gd s e i aa sz :
+  Let x := sem_pexpr gd s e in to_int x = ok i ->
+  mk_ofsi aa sz e <> None ->
+  mk_ofsi aa sz e = Some (i * mk_scale aa sz).
+Proof. by case: e => //= _ [->]. Qed.
 
 Section EXPR.
-  Variables (rmap:regions) (m0:mem) (s:estate) (s':estate).
+  Variables (rmap:region_map) (m0:mem) (s:estate) (s':estate).
   Hypothesis (hvalid: valid_state rmap m0 s s').
 
+  (* If [x] is a register, it is not impacted by the presence of global
+     variables per hypothesis [vs_eq_vm].
+  *)
   Lemma get_var_kindP x v:
-    get_var_kind pmap x = ok None -> 
+    get_var_kind pmap x = ok None ->
+    ~ Sv.In x.(gv) pmap.(vnew) ->
     get_gvar gd (evm s) x = ok v ->
     get_gvar [::] (evm s') x = ok v.
   Proof.
     rewrite /get_var_kind; case: ifPn => hglob; first by t_xrbindP.
-    case hgl : get_local => // _.
-    assert (heq := vs_eq_vm hgl). 
+    case hgl : get_local => // _ /(vs_eq_vm hgl) heq.
     by rewrite !get_gvar_nglob // heq.
   Qed.
 
-  Lemma check_mk_addr_ptr (x:var_i) aa ws xi ei e1 i1 pk mp :
+  Lemma base_ptrP sc : get_var (evm s') (base_ptr pmap sc) = ok (Vword (wbase_ptr sc)).
+  Proof. by case: sc => /=; [apply: vs_rsp | apply: vs_rip]. Qed.
+
+  Lemma Zland_mod z ws : Z.land z (wsize_size ws - 1) = z mod wsize_size ws.
+  Proof.
+    rewrite wsize_size_is_pow2 -Z.land_ones; last by case: ws.
+    by rewrite Z.ones_equiv.
+  Qed.
+
+  Lemma check_alignP sr ty ws tt :
+    wf_sub_region sr ty ->
+    check_align sr ws = ok tt ->
+    is_align (sub_region_addr sr) ws.
+  Proof.
+    move=> hwf; rewrite /check_align; t_xrbindP => ? /assertP halign /assertP /eqP halign2.
+    have: is_align (Addr sr.(sr_region).(r_slot)) ws.
+    + apply (is_align_m halign).
+      rewrite -hwf.(wfr_align).
+      by apply (slot_align hwf.(wfr_slot)).
+    rewrite /is_align !p_to_zE (wunsigned_sub_region_addr hwf) Z.add_mod //.
+    move=> /eqP -> /=.
+    by rewrite -(Zland_mod (z_ofs _)) halign2.
+  Qed.
+
+  Lemma get_sub_regionP x sr :
+    get_sub_region rmap x = ok sr <-> Mvar.get rmap.(var_region) x = Some sr.
+  Proof.
+    rewrite /get_sub_region; case: Mvar.get; last by split.
+    by move=> ?; split => -[->].
+  Qed.
+
+  Lemma check_validP (x : var_i) ofs len sr sr' :
+    check_valid rmap x ofs len = ok (sr, sr') ->
+    exists bytes, [/\
+      check_gvalid rmap (mk_lvar x) = Some (sr, bytes),
+      sr' = sub_region_at_ofs sr ofs len &
+      let isub_ofs := interval_of_zone sr'.(sr_zone) in
+      ByteSet.mem bytes isub_ofs].
+  Proof.
+    rewrite /check_valid /check_gvalid.
+    t_xrbindP=> sr'' /get_sub_regionP -> _ /assertP hmem ? <-; subst sr''.
+    by eexists.
+  Qed.
+
+  Lemma sub_region_addr_glob x ofs ws :
+    wf_global x ofs ws ->
+    sub_region_addr (sub_region_glob x ws) = (rip + wrepr _ ofs)%R.
+  Proof.
+    by move=> hwf; rewrite /sub_region_addr /= hwf.(wfg_offset) wrepr0 GRing.addr0.
+  Qed.
+
+  Lemma sub_region_addr_direct x sl ofs ws z sc :
+    wf_direct x sl ofs ws z sc ->
+    sub_region_addr (sub_region_direct sl ws sc z) = (wbase_ptr sc + wrepr _ (ofs + z.(z_ofs)))%R.
+  Proof.
+    by move=> hwf; rewrite /sub_region_addr hwf.(wfd_offset) wrepr_add GRing.addrA.
+  Qed.
+
+  Lemma sub_region_direct_wf x sl ofs ws z sc :
+    wf_direct x sl ofs ws z sc ->
+    wf_sub_region (sub_region_direct sl ws sc z) x.(vtype).
+  Proof. by case. Qed.
+
+  Lemma sub_region_addr_stkptr x sl ofs ws z f :
+    wf_stkptr x sl ofs ws z f ->
+    sub_region_addr (sub_region_stkptr sl ws z) = (rsp + wrepr _ (ofs + z.(z_ofs)))%R.
+  Proof.
+    by move=> hwf; rewrite /sub_region_addr /= hwf.(wfs_offset) wrepr_add GRing.addrA.
+  Qed.
+
+  Lemma sub_region_stkptr_wf y sl ofs ws z f :
+    wf_stkptr y sl ofs ws z f ->
+    wf_sub_region (sub_region_stkptr sl ws z) spointer.
+  Proof. by case. Qed.
+
+  Lemma check_vpkP x vpk ofs len sr sr' :
+    (forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + len <= size_slot x.(gv)) ->
+    get_var_kind pmap x = ok (Some vpk) ->
+    check_vpk rmap x.(gv) vpk ofs len = ok (sr, sr') ->
+    exists bytes,
+      [/\ check_gvalid rmap x = Some (sr, bytes),
+      sr' = sub_region_at_ofs sr ofs len &
+      let isub_ofs := interval_of_zone sr'.(sr_zone) in
+      ByteSet.mem bytes isub_ofs].
+  Proof.
+    move=> hofs; rewrite /get_var_kind /check_gvalid.
+    case : (@idP (is_glob x)) => hg.
+    + t_xrbindP=> -[_ ws'] /get_globalP /dup [] /wf_globals /sub_region_glob_wf hwf -> <- /= [<- <-].
+      set bytes := ByteSet.full _.
+      exists bytes; split=> //.
+      apply: mem_incl_r; last by apply mem_full.
+      rewrite subset_interval_of_zone.
+      by apply (zbetween_zone_sub_zone_at_ofs hwf).
+    by case hlocal: get_local => [pk|//] [<-] /(check_validP).
+  Qed.
+
+  Lemma check_vpk_wordP x vpk ofs ws t :
+    (forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + wsize_size ws <= size_slot x.(gv)) ->
+    get_var_kind pmap x = ok (Some vpk) ->
+    check_vpk_word rmap x.(gv) vpk ofs ws = ok t ->
+    exists sr bytes, [/\
+      check_gvalid rmap x = Some (sr, bytes),
+      let isub_ofs := interval_of_zone (sub_zone_at_ofs sr.(sr_zone) ofs (wsize_size ws)) in
+      ByteSet.mem bytes isub_ofs &
+      is_align (sub_region_addr sr) ws].
+  Proof.
+    move=> hofs hget.
+    rewrite /check_vpk_word.
+    t_xrbindP=> -[sr sr'] /(check_vpkP hofs hget) [bytes [hgvalid -> hmem]].
+    assert (hwf := check_gvalid_wf wfr_wf hgvalid).
+    move=> /(check_alignP hwf) hal.
+    by exists sr, bytes.
+  Qed.
+
+  Lemma addr_from_pkP (x:var_i) pk sr xi ofs :
+    wf_local x pk ->
+    valid_pk rmap s' sr pk ->
+    addr_from_pk pmap x pk = ok (xi, ofs) ->
+    exists w,
+      get_var (evm s') xi >>= to_pointer = ok w /\
+      sub_region_addr sr = (w + wrepr _ ofs)%R.
+  Proof.
+    case: pk => //.
+    + move=> sl ofs' ws z sc hwfpk /= -> [<- <-].
+      rewrite /= /get_gvar /= base_ptrP /= truncate_word_u.
+      eexists; split; first by reflexivity.
+      by rewrite (sub_region_addr_direct hwfpk).
+    move=> p hwfpk /= hpk [<- <-].
+    rewrite /= /get_gvar /= hpk /= truncate_word_u.
+    eexists; split; first by reflexivity.
+    by rewrite wrepr0 GRing.addr0.
+  Qed.
+
+  (* If [x] is a local variable *)
+  Lemma check_mk_addr_ptr (x:var_i) aa ws xi ei e1 i1 pk sr :
     sem_pexpr [::] s' e1 >>= to_int = ok i1 ->
-    get_local pmap x = Some pk ->
-    Mvar.get (var_region rmap) x = Some mp ->
-    is_align (wrepr Uptr mp.(mp_ofs)) ws ->
+    wf_local x pk ->
+    valid_pk rmap s' sr pk ->
     mk_addr_ptr pmap x aa ws pk e1 = ok (xi, ei) ->
     ∃ (wx wi : u64),
       [/\ Let x := get_var (evm s') xi in to_pointer x = ok wx,
-          Let x := sem_pexpr [::] s' ei in to_pointer x = ok wi, (mp_addr mp + wrepr U64 (i1 * mk_scale aa ws))%R = (wx + wi)%R
-          & is_align (mp_addr mp) ws].
+          Let x := sem_pexpr [::] s' ei in to_pointer x = ok wi
+        & (sub_region_addr sr + wrepr U64 (i1 * mk_scale aa ws))%R = (wx + wi)%R].
   Proof.
-    move=> he1 hloc hgetr hal.
-    rewrite /mk_addr_ptr; assert (h := wfr_ptr hgetr).
-    case: h => [pk' []]; rewrite hloc => -[?]; subst pk'.
-    case: pk hloc => //[ ofs | p] hloc /= hvmk [<- <-].
-    + exists rsp, (wrepr U64 ofs + wrepr U64 (i1 * mk_scale aa ws))%R. 
-      subst mp; rewrite (mk_ofsP aa ws ofs he1) /= /mp_addr /wptr vs_rsp /= !truncate_word_u. 
-      split => //.
-      + by f_equal; rewrite !(wrepr_add, wrepr_mul); ssrring.ssring.
-      + by ssrring.ssring.
-      by apply is_align_add.
-    exists (mp_addr mp), (wrepr U64 (i1 * mk_scale aa ws)).
-    rewrite (mk_ofsP aa ws 0 he1) /= hvmk /= !truncate_word_u; split => //.
-    + by f_equal; rewrite !(wrepr_add, wrepr_mul, wrepr0); ssrring.ssring.
-    by case: (mp) hal => -[] /= ofs ?; apply is_align_add.
+    move=> he1 hwfpk hpk.
+    rewrite /mk_addr_ptr.
+    t_xrbindP=> -[xi' ofs] haddr <- <-.
+    move: haddr => /(addr_from_pkP hwfpk hpk) [wx [-> ->]].
+    rewrite (mk_ofsP _ _ _ he1) /= truncate_word_u.
+    eexists _, _; split=> //.
+    by rewrite Z.add_comm wrepr_add GRing.addrA.
   Qed.
 
-  Lemma check_mk_addr x vpk aa ws t xi ei e1 i1: 
+  Lemma addr_from_vpkP (x:var_i) vpk sr xi ofs :
+    wf_vpk x vpk ->
+    valid_vpk rmap s' x sr vpk ->
+    addr_from_vpk pmap x vpk = ok (xi, ofs) ->
+    exists w,
+      get_var (evm s') xi >>= to_pointer = ok w /\
+      sub_region_addr sr = (w + wrepr _ ofs)%R.
+  Proof.
+    case: vpk => [[ofs' ws]|pk].
+    + move=> hwfpk /= -> [<- <-].
+      rewrite /= /get_gvar /= vs_rip /= truncate_word_u.
+      eexists; split; first by reflexivity.
+      by rewrite (sub_region_addr_glob hwfpk).
+    by apply addr_from_pkP.
+  Qed.
+
+  Lemma check_mk_addr (x:var_i) aa ws xi ei e1 i1 vpk sr :
     sem_pexpr [::] s' e1 >>= to_int = ok i1 ->
-    get_var_kind pmap x = ok (Some vpk) ->
-    check_vpk_word rmap (gv x) vpk ws = ok t ->
-    mk_addr pmap (gv x) aa ws vpk e1 = ok (xi, ei) ->
-    exists mp wx wi, 
-    [/\ check_gvalid rmap x = Some mp,
-        get_var (evm s') xi >>= to_pointer = ok wx,
-        sem_pexpr [::] s' ei >>= to_pointer = ok wi, 
-        (mp_addr mp + wrepr Uptr (i1 * mk_scale aa ws)%Z = wx + wi)%R & 
-        is_align (mp_addr mp) ws].
+    wf_vpk x vpk ->
+    valid_vpk rmap s' x sr vpk ->
+    mk_addr pmap x aa ws vpk e1 = ok (xi, ei) ->
+    ∃ (wx wi : u64),
+      [/\ Let x := get_var (evm s') xi in to_pointer x = ok wx,
+          Let x := sem_pexpr [::] s' ei in to_pointer x = ok wi
+        & (sub_region_addr sr + wrepr U64 (i1 * mk_scale aa ws))%R = (wx + wi)%R].
   Proof.
-    move=> he1; rewrite /get_var_kind /check_vpk_word /mk_addr /with_var.
-    case: ifP => hglob.
-    + t_xrbindP => ofs /get_globalP hget <- /assertP halign [<-] <-.
-      exists {| mp_s := MSglob; mp_ofs := ofs |}, rip,
-        (wrepr U64 ofs + wrepr U64 (i1 * mk_scale aa ws))%R. 
-      rewrite /mp_addr /= /wptr vs_rip (mk_ofsP aa ws ofs he1) /= !truncate_word_u /check_gvalid hglob hget.
-      split => //.
-      + by f_equal; rewrite !(wrepr_add, wrepr_mul); ssrring.ssring.
-      + by ssrring.ssring.
-      by apply is_align_add. 
-    move=> []; case hloc: get_local => [pk | //] [<-] hc ha.
-    move: hc; rewrite /check; t_xrbindP => mp hcv.
-    case /check_validP: (hcv) => [hgetr _] /assertP hal.
-    have [wx [wi [*]]] := check_mk_addr_ptr he1 hloc hgetr hal ha.   
-    exists mp, wx, wi; split => //.
-    by rewrite /check_gvalid hglob hcv.
+    move=> he1 hwfpk hpk.
+    rewrite /mk_addr.
+    t_xrbindP=> -[xi' ofs] haddr <- <-.
+    move: haddr => /(addr_from_vpkP hwfpk hpk) [wx [-> ->]].
+    rewrite (mk_ofsP _ _ _ he1) /= truncate_word_u.
+    eexists _, _; split=> //.
+    by rewrite Z.add_comm wrepr_add GRing.addrA.
   Qed.
 
-  Lemma ge0_wunsigned ws (w:word ws) : 0 <= wunsigned w.
-  Proof. by case (wunsigned_range w). Qed.
-  
-  Lemma wunsigned_repr_le ws z : 0 <= z -> wunsigned (wrepr ws z) <= z. 
-  Proof. by move=> hz; rewrite wunsigned_repr; apply Z.mod_le. Qed.
-
-  Lemma arr_is_align p ws : WArray.is_align p ws -> is_align (wrepr _ p) ws.
+  Lemma validw_sub_region_addr sr ws :
+    wf_sub_region sr (sword ws) ->
+    is_align (sub_region_addr sr) ws ->
+    validw (emem s') (sub_region_addr sr) ws.
   Proof.
-    move=> /eqP h1; apply is_align_mod.
-    have hn := wsize_size_pos ws.
-    have hnz : wsize_size ws ≠ 0%Z by Psatz.lia.
-    by rewrite wunsigned_repr -/(wbase Uptr) (cut_wbase_Uptr ws) Z.mul_comm mod_pq_mod_q.
+    move=> hwf hal.
+    have /vs_slot_valid hptr := hwf.(wfr_slot).
+    apply /validwP; split=> //.
+    move=> k hk; apply hptr; move: hk.
+    apply between_byte.
+    + by apply (no_overflow_sub_region_addr hwf).
+    by apply (zbetween_sub_region_addr hwf).
   Qed.
 
-  Lemma check_gvalid_mp x mp : 
-    check_gvalid rmap x = Some mp ->
-    valid_mp mp (vtype (gv x)).
+  Lemma validw_sub_region_at_ofs sr ty ofs ws :
+    wf_sub_region sr ty ->
+    0 <= ofs /\ ofs + wsize_size ws <= size_of ty ->
+    is_align (sub_region_addr sr + wrepr _ ofs)%R ws ->
+    validw (emem s') (sub_region_addr sr + wrepr _ ofs)%R ws.
   Proof.
-    rewrite /check_gvalid; case:ifP => hglob.
-    + case heq: Mvar.get => [ofs /= | //] [<-].
-      by exists (gv x); rewrite /get_global heq; split => //; rewrite Z.leb_refl.
-    case heq: check_valid => [mp' | //] [?]; subst mp'.
-    move: heq; rewrite check_validP => -[hget _].
-    by apply: wfr_valid_mp hget.
-  Qed.
-
-  Lemma check_gvalid_valid_pointer (n:positive) x mp aa ws i : 
-    vtype (gv x) = sarr n ->
-    check_gvalid rmap x = Some mp -> 
-    is_align (mp_addr mp) ws ->
-    0 <= i * mk_scale aa ws ->
-    i * mk_scale aa ws + wsize_size ws <= n ->
-    WArray.is_align (i * mk_scale aa ws) ws ->
-    valid_pointer (emem s') (mp_addr mp + wrepr U64 (i * mk_scale aa ws))%R ws.
-  Proof.
-    move=> hty hcheck hal h0i hi hala.    
-    apply Memory.is_align_valid_pointer.
-    + by apply is_align_add => //; apply arr_is_align.
-    move=> k hk; have := check_gvalid_mp hcheck.
-    rewrite hty => -[x' [/subtypeEl /= [n' [hty' hnn']] hget]].
-    rewrite /mp_addr -!GRing.addrA -!wrepr_add.
-    apply vs_val_ptr; split; first by apply ge0_wunsigned.
-    case: (mp) hget => -[] ofs /= hget;rewrite /wptr /wptr_size /=.
-    + assert (h:= wfg_ofs wf_globals); move: (h x').
-      move: hget; rewrite get_globalP => hget.
-      rewrite /global_pos /wptr hget => /(_ _ _ erefl) [h0z].
-      rewrite hty' /= => hbound; apply: Z.le_lt_trans. 
-      + by apply wunsigned_repr_le; nia.
-      lia.
-    assert (h:= wfg_ofs wf_locals); move: (h x').
-    rewrite /local_pos /wptr hget => /(_ _ _ erefl) [h0z].
-    rewrite hty' /= => hbound; apply: Z.le_lt_trans. 
-    + by apply wunsigned_repr_le; nia.
-    lia.
-  Qed.
-   
-  Lemma get_arr_read_mem (n:positive) (t : WArray.array n) mp aa ws i w x:
-    vtype (gv x) = sarr n ->
-    eq_mp_val (sarr n) (emem s') mp (Varr t) ->
-    check_gvalid rmap x = Some mp ->
-    WArray.get aa ws t i = ok w ->
-    is_align (mp_addr mp) ws ->
-    read_mem (emem s') (mp_addr mp + wrepr U64 (i * mk_scale aa ws)) ws = ok w.
-  Proof.
-    move=> hty heq hval hget hal.
-    rewrite Memory.readP /CoreMem.read.
-    have [hbound1 hbound2 hbound3] := WArray.get_bound hget.
-    have := check_gvalid_valid_pointer hty hval hal hbound1 hbound2 hbound3. 
-    rewrite -validr_valid_pointer => /is_okP [?] /= => hv; rewrite hv.
-    case: heq => t' [] /Varr_inj [] heq.
-    rewrite (Eqdep_dec.UIP_dec Pos.eq_dec heq erefl) /= => {heq} ? hgr;subst t'.
-    move: (hget);rewrite /WArray.get /CoreMem.read; t_xrbindP => ? _ <-.
-    do 2 f_equal; rewrite /CoreMem.uread.
-    apply eq_map_ziota => k hk /=.
-    have [v hget8]:= WArray.get_get8 AAscale hget hk.
-    have /WArray.get_uget -> := hget8.
-    move /hgr: hget8; rewrite Memory.readP /CoreMem.read.
-    have h: 0 <= i * mk_scale aa ws + k ∧ i * mk_scale aa ws + k < n by lia.
-    move=> /(_ h){h}; t_xrbindP => ? hvr.
-    have -> : (wptr (mp_s mp) + wrepr U64 (i * mk_scale aa ws + k + mp_ofs mp))%R = 
-              ((mp_addr mp + wrepr U64 (i * mk_scale aa ws)) + wrepr U64 k)%R.
-    + by rewrite /mp_addr !wrepr_add; ssrring.ssring.
-    by rewrite CoreMem.uread8_get Memory.addP => ->.
+    move=> hwf hbound.
+    have hofs: forall zofs : Z, Some ofs = Some zofs ->
+      0 <= zofs /\ zofs + size_of (sword ws) <= size_of ty.
+    + by move=> _ [<-].
+    have hwf' := sub_region_at_ofs_wf hwf hofs.
+    rewrite (sub_region_addr_offset (wsize_size ws)).
+    by apply (validw_sub_region_addr hwf').
   Qed.
 
   Let X e : Prop :=
@@ -463,9 +1088,37 @@ Section EXPR.
     get_var_kind pmap (mk_lvar x) = ok None.
   Proof. by rewrite /check_var /get_var_kind /=; case: get_local. Qed.
 
+  Lemma get_gvar_word x ws gd vm v :
+    x.(gv).(vtype) = sword ws ->
+    get_gvar gd vm x = ok v ->
+    exists (ws' : wsize) (w : word ws'), (ws' <= ws)%CMP /\ v = Vword w.
+  Proof.
+    move=> hty hget.
+    have := type_of_get_gvar hget; rewrite hty => /subtypeE [ws' [hty' hsub]].
+    case /type_of_val_word : hty'.
+    + move=> [_ [??]]; subst v.
+      by have := get_gvar_undef hget erefl.
+    move=> [w ->].
+    by exists ws', w.
+  Qed.
+
+  Lemma check_diffP x t : check_diff pmap x = ok t -> ~Sv.In x (vnew pmap).
+  Proof. by rewrite /check_diff; case:ifPn => /Sv_memP. Qed.
+
+  (* Maybe a bit too specialized. *)
+  Lemma ofs_bound_option z len size ofs :
+    0 <= z /\ z + len <= size ->
+    (ofs <> None -> ofs = Some z) ->
+    forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + len <= size.
+  Proof.
+    move=> hbound.
+    case: ofs => //.
+    by move=> _ /(_ ltac:(discriminate)) [->] _ [<-].
+  Qed.
+
   Lemma check_e_esP : (∀ e, X e) * (∀ es, Y es).
   Proof.
-    apply: pexprs_ind_pair; subst X Y; split => /=.
+    apply: pexprs_ind_pair; subst X Y; split => //=.
     + by move=> ?? [<-] [<-].
     + move=> e he es hes ??; t_xrbindP => e' /he{he}he es' /hes{hes}hes <- /=.
       by move=> v /he -> vs /hes -> <-.
@@ -473,28 +1126,56 @@ Section EXPR.
     + by move=> b ?? [<-] [<-].
     + by move=> n ?? [<-] [<-].
     + move=> x e' v; t_xrbindP => -[ vpk | ] hgvk; last first.
-      + by move=> [<-]; apply: get_var_kindP hgvk.
-      case hty: is_word_type => [ws | //]; move /is_word_typeP: hty => hty.
-      t_xrbindP => ? hcheck [xi ei] haddr <- /=.
+      + by t_xrbindP=> _ /check_diffP hnnew <-; apply: get_var_kindP.
+      case hty: is_word_type => [ws | //]; move /is_word_typeP in hty.
+      t_xrbindP => ? hcheck [xi ei] haddr <- hget /=.
       have h0: Let x := sem_pexpr [::] s' 0 in to_int x = ok 0 by done.
-      have [mp [wx [wi [hgval -> -> /= <- hal ]]]]:= check_mk_addr h0 hgvk hcheck haddr.
-      by move=> /(wfr_val hgval); rewrite hty wrepr0 GRing.addr0 => -[ w [-> ->]].
+      have h1: 0 <= 0 /\ wsize_size ws <= size_slot x.(gv).
+      + by rewrite hty /=; lia.
+      have h1' := ofs_bound_option h1 (fun _ => refl_equal).
+      have [sr [bytes [hgvalid hmem halign]]] := check_vpk_wordP h1' hgvk hcheck.
+      have h2: valid_vpk rmap s' x.(gv) sr vpk.
+      + have /wfr_gptr := hgvalid.
+        by rewrite hgvk => -[_ [[]] <-].
+      have [wx [wi [-> -> /= haddr2]]] := check_mk_addr h0 (get_var_kind_wf hgvk) h2 haddr.
+      rewrite -haddr2.
+      assert (heq := wfr_val hgvalid hget); rewrite hty in heq.
+      case: heq => hread hty'.
+      assert (hwf := check_gvalid_wf wfr_wf hgvalid).
+      have [ws' [w [_ ?]]] := get_gvar_word hty hget; subst v.
+      case: hty' => ?; subst ws'.
+      rewrite (eq_sub_region_val_read_word hwf hread hmem _ h1 (get_val_byte_word w) (w:=w)) //.
+      by rewrite wrepr0 GRing.addr0 halign.
     + move=> aa sz x e1 he1 e' v he'; apply: on_arr_gvarP => n t hty /= hget.
       t_xrbindP => i vi /he1{he1}he1 hvi w hw <-.
-      move: he'; t_xrbindP => e1' /he1{he1}he1' _ _. 
+      move: he'; t_xrbindP => e1' /he1{he1}he1'.
       have h0 : sem_pexpr [::] s' e1' >>= to_int = ok i.
       + by rewrite he1'.
-      move=> [vptr | ]; last first.
-      + by move => /get_var_kindP -/(_ _ hget) h [<-] /=; rewrite h /= h0 /= hw.
+      move=> [vpk | ]; last first.
+      + t_xrbindP => h _ /check_diffP h1 <- /=.
+        by rewrite (get_var_kindP h h1 hget) /= h0 /= hw.
       t_xrbindP => hgvk ? hcheck [xi ei] haddr <- /=.
-      have [mp [wx [wi [hgval -> -> /= <- hal ]]]] := check_mk_addr h0 hgvk hcheck haddr.
-      assert (h:= wfr_val hgval hget); move: h;rewrite hty => h.
-      by rewrite (get_arr_read_mem hty h hgval hw hal).
+      have [h1 h2 h3] := WArray.get_bound hw.
+      have h4: 0 <= i * mk_scale aa sz /\ i * mk_scale aa sz + wsize_size sz <= size_slot x.(gv).
+      + by rewrite hty.
+      have h4' := ofs_bound_option h4 (mk_ofsiP h0).
+      have [sr [bytes [hgvalid hmem halign]]] := check_vpk_wordP h4' hgvk hcheck.
+      have h5: valid_vpk rmap s' x.(gv) sr vpk.
+      + have /wfr_gptr := hgvalid.
+        by rewrite hgvk => -[_ [[]] <-].
+      have [wx [wi [-> -> /= haddr2]]] := check_mk_addr h0 (get_var_kind_wf hgvk) h5 haddr.
+      rewrite -haddr2.
+      assert (heq := wfr_val hgvalid hget).
+      case: heq => hread _.
+      assert (hwf := check_gvalid_wf wfr_wf hgvalid).
+      have [_ h6] := (read_read8 hw).
+      rewrite (eq_sub_region_val_read_word hwf hread hmem (mk_ofsiP h0) (w:=w)) //.
+      by rewrite (is_align_addE halign) WArray.arr_is_align h3.
     + move=> sz1 v1 e1 IH e2 v.
-      t_xrbindP => ? /check_varP hc e1' /IH hrec <- wv1 vv1 /= hget hto' we1 ve1.
-      move=> /hrec -> hto wr hr ?;subst v. 
-      have := get_var_kindP hc hget; rewrite /get_gvar /= => -> /=.
-      by rewrite hto' hto /= -(vs_eq_mem (read_mem_valid_pointer hr)) hr.
+      t_xrbindP => _ /check_varP hc _ /check_diffP hnnew e1' /IH hrec <- wv1 vv1 /= hget hto' we1 ve1.
+      move=> /hrec -> hto wr hr ?; subst v.
+      have := get_var_kindP hc hnnew hget; rewrite /get_gvar /= => -> /=.
+      by rewrite hto' hto /= -(eq_mem_source_word hvalid (readV hr)) hr.
     + move=> o1 e1 IH e2 v.
       by t_xrbindP => e1' /IH hrec <- ve1 /hrec /= ->.
     + move=> o1 e1 H1 e1' H1' e2 v.
@@ -502,7 +1183,7 @@ Section EXPR.
     + move => e1 es1 H1 e2 v.
       t_xrbindP => es1' /H1{H1}H1 <- vs /H1{H1} /=.
       by rewrite /sem_pexprs => ->.
-    move=> t e He e1 H1 e1' H1' e2 v.   
+    move=> t e He e1 H1 e1' H1' e2 v.
     t_xrbindP => e_ /He he e1_ /H1 hrec e1'_ /H1' hrec' <-.
     by move=> b vb /he /= -> /= -> ?? /hrec -> /= -> ?? /hrec' -> /= -> /= ->.
   Qed.
@@ -512,57 +1193,15 @@ Section EXPR.
 
 End EXPR.
 
-Lemma check_diffP x t : check_diff pmap x = ok t -> ~Sv.In x (vnew pmap).
-Proof. by rewrite /check_diff; case:ifPn => /Sv_memP. Qed.
-
-Lemma get_var_eq x vm v : get_var vm.[x <- v] x = on_vu (pto_val (t:=vtype x)) undef_error v.
-Proof. by rewrite /get_var Fv.setP_eq. Qed.
-
-Lemma get_var_neq x y vm v : x <> y -> get_var vm.[x <- v] y = get_var vm y.
-Proof. by move=> /eqP h; rewrite /get_var Fv.setP_neq. Qed.
-
-Lemma get_var_set_eq vm1 vm2 (x y : var) v: 
-  get_var vm1 y = get_var vm2 y ->
-  get_var vm1.[x <- v] y = get_var vm2.[x <- v] y.
-Proof.
-  by case:( x =P y) => [<- | hne]; rewrite !(get_var_eq, get_var_neq).
-Qed.
-
-Lemma is_lvar_is_glob x : is_lvar x = ~~is_glob x.
-Proof. by case: x => ? []. Qed.
-
-Lemma get_gvar_eq gd x vm v : 
-  ~is_glob x -> get_gvar gd vm.[gv x <- v] x = on_vu (pto_val (t:=vtype (gv x))) undef_error v.
-Proof. 
-  by move=> /negP => h; rewrite /get_gvar is_lvar_is_glob h get_var_eq.
-Qed.
-
-Lemma get_gvar_neq gd (x:var) y vm v : (~is_glob y -> x <> (gv y)) -> get_gvar gd vm.[x <- v] y = get_gvar gd vm y.
-Proof. 
-  move=> h; rewrite /get_gvar is_lvar_is_glob. 
-  by case: negP => // hg; rewrite get_var_neq //; apply h.
-Qed.
-
-Lemma get_gvar_set_eq gd vm1 vm2 x y v: 
-  get_gvar gd vm1 y = get_gvar gd vm2 y ->
-  get_gvar gd vm1.[x <- v] y = get_gvar gd vm2.[x <- v] y.
-Proof.
-  case : (@idP (is_glob y)) => hg; first by rewrite !get_gvar_neq.
-  case:( x =P (gv y)) => heq; last by rewrite !get_gvar_neq.
-  by move: v; rewrite heq => v; rewrite !get_gvar_eq.
-Qed.
-
-Lemma get_localn_checkg_diff rmap mp s2 x y : 
+Lemma get_localn_checkg_diff rmap sr_bytes s2 x y : 
   get_local pmap x = None ->
   wfr_PTR rmap s2 ->
-  check_gvalid rmap y = Some mp ->
+  check_gvalid rmap y = Some sr_bytes ->
   (~is_glob y -> x <> (gv y)).
 Proof.
-  rewrite /check_gvalid /wfr_PTR; case:ifPn => // hg hl hwf.
-  case heq: check_valid => [mp' | // ].
-  move=> [?] _; subst mp'.
-  have /check_validP [ /hwf [mpy [hy _]] _] := heq.
-  by move=> hx; subst x; move: hy; rewrite hl.
+  rewrite /check_gvalid; case:is_glob => // hl hwf.
+  case heq: Mvar.get => [sr' | // ] _ _.
+  by have /hwf [pk [hy _]] := heq; congruence.
 Qed.
 
 Lemma valid_state_set_var rmap m0 s1 s2 x v:
@@ -571,271 +1210,500 @@ Lemma valid_state_set_var rmap m0 s1 s2 x v:
   ¬ Sv.In x (vnew pmap) ->
   valid_state rmap m0 (with_vm s1 (evm s1).[x <- v]) (with_vm s2 (evm s2).[x <- v]).
 Proof.
-  case: s1 s2 => mem1 vm1 [mem2 vm2] [/=] hvptr hdisj hrip hrsp hf heqvm hwfr heqg hnotm hget hnin.
+  case: s1 s2 => mem1 vm1 [mem2 vm2] [/=] hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop hget hnin.
   constructor => //=.
   + by rewrite get_var_neq //; assert (h:=rip_in_new); SvD.fsetdec.
   + by rewrite get_var_neq //; assert (h:=rsp_in_new); SvD.fsetdec.
-  + by move=> y hy; apply get_var_set_eq; apply heqvm.
-  rewrite /with_vm /=; case: hwfr => /= hgmp hval hptr.
-  constructor => //=.
-  + move=> y mp vy hy; have ? := get_localn_checkg_diff hget hptr hy.
+  + by move=> y hy hnnew; apply get_var_set_eq; apply heqvm.
+  rewrite /with_vm /=; case: hwfr => hwfsr hval hptr.
+  constructor => //.
+  + move=> y sr bytes vy hy; have ? := get_localn_checkg_diff hget hptr hy.
     by rewrite get_gvar_neq //; apply hval.
   move=> y mp hy; have [pk [hgety hpk]]:= hptr y mp hy; exists pk; split => //.
-  case: pk hgety hpk => //= yp hyp.  
-  assert (h := disj_ptr hyp); case: h => _ _ hin _ <-.
+  case: pk hgety hpk => //= yp hyp.
+  assert (h := wfr_new (wf_locals hyp)).
   by rewrite get_var_neq //; SvD.fsetdec.
 Qed.
 
-Lemma set_wordP rmap x ws rmap': 
-  set_word rmap x ws = ok rmap' ->
-  exists mp,
-  [/\ Mvar.get (var_region rmap) x = Some mp,
-      mp_s mp = MSstack, 
-      is_align (wrepr Uptr (mp_ofs mp)) ws &
-      rmap' = rset_word rmap x mp]. 
+Lemma eq_sub_region_val_disjoint_zrange sr bytes ty mem1 mem2 v p sz :
+  (forall p1 ws1,
+    disjoint_zrange p sz p1 (wsize_size ws1) ->
+    read mem2 p1 ws1 = read mem1 p1 ws1) ->
+  disjoint_zrange p sz (sub_region_addr sr) (size_of ty) ->
+  eq_sub_region_val ty mem1 sr bytes v ->
+  eq_sub_region_val ty mem2 sr bytes v.
 Proof.
-  rewrite /set_word.
-  case heq : Mvar.get => [ [[] ofs] | ] //=.
-  t_xrbindP => ? /assertP hal <-.
-  by eexists; split; first reflexivity.
+  move=> hreadeq hd [hread hty]; split=> // off hmem w' hget.
+  rewrite -(hread _ hmem _ hget).
+  apply hreadeq.
+  apply (disjoint_zrange_byte hd).
+  rewrite -hty.
+  by apply (get_val_byte_bound hget).
 Qed.
 
-Lemma wsize_size_le ws ws': (ws ≤ ws')%CMP -> (wsize_size ws <= wsize_size ws').
-Proof. by case: ws ws' => -[]. Qed.
-
-Lemma size_of_le ty ty' : subtype ty ty' -> size_of ty <= size_of ty'.
+Lemma wf_region_slot_inj r1 r2 :
+  wf_region r1 -> wf_region r2 ->
+  r1.(r_slot) = r2.(r_slot) ->
+  r1 = r2.
 Proof.
-  case: ty => [||p|ws]; case:ty' => [||p'|ws'] //.
-  + by move=> /ZleP.
-  by apply wsize_size_le.
-Qed.
-  
-Lemma gt0_size_of ty : 0 < size_of ty.
-Proof. by case: ty. Qed.
-
-Lemma check_gvalid_rset_word rmap x y mp mpy: 
-  mp_s mp = MSstack ->
-  Mvar.get (var_region rmap) x = Some mp ->
-  check_gvalid (rset_word rmap x mp) y = Some mpy ->
-  [/\ ~is_glob y, x = (gv y) & mp = mpy] \/ 
-  [/\ (~is_glob y -> x <> gv y), mp <> mpy &check_gvalid rmap y = Some mpy].
-Proof.
-  rewrite /check_gvalid /rset_word => hmps hgx.
-  case:ifPn => ?.
-  + move=> h; right;split => //.
-    by case: Mvar.get h => // ? [<-] => ?; subst mp.
-  case heq : check_valid => [mp1 | //] [?]; subst mp1.
-  move:heq; rewrite check_validP => /= -[hgy [xs []]].
-  rewrite Mmp.setP; case: eqP => [? [?]| ].
-  + by subst mpy xs => /SvD.F.singleton_iff ?; left.
-  move=> hd hg /Sv_memP hin; right; split => //.
-  + by move=> _ ?; subst x; apply hd; move: hgy;rewrite hgx => -[].
-  by rewrite /check_valid hgy hg hin.
+  move=> hwf1 hwf2.
+  have := hwf1.(wfr_align).
+  have := hwf2.(wfr_align).
+  have := hwf1.(wfr_writable).
+  have := hwf2.(wfr_writable).
+  by case: (r1); case: (r2) => /=; congruence.
 Qed.
 
-Lemma get_global_pos x ofs: 
-  get_global pmap x = ok ofs ->
-  global_pos x = Some (ofs, vtype x).
-Proof. by rewrite get_globalP /global_pos => ->. Qed.
-
-Lemma get_local_pos x ofs:
-  get_local pmap x = Some (Pstack ofs) ->
-  local_pos x = Some (ofs, vtype x).
-Proof. by rewrite /local_pos => ->. Qed.
-
-Lemma valid_mp_bound mp ty : 
-  valid_mp mp ty ->
-  0 <= mp_ofs mp ∧ 
-  mp_ofs mp + size_of ty <= wptr_size (mp_s mp).
+Lemma distinct_regions_disjoint_zrange sr1 sr2 ty1 ty2 :
+  wf_sub_region sr1 ty1 ->
+  wf_sub_region sr2 ty2 ->
+  sr1.(sr_region) <> sr2.(sr_region) ->
+  sr1.(sr_region).(r_writable) ->
+  disjoint_zrange (sub_region_addr sr1) (size_of ty1) (sub_region_addr sr2) (size_of ty2).
 Proof.
-  move=> [x [/size_of_le hsub hv]].
-  case: eqP hv => heq.
-  + rewrite heq => /get_global_pos hgp. 
-    assert (h:= wfg_ofs wf_globals hgp); rewrite /wptr_size /=; lia.
-  move=> /get_local_pos hgx.
-  assert (h:= wfg_ofs wf_locals hgx).
-  have -> : mp_s mp = MSstack by case: (mp_s mp) heq.
-  rewrite /wptr_size /=; lia.
+  move=> hwf1 hwf2 hneq hw.
+  apply (disjoint_zrange_incl (zbetween_sub_region_addr hwf1) (zbetween_sub_region_addr hwf2)).
+  apply (disjoint_writable hwf1.(wfr_slot) hwf2.(wfr_slot)); last by rewrite hwf1.(wfr_writable).
+  by move=> /(wf_region_slot_inj hwf1 hwf2).
 Qed.
 
-Lemma valid_mp_addr mp ty: 
-  valid_mp mp ty ->
-  wunsigned (mp_addr mp) = wunsigned (wptr (mp_s mp)) + (mp_ofs mp).
+Lemma eq_sub_region_val_distinct_regions s2 sr ty sry ty' mem2 bytes v :
+  wf_sub_region sr ty ->
+  wf_sub_region sry ty' ->
+  sr.(sr_region) <> sry.(sr_region) ->
+  sr.(sr_region).(r_writable) ->
+  (forall p ws,
+    disjoint_zrange (sub_region_addr sr) (size_of ty) p (wsize_size ws) ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  eq_sub_region_val ty' (emem s2) sry bytes v ->
+  eq_sub_region_val ty' mem2 sry bytes v.
 Proof.
-  move=> /valid_mp_bound; rewrite /mp_addr => h.
-  apply wunsigned_add; have ? := gt0_size_of ty.
-  have := @ge0_wunsigned Uptr (wptr (mp_s mp)).
-  by case: (mp_s mp) h; rewrite /wptr /wptr_size /=; lia.
+  move=> hwf hwfy hneq hw hreadeq.
+  apply (eq_sub_region_val_disjoint_zrange hreadeq).
+  by apply distinct_regions_disjoint_zrange.
 Qed.
 
-Lemma valid_mp_addr_bound mp ty: 
-  valid_mp mp ty ->
-  wunsigned (wptr (mp_s mp)) <= wunsigned (mp_addr mp) /\
-  wunsigned (mp_addr mp) + size_of ty <= wunsigned (wptr (mp_s mp)) + wptr_size (mp_s mp).
+Lemma disjoint_zones_disjoint_zrange sr1 ty1 sr2 ty2 :
+  wf_sub_region sr1 ty1 ->
+  wf_sub_region sr2 ty2 ->
+  sr1.(sr_region) = sr2.(sr_region) ->
+  disjoint_zones (sub_zone_at_ofs sr1.(sr_zone) (Some 0) (size_of ty1))
+                 (sub_zone_at_ofs sr2.(sr_zone) (Some 0) (size_of ty2)) ->
+  disjoint_zrange (sub_region_addr sr1) (size_of ty1) (sub_region_addr sr2) (size_of ty2).
 Proof.
-  move=> h; rewrite (valid_mp_addr h); have := (valid_mp_bound h); lia.
+  move=> hwf1 hwf2 heq.
+  have := addr_no_overflow (wfr_slot hwf1).
+  have := addr_no_overflow (wfr_slot hwf2).
+  rewrite /disjoint_zones /disjoint_range /disjoint_zrange /no_overflow !zify /=.
+  rewrite (wunsigned_sub_region_addr hwf1) (wunsigned_sub_region_addr hwf2).
+  have /= := wfz_len hwf1.
+  have /= := wfz_len hwf2.
+  have := wfz_ofs hwf1.
+  have := wfz_ofs hwf2.
+  rewrite heq.
+  by split; rewrite ?zify; lia.
 Qed.
 
-Lemma ms_bound s : wunsigned (wptr s) + wptr_size s <= wbase Uptr.
-Proof. by case: s. Qed.
-
-Lemma disjoint_eq_mp_val p mp ty mem1 mem2 ws w v: 
-  valid_mp mp ty ->
-  disjoint_zrange p (wsize_size ws) (mp_addr mp) (size_of ty) ->
-  write_mem mem1 p ws w = ok mem2 ->
-  eq_mp_val ty mem1 mp v → 
-  eq_mp_val ty mem2 mp v.
+Lemma eq_sub_region_val_same_region s2 sr ty sry ty' mem2 bytes v :
+  wf_sub_region sr ty ->
+  wf_sub_region sry ty' ->
+  sr.(sr_region) = sry.(sr_region) ->
+  (forall p ws,
+    disjoint_zrange (sub_region_addr sr) (size_of ty) p (wsize_size ws) ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  eq_sub_region_val ty' (emem s2) sry bytes v ->
+  eq_sub_region_val ty' mem2 sry (ByteSet.remove bytes (interval_of_zone sr.(sr_zone))) v.
 Proof.
-  have hba := @ms_bound (mp_s mp); have hge0 := @ge0_wunsigned Uptr (mp_addr mp).
-  move=> /valid_mp_addr_bound.
-  case: ty => // [pt | ws']; rewrite /size_of => hbound hd hw /=.
-  + move=> [t] [-> heq]; exists t;split => // off hoff v1 /(heq _ hoff) <-.     
-    apply: (Memory.writeP_neq hw).
-    case: hd => hno1 hno2 hd; rewrite /disjoint_range /disjoint_zrange wsize8.
-    rewrite wrepr_add (GRing.addrC (wrepr _ _)) GRing.addrA -/(mp_addr mp).
-    have heqa : wunsigned (mp_addr mp + wrepr U64 off) = wunsigned (mp_addr mp) + off.
-    + rewrite wunsigned_add //; lia.
-    split => //; rewrite /no_overflow ?zify; lia.
-  move=> [w1] [-> heq]; exists w1; split => //; rewrite -heq.
-  by apply: (Memory.writeP_neq hw). 
+  move=> hwf hwfy hr hreadeq [hread hty'].
+  split=> // off hmem v1 /dup[] /get_val_byte_bound; rewrite hty' => hoff hget.
+  have hwfy' := sub_region_at_ofs_wf_byte hwfy hoff.
+  move: hmem; rewrite memi_mem_U8.
+  move=> /(mem_remove_interval_of_zone (wf_zone_len_gt0 hwf) (wf_zone_len_gt0 hwfy')) [hmem hdisj].
+  rewrite -(hread _ _ _ hget); last by rewrite memi_mem_U8.
+  apply hreadeq.
+  rewrite (sub_region_addr_offset (wsize_size U8)).
+  apply (disjoint_zones_disjoint_zrange hwf hwfy' hr).
+  by apply (disjoint_zones_incl (zbetween_zone_sub_zone_at_ofs_0 hwf)
+                                (zbetween_zone_sub_zone_at_ofs_0 hwfy')).
 Qed.
 
-Lemma valid_mp_disjoint mp1 mp2 ty1 ty2: 
-  valid_mp mp1 ty1 -> 
-  valid_mp mp2 ty2 ->
-  mp1 <> mp2 -> 
-  wunsigned (mp_addr mp1) + size_of ty1 <= wunsigned (mp_addr mp2) ∨ 
-  wunsigned (mp_addr mp2) + size_of ty2 <= wunsigned (mp_addr mp1).
+Lemma sub_region_pk_valid rmap s sr pk :
+  sub_region_pk pk = ok sr -> valid_pk rmap s sr pk.
+Proof. by case: pk => // v ofs ws z [|//] [<-]. Qed.
+
+Lemma sub_region_pk_wf x pk sr ws :
+  get_local pmap x = Some pk ->
+  x.(vtype) = sword ws ->
+  sub_region_pk pk = ok sr ->
+  wf_sub_region sr x.(vtype).
 Proof.
-  move=> h1 h2; rewrite (valid_mp_addr h1) (valid_mp_addr h2).
-  case: mp1 mp2 h1 h2 => [ms1 ofs1] [ms2 ofs2].
-  move=> [x1 [/size_of_le hle1 /= hget1]] [x2 [/size_of_le hle2 /= hget2]].
-  have ? := gt0_size_of (vtype x1); have ? := gt0_size_of (vtype x2).
-  assert (wfg := wf_globals); assert (wfl := wf_locals).
-  case: ms1 hget1 => /= [/get_global_pos | /get_local_pos] h1.
-  + have hg1 := wfg_ofs wfg h1; have hg2 := wfg_disj wfg _ h1.
-    case: ms2 hget2 => /= [/get_global_pos | /get_local_pos] h2 hd.
-    + have hxd: x1 <> x2 by move=> h;apply hd; move: h2; rewrite -h h1 => -[->].
-      by have:= hg2 _ _ _ hxd h2; lia.
-    have hl2:=  wfg_ofs wfl h2; rewrite /wptr /wptr_size /=; lia.
-  have hl1 := wfg_ofs wfl h1; have hl2 := wfg_disj wfl _ h1.
-  case: ms2 hget2 => /= [/get_global_pos | /get_local_pos] h2 hd.
-  + have hg2:=  wfg_ofs wfg h2; rewrite /wptr /wptr_size /=; lia.
-  have hxd: x1 <> x2 by move=> h;apply hd; move: h2; rewrite -h h1 => -[->].
-  by have:= hl2 _ _ _ hxd h2; lia.
+  case: pk => // v ofs ws' z [|//] /wf_locals /= hget hty /= [<-].
+  case: hget => *.
+  by rewrite /sub_region_addr /sub_region_stack; split.
 Qed.
 
-Lemma eq_mp_val_write_disj rmap m0 s1 s2 x y mp mpy mem2 v ws w p:
-  valid_state rmap m0 s1 s2 ->  
-  Mvar.get (var_region rmap) x = Some mp ->
-  mp_s mp = MSstack ->
-  between (mp_addr mp) (size_of (vtype x)) p ws ->
-  check_gvalid rmap y = Some mpy ->
-  mp ≠ mpy ->
-  write_mem (emem s2) p ws w = ok mem2 ->
-  eq_mp_val (vtype (gv y)) (emem s2) mpy v → 
-  eq_mp_val (vtype (gv y)) mem2 mpy v.
+Lemma is_align_sub_region_stkptr x s ofs ws z f :
+  wf_stkptr x s ofs ws z f ->
+  is_align (sub_region_addr (sub_region_stkptr s ws z)) Uptr.
 Proof.
-  move=> hvs hgx hs hb hcv hd.
-  have hmpy := check_gvalid_mp hvs hcv; assert (hmp := wfr_valid_mp hgx).
-  apply: disjoint_eq_mp_val => //.
-  move: hb; rewrite /between !zify.
-  have ? := valid_mp_addr_bound hmp; have ? := valid_mp_addr_bound hmpy.
-  have ? := @ms_bound (mp_s mp); have ? := @ms_bound (mp_s mpy).
-  split; rewrite /no_overflow ?zify. 
-  + lia. + lia. 
-  have := valid_mp_disjoint hmp hmpy hd; lia.
+  move=> hlocal.
+  rewrite /sub_region_addr /=.
+  (* TODO: could wfs_offset_align be is_align z.(z_ofs) U64 ?
+     does it make sense ?
+  *)
+  apply: is_align_add hlocal.(wfs_offset_align).
+  apply (is_align_m hlocal.(wfs_align_ptr)).
+  rewrite -hlocal.(wfs_align).
+  by apply (slot_align (sub_region_stkptr_wf hlocal).(wfr_slot)).
 Qed.
 
-Lemma get_local_pos_sptr x ofs : get_local pmap x = Some (Pstkptr ofs) -> local_pos x = Some(ofs, sword Uptr).
-Proof. by rewrite /local_pos => ->. Qed.
+Lemma set_bytesP rmap x sr ofs len rv :
+  set_bytes rmap x sr ofs len = ok rv ->
+  sr.(sr_region).(r_writable) /\ rv = set_pure_bytes rmap x sr ofs len.
+Proof. by rewrite /set_bytes; t_xrbindP=> _ /assertP. Qed.
 
-Lemma sptr_addr x ofs: 
-  local_pos x = Some (ofs, sword Uptr) ->
-  wunsigned (mp_addr {| mp_s := MSstack; mp_ofs := ofs |}) = wunsigned rsp + ofs.
+Lemma set_sub_regionP rmap x sr ofs len rmap2 :
+  set_sub_region rmap x sr ofs len = ok rmap2 ->
+  sr.(sr_region).(r_writable) /\
+  rmap2 = {| var_region := Mvar.set (var_region rmap) x sr;
+             region_var := set_pure_bytes rmap x sr ofs len |}.
+Proof. by rewrite /set_sub_region; t_xrbindP=> _ /set_bytesP [? ->] <-. Qed.
+
+Lemma get_bytes_map_setP rv r r' bm :
+  get_bytes_map r (Mr.set rv r' bm) = if r' == r then bm else get_bytes_map r rv.
+Proof. by rewrite /get_bytes_map Mr.setP; case: eqP. Qed.
+
+Lemma get_bytes_setP bm x x' bytes :
+  get_bytes x (Mvar.set bm x' bytes) = if x' == x then bytes else get_bytes x bm.
+Proof. by rewrite /get_bytes Mvar.setP; case: eqP. Qed.
+
+Lemma get_bytes_clear x i bm :
+  get_bytes x (clear_bytes_map i bm) =
+  ByteSet.remove (get_bytes x bm) i.
 Proof.
-  move=> h; assert (h1:= wfg_ofs wf_locals h).
-  rewrite /mp_addr /wptr /=; apply wunsigned_add.
-  move: (gt0_size_of (sword Uptr)) (@ge0_wunsigned Uptr rsp); lia.
+  rewrite /clear_bytes_map /get_bytes.
+  by rewrite Mvar.mapP; case: Mvar.get => //=; rewrite remove_empty.
 Qed.
 
-Lemma sptr_addr_bound x ofs:
-  local_pos x = Some (ofs, sword Uptr) ->
-  wunsigned rsp <= wunsigned (mp_addr {| mp_s := MSstack; mp_ofs := ofs |}) /\
-  wunsigned (mp_addr {| mp_s := MSstack; mp_ofs := ofs |}) + wsize_size Uptr <= wunsigned rsp + stk_size.
+Lemma get_var_bytes_set_pure_bytes rmap x sr ofs len r y :
+  get_var_bytes (set_pure_bytes rmap x sr ofs len) r y =
+    let bytes := get_var_bytes rmap r y in
+    if sr.(sr_region) != r then
+      bytes
+    else
+      let i := interval_of_zone (sub_zone_at_ofs sr.(sr_zone) ofs len) in
+      if x == y then
+        if ofs is None then
+          bytes
+        else
+          ByteSet.add i bytes
+      else
+        ByteSet.remove bytes i.
 Proof.
-  move=> h; rewrite (sptr_addr h).
-  assert (h1:= wfg_ofs wf_locals h); move: h1 => /=; lia.
+  rewrite /set_pure_bytes /get_var_bytes.
+  rewrite get_bytes_map_setP.
+  case: eqP => [->|] //=.
+  rewrite get_bytes_setP.
+  by case: eqP => [->|] // _; rewrite get_bytes_clear.
 Qed.
 
-Lemma wfr_PTR_rset_word rmap m0 s1 s2 x mp p ws w mem2:
-  valid_state rmap m0 s1 s2 ->  
-  Mvar.get (var_region rmap) x = Some mp ->
-  mp_s mp = MSstack ->
-  between (mp_addr mp) (size_of (vtype x)) p ws ->
-  write_mem (emem s2) p ws w = ok mem2 ->
+(*
+Definition get_gvar_bytes rv r x :=
+  if is_glob x then
+    ByteSet.full (interval_of_zone {| z_ofs := 0; z_len := size_slot x.(gv) |})
+  else get_var_bytes rv r x.(gv).
+*)
+
+Lemma check_gvalid_set_sub_region rmap x sr ofs len rmap2 y sry bytes :
+  wf_sub_region sr x.(vtype) ->
+  set_sub_region rmap x sr ofs len = ok rmap2 ->
+  check_gvalid rmap2 y = Some (sry, bytes) ->
+    [/\ ~ is_glob y, x = gv y, sr = sry &
+         bytes = get_var_bytes rmap2 sr.(sr_region) x]
+  \/
+    [/\ ~ is_glob y -> x <> gv y &
+        exists bytes', check_gvalid rmap y = Some (sry, bytes') /\
+          bytes =
+            if sr.(sr_region) != sry.(sr_region) then bytes'
+            else ByteSet.remove bytes' (interval_of_zone (sub_zone_at_ofs sr.(sr_zone) ofs len))].
+Proof.
+  move=> hwf /set_sub_regionP [hw ->]; rewrite /check_gvalid.
+  case: (@idP (is_glob y)) => hg.
+  + case heq: Mvar.get => [[ofs' ws]|//] [<- <-].
+    right; split => //.
+    eexists; split; first by reflexivity.
+    case: eqP => heqr //=.
+    by rewrite -hwf.(wfr_writable) heqr (sub_region_glob_wf (wf_globals heq)).(wfr_writable) in hw.
+  rewrite Mvar.setP; case: eqP.
+  + by move=> -> [<- <-]; left; split.
+  move=> hneq.
+  case heq': Mvar.get => [sr'|//] [? <-]; subst sr'.
+  right; split => //.
+  eexists; split; first by reflexivity.
+  rewrite get_var_bytes_set_pure_bytes.
+  by move: hneq => /eqP /negPf ->.
+Qed.
+
+Definition between_at_ofs sr ty ofs ty2 p ws :=
+  between (sub_region_addr (sub_region_at_ofs sr ofs (size_of ty2)))
+          (size_of (stype_at_ofs ofs ty2 ty))
+          p ws.
+
+(* This lemma is used for [set_sub_region] and [set_stack_ptr]. *)
+Lemma mem_unchanged_write_slot m0 s1 s2 sr ty mem2 :
+  wf_sub_region sr ty ->
+  sr.(sr_region).(r_writable) ->
+  (forall p ws,
+    disjoint_zrange (sub_region_addr sr) (size_of ty) p (wsize_size ws) ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  mem_unchanged (emem s1) m0 (emem s2) ->
+  mem_unchanged (emem s1) m0 mem2.
+Proof.
+  move=> hwf hwritable hreadeq hunch p hvalid1 hvalid2 hdisj.
+  rewrite (hunch _ hvalid1 hvalid2 hdisj).
+  symmetry; apply hreadeq.
+  apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf)).
+  apply (hdisj _ hwf.(wfr_slot)).
+  by rewrite hwf.(wfr_writable).
+Qed.
+
+(* I tried to avoid proof duplication with this auxiliary lemma. But there is
+   some duplication even in the proof of this lemma...
+*)
+Lemma valid_pk_set_pure_bytes rmap s2 x sr ofs ty mem2 y pk sry :
+  wf_sub_region sr x.(vtype) ->
+  ~ Sv.In x pmap.(vnew) ->
+  (forall p ws,
+    disjoint_zrange (sub_region_addr (sub_region_at_ofs sr ofs (size_of ty)))
+                    (size_of (stype_at_ofs ofs ty x.(vtype)))
+                    p (wsize_size ws) ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  wf_local y pk ->
+  (forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + size_of ty <= size_of x.(vtype)) ->
+  valid_pk rmap s2 sry pk ->
+  valid_pk (set_pure_bytes rmap x sr ofs (size_of ty)) (with_mem s2 mem2) sry pk.
+Proof.
+  move=> hwf hnin hreadeq hlocal hofs hpk.
+  case: pk hlocal hofs hpk => //= s ofs' ws' z f hlocal hofs hpk.
+  have hwf' := sub_region_at_ofs_wf hwf hofs.
+  have hwf2 := sub_region_stkptr_wf hlocal.
+  rewrite /check_stack_ptr get_var_bytes_set_pure_bytes.
+  case: eqP => heqr /=.
+  + case: eqP => heq2.
+    + by have := hlocal.(wfs_new); congruence.
+    move=> /(mem_remove_interval_of_zone (wf_zone_len_gt0 hwf')) -/(_ ltac:(done)) [/hpk <- hdisj].
+    apply hreadeq.
+    apply (disjoint_zones_disjoint_zrange hwf' hwf2 heqr).
+    apply: disjoint_zones_incl_l hdisj.
+    by apply (zbetween_zone_sub_zone_at_ofs_0 hwf').
+  move=> /hpk <-.
+  apply hreadeq.
+  apply disjoint_zrange_sym.
+  by apply (distinct_regions_disjoint_zrange hwf2 hwf' (not_eq_sym heqr)).
+Qed.
+
+Lemma wfr_PTR_set_sub_region (rmap : region_map) s2 x pk sr ofs ty mem2 rmap2 :
+  get_local pmap x = Some pk ->
+  wf_sub_region sr x.(vtype) ->
+  valid_pk rmap s2 sr pk ->
+  (forall p ws,
+    disjoint_zrange (sub_region_addr (sub_region_at_ofs sr ofs (size_of ty)))
+                    (size_of (stype_at_ofs ofs ty x.(vtype)))
+                    p (wsize_size ws) ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  (forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + size_of ty <= size_of x.(vtype)) ->
+  set_sub_region rmap x sr ofs (size_of ty) = ok rmap2 ->
   wfr_PTR rmap s2 ->
-  wfr_PTR (rset_word rmap x mp) (with_mem s2 mem2).
+  wfr_PTR rmap2 (with_mem s2 mem2).
 Proof.
-  move=> hvs hgx hms hb hw hwf y mpy /hwf [pk] [hgl hvpk]; exists pk;split => //.
-  case: pk hgl hvpk => //= ofs hy <-.
-  apply: (Memory.writeP_neq hw).
-  assert (hmp := wfr_valid_mp hgx).
-  case: (hmp) => x' [] /size_of_le hle; rewrite hms /= => hx.
-  have hly:= get_local_pos_sptr hy; have hlx := get_local_pos hx.
-  split.
-  + by apply (is_align_no_overflow (Memory.valid_align (write_mem_valid_pointer hw))).
-  + rewrite /no_overflow zify.
-    have := sptr_addr_bound hly; lia.
-  move: hb; rewrite /between !zify.
-  assert (hwl := wf_locals).
-  have hd : y <> x' by move=> heq;move: hy;rewrite heq hx.
-  have /= := wfg_disj hwl hd hly hlx.
-  rewrite (sptr_addr hly) (valid_mp_addr hmp) hms /wptr /=; lia.
+  move=> hlx hwf hpk hreadeq hofs /set_sub_regionP [_ ->] hptr y sry.
+  have /wf_vnew hnnew := hlx.
+  rewrite Mvar.setP; case: eqP.
+  + move=> <- [<-].
+    exists pk; split=> //.
+    by apply (valid_pk_set_pure_bytes hwf hnnew hreadeq (wf_locals hlx) hofs hpk).
+  move=> _ /hptr {pk hlx hpk} [pk [hly hpk]].
+  exists pk; split=> //.
+  by apply (valid_pk_set_pure_bytes hwf hnnew hreadeq (wf_locals hly) hofs hpk).
 Qed.
 
-Lemma eq_glob_rset_word rmap m0 s1 s2 x mp p ws w mem2:
-  valid_state rmap m0 s1 s2 ->  
-  Mvar.get (var_region rmap) x = Some mp ->
-  mp_s mp = MSstack ->
-  between (mp_addr mp) (size_of (vtype x)) p ws ->
-  write_mem (emem s2) p ws w = ok mem2 ->
-  eq_glob (emem s1) (emem s2) ->
-  eq_glob (emem s1) mem2.
+(* This lemma is used only for [set_sub_region]. *)
+Lemma wfr_VAL_set_sub_region rmap s1 s2 sr x ofs ty mem2 (rmap2 : region_map) v :
+  wf_rmap rmap s1 s2 ->
+  wf_sub_region sr x.(vtype) ->
+  (forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + size_of ty <= size_of x.(vtype)) ->
+  (forall p ws,
+    disjoint_zrange (sub_region_addr (sub_region_at_ofs sr ofs (size_of ty)))
+                    (size_of (stype_at_ofs ofs ty x.(vtype)))
+                    p (wsize_size ws) ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  set_sub_region rmap x sr ofs (size_of ty) = ok rmap2 ->
+  eq_sub_region_val x.(vtype) mem2 sr (get_var_bytes rmap2 sr.(sr_region) x) v ->
+  wfr_VAL rmap2 (with_vm s1 (evm s1).[x <- pof_val (vtype x) v]) (with_mem s2 mem2).
 Proof.
-  move=> hvs hgx hms hb hw heg p1 ws1 hvp.
-  rewrite (heg _ _ hvp); symmetry; apply: (Memory.writeP_neq hw).
-  assert (hd:= vs_disj (ms:= mp_s mp) hvp); move:hd; rewrite hms /wptr /wptr_size /= => hd.
-  assert (hmp := wfr_valid_mp hgx).
-  case: (hmp) => x' [] /size_of_le hle; rewrite hms /= => hx.
-  split.
-  + by apply (is_align_no_overflow (Memory.valid_align (write_mem_valid_pointer hw))).
-  + by apply: is_align_no_overflow (Memory.valid_align hvp).
-  move: hb; rewrite /between !zify.
-  assert (hwl := wfg_ofs wf_locals (get_local_pos hx)).
-  rewrite (valid_mp_addr hmp) /wptr hms /=; lia.
+  move=> hwfr hwf hofs hreadeq hset hval y sry bytesy vy.
+  move=> /(check_gvalid_set_sub_region hwf hset) [].
+  + move=> [? ? <- ->]; subst x.
+    have [_ hty] := hval.
+    rewrite get_gvar_eq //.
+    apply on_vuP => //; rewrite -hty.
+    by move => ? hof hto; rewrite -hto (pto_val_pof_val hof) hty.
+  move=> [? [bytes [hgvalid ->]]].
+  rewrite get_gvar_neq => //; move=> /(wfr_val hgvalid).
+  assert (hwfy := check_gvalid_wf wfr_wf hgvalid).
+  have hwf' := sub_region_at_ofs_wf hwf hofs.
+  case: eqP => heqr /=.
+  + apply (eq_sub_region_val_same_region hwf' hwfy heqr hreadeq).
+  apply: (eq_sub_region_val_distinct_regions hwf' hwfy heqr _ hreadeq).
+  by case /set_sub_regionP : hset.
 Qed.
 
-Lemma eq_not_mod_rset_word rmap m0 s1 s2 x mp p ws w mem2:
-  valid_state rmap m0 s1 s2 ->  
-  Mvar.get (var_region rmap) x = Some mp ->
-  mp_s mp = MSstack ->
-  between (mp_addr mp) (size_of (vtype x)) p ws ->
-  write_mem (emem s2) p ws w = ok mem2 ->
-  eq_not_mod m0 (emem s2) -> 
-  eq_not_mod m0 mem2. 
+(* This lemma is used for [set_sub_region] and [set_stack_ptr]. *)
+Lemma eq_mem_source_write_slot rmap m0 s1 s2 sr ty mem2:
+  valid_state rmap m0 s1 s2 ->
+  wf_sub_region sr ty ->
+  (forall p ws,
+    disjoint_zrange (sub_region_addr sr) (size_of ty) p (wsize_size ws) ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  eq_mem_source (emem s1) mem2.
 Proof.
-  move=> hvs hgx hms hb hw heg p1 ws1 hvp.
-  rewrite (heg _ _ hvp) //; symmetry; apply: (Memory.writeP_neq hw).
-  assert (hmp := wfr_valid_mp hgx).
-  case: (hmp) => x' [] /size_of_le hle; rewrite hms /= => hx.
-  split.
-  + by apply (is_align_no_overflow (Memory.valid_align (write_mem_valid_pointer hw))).
-  + by apply: is_align_no_overflow; apply is_align8.
-  move: hb; rewrite /between !zify.
-  have:= hvp _ _ _ (get_local_pos hx).
-  rewrite wunsigned_add; last by have := @ge0_wunsigned _ rsp; lia.
-  rewrite (valid_mp_addr hmp) /wptr hms wsize8 /=; lia.
+  move=> hvs hwf hreadeq p hvp.
+  rewrite (vs_eq_mem hvp).
+  symmetry; apply hreadeq.
+  apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf)).
+  by apply (vs_disjoint hwf.(wfr_slot) hvp).
+Qed.
+
+Lemma set_wordP rmap x sr ws rmap2 :
+  wf_sub_region sr x.(vtype) ->
+  set_word rmap x sr ws = ok rmap2 ->
+    is_align (sub_region_addr sr) ws /\
+    set_sub_region rmap x sr (Some 0) (size_slot x) = ok rmap2.
+Proof.
+  by rewrite /set_word; t_xrbindP=> hwf _ /(check_alignP hwf).
+Qed.
+
+(* TODO: better name? *)
+Lemma wfr_WF_set rmap x sr rmap2 :
+  wfr_WF rmap ->
+  wf_sub_region sr x.(vtype) ->
+  rmap2.(var_region) = Mvar.set rmap.(var_region) x sr ->
+  wfr_WF rmap2.
+Proof.
+  move=> hwsrf hwfsr hrmap2 y sry.
+  rewrite hrmap2 Mvar.setP.
+  by case: eqP; [congruence|auto].
+Qed.
+
+(* We show that, under the right hypotheses, [set_sub_region] preserves
+   the [valid_state] invariant.
+   This lemma is used both for words and arrays.
+*)
+Lemma valid_state_set_sub_region rmap m0 s1 s2 sr x pk ofs ty mem2 v (rmap2 : region_map) :
+  valid_state rmap m0 s1 s2 ->
+  wf_sub_region sr x.(vtype) ->
+  get_local pmap x = Some pk ->
+  valid_pk rmap.(region_var) s2 sr pk ->
+  (forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + size_of ty <= size_of x.(vtype)) ->
+  stack_stable (emem s2) mem2 ->
+  (forall p ws, validw mem2 p ws = validw (emem s2) p ws) ->
+  (forall p ws,
+    disjoint_zrange (sub_region_addr (sub_region_at_ofs sr ofs (size_of ty)))
+                    (size_of (stype_at_ofs ofs ty x.(vtype)))
+                    p (wsize_size ws) ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  set_sub_region rmap x sr ofs (size_of ty) = ok rmap2 ->
+  eq_sub_region_val x.(vtype) mem2 sr (get_var_bytes rmap2 sr.(sr_region) x) v ->
+  valid_state rmap2 m0 (with_vm s1 (evm s1).[x <- pof_val x.(vtype) v]) (with_mem s2 mem2).
+Proof.
+  move=> hvs hwf hlx hpk hofs hss hvalideq hreadeq hset heqval.
+  have hwf' := sub_region_at_ofs_wf hwf hofs.
+  case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  constructor => //=.
+  + by move=> ??; rewrite hvalideq; apply hvalid.
+  + by move=> ??; rewrite hvalideq; apply hincl.
+  + by move=> ??; rewrite hvalideq; apply hincl2.
+  + case /set_sub_regionP : hset => hwritable _.
+    by apply (mem_unchanged_write_slot hwf' hwritable hreadeq hunch).
+  + move=> y hget; rewrite get_var_neq; first by apply heqvm.
+    by rewrite /get_local in hlx; congruence.
+  + case: (hwfr) => hwfsr hval hptr; split.
+    + apply (wfr_WF_set hwfsr hwf).
+      by have [_ ->] := set_sub_regionP hset.
+    + by apply (wfr_VAL_set_sub_region hwfr hwf hofs hreadeq hset heqval).
+    by apply (wfr_PTR_set_sub_region hlx hwf hpk hreadeq hofs hset hptr).
+  + by apply (eq_mem_source_write_slot hvs hwf' hreadeq).
+  by rewrite -hss.(ss_top_stack).
+Qed.
+
+Lemma set_arr_wordP rmap m0 s1 s2 x ofs ws rmap2 :
+  valid_state rmap m0 s1 s2 ->
+  set_arr_word rmap x ofs ws = ok rmap2 ->
+  exists sr, [/\
+    Mvar.get rmap.(var_region) x = Some sr,
+    is_align (sub_region_addr sr) ws &
+    set_sub_region rmap x sr ofs (wsize_size ws) = ok rmap2].
+Proof.
+  move=> hvs.
+  rewrite /set_arr_word; t_xrbindP=> sr /get_sub_regionP hget.
+  have /wfr_wf hwf := hget.
+  move=> _ /(check_alignP hwf) halign.
+  by exists sr; split.
+Qed.
+
+Lemma zbetween_zone_zbetween sr1 sr2 ty1 ty2 :
+  wf_sub_region sr1 ty1 ->
+  wf_sub_region sr2 ty2 ->
+  sr_region sr1 = sr_region sr2 ->
+  zbetween_zone (sub_zone_at_ofs (sr_zone sr1) (Some 0) (size_of ty1))
+                (sub_zone_at_ofs (sr_zone sr2) (Some 0) (size_of ty2)) ->
+  zbetween (sub_region_addr sr1) (size_of ty1) (sub_region_addr sr2) (size_of ty2).
+Proof.
+  move=> hwf1 hwf2 heq.
+  rewrite /zbetween_zone /zbetween !zify /=.
+  rewrite (wunsigned_sub_region_addr hwf1).
+  rewrite (wunsigned_sub_region_addr hwf2).
+  rewrite heq.
+  by lia.
+Qed.
+
+(* A version of [write_read8] easier to use. *)
+Lemma write_read8_no_overflow mem1 mem2 p ofs ws (w: word ws) :
+  0 <= ofs /\ ofs + wsize_size ws <= wbase Uptr ->
+  write mem1 (p + wrepr _ ofs)%R w = ok mem2 ->
+  forall k, 0 <= k < wbase Uptr ->
+    read mem2 (p + wrepr _ k)%R U8 =
+      let i := k - ofs in
+      if (0 <=? i) && (i <? wsize_size ws) then ok (LE.wread8 w i)
+      else read mem1 (p + wrepr _ k)%R U8.
+Proof.
+  move=> hofs hmem2 k hk.
+  rewrite (write_read8 hmem2).
+  rewrite subE {1}(GRing.addrC p) GRing.addrKA /=.
+  rewrite wunsigned_sub_if.
+  have hws := wsize_size_pos ws.
+  rewrite !wunsigned_repr_small //; last by lia.
+  case: (ZleP ofs k) => [//|hlt].
+  case: (ZleP 0 (k - ofs)) => [|_]; first by lia.
+  case: ZltP => [|_]; first by lia.
+  by rewrite andFb andbF.
+Qed.
+
+(* Hypotheses are a bit restrictive but are those available in the proofs. *)
+Lemma write_read8_sub_region mem1 mem2 sr ty ofs ws (w: word ws) :
+  wf_sub_region sr ty ->
+  0 <= ofs /\ ofs + wsize_size ws <= size_of ty ->
+  write mem1 (sub_region_addr sr + wrepr _ ofs)%R w = ok mem2 ->
+  forall k, 0 <= k < size_of ty ->
+    read mem2 (sub_region_addr sr + wrepr _ k)%R U8 =
+      let i := k - ofs in
+      if (0 <=? i) && (i <? wsize_size ws) then ok (LE.wread8 w i)
+      else read mem1 (sub_region_addr sr + wrepr _ k)%R U8.
+Proof.
+  move=> hwf hofs hmem2 k hk.
+  have := no_overflow_sub_region_addr hwf; rewrite /no_overflow !zify => hover.
+  have ? := wunsigned_range (sub_region_addr sr).
+  by apply: (write_read8_no_overflow _ hmem2); lia.
 Qed.
 
 Lemma alloc_lvalP rmap r1 r2 v ty m0 (s1 s2: estate) :
@@ -846,183 +1714,153 @@ Lemma alloc_lvalP rmap r1 r2 v ty m0 (s1 s2: estate) :
   exists s2', write_lval [::] r2.2 v s2 = ok s2' /\ valid_state r2.1 m0 s1' s2'.
 Proof.
   move=> ha hvs ?; subst ty.
-  case: r1 ha => /=.
+  case: r1 ha => //; rewrite /alloc_lval.
   (* Lnone *)
   + move=> vi ty1 [<-] /= s1' /write_noneP [->] h; exists s2; split => //.
     by rewrite /write_none; case: h => [ [? ->]| [-> ->]].
 
   (* Lvar *)
-  + move=> x; case hlx: get_local => [pk | ]; last first.
-    + t_xrbindP => ? /check_diffP hnnew <- s1'.
+  + move=> x.
+    case hlx: get_local => [pk | ]; last first.
+    + t_xrbindP=> _ /check_diffP hnnew <- s1' /=.
       rewrite /write_var; t_xrbindP => vm1 hvm1 <- /=.
       by apply: set_varP hvm1=> [v' hv <- | hb hv <-]; rewrite /write_var /set_var hv /= ?hb /=;
         eexists;(split;first by reflexivity); apply valid_state_set_var.
     case heq: is_word_type => [ws | //]; move /is_word_typeP : heq => hty.
-    case: eqP => htyv //; rewrite /write_var.
-    t_xrbindP => -[xi ei] ha rmap2 hsetw <- s1' vm1' hvm1' ?; subst s1' => /=.
+    case htyv: subtype => //; rewrite /= /write_var.
+    t_xrbindP => -[xi ei] ha sr hsr rmap2 hsetw <- /= s1' vm1' hvm1' ?; subst s1' => /=.
     have he1 : sem_pexpr [::] s2 0 >>= to_int = ok 0 by done.
-    have [mp [hgetr hins hal ->]] := set_wordP hsetw. 
-    have [wx [wi [-> -> /= <- hmpal]]]:= check_mk_addr_ptr hvs he1 hlx hgetr hal ha.
+    have hpk := sub_region_pk_valid rmap s2 hsr.
+    have [wx [wi [-> -> /= <-]]]:= check_mk_addr_ptr hvs he1 (wf_locals hlx) hpk ha.
     move: hvm1'; apply set_varP; last by rewrite {1}hty.
-    move=> {ha hsetw}; case: x hty hlx hgetr => -[xty xn] xii /= ->.
-    set x := {| vtype := sword ws; vname := xn |} => hlx hgetr /= w.
-    move=> /(type_of_val_to_pword htyv) [w' [??]] ?; subst v vm1' => /=.
-    rewrite truncate_word_u /= wrepr0 GRing.addr0.
-    assert (hmp := wfr_valid_mp hgetr).
-    have ha := valid_mp_addr hmp; have /= hab:= valid_mp_addr_bound hmp.
-    have hmpb := valid_mp_bound hmp; have hmsb:= @ms_bound (mp_s mp).
-    have hvp: valid_pointer (emem s2) (mp_addr mp) ws.
-    + apply Memory.is_align_valid_pointer => //.
-      move=> k hk.
-      rewrite /mp_addr -GRing.addrA -wrepr_add.
-      apply vs_val_ptr; split; first by apply ge0_wunsigned.
-      by apply: Z.le_lt_trans; first apply wunsigned_repr_le; lia.
-    have /Memory.writeV -/(_ w') [mem2 hmem2] := hvp.
+    move=> {ha}; case: x hty hlx hsetw => -[xty xn] xii /= ->.
+    set x := {| vtype := sword ws; vname := xn |} => hlx hsetw /= w hto <-.
+    have [ws' [w' [hle ??]]] := subtype_of_val_to_pword htyv hto; subst w v.
+    rewrite /= /truncate_word hle /=.
+    have hwf := sub_region_pk_wf hlx refl_equal hsr.
+    have hvp: validw (emem s2) (sub_region_addr sr + wrepr _ 0)%R ws.
+    + rewrite wrepr0 GRing.addr0.
+      have [halign _] := set_wordP hwf hsetw.
+      by apply (validw_sub_region_addr hvs hwf halign).
+    have /writeV -/(_ (zero_extend ws w')) [mem2 hmem2] := hvp.
     rewrite hmem2 /=; eexists;split;first by reflexivity.
     (* valid_state update word *)
-    case:(hvs) => vptr hdisj hrip hrsp hf heqvm hwfr heqg hnotm. 
-    have hbet: between (mp_addr mp) (size_of (vtype x)) (mp_addr mp) ws.
-    + by rewrite /between /x /= !Z.leb_refl.
-    constructor => //=.
-    + by move=> ???; rewrite (Memory.write_valid _ _ hmem2); apply vptr.
-    + by rewrite -(ss_frames (Memory.write_mem_stable hmem2)).
-    + move=> y hy; rewrite get_var_neq; first by apply heqvm.
-      by move=> heq;move: hy; rewrite -heq hlx.
-    + case: (hwfr) => h1 h2 h3; constructor => //=.
-      + move=> y mpy v /(check_gvalid_rset_word hins hgetr) [].
-        + move=> [ hng heq ?]; subst mpy.
-          have -> : y = mk_lvar {|v_var := x; v_info := v_info (gv y) |}.
-          + by case: y hng heq => -[yv vi] [] //= _ ->.
-          have /= -> // := @get_gvar_eq gd (mk_lvar {| v_var := x; v_info := v_info (gv y) |}) (evm s1) (ok w).
-          move=> [<-]; exists w';split;first by subst w.
-          by apply: Memory.writeP_eq hmem2.
-        move=> [hd hdm hcv]; rewrite get_gvar_neq // => /h2 -/(_ _ hcv) /=.
-        by apply: (eq_mp_val_write_disj hvs hgetr) hmem2.
-      by apply: wfr_PTR_rset_word hmem2 h3.
-    + by apply: (eq_glob_rset_word hvs hgetr) hmem2 heqg.
-    by apply: (eq_not_mod_rset_word hvs hgetr) hmem2 hnotm.
+    have [_ hset] := set_wordP hwf hsetw.
+    rewrite -to_pword_u.
+    have hofs: 0 <= 0 /\ size_of (sword ws) <= wsize_size ws by rewrite /=; lia.
+    have hofs' := ofs_bound_option hofs (fun _ => refl_equal).
+    apply: (valid_state_set_sub_region hvs hwf hlx hpk hofs' _ _ _ hset (v:=Vword (zero_extend ws w'))).
+    + by apply (Memory.write_mem_stable hmem2).
+    + by move=> ??; apply (write_validw_eq hmem2).
+    + move=> p ws''.
+      rewrite -sub_region_addr_offset.
+      by apply (writeP_neq hmem2).
+    split => //.
+    move=> off hmem w hget.
+    have /= hoff := get_val_byte_bound hget.
+    rewrite (write_read8_sub_region hwf hofs hmem2 hoff) Z.sub_0_r /=.
+    move: (hoff); rewrite -!zify => ->.
+    by rewrite -(get_val_byte_word _ hoff).
 
   (* Lmem *)
-  + move=> ws x e1; t_xrbindP => ? /check_varP hx e1' /(alloc_eP hvs) he1 <-.
-    move=> s1' xp ? hgx hxp w1 v1 /he1 he1' hv1 w hvw mem2 hw <- /=.
-    have := get_var_kindP hvs hx; rewrite /get_gvar /= => /(_ _ hgx) -> /=.
+  + move=> ws x e1 /=; t_xrbindP => _ /check_varP hx _ /check_diffP hnnew e1' /(alloc_eP hvs) he1 <-.
+    move=> s1' xp ? hgx hxp w1 v1 /he1 he1' hv1 w hvw mem1 hmem1 <- /=.
+    have := get_var_kindP hvs hx hnnew; rewrite /get_gvar /= => /(_ _ hgx) -> /=.
     rewrite he1' hxp /= hv1 /= hvw /=.
-    have hvp1 := write_mem_valid_pointer hw.
-    have hvp2: valid_pointer (emem s2) (xp + w1) ws.
-    + by apply /Memory.readV; assert (h := vs_eq_mem hvp1); rewrite -h; apply /Memory.readV.
-    have /Memory.writeV  -/(_ w) [mem2' hmem2] := hvp2.
+    have hvp1 := write_validw hmem1.
+    have /valid_incl_word hvp2 := hvp1.
+    have /writeV -/(_ w) [mem2 hmem2] := hvp2.
     rewrite hmem2 /=; eexists;split;first reflexivity.
     (* valid_state update mem *)
-    case:(hvs) => vptr hdisj hrip hrsp hf heqvm hwfr heqg hnotm. 
-    have ha1 := Memory.valid_align hvp1.
-    have hno1 := is_align_no_overflow ha1.
+    case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
     constructor => //=.
-    + by move=> ???; rewrite (Memory.write_valid _ _ hmem2); apply vptr.
-    + by move=> ??; rewrite (Memory.write_valid _ _ hw); apply hdisj.
-    + by rewrite -(ss_frames (Memory.write_mem_stable hmem2)).
-    + case: (hwfr) => h1 h2 h3; constructor => //=.
-      + move=> y mpy vy hcv hgy.
-        have hmp := check_gvalid_mp hvs hcv.
-        apply: (disjoint_eq_mp_val hmp _ hmem2 (h2 _ _ _ hcv hgy)).
-        have hb1 := valid_mp_addr_bound hmp; have hb2 := @ms_bound (mp_s mpy).
-        split => //.
-        + by rewrite /no_overflow !zify; lia.
-        by have:= hdisj _ _ (mp_s mpy) hvp1; lia.
-      move=> y mpy hgy.
-      have [pk [hgpk hvpk]] := h3 _ _ hgy; exists pk; split => //.
-      case: pk hgpk hvpk => //= ofs /get_local_pos_sptr hgpk <-.
-      apply: (Memory.writeP_neq hmem2).
-      have h := sptr_addr_bound hgpk; split => //.
-      + rewrite /no_overflow !zify; lia.
-      by have:= hdisj _ _ MSstack hvp1; rewrite /wptr /wptr_size /=; lia.
-    + move=> w2 sz; rewrite (Memory.write_valid _ _ hw) => hv.
-      by apply: Memory.read_write_any_mem (hw) (hmem2) => //; apply heqg.
-    move=> ofs hofs hl; rewrite hnotm //.
-    symmetry; apply: (Memory.writeP_neq hmem2).
-    split => //.
-    + by rewrite /no_overflow zify wsize8; have := wunsigned_range (rsp + wrepr U64 ofs); lia.
-    rewrite wsize8 wunsigned_add; last by have := @ge0_wunsigned _ rsp; lia.
-    by have:= hdisj _ _ MSstack hvp1; rewrite /wptr /wptr_size /=; lia.
-  
+    + move=> ??; rewrite (write_validw_eq hmem2); apply hvalid.
+    + by move=> ???; rewrite (write_validw_eq hmem1); apply hdisj.
+    + move=> ?; rewrite (write_validw_eq hmem1) (write_validw_eq hmem2); apply hincl.
+    + move=> ?; rewrite (write_validw_eq hmem2); apply hincl2.
+    + move=> p hvalid2; rewrite (write_validw_eq hmem1) => hvalid3 hdisj2.
+      rewrite (hunch p hvalid2 hvalid3 hdisj2).
+      symmetry; apply (writeP_neq hmem2).
+      by apply (disjoint_range_valid_not_valid_U8 hvp1 hvalid3).
+    + case: (hwfr) => hwfsr hval hptr; split=> //.
+      + move=> y sry bytes vy hgvalid hgy.
+        assert (hwfy := check_gvalid_wf hwfsr hgvalid).
+        have hreadeq := writeP_neq hmem2.
+        apply: (eq_sub_region_val_disjoint_zrange hreadeq _ (hval _ _ _ _ hgvalid hgy)).
+        apply disjoint_zrange_sym.
+        apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwfy)).
+        by apply: disjoint_source_word hwfy.(wfr_slot) hvp1.
+      move=> y sry hgy.
+      have [pk [hgpk hvpk]] := hptr _ _ hgy; exists pk; split => //.
+      case: pk hgpk hvpk => //= s ofs ws' z f hgpk hread /hread <-.
+      apply: (writeP_neq hmem2).
+      assert (hwf' := sub_region_stkptr_wf (wf_locals hgpk)).
+      apply disjoint_zrange_sym.
+      apply: (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf')).
+      by apply: disjoint_source_word hwf'.(wfr_slot) hvp1.
+    + move=> p; rewrite (write_validw_eq hmem1) => hv.
+      apply: read_write_any_mem hmem1 hmem2.
+      by apply heqmem.
+    by rewrite -(Memory.write_mem_stable hmem2).(ss_top_stack).
+
   (* Laset *)
-  move=> aa ws x e1; t_xrbindP => e1' /(alloc_eP hvs) he1.
+  move=> aa ws x e1 /=; t_xrbindP => e1' /(alloc_eP hvs) he1.
   move=> hr2 s1'; apply on_arr_varP => n t hty hxt.
   t_xrbindP => i1 v1 /he1 he1' hi1 w hvw t' htt' vm1 hvm1 ?; subst s1'.
   case hlx: get_local hr2 => [pk | ]; last first.
-  + t_xrbindP => ? /check_diffP hnnew <-.
-    have /get_var_kindP -/(_ _ hxt) : get_var_kind pmap (mk_lvar x) = ok None.
+  + t_xrbindP=> _ /check_diffP hnnew <-.
+    have /get_var_kindP -/(_ _ hnnew hxt) : get_var_kind pmap (mk_lvar x) = ok None.
     + by rewrite /get_var_kind /= hlx.
     rewrite /get_gvar /= => hxt2.
     rewrite he1' /= hi1 hxt2 /= hvw /= htt' /=.
     apply: set_varP hvm1=> [v' hv <- | ]; last by rewrite {1} hty.
     rewrite /set_var hv /=.
-    by eexists;(split;first by reflexivity); apply valid_state_set_var. 
-  t_xrbindP => mp hc -[xi ei] ha rmap2 hsetw <- /=.
+    by eexists;(split;first by reflexivity); apply valid_state_set_var.
+  t_xrbindP => rmap2 /set_arr_wordP [sr [hget hal hset]] [xi ei] ha <- /=.
   have {he1} he1 : sem_pexpr [::] s2 e1' >>= to_int = ok i1 by rewrite he1'.
-  have [mp' [hgetr hins hal ->]] := set_wordP hsetw. 
-  have ? : mp = mp'.
-  + by move /check_validP : hc; rewrite hgetr => -[[->]].
-  subst mp'.
-  have [wx [wi [-> -> /= <- hmpal]]]:= check_mk_addr_ptr hvs he1 hlx hgetr hal ha.
+  have /wfr_ptr [pk' [hlx' hpk]] := hget.
+  have hgvalid := check_gvalid_lvar hget.
+  move: hlx'; rewrite hlx => -[?]; subst pk'.
+  have [wx [wi [-> -> /= <-]]]:= check_mk_addr_ptr hvs he1 (wf_locals hlx) hpk ha.
   move: hvm1; apply set_varP; last by rewrite {1}hty.
-  move=> {ha hsetw}; case: x hty hlx hxt hc hgetr => -[xty xn] xii /= ->.
-  set x := {| vtype := sarr n; vname := xn |} => hlx hxt hc hgetr /= ti [?] ?; subst ti vm1.
+  move=> {ha}; case: x hty hlx hxt hget hset hgvalid => -[xty xn] xii /= ->.
+  set x := {| vtype := sarr n; vname := xn |} => hlx hxt hget hset hgvalid /= ti <- ?; subst vm1.
   rewrite hvw /=.
+  have /wfr_wf hwf := hget.
   have [hge0 hlen haa] := WArray.set_bound htt'.
-  assert (hmp := wfr_valid_mp hgetr).
-  have ha := valid_mp_addr hmp; have /= hab:= valid_mp_addr_bound hmp.
-  have /= hmpb := valid_mp_bound hmp; have hmsb:= @ms_bound (mp_s mp).
-  have hvp: valid_pointer (emem s2) (mp_addr mp + wrepr Uptr (i1 * mk_scale aa ws)) ws.
-  + apply Memory.is_align_valid_pointer. 
-    + by apply is_align_add => //; apply arr_is_align. 
-    move=> k hk; rewrite /mp_addr -!GRing.addrA -!wrepr_add.
-    apply vs_val_ptr; split; first by apply ge0_wunsigned.
-    by apply: Z.le_lt_trans; first apply wunsigned_repr_le; lia.
-  have /Memory.writeV -/(_ w) [mem2 hmem2] := hvp.
+  have hvp: validw (emem s2) (sub_region_addr sr + wrepr _ (i1 * mk_scale aa ws))%R ws.
+  + apply (validw_sub_region_at_ofs _ hwf (conj hge0 hlen)).
+    apply is_align_add => //.
+    by rewrite WArray.arr_is_align.
+  have /writeV -/(_ w) [mem2 hmem2] := hvp.
   rewrite hmem2 /=; eexists;split;first by reflexivity.
   (* valid_state update array *)
-  have hgt0ws := wsize_size_pos ws; have ge0_mps := @ge0_wunsigned _ (wptr (mp_s mp)).
-  have heqa : wunsigned (mp_addr mp + wrepr U64 (i1 * mk_scale aa ws)) = 
-              wunsigned (mp_addr mp) + i1 * mk_scale aa ws.
-  + by apply wunsigned_add; lia.
-  case:(hvs) => vptr hdisj hrip hrsp hf heqvm hwfr heqg hnotm. 
-  have hbet: between (mp_addr mp) (size_of (vtype x)) (mp_addr mp + wrepr U64 (i1 * mk_scale aa ws)) ws.
-  + by rewrite /between /x /= !zify; lia.
-  constructor => //=.
-  + by move=> ???; rewrite (Memory.write_valid _ _ hmem2); apply vptr.
-  + by rewrite -(ss_frames (Memory.write_mem_stable hmem2)).
-  + move=> y hy; rewrite get_var_neq; first by apply heqvm.
-    by move=> heq;move: hy; rewrite -heq hlx.
-  + case: (hwfr) => h1 h2 h3; constructor => //=.
-    + move=> y mpy vy /(check_gvalid_rset_word hins hgetr) [].
-      + move=> [ hng heq ?]; subst mpy.
-        have -> : y = mk_lvar {|v_var := x; v_info := v_info (gv y) |}.
-        + by case: y hng heq => -[yv vi] [] //= _ ->.
-        set X := (mk_lvar {| v_var := x; v_info := v_info (gv y) |}).
-        have /= -> // := @get_gvar_eq gd X (evm s1) (ok (WArray.inject n t')).
-        move=> [<-]; eexists (WArray.inject n t');split => //.
-        move=> off hoff v0.
-        have -> :  WArray.get AAscale U8 (WArray.inject n t') off = WArray.get AAscale U8 t' off.
-        + by rewrite /WArray.inject Z.ltb_irrefl.
-        rewrite Z.add_comm wrepr_add GRing.addrA -/(mp_addr mp) (WArray.set_get8 off htt') /=.
-        have -> /= := Memory.write_read8 (mp_addr mp + wrepr U64 off) hmem2.
-        set t1 := (x in (if x then _ else _)).
-        set t2 := (x in _ -> (if x then _ else _) = _).
-        have <- : t1 = t2.
-        + rewrite Bool.eq_iff_eq_true -/(is_true t1) -/(is_true t2) /t1 /t2 !zify.
-          by rewrite !(@wunsigned_add _ (mp_addr mp)); lia.
-        case:ifPn; rewrite /t1 !zify => hi {t1 t2}.
-        + move=> [<-]; do 2 f_equal; rewrite !(@wunsigned_add _ (mp_addr mp)); lia.
-        move=> hh; have hcg : check_gvalid rmap X = Some mp.
-        + by rewrite /check_gvalid /= hc.
-        have /= [t1 [/Varr_inj]]:= h2 _ _ _ hcg hxt.
-        move=> [heq1]; rewrite (Eqdep_dec.UIP_dec Pos.eq_dec heq1 erefl) /= => ?; subst t1 => {heq1}.
-        by move=> /(_ _ hoff _ hh) <-; rewrite Z.add_comm wrepr_add GRing.addrA -/(mp_addr mp).
-      move=> [hd hdm hcv]; rewrite get_gvar_neq // => /h2 -/(_ _ hcv) /=.
-      by apply: (eq_mp_val_write_disj hvs hgetr) hmem2.
-    by apply: wfr_PTR_rset_word hmem2 h3.
-  + by apply: (eq_glob_rset_word hvs hgetr) hmem2 heqg.
-  by apply: (eq_not_mod_rset_word hvs hgetr) hmem2 hnotm.
+  have hofs: 0 <= i1 * mk_scale aa ws /\ i1 * mk_scale aa ws + size_of (sword ws) <= size_slot x.
+  + done.
+  have hofs' := ofs_bound_option hofs (mk_ofsiP he1).
+  have hvalideq := write_validw_eq hmem2.
+  apply: (valid_state_set_sub_region hvs hwf hlx hpk hofs' _ hvalideq _ hset (v:=Varr t')).
+  + by apply (Memory.write_mem_stable hmem2).
+  + move=> p ws' hdisj.
+    apply (writeP_neq hmem2).
+    apply: disjoint_zrange_incl_l hdisj.
+    by apply: (zbetween_sub_region_at_ofs_option hwf _ (mk_ofsiP he1)).
+  split=> //.
+  move=> off hmem w0 hget'.
+  have /= hoff := get_val_byte_bound hget'.
+  rewrite (write_read8_sub_region hwf hofs hmem2 hoff) /=.
+  move: hget'; rewrite /= (write_read8 htt') WArray.subE /=.
+  case: ifP => // hle.
+  assert (hval := wfr_val hgvalid hxt).
+  case: hval => hread _.
+  apply hread.
+  move: hset hmem => /set_sub_regionP [_ ->] /=.
+  rewrite get_var_bytes_set_pure_bytes !eq_refl /=.
+  case heq: mk_ofsi => [ofs'|//].
+  have := mk_ofsiP he1 (aa:=aa) (sz:=ws).
+  rewrite heq => /(_ ltac:(discriminate)) [->].
+  rewrite ByteSet.addE => /orP [|//].
+  by move /andP : hle; rewrite /I.memi /= !zify; lia.
 Qed.
 
 Lemma alloc_lvalsP rmap r1 r2 vs ty m0 (s1 s2: estate) :
@@ -1041,1039 +1879,1956 @@ Proof.
   by exists s2''; split => //=; rewrite hs2'.
 Qed.
 
-
-
-(*Hypothesis P
-
-Let P' : sprog := 
-    {| p_globs := [::];
-       p_funcs := SP;
-       p_extra := {|
-         sp_rip := gm.(stack_alloc.rip); 
-         sp_globs := data; 
-         sp_stk_id := nrsp |}
-    |}. *)
-
 Variable (P' : sprog).
 Hypothesis P'_globs : P'.(p_globs) = [::].
-Variable (m0:mem).
 
-Let Pi_r s1 (i1:instr_r) s2 :=
-  forall rmap1 rmap2 ii1 ii2 i2, alloc_i pmap rmap1 (MkI ii1 i1) = ok (rmap2, MkI ii2 i2) ->
-  forall s1', valid_state rmap1 m0 s1 s1' ->
-  exists s2', sem_i (sCP:= sCP_stack) P' rip s1' i2 s2' /\ valid_state rmap2 m0 s2 s2'.
+Local Opaque arr_size.
 
-Let Pi s1 (i1:instr) s2 :=
-  forall rmap1 rmap2 i2, alloc_i pmap rmap1 i1 = ok (rmap2, i2) ->
-  forall s1', valid_state rmap1 m0 s1 s1' ->
-  exists s2', sem_I (sCP:= sCP_stack) P' rip s1' i2 s2' /\ valid_state rmap2 m0 s2 s2'.
-
-Let Pc s1 (c1:cmd) s2 :=
-  forall rmap1 rmap2 c2,  fmapM (alloc_i pmap) rmap1 c1 = ok (rmap2, c2) ->
-  forall s1', valid_state rmap1 m0 s1 s1' ->
-  exists s2', sem (sCP:= sCP_stack) P' rip s1' c2 s2' /\ valid_state rmap2 m0 s2 s2'.
-
-Let Pfor (i1: var_i) (vs: seq Z) (s1: estate) (c: cmd) (s2: estate) := True.
-
-Let Pfun (m1: mem) (fn: funname) (vargs: seq value) (m2: mem) (vres: seq value) := True.
-
-Local Lemma Hskip : sem_Ind_nil Pc.
+Lemma get_ofs_subP gd s i aa ws e ofs :
+  sem_pexpr gd s e >>= to_int = ok i ->
+  get_ofs_sub aa ws e = ok ofs ->
+  ofs = i * mk_scale aa ws.
 Proof.
-  move=> s rmap1 rmap2 /= c2 [??] s' hv;subst rmap1 c2.
-  exists s'; split => //; exact: Eskip. 
+  move=> he; rewrite /get_ofs_sub.
+  case heq: mk_ofsi => [ofs'|//] [<-].
+  have := mk_ofsiP he (aa:=aa) (sz:=ws).
+  by rewrite heq; move=> /(_ ltac:(discriminate)) [->].
 Qed.
 
-Local Lemma Hcons : sem_Ind_cons P ev Pc Pi.
+Lemma get_var_bytes_set_move_bytes rmap x sr r y :
+  get_var_bytes (set_move_bytes rmap x sr) r y =
+    let bytes := get_var_bytes rmap r y in
+    if sr_region sr != r then
+      bytes
+    else
+      if x == y then
+        ByteSet.add (interval_of_zone sr.(sr_zone)) bytes
+      else bytes.
 Proof.
-  move=> s1 s2 s3 i c _ Hi _ Hc sm1 _sm3 c1 /=;t_xrbindP => -[sm2 i'] hi [sm3 c'] hc /= ?? s1' hv. 
-  subst c1 _sm3.
-  have [s2' [si hv2]]:= Hi _ _ _ hi _ hv.
-  have [s3' [sc hv3]]:= Hc _ _ _ hc _ hv2.
-  exists s3'; split => //; apply: Eseq; [exact: si|exact: sc].
+  rewrite /set_move_bytes /get_var_bytes get_bytes_map_setP.
+  case: eqP => //= <-.
+  rewrite get_bytes_setP.
+  by case: eqP => //= <-.
 Qed.
 
-Local Lemma HmkI : sem_Ind_mkI P ev Pi_r Pi.
+Lemma check_gvalid_set_move rmap x sr y sry bytes :
+  check_gvalid (set_move rmap x sr) y = Some (sry, bytes) ->
+    [/\ ~ is_glob y, x = gv y, sr = sry &
+        bytes = get_var_bytes (set_move_bytes rmap x sr) sr.(sr_region) x]
+  \/
+    [/\ ~ is_glob y -> x <> gv y &
+        check_gvalid rmap y = Some (sry, bytes)].
 Proof.
-  move=> ii i s1 s2 _ Hi sm1 sm2 [ii' ir'] ha s1' hv.
-  by have [s2' [Hs2'1 Hs2'2]] := Hi _ _ _ _ _ ha _ hv; exists s2'; split.
-Qed.
-(*
-Lemma alloc_assgnP s1 s2 x tag ty e v v' ii1 ii2 i2 sm1 sm2:
-  sem_pexpr gd s1 e = ok v -> 
-  truncate_val ty v = ok v' -> 
-  write_lval gd x v' s1 = ok s2 -> 
-  Let ir := alloc_assgn nrsp gm sm1 ii1 x tag ty e in ok (ir.1, MkI ii1 ir.2) = ok (sm2, MkI ii2 i2) ->
-  forall s1', valid sm1 s1 s1' → 
-   ∃ s2', sem_i (sCP:= sCP_stack) P' rip s1' i2 s2' ∧ valid sm2 s2 s2'.
-Proof.
-  move=> hv htr Hw; rewrite /alloc_assgn.
-  t_xrbindP => -[sm i'] e'; apply: add_iinfoP => he [sm' x'].
-  apply: add_iinfoP => ha /= [?] ???? s1' hs1; subst i' sm sm' ii1 i2.
-  have [v1 [He' Uvv1]] := alloc_eP he hs1 hv.
-  have [v1' htr' Uvv1']:= truncate_value_uincl Uvv1 htr.
-  have hty := truncate_val_has_type htr.
-  have [s2' [Hw' Hs2']] := alloc_lvalP ha hs1 hty Uvv1' Hw.
-  by exists s2'; split=> //;apply: Eassgn;eauto.
+  rewrite /check_gvalid.
+  case: (@idP (is_glob y)) => hg.
+  + case heq: Mvar.get => [[ofs ws]|//] [<- <-].
+    by right; split.
+  rewrite Mvar.setP; case: eqP.
+  + by move=> -> [<- <-]; left; split.
+  move=> hneq.
+  case heq': Mvar.get => [sr'|//] [? <-]; subst sr'.
+  right; split => //.
+  rewrite get_var_bytes_set_move_bytes.
+  case: eqP => [_|//].
+  by move: hneq=> /eqP /negPf ->.
 Qed.
 
-  Lemma is_arr_typeP ty : is_arr_type ty -> exists n, ty = sarr n.
-  Proof. case ty => //;eauto. Qed.
+Lemma set_arr_subP rmap x ofs len sr_from rmap2 :
+  set_arr_sub rmap x ofs len sr_from = ok rmap2 ->
+  exists sr, [/\
+    Mvar.get rmap.(var_region) x = Some sr,
+    sub_region_at_ofs sr (Some ofs) len = sr_from &
+    set_move_sub rmap x (sub_region_at_ofs sr (Some ofs) len) = rmap2].
+Proof.
+  rewrite /set_arr_sub.
+  t_xrbindP=> sr /get_sub_regionP -> _ /assertP /eqP heqsub hmove.
+  by exists sr.
+Qed.
 
-  Lemma is_varP e y: is_var e = Some y -> e = Pvar y.
-  Proof. by case e => // ? [->]. Qed.
+Lemma check_gvalid_set_move_sub rmap x sr y sry bytes :
+  check_gvalid (set_move_sub rmap x sr) y = Some (sry, bytes) ->
+    ([/\ ~ is_glob y, x = gv y, Mvar.get rmap.(var_region) x = Some sry &
+         bytes = get_var_bytes (set_move_sub rmap x sr) sry.(sr_region) x]
+  \/
+    [/\ ~ is_glob y -> x <> gv y &
+        check_gvalid rmap y = Some (sry, bytes)]).
+Proof.
+  rewrite /check_gvalid.
+  case: (@idP (is_glob y)) => hg.
+  + case heq: Mvar.get => [[ofs' ws]|//] [<- <-].
+    by right; split.
+  case heq: Mvar.get => [sr'|//] [? <-]; subst sr'.
+  case: (x =P y.(gv)).
+  + move=> ?; subst x.
+    by left.
+  move=> hneq.
+  right; split=> //.
+  rewrite get_var_bytes_set_move_bytes.
+  case: eqP => //= _.
+  by move: hneq=> /eqP /negPf ->.
+Qed.
 
-  Lemma find_gvar_set sm x ap z: 
-    find_gvar gm (Mvar.set sm x ap) z = 
-      if is_lvar z && (x == gv z) then Some (mp_of_ap ap) else find_gvar gm sm z.
-  Proof.
-    by rewrite /find_gvar; case: ifP => //= ?; rewrite Mvar.setP; case: ifP.
-  Qed.
+Lemma type_of_get_gvar_array gd vm x n (a : WArray.array n) :
+  get_gvar gd vm x = ok (Varr a) ->
+  x.(gv).(vtype) = sarr n.
+Proof.
+  move=> hget.
+  have hnword: ~ is_sword x.(gv).(vtype).
+  + by have [? [-> _]] := subtypeEl (type_of_get_gvar hget).
+  by have := type_of_get_gvar_not_word hnword hget.
+Qed.
+
+Lemma get_Pvar_sub_bound s1 v e y suby ofs len :
+  sem_pexpr gd s1 e = ok v ->
+  get_Pvar_sub e = ok (y, suby) ->
+  match suby with
+  | Some p => p
+  | None => (0, size_slot y.(gv))
+  end = (ofs, len) ->
+  0 < len /\
+  0 <= ofs /\ ofs + len <= size_slot y.(gv).
+Proof.
+  case: e => //=.
+  + move=> _ _ [_ <-] [<- <-].
+    split; first by apply size_of_gt0.
+    by lia.
+  move=> aa ws len' x e'.
+  apply: on_arr_gvarP.
+  t_xrbindP=> n _ hty _ i v' he' hv' _ /WArray.get_sub_bound hbound _ ofs' hofs' <- <- [<- <-].
+  split=> //.
+  rewrite hty.
+  have {he' hv'} he' : sem_pexpr gd s1 e' >>= to_int = ok i by rewrite he'.
+  by move: hofs' => /(get_ofs_subP he') ->.
+Qed.
+
+Lemma get_Pvar_subP s1 n (a : WArray.array n) e y ofsy ofs len :
+  sem_pexpr gd s1 e = ok (Varr a) ->
+  get_Pvar_sub e = ok (y, ofsy) ->
+  match ofsy with
+  | None => (0%Z, size_slot y.(gv))
+  | Some p => p
+  end = (ofs, len) ->
+  n = Z.to_pos len /\
+  exists (t : WArray.array (Z.to_pos (size_slot y.(gv)))),
+    get_gvar gd (evm s1) y = ok (Varr t) /\
+    (forall i w, read a i U8 = ok w -> read t (ofs + i) U8 = ok w).
+Proof.
+  case: e => //=.
+  + move=> y' hget [? <-] [<- ?]; subst y' len.
+    have -> := type_of_get_gvar_array hget.
+    split=> //.
+    by exists a; split.
+  move=> aa ws len' x e.
+  apply: on_arr_gvarP.
+  move=> n1 a1 hty hget.
+  (* We manually apply [rbindP], because [t_xrbindP] is a bit too aggressive. *)
+  apply: rbindP => i he.
+  apply: rbindP => a2 hgsub heq.
+  have := Varr_inj (ok_inj heq) => {heq} -[?]; subst n => /= ?; subst a2.
+  t_xrbindP=> _ /(get_ofs_subP he) -> <- <- [<- <-].
+  split=> //.
+  rewrite hty.
+  exists a1; split=> //.
+  move=> k w.
+  move=> /dup[]; rewrite -{1}get_read8 => /WArray.get_valid8 /WArray.in_boundP => hbound.
+  rewrite (WArray.get_sub_get8 hgsub) /=.
+  by move: hbound; rewrite -!zify => ->.
+Qed.
+
+Lemma is_stack_ptrP vpk s ofs ws z f :
+  is_stack_ptr vpk = Some (s, ofs, ws, z, f) ->
+  vpk = VKptr (Pstkptr s ofs ws z f).
+Proof.
+  case: vpk => [|[]] => //=.
+  by move=> _ _ _ _ _ [-> -> -> -> ->].
+Qed.
+
+(* is mk_addr_pexpr a good name ?
+   could be pexpr_addr_from_vpk ?
 *)
-
-Lemma is_sarrP ty : reflect (exists n, ty = sarr n) (is_sarr ty).
+Lemma mk_addr_pexprP rmap m0 s1 s2 (x : var_i) vpk sr e1 ofs :
+  valid_state rmap m0 s1 s2 ->
+  wf_vpk x vpk ->
+  valid_vpk rmap s2 x sr vpk ->
+  mk_addr_pexpr pmap rmap x vpk = ok (e1, ofs) ->
+  exists w,
+    sem_pexpr [::] s2 e1 >>= to_pointer = ok w /\
+    sub_region_addr sr = (w + wrepr _ ofs)%R.
 Proof.
-  case: ty => /= [||n|ws]; constructor; try by move => -[].
-  by exists n.
+  move=> hvs hwfpk hpk.
+  rewrite /mk_addr_pexpr.
+  case heq: is_stack_ptr => [[[[[s ws] ofs'] z] f]|]; last first.
+  + by t_xrbindP=> -[x' ofs'] /(addr_from_vpkP hvs hwfpk hpk) haddr <- <-.
+  move /is_stack_ptrP in heq; subst vpk.
+  rewrite /= in hpk hwfpk.
+  t_xrbindP=> _ /assertP /hpk hread <- <- /=.
+  rewrite (sub_region_addr_stkptr hwfpk) in hread.
+  rewrite vs_rsp /= !zero_extend_u hread /= truncate_word_u.
+  eexists; split; first by reflexivity.
+  by rewrite wrepr0 GRing.addr0.
 Qed.
 
-Lemma get_set_region rmap x mp y :
-  Mvar.get (var_region (set rmap x mp)) y = 
-  if x == y then Some mp else Mvar.get (var_region rmap) y.
-Proof. rewrite /set /= Mvar.setP; case: ifPn => // hne. Qed.
-
-Lemma set_VALID rmap x mp: 
-  valid_mp mp (vtype x) -> wfr_VALID rmap -> wfr_VALID (set rmap x mp).    
+(* Alternative form of cast_get8, easier to use in our case *)
+Lemma cast_get8 len1 len2 (m : WArray.array len2) (m' : WArray.array len1) :
+  WArray.cast len1 m = ok m' ->
+  forall k w,
+    read m' k U8 = ok w ->
+    read m k U8 = ok w.
 Proof.
-  by move=> hv hV y mpy; rewrite get_set_region; case: eqP => [<- [<-]| _ /hV ].
+  move=> hcast k w.
+  move=> /dup[]; rewrite -{1}get_read8 => /WArray.get_valid8 /WArray.in_boundP => hbound.
+  rewrite (WArray.cast_get8 hcast).
+  by case: hbound => _ /ZltP ->.
 Qed.
 
-Lemma check_gvalid_set rmap x mp y: 
-  check_gvalid (set rmap x mp) y = 
-    if (x == (gv y)) && ~~is_glob y then Some mp 
-    else check_gvalid rmap y.
+Lemma valid_pk_set_move (rmap:region_map) s2 x sr y pk sry :
+  ~ Sv.In x pmap.(vnew) ->
+  wf_local y pk ->
+  valid_pk rmap s2 sry pk ->
+  valid_pk (set_move rmap x sr) s2 sry pk.
 Proof.
-  rewrite /check_gvalid; case: ifPn => ? /=; first by rewrite andbF.
-  rewrite andbT /check_valid get_set_region; case: eqP => [-> | hne].
-  + by rewrite /set /= Mmp.setP_eq SvP.add_mem_1.
-  case: Mvar.get => // mpy.
-  rewrite /set /= Mmp.setP; case: eqP => // <-.
-  by rewrite SvD.F.add_neq_b //; case: Mmp.get.
+  move=> hnnew hlocal.
+  case: pk hlocal => //=.
+  move=> s ofs ws z f hlocal.
+  rewrite /check_stack_ptr get_var_bytes_set_move_bytes.
+  case: eqP => [_|//].
+  case: eqP => //.
+  by have := hlocal.(wfs_new); congruence.
 Qed.
 
-Lemma set_VAL rmap x mp v s s': 
-  eq_mp_val (vtype x) (emem s') mp (pto_val v) ->
-  wfr_VAL rmap s s' -> 
-  wfr_VAL (set rmap x mp) (with_vm s (evm s).[x <- ok v]) s'.
+Lemma wfr_VAL_set_move rmap s1 s2 x sr v :
+  eq_sub_region_val x.(vtype) (emem s2) sr (get_var_bytes (set_move rmap x sr) sr.(sr_region) x) v ->
+  wfr_VAL rmap s1 s2 ->
+  wfr_VAL (set_move rmap x sr) (with_vm s1 (evm s1).[x <- pof_val x.(vtype) v]) s2.
 Proof.
-  move=> hv hV y mpy vy; rewrite check_gvalid_set.
-  case: ifPn => [ /andP[]/eqP heq /negP ? [<-]| ].
-  + by subst x; rewrite get_gvar_eq /= => [[<-]| ].
-  move=> h /hV hc;rewrite get_gvar_neq => [/hc // |/negP hn ].
-  by move: h;rewrite hn andbT => /eqP. 
+  move=> heqval hval y sry bytesy vy /check_gvalid_set_move [].
+  + move=> [? ? <- ->]; subst x.
+    rewrite get_gvar_eq //.
+    case: heqval => hread hty'.
+    apply on_vuP => //; rewrite -hty'.
+    by move => ? hof hto; rewrite -hto (pto_val_pof_val hof) hty'.
+  move=> [? hgvalid].
+  rewrite get_gvar_neq => //.
+  by apply hval.
 Qed.
 
-Lemma type_of_get_var x vm v: get_var vm x = ok v → subtype (type_of_val v) (vtype x).
+Lemma wfr_PTR_set_move (rmap : region_map) s2 x pk sr :
+  get_local pmap x = Some pk ->
+  valid_pk rmap s2 sr pk ->
+  wfr_PTR rmap s2 ->
+  wfr_PTR (set_move rmap x sr) s2.
 Proof.
-  rewrite /get_var; apply on_vuP => // v' _ <-; apply subtype_type_of_val.
+  move=> hlx hpk hptr y sry.
+  have /wf_vnew hnnew := hlx.
+  rewrite Mvar.setP; case: eqP.
+  + move=> <- [<-].
+    exists pk; split=> //.
+    by apply (valid_pk_set_move _ hnnew (wf_locals hlx) hpk).
+  move=> _ /hptr {pk hlx hpk} [pk [hly hpk]].
+  exists pk; split=> //.
+  by apply (valid_pk_set_move _ hnnew (wf_locals hly) hpk).
 Qed.
 
-Lemma type_of_get_gvar x gd vm v: get_gvar gd vm x = ok v → subtype (type_of_val v) (vtype (gv x)).
+(* There are several lemmas about [set_move] and [valid_state], and all are useful. *)
+Lemma valid_state_set_move rmap m0 s1 s2 x sr pk v :
+  valid_state rmap m0 s1 s2 ->
+  wf_sub_region sr x.(vtype) ->
+  get_local pmap x = Some pk ->
+  valid_pk rmap.(region_var) s2 sr pk ->
+  eq_sub_region_val x.(vtype) (emem s2) sr (get_var_bytes (set_move rmap x sr) sr.(sr_region) x) v ->
+  valid_state (set_move rmap x sr) m0 (with_vm s1 (evm s1).[x <- pof_val x.(vtype) v]) s2.
 Proof.
-  by rewrite /get_gvar; case: ifPn => [ ? /type_of_get_var | ? /type_of_get_global ->].
+  move=> hvs hwf hlx hpk heqval.
+  case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  constructor=> //=.
+  + move=> y hget; rewrite get_var_neq; first by apply heqvm.
+    by rewrite /get_local in hlx; congruence.
+  case: (hwfr) => hwfsr hval hptr; split.
+  + by apply (wfr_WF_set hwfsr hwf).
+  + by apply (wfr_VAL_set_move heqval hval).
+  by apply (wfr_PTR_set_move hlx hpk hptr).
 Qed.
 
-Definition lea_ptr' y ptr ofs := 
-  add (Pvar (mk_lvar (with_var y ptr))) (cast_const ofs).
-
-Lemma get_addrP s1 s1' rmap1 rmap2 i2 x dx y:
-  valid_state rmap1 m0 s1 s1' ->
-  get_addr pmap rmap1 x dx y = ok (rmap2, i2) ->
-  exists mp, 
-    [/\ check_gvalid rmap1 y = Some mp,
-        rmap2 = set rmap1 x mp &
-        forall s2', write_lval [::] dx (Vword (mp_addr mp)) s1' = ok s2' ->
-                     sem_i P' rip s1' i2 s2'].
+Lemma valid_state_set_move_regptr rmap m0 s1 s2 x sr v p :
+  valid_state rmap m0 s1 s2 ->
+  wf_sub_region sr x.(vtype) ->
+  get_local pmap x = Some (Pregptr p) ->
+  eq_sub_region_val x.(vtype) (emem s2) sr (get_var_bytes (set_move rmap x sr) sr.(sr_region) x) v ->
+  valid_state (set_move rmap x sr) m0 (with_vm s1 (evm s1).[x <- pof_val x.(vtype) v])
+                                      (with_vm s2 (evm s2).[p <- pof_val p.(vtype) (Vword (sub_region_addr sr))]).
 Proof.
-  move=> hvs; rewrite /get_addr /check_gvalid.   
-  case: ifPn => hglob.             
-  + t_xrbindP => ofs /get_globalP -> <- <- /=.
-    exists {| mp_s := MSglob; mp_ofs := ofs |}.
-    split => //= s2' hs; constructor.
-    by rewrite /sem_sopn /= P'_globs /get_gvar /= vs_rip /= /sem_sop2 /= !zero_extend_u hs.
-  case heq: get_local => [pk | //].         
-  rewrite /set_move; t_xrbindP => rmap2' mp hva <- <- <-; rewrite hva.
-  case /check_validP : hva => hgmp _.
-  assert (h := wfr_ptr hgmp); case: h => pk' [];rewrite heq => -[?] hvp {heq}; subst pk'.
-  exists mp; split => // s2' hs .
-  case: pk hvp => /= [ofs | p | ofs] h.
-  + subst mp; constructor.
-    by rewrite /sem_sopn /= P'_globs /get_gvar /= vs_rsp /= /sem_sop2 /= !zero_extend_u hs.
-  + by constructor; rewrite /sem_sopn /= P'_globs /get_gvar /= h /= !zero_extend_u hs.
-  by constructor; rewrite /sem_sopn /= P'_globs vs_rsp /= !zero_extend_u h /= !zero_extend_u hs.
+  move=> hvs hwf hlx heqval.
+  have /wf_locals /= hlocal := hlx.
+  case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  constructor=> //=.
+  + rewrite get_var_neq //.
+    by apply hlocal.(wfr_not_vrip).
+  + rewrite get_var_neq //.
+    by apply hlocal.(wfr_not_vrsp).
+  + move=> y hget hnnew.
+    rewrite get_var_neq; last by rewrite /get_local in hlx; congruence.
+    rewrite get_var_neq; last by have := hlocal.(wfr_new); congruence.
+    by apply heqvm.
+  case: (hwfr) => hwfsr hval hptr; split.
+  + by apply (wfr_WF_set hwfsr hwf).
+  + move=> y sry bytesy vy.
+    move=> /(check_gvalid_set_move) [].
+    + move=> [? ? <- ->]; subst x.
+      rewrite get_gvar_eq //.
+      case: heqval => hread hty'.
+      apply on_vuP => //; rewrite -hty'.
+      by move => ? hof hto; rewrite -hto (pto_val_pof_val hof) hty'.
+    move=> [? hgvalid].
+    rewrite get_gvar_neq => //.
+    by apply hval.
+  move=> y sry.
+  rewrite Mvar.setP; case: eqP.
+  + move=> <- [<-].
+    exists (Pregptr p); split=> //=.
+    rewrite get_var_eq.
+    by rewrite hlocal.(wfr_rtype).
+  move=> hneq /hptr [pk [hly hpk]].
+  exists pk; split=> //.
+  case: pk hly hpk => //=.
+  + move=> p2 hly.
+    rewrite get_var_neq //.
+    by apply (hlocal.(wfr_distinct) hly hneq).
+  move=> s ofs ws z f hly.
+  rewrite /check_stack_ptr get_var_bytes_set_move_bytes.
+  case: eqP => [_|//].
+  case: eqP => //.
+  have /is_sarrP [n hty] := hlocal.(wfr_type).
+  have /wf_locals /wfs_new := hly.
+  by have /wf_vnew := hlx; congruence.
 Qed.
 
-Lemma alloc_array_moveP s1 s2 s1' rmap1 rmap2 x e v v' n i2 : 
-  valid_state rmap1 m0 s1 s1' ->
+Lemma var_region_not_new rmap m0 s1 s2 x sr :
+  valid_state rmap m0 s1 s2 ->
+  Mvar.get rmap.(var_region) x = Some sr ->
+  ~ Sv.In x pmap.(vnew).
+Proof. by move=> hvs /wfr_ptr [_ [/wf_vnew ? _]]. Qed.
+
+(* The lemma manipulates [set_stack_ptr (set_move ...)], rather than
+   [set_stack_ptr] alone.
+*)
+Lemma check_gvalid_set_stack_ptr rmap m0 s1 s2 s ws z f y sry bytes x sr :
+  valid_state rmap m0 s1 s2 ->
+  ~ Sv.In x pmap.(vnew) ->
+  Sv.In f pmap.(vnew) ->
+  check_gvalid (set_stack_ptr (set_move rmap x sr) s ws z f) y = Some (sry, bytes) ->
+  exists bytes',
+    [/\ check_gvalid (set_move rmap x sr) y = Some (sry, bytes'),
+        ~ is_glob y -> f <> gv y &
+        bytes =
+          if (sub_region_stkptr s ws z).(sr_region) != sry.(sr_region) then bytes'
+          else ByteSet.remove bytes' (interval_of_zone (sub_zone_at_ofs (sub_region_stkptr s ws z).(sr_zone) (Some 0) (wsize_size Uptr)))].
+Proof.
+  move=> hvs hnnew hnew.
+  rewrite /check_gvalid /=.
+  case: (@idP (is_glob y)) => hg.
+  + case heq: Mvar.get => [[ofs ws']|//] [<- <-].
+    eexists; split=> //.
+    by case: eqP.
+  case heq: Mvar.get => [sr'|//] [<- <-].
+  have hneq: f <> y.(gv).
+  + move: heq; rewrite Mvar.setP.
+    case: eqP => [|_].
+    + by congruence.
+    by move=> /var_region_not_new; congruence.
+  eexists; split=> //.
+  rewrite get_var_bytes_set_pure_bytes.
+  by have /eqP /negPf -> := hneq.
+Qed.
+
+Lemma valid_pk_set_stack_ptr (rmap : region_map) s2 x s ofs ws z f mem2 y pk sr:
+  wf_stkptr x s ofs ws z f ->
+  (forall p ws,
+    disjoint_range (sub_region_addr (sub_region_stkptr s ws z)) Uptr p ws ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  x <> y ->
+  get_local pmap y = Some pk ->
+  valid_pk rmap s2 sr pk ->
+  valid_pk (set_stack_ptr rmap s ws z f) (with_mem s2 mem2) sr pk.
+Proof.
+  move=> hlocal hreadeq hneq.
+  case: pk => //= s1 ofs1 ws1 z1 f1 hly hpk.
+  have hwf := sub_region_stkptr_wf hlocal.
+  assert (hwf1 := sub_region_stkptr_wf (wf_locals hly)).
+  rewrite /check_stack_ptr get_var_bytes_set_pure_bytes.
+  case: eqP => heqr /=.
+  + have hneqf := hlocal.(wfs_distinct) hly hneq.
+    have /eqP /negPf -> := hneqf.
+    move=> /mem_remove_interval_of_zone -/(_ ltac:(done) ltac:(done)) [/hpk <- hdisj].
+    apply hreadeq.
+    by apply (disjoint_zones_disjoint_zrange hwf hwf1 heqr).
+  move=> /hpk <-.
+  apply hreadeq.
+  by apply (distinct_regions_disjoint_zrange hwf hwf1 heqr).
+Qed.
+
+Lemma valid_state_set_stack_ptr rmap m0 s1 s2 x s ofs ws z f mem2 sr v :
+  valid_state rmap m0 s1 s2 ->
+  wf_sub_region sr x.(vtype) ->
+  get_local pmap x = Some (Pstkptr s ofs ws z f) ->
+  stack_stable (emem s2) mem2 ->
+  (forall p ws,
+    validw mem2 p ws = validw (emem s2) p ws) ->
+  (forall p ws,
+    disjoint_range (sub_region_addr (sub_region_stkptr s ws z)) Uptr p ws ->
+    read mem2 p ws = read (emem s2) p ws) ->
+  read mem2 (sub_region_addr (sub_region_stkptr s ws z)) U64 = ok (sub_region_addr sr) ->
+  eq_sub_region_val x.(vtype) (emem s2) sr (get_var_bytes (set_move rmap x sr) sr.(sr_region) x) v ->
+  valid_state (set_stack_ptr (set_move rmap x sr) s ws z f) m0 (with_vm s1 (evm s1).[x <- pof_val x.(vtype) v]) (with_mem s2 mem2).
+Proof.
+  move=> hvs hwf hlx hss hvalideq hreadeq hreadptr heqval.
+  have hreadeq': forall p ws,
+    disjoint_range (sub_region_addr (sub_region_at_ofs (sub_region_stkptr s ws z) (Some 0) (wsize_size U64))) Uptr p ws ->
+    read mem2 p ws = read (emem s2) p ws.
+  + by move=> ??; rewrite -sub_region_addr_offset wrepr0 GRing.addr0; apply hreadeq.
+  have /wf_locals hlocal := hlx.
+  have hwfs := sub_region_stkptr_wf hlocal.
+  have hwfs' := sub_region_at_ofs_0_wf hwfs.
+  case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  constructor=> //=.
+  + by move=> ??; rewrite hvalideq; apply hvalid.
+  + by move=> ??; rewrite hvalideq; apply hincl.
+  + by move=> ??; rewrite hvalideq; apply hincl2.
+  + by apply (mem_unchanged_write_slot hwfs refl_equal hreadeq hunch).
+  + move=> y hget; rewrite get_var_neq; first by apply heqvm.
+    by rewrite /get_local in hlx; congruence.
+  case: (hwfr) => hwfsr hval hptr; split.
+  + by apply (wfr_WF_set hwfsr hwf).
+  + move=> y sry bytesy vy /(check_gvalid_set_stack_ptr hvs (wf_vnew hlx) hlocal.(wfs_new)).
+    move=> {bytesy} [bytesy [hgvalidy ? ->]] hgety.
+    have /(check_gvalid_wf (wfr_WF_set hwfsr hwf _)) -/(_ refl_equal) hwfy := hgvalidy.
+    assert (heqvaly := wfr_VAL_set_move heqval wfr_val hgvalidy hgety).
+    case: eqP => heqr /=.
+    + by apply (eq_sub_region_val_same_region hwfs' hwfy heqr hreadeq' heqvaly).
+    by apply (eq_sub_region_val_distinct_regions hwfs' hwfy heqr refl_equal hreadeq' heqvaly).
+  + move=> y sry.
+    rewrite Mvar.setP.
+    case: eqP.
+    + move=> <- [<-].
+      by exists (Pstkptr s ofs ws z f); split.
+    move=> hneq /wfr_ptr [pky [hly hpky]].
+    exists pky; split=> //.
+    apply (valid_pk_set_stack_ptr hlocal hreadeq hneq hly).
+    by apply (valid_pk_set_move sr (wf_vnew hlx) (wf_locals hly) hpky).
+  + by apply (eq_mem_source_write_slot hvs hwfs hreadeq).
+  by rewrite -hss.(ss_top_stack).
+Qed.
+
+Lemma valid_state_set_move_sub rmap m0 s1 s2 x pk v sr :
+  valid_state rmap m0 s1 s2 ->
+  get_local pmap x = Some pk ->
+  (forall srx, Mvar.get rmap.(var_region) x = Some srx ->
+    eq_sub_region_val x.(vtype) (emem s2) srx (get_var_bytes (set_move_sub rmap x sr) srx.(sr_region) x) v) ->
+  valid_state (set_move_sub rmap x sr) m0 (with_vm s1 (evm s1).[x <- pof_val x.(vtype) v]) s2.
+Proof.
+  move=> hvs hlx heqval.
+  case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  constructor => //=.
+  + move=> y hgety; rewrite get_var_neq; first by apply heqvm.
+    by rewrite /get_local in hlx; congruence.
+  case: (hwfr) => hwfsr hval hptr; split=> //.
+  + move=> y sry bytesy vy.
+    move=> /check_gvalid_set_move_sub [].
+    + move=> [? ? hget ->]; subst x.
+      case: (heqval _ hget) => hread hty.
+      rewrite get_gvar_eq //.
+      apply on_vuP => //; rewrite -hty.
+      by move => ? hof hto; rewrite -hto (pto_val_pof_val hof) hty.
+    move=> [? hgvalid].
+    rewrite get_gvar_neq => //.
+    by apply hval.
+  move=> y sry.
+  move=> /hptr [pky [hly hpky]].
+  exists pky; split=> //.
+  case: pky hly hpky => //=.
+  move=> s ofs' ws z f hly heq.
+  rewrite /check_stack_ptr get_var_bytes_set_move_bytes.
+  case: eqP => // _.
+  case: eqP => //.
+  have /wf_vnew := hlx.
+  by have /wf_locals /wfs_new := hly; congruence.
+Qed.
+
+(* This reasoning appears both in [alloc_array_moveP] and [alloc_array_move_initP],
+   therefore we factorize it in this lemma.
+   Note that we assume [eq_sub_region_val_read] only on the (sub-)sub-region
+   [sub_region_at_ofs sr (Some ofs) len]. We do not need it for the full
+   sub-region [sr], since we can derive it for the rest of [sr] from
+   the [valid_state] hypothesis.
+*)
+Lemma valid_state_set_move_sub_write_lval rmap m0 s1 s2 r x ofsx ofs len n (a : WArray.array n) s1' pk sr :
+  valid_state rmap m0 s1 s2 ->
+  get_Lvar_sub r = ok (x, ofsx) ->
+  match ofsx with
+  | Some p => p
+  | None => (0, size_slot x)
+  end = (ofs, len) ->
+  write_lval gd r (Varr a) s1 = ok s1' ->
+  get_local pmap x = Some pk ->
+  (forall srx, Mvar.get rmap.(var_region) x = Some srx -> srx = sr) ->
+  let: rmap2 := set_move_sub rmap x (sub_region_at_ofs sr (Some ofs) len) in
+  eq_sub_region_val_read (emem s2) (sub_region_at_ofs sr (Some ofs) len) (get_var_bytes rmap2 sr.(sr_region) x) (Varr a) ->
+  valid_state rmap2 m0 s1' s2.
+Proof.
+  move=> hvs.
+  set valid_state := valid_state. (* hack due to typeclass interacting badly *)
+  case: r => //=.
+  + move=> _ [-> <-] [<- <-].
+    rewrite /write_var; t_xrbindP=> vm1'; apply: set_varP; last first.
+    + by move=> /is_sboolP h1 h2; elimtype False; move: h2; rewrite h1.
+    case: x => -[xty xn] xii; case: xty => //=.
+    move=> nx ax hax <- <-.
+    set x := {| vname := xn |} => hlx hget hread.
+    rewrite -(WArray.castK ax).
+    apply (valid_state_set_move_sub hvs hlx (v:=Varr ax)).
+    move=> _ /hget ->.
+    split=> // off hmem w /(cast_get8 hax) /hread.
+    (* TODO: can we do something nicer than [Z.add_0_r]? *)
+    rewrite -sub_region_addr_offset wrepr0 GRing.addr0 /= Z.add_0_r.
+    by apply.
+
+  t_xrbindP=> aa ws {len}len _ e ofs' hofs -> <- [? <-]; subst ofs'.
+  apply: on_arr_varP.
+  t_xrbindP=> nx ax htyx hxa i v he hv a2 ha2 a3 ha3 vm1'.
+  have {he hv} he : sem_pexpr gd s1 e >>= to_int = ok i.
+  + by rewrite he.
+  have {hofs} -> := get_ofs_subP he hofs.
+  apply: set_varP; last by rewrite {1}htyx.
+  case: x htyx hxa => -[_ xn] xii /= ->.
+  set x := {| vname := xn |} => hxa /= _ <- <- <- hlx hget hread.
+  apply (valid_state_set_move_sub hvs hlx (v := Varr a3)).
+  move=> srx /dup[] /hget{hget} ? hget; subst srx.
+  split=> // off hmem w /=.
+  rewrite (WArray.set_sub_get8 ha3) /=.
+  case: ifPn => [_|].
+  + move=> /(cast_get8 ha2).
+    move: hmem w.
+    rewrite -{1 3}(Zplus_minus (i * mk_scale aa ws) off).
+    move: {off} (off - i * mk_scale aa ws) => off.
+    rewrite wrepr_add GRing.addrA (sub_region_addr_offset (arr_size ws len)) Z.add_assoc.
+    by apply hread.
+  rewrite !zify => hbound.
+  have hgvalid := check_gvalid_lvar (x:={|v_var := x; v_info := xii|}) hget.
+  case: (wfr_val hgvalid hxa) => hread' _.
+  apply hread'.
+  move: hmem.
+  rewrite get_var_bytes_set_move_bytes !eq_refl /=.
+  rewrite ByteSet.addE => /orP [|//].
+  by rewrite /I.memi /= !zify; lia.
+Qed.
+
+Lemma lea_ptrP s1 e i x ofs w s2 :
+  sem_pexpr [::] s1 e >>= to_pointer = ok i ->
+  write_lval [::] x (Vword (i + wrepr _ ofs)) s1 = ok s2 ->
+  sem_i P' w s1 (lea_ptr x e ofs) s2.
+Proof.
+  move=> he hx.
+  constructor.
+  rewrite /sem_sopn /= P'_globs /sem_sop2 /=.
+  move: he; t_xrbindP=> _ -> /= -> /=.
+  by rewrite !zero_extend_u hx.
+Qed.
+
+Lemma mov_ptrP s1 e i x w s2 :
+  sem_pexpr [::] s1 e >>= to_pointer = ok i ->
+  write_lval [::] x (Vword i) s1 = ok s2 ->
+  sem_i P' w s1 (mov_ptr x e) s2.
+Proof.
+  move=> he hx.
+  constructor.
+  rewrite /sem_sopn P'_globs /= /exec_sopn /=.
+  move: he; t_xrbindP=> _ -> /= -> /=.
+  by rewrite hx.
+Qed.
+
+Lemma mov_ofsP s1 e i x ofs w mk s2 :
+  sem_pexpr [::] s1 e >>= to_pointer = ok i ->
+  write_lval [::] x (Vword (i + wrepr _ ofs)) s1 = ok s2 ->
+  sem_i P' w s1 (mov_ofs x mk e ofs) s2.
+Proof.
+  case: mk.
+  + by apply lea_ptrP.
+  rewrite /=.
+  case: eqP => [->|_].
+  + rewrite wrepr0 GRing.addr0.
+    by apply mov_ptrP.
+  by apply lea_ptrP.
+Qed.
+
+Lemma alloc_array_moveP m0 s1 s2 s1' rmap1 rmap2 r e v v' n i2 : 
+  valid_state rmap1 m0 s1 s2 ->
   sem_pexpr gd s1 e = ok v ->
   truncate_val (sarr n) v = ok v' ->
-  write_lval gd x v' s1 = ok s2 ->
-  alloc_array_move pmap rmap1 x e = ok (rmap2, i2) → 
-  ∃ s2' : estate, sem_i P' rip s1' i2 s2' ∧ valid_state rmap2 m0 s2 s2'.
+  write_lval gd r v' s1 = ok s1' ->
+  alloc_array_move pmap rmap1 r e = ok (rmap2, i2) → 
+  ∃ s2' : estate, sem_i P' rip s2 i2 s2' ∧ valid_state rmap2 m0 s1' s2'.
 Proof.
-  move=> hvs he htr hw.
+  move=> hvs he; rewrite /truncate_val /=.
+  t_xrbindP=> a' /to_arrI [m [a [? ha']]] ? hw; subst v v'.
   rewrite /alloc_array_move.
-  case: x hw => //= x.
-  rewrite /write_var; t_xrbindP => vm1 hvm1 <- /=.
-  have hu := value_uincl_truncate_val htr.
-  have /type_of_val_arr := truncate_val_has_type htr.
-  case => -[t ?];subst v'.
-  + apply: set_varP hvm1.
-    + by move=> ? /pof_val_undef_ok. 
-    by move=> /is_sboolP h1 h2; elimtype False; move: h2; rewrite h1.
-  apply: set_varP hvm1; last first.
-  by move=> /is_sboolP h1 h2; elimtype False; move: h2; rewrite h1.
-  case: x => -[[]// sx xn] xii /= t' [?] ?; subst t' vm1.
-  set x := {|vname := xn|}.
-  case: e he => //= y hy.
-  have [sy [htyy hsy]]: exists sy, vtype (gv y) = sarr sy /\ n <= sy. 
-  + have /= := subtype_trans (value_uincl_subtype hu) (type_of_get_gvar hy) .
-    by case: vtype => // => sy /ZleP ?;eauto.
-  have [sv [tv ? htv]] := value_uinclE hu; subst v.
+  t_xrbindP=> -[x ofsx] hgetr [y ofsy] hgete.
+  case hkindy: (get_var_kind pmap y) => [vk|] //.
+  case hofsy: (match ofsy with
+               | Some p => p
+               | None => (0, size_slot (gv y))
+               end) => [ofs len].
+  case: vk hkindy => [vpky|//] hkindy.
+  have [hlen hofs] := get_Pvar_sub_bound he hgete hofsy.
+  have hofs': forall zofs, Some ofs = Some zofs -> 0 <= zofs /\ zofs + len <= size_slot y.(gv).
+  + by move=> _ [<-].
+  t_xrbindP=> -[[[sry' mk] ey] ofs2'] _ <-.
+  t_xrbindP=> -[sry _] /(check_vpkP hofs' hkindy) [bytesy [hgvalidy -> hmemy]].
+  assert (hwfy := check_gvalid_wf wfr_wf hgvalidy).
+  have hwfy': wf_sub_region (sub_region_at_ofs sry (Some ofs) len) (sarr (Z.to_pos len)).
+  + move: hofs'.
+    have {1 2}-> : len = size_of (sarr (Z.to_pos len)) by rewrite /= Z2Pos.id.
+    by apply: (sub_region_at_ofs_wf hwfy).
+  have hwfpky := get_var_kind_wf hkindy.
+  have hpky: valid_vpk rmap1 s2 y.(gv) sry vpky.
+  + have /wfr_gptr := hgvalidy.
+    by rewrite hkindy => -[_ [[]] <-].
+  move=> [e1 ofs2] /(mk_addr_pexprP _ hwfpky hpky) [w [he1 haddr]] ? <- <- ?; subst sry' ofs2'.
+  have [? [ay [hgety hay]]] := get_Pvar_subP he hgete hofsy; subst m.
 
-  have heqma: forall mp, eq_mp_array (emem s1') mp sy (Varr tv) → 
-                   eq_mp_array (emem s1') mp sx (Varr (WArray.inject sx t)).
-  + rewrite /eq_mp_array => mp [tv' []] /Varr_inj [?]; subst sv => /= ? hgtv; subst tv'.
-     eexists; split;first reflexivity.
-     move=> off hoff v0 hget.
-     have [hoffsy hgettv]: (off < sy)%Z /\  @WArray.get sy AAscale U8 tv off = ok v0.
-     + move: hget; rewrite /WArray.get /CoreMem.read /= /wsize_size Z.mul_1_r /WArray.validr /WArray.validw /=.
-       rewrite Z.add_0_r !andbT /CoreMem.uread /= /WArray.uget /WArray.add Z.add_0_r.
-       rewrite WArray.zget_inject //; t_xrbindP => ??? /assertP hr /assertP -> /assertP.
-       case: ZltP => // hlt hget hdec.  
-       have -> /= : (WArray.in_range sy off U8).
-       + move: hr;rewrite /WArray.in_range !zify /wsize_size; lia.
-       case: htv => _ h; case heq: Mz.get hget hdec => [w | ] //= _.
-       by rewrite (h _ _ _ heq); [ move=> <- /=;split => // | ]; lia.
-     by apply hgtv => //; lia.
+  have hread: forall bytes,
+    eq_sub_region_val_read (emem s2) (sub_region_at_ofs sry (Some ofs) len) bytes (Varr a').
+  + move=> bytes off hmem w' /(cast_get8 ha') /dup[].
+    rewrite -{1}get_read8 => /WArray.get_valid8 /WArray.in_boundP; rewrite Z2Pos.id // => hoff.
+    move=> /hay.
+    rewrite -sub_region_addr_offset -GRing.addrA -wrepr_add.
+    assert (hval := wfr_val hgvalidy hgety).
+    case: hval => hread _.
+    apply hread.
+    rewrite memi_mem_U8; apply: mem_incl_r hmemy; rewrite subset_interval_of_zone.
+    rewrite -(sub_zone_at_ofs_compose _ _ _ len).
+    apply zbetween_zone_byte => //.
+    by apply zbetween_zone_refl.
 
-  case hglx : get_local => [[ofs | p | ofs] | //].
-  + t_xrbindP => _ /assertP; rewrite is_lvar_is_glob => /negP hngy mpy hcvy.
-    move=> _ /assertP -/eqP ???; subst mpy rmap2 i2.
-    exists s1';split;first by constructor.
-    case: (hvs) => vptr hdisj hrip hrsp hf heqvm hwfr heqg hnotm. 
-    constructor => //.
-    + move=> x1 hx1; rewrite -heqvm // get_var_neq //.
-      by move=> heq;move: hx1;rewrite -heq hglx.
-    case: (hwfr) => h1 h2 h3; constructor => //=.
-    + by apply: set_VALID => //; exists x; split.
-    + apply: set_VAL => //=.
-      have : check_gvalid rmap1 y = Some {| mp_s := MSstack; mp_ofs := ofs |}.
-      + by move/negP:hngy; rewrite /check_gvalid hcvy => /negbTE ->.
-      by move=> /h2 -/(_ _ hy); rewrite htyy /=; apply heqma.
-    move=> x1 mp1; rewrite get_set_region; case: eqP => [<- [<-]| _ /h3 //].
-    rewrite hglx; move /check_validP: hcvy => [] /h3 [pk] [] ???.
-    by exists (Pstack ofs).
+  case: r hgetr hw => //.
+  + move=> _ [-> <-].
+    rewrite /write_lval /write_var; t_xrbindP=> vm1'; apply: set_varP; last first.
+    + by move=> /is_sboolP h1 h2; elimtype False; move: h2; rewrite h1.
+    case: x => -[xty xn] xii; case: xty => //=.
+    move=> nx ax hax <- <-.
+    set x := {| vname := xn |}.
+    case hlx: (get_local pmap x) => [pk|//].
+    have /wf_locals hlocal := hlx.
 
-  + move=> /get_addrP => -[mp [hcmp ?]]; subst rmap2.
-    rewrite /write_lval /write_var /= /set_var.
-    assert (hp := wt_rptr hglx) => {hglx}.
-    rewrite (var_surj p) hp /=.
-    move=> /(_ _ erefl) ?;eexists;split; first by eauto.
-    case: (hvs) => vptr hdisj hrip hrsp hf heqvm hwfr heqg hnotm. 
-    constructor => //.
-    + assert (h:=disj_ptr).
-    + 
-    + move=> x1 hx1; rewrite -heqvm // get_var_neq //.
-      by move=> heq;move: hx1;rewrite -heq hglx.
-    case: (hwfr) => h1 h2 h3; constructor => //=.
-    + by apply: set_VALID => //; exists x; split.
-    + apply: set_VAL => //=.
-      have : check_gvalid rmap1 y = Some {| mp_s := MSstack; mp_ofs := ofs |}.
-      + by move/negP:hngy; rewrite /check_gvalid hcvy => /negbTE ->.
-      by move=> /h2 -/(_ _ hy); rewrite htyy /=; apply heqma.
-    move=> x1 mp1; rewrite get_set_region; case: eqP => [<- [<-]| _ /h3 //].
-    rewrite hglx; move /check_validP: hcvy => [] /h3 [pk] [] ???.
-    by exists (Pstack ofs).
-    case: p hp => pty pn.
-Search vtype.
-Search set_var.
-Search write_var.
+    have heqval: forall bytes,
+      eq_sub_region_val x.(vtype) (emem s2) (sub_region_at_ofs sry (Some ofs) len)
+                        bytes (Varr ax).
+    + move=> bytes.
+      by split=> // off /hread{hread}hread w' /(cast_get8 hax) /hread.
 
-  get_addrP
-Print instr_r.
+    have hwf: wf_sub_region (sub_region_at_ofs sry (Some ofs) len) x.(vtype).
+    + apply: (wf_sub_region_subtype _ hwfy').
+      apply /ZleP.
+      by apply: Z.le_trans (WArray.cast_len hax) (WArray.cast_len ha').
 
-  + rewrite /get_addr.
-   
-       
+    rewrite -(WArray.castK ax).
 
-Search g
+    case: pk hlx hlocal.
+    + t_xrbindP=> s ofs' ws z sc hlx hlocal _ /assertP /eqP heqsub <- <-.
+      exists s2; split; first by constructor.
+      (* valid_state update *)
+      by apply: (valid_state_set_move hvs hwf hlx _ (heqval _)).
+    + move=> p hlx hlocal [<- <-].
+      set vp := pof_val p.(vtype) (Vword (sub_region_addr (sub_region_at_ofs sry (Some ofs) len))).
+      exists (with_vm s2 (evm s2).[p <- vp]); split.
+      + rewrite /vp -sub_region_addr_offset haddr -GRing.addrA -wrepr_add.
+        apply (mov_ofsP _ _ he1).
+        by case: (p) hlocal.(wfr_rtype) => ? pn /= ->.
+      (* valid_state update *)
+      by apply (valid_state_set_move_regptr hvs hwf hlx (heqval _)).
+    move=> s ofs' ws z f hlx hlocal [<- hi2].
 
-Search _ check_valid.
+    have {hi2} [mem2 [hsemi hss hvalideq hreadeq hreadptr]]:
+      exists mem2,
+      [/\ sem_i P' rip s2 i2 (with_mem s2 mem2),
+          stack_stable (emem s2) mem2,
+          (forall p ws, validw mem2 p ws = validw (emem s2) p ws),
+          (forall p ws,
+            disjoint_range (sub_region_addr (sub_region_stkptr s ws z)) U64 p ws ->
+            read mem2 p ws = read (emem s2) p ws) &
+          read mem2 (sub_region_addr (sub_region_stkptr s ws z)) U64 =
+            ok (sub_region_addr (sub_region_at_ofs sry (Some ofs) len))].
+    + subst i2.
+      case: ifP.
+      + case heq: Mvar.get => [srx|//] /andP [/eqP heqsub hcheck].
+        exists (emem s2); split=> //.
+        + by rewrite with_mem_same; constructor.
+        + have /wfr_ptr := heq; rewrite hlx => -[_ [[<-] hpk]].
+          rewrite -heqsub.
+          by apply hpk.
+      have hwfs := sub_region_stkptr_wf hlocal.
+      have hvp: validw (emem s2) (sub_region_addr (sub_region_stkptr s ws z)) Uptr.
+      + apply (validw_sub_region_addr hvs hwfs).
+        by apply (is_align_sub_region_stkptr hlocal).
+      have /writeV -/(_ (w + wrepr U64 (ofs2 + ofs))%R) [mem2 hmem2] := hvp.
+      exists mem2; split.
+      + apply (mov_ofsP _ _ he1).
+        rewrite /= vs_rsp /= !zero_extend_u.
+        by rewrite -(sub_region_addr_stkptr hlocal) hmem2.
+      + by apply (Memory.write_mem_stable hmem2).
+      + by move=> ??; apply (write_validw_eq hmem2).
+      + by move=> ??; apply (writeP_neq hmem2).
+      rewrite (writeP_eq hmem2).
+      by rewrite wrepr_add GRing.addrA -haddr -sub_region_addr_offset.
 
-hv hV y mpy; rewrite get_set_region; case: eqP => [<- [<-]| _ /hV ].
-Print wfr_PTR.
-          rewrite /eq_mp_array. => -[tv' []] /Varr_inj [?]. subst sv => /= ? hgtv; subst tv'.
-          eexists; split;first reflexivity.
-          move=> off hoff v0 hget.
-  
+    exists (with_mem s2 mem2); split=> //.
+    by apply (valid_state_set_stack_ptr hvs hwf hlx hss hvalideq hreadeq hreadptr (heqval _)).
 
-          apply hgtv; first admit. 
-Set Printing Implicit.
-Set Printing Coer
-          move: hget; rewrite /WArray.get /CoreMem.read /= /wsize_size Z.mul_1_r /WArray.validr /WArray.validw /=.
-          rewrite Z.add_0_r !andbT /CoreMem.uread /= /WArray.uget /WArray.add Z.add_0_r.
-          rewrite WArray.zget_inject //; t_xrbindP => ??? /assertP hr /assertP hal /assertP.
-          case: ZltP => // hlt hget hdec.       
-          have -> : (WArray.in_range sy off U8).
-          + move: hr;rewrite /WArray.in_range !zify; lia.
-          case:ifP =
-            
+  (* interestingly, we can prove that n = Z.to_pos len = Z.to_pos (arr_size ws len2)
+     but it does not seem useful
+  *)
+  move=> aa ws len2 x' e' hgetr hw.
+  have /= := hgetr; t_xrbindP=> ofs3 hofs3 ? ?; subst x' ofsx.
+  case hlx: (get_local pmap x) => [pk|//].
+  t_xrbindP=> _ /set_arr_subP [srx [hgetx heqsub <-]] <- <-.
+  exists s2; split; first by constructor.
+  apply (valid_state_set_move_sub_write_lval hvs hgetr refl_equal hw hlx).
+  + by move=> ?; rewrite hgetx => -[].
+  by rewrite heqsub.
+Qed.
 
-Search WArray.inject.
-          have : off < sy /\ WArray.get AAscale U8 t off = ok v0.
-          + move: 
-Print WArray.uincl.
-          case: (ZltP off sy) => hoffsy.
-          + apply hgtv. lia. 
-            move: hget; rewrite /WArray.get /CoreMem.read /= /wsize_size Z.mul_1_r /WArray.validr /WArray.validw /=.
-            rewrite /CoreMem.uread WArray.zget_inject Z.
+Lemma is_array_initP e : reflect (exists n, e = Parr_init n) (is_array_init e).
+Proof.
+  case: e => /=; constructor; try by move => -[].
+  by eexists.
+Qed.
 
-Search WArray.inject.
+Lemma get_Lvar_sub_bound s1 s1' v r x subx ofs len :
+  write_lval gd r v s1 = ok s1' ->
+  get_Lvar_sub r = ok (x, subx) ->
+  match subx with
+  | Some p => p
+  | None => (0, size_slot x)
+  end = (ofs, len) ->
+  0 < len /\
+  0 <= ofs /\ ofs + len <= size_slot x.
+Proof.
+  case: r => //=.
+  + move=> _ _ [_ <-] [<- <-].
+    split; first by apply size_of_gt0.
+    by lia.
+  move=> aa ws len' x' e.
+  apply: on_arr_varP.
+  t_xrbindP=> n _ hty _ i v' he hv' _ _ _ /WArray.set_sub_bound hbound _ _ _ ofs' hofs' <- <- [<- <-].
+  split=> //.
+  rewrite hty.
+  have {he hv'} he : sem_pexpr gd s1 e >>= to_int = ok i by rewrite he.
+  by move: hofs' => /(get_ofs_subP he) ->.
+Qed.
 
+Lemma alloc_array_move_initP m0 s1 s2 s1' rmap1 rmap2 r e v v' n i2 : 
+  valid_state rmap1 m0 s1 s2 ->
+  sem_pexpr gd s1 e = ok v ->
+  truncate_val (sarr n) v = ok v' ->
+  write_lval gd r v' s1 = ok s1' ->
+  alloc_array_move_init pmap rmap1 r e = ok (rmap2, i2) → 
+  ∃ s2' : estate, sem_i P' rip s2 i2 s2' ∧ valid_state rmap2 m0 s1' s2'.
+Proof.
+  move=> hvs.
+  rewrite /alloc_array_move_init.
+  case: is_array_initP; last first.
+  + by move=> _; apply alloc_array_moveP.
+  move=> [m ->] /= [<-].
+  rewrite /truncate_val /=.
+  t_xrbindP=> _ /WArray.cast_empty_ok -> {m} <- hw [x ofsx] hgetr.
+  case hofsx: (match ofsx with
+               | Some p => p
+               | None => (0, size_slot x)
+               end) => [ofs len].
+  case hlx: get_local => [pk|//].
+  t_xrbindP=> sr hsr <- <-.
+  exists s2; split; first by constructor.
+  (* valid_state update *)
+  apply (valid_state_set_move_sub_write_lval hvs hgetr hofsx hw hlx).
+  + move=> srx hgetx.
+    case: pk hlx hsr.
+    + move=> s ofs' ws z [] // hlx [<-].
+      have /wfr_ptr := hgetx.
+      by rewrite hlx => -[_ [[<-] ->]].
+    + by move=> _ _ /get_sub_regionP; congruence.
+    by move=> _ _ _ _ _ _ /get_sub_regionP; congruence.
+  move=> off hmem w /=.
+  by rewrite WArray.get_empty; case: ifP.
+Qed.
 
-
-sy < sx 
-
-t : arr n
-tv : arr sy
-
-Print subtype.
-          have := htv.          
-rewrite /WArray.uincl.
-Print WArray.inject.
-          rewrite /WArray.get /CoreMem.read /= /wsize_size Z.mul_1_r.
-          t_xrbindP.
-          
-Search CoreMem.read.
- hget.
-
-Search WArray.get.
-Search WArray.validr. 
-
-          have /= []:= WArray.get_bound hget.
-          rewrite /wsize_size.
-
-          have := WArray.get_uget hget. rewrite /WArray.uget.
-          Search WArray.uget.
-Search eq_mp_val.
-Print WArray.uincl.
-Search _ value_uincl.
-
-Search WArray.inject.
-          have := h2 y.
-rewrite /eq_mp_array.
-Search eq_mp_val.
-
-        + move=> x1 mp1 v1.
-
-  get_gvar 
-Print check_valid.
-admit.
-move=> ?.
-
-  exists xs, 
-
- have := h2 x1 mp1 v1; rewrite /check_gvalid.
-        case: ifPn => [ hg h /h| hng ]; first by rewrite get_gvar_neq ?hg.
-        rewrite /check_valid.
-admit.        
-      + move=> x1.
-
-
-
-        Print check_valid.
-Lemma rm_setP x
-Print rm_set.        
-Print 
-Search rm_set.
-
-          + apply h1 => //. by apply /eqP.
-          have := h1 _.
-        Search _ Mvar.get Mvar.remove.
-        case: 
-Print get_local.
-        Search remove.
-Print valid_mp.
-exists (mk_lvar {|v_var := x; v_info := xii|}).
-Print valid_mp.
-Search _ Mvar.get Mvar.set.
-Check wfr_PTR_rset_word.
-Print rset_word.
-      + move=> y mpy v /(check_gvalid_rset_word hins hgetr) [].
-        + move=> [ hng heq ?]; subst mpy.
-          have -> : y = mk_lvar {|v_var := x; v_info := v_info (gv y) |}.
-          + by case: y hng heq => -[yv vi] [] //= _ ->.
-          have /= -> // := @get_gvar_eq gd (mk_lvar {| v_var := x; v_info := v_info (gv y) |}) (evm s1) (ok w).
-          move=> [<-]; exists w';split;first by subst w.
-          by apply: Memory.writeP_eq hmem2.
-        move=> [hd hdm hcv]; rewrite get_gvar_neq // => /h2 -/(_ _ hcv) /=.
-        by apply: (eq_mp_val_write_disj hvs hgetr) hmem2.
-      by apply: wfr_PTR_rset_word hmem2 h3.
-    + by apply: (eq_glob_rset_word hvs hgetr) hmem2 heqg.
-    by apply: (eq_not_mod_rset_word hvs hgetr) hmem2 hnotm.
-
-
-Search _ is_lvar.
-Print is_Pvar.
-Search _ is_Pvar.
-Print is_lv_var.
-Search _ is_lv_var.
+(* Link between a reg ptr argument value [va] in the source and
+   the corresponding pointer [p] in the target. [m1] is the source memory,
+   [m2] is the target memory.
 *)
-(*
-Local Lemma Hassgn : sem_Ind_assgn P Pi_r.
-Proof.
-  move=> s1 s2 x tag ty e v v' hv htr hw rmap1 rmap2 ii1 ii2 i2 /=.
-  t_xrbindP => -[rmap2' i2'] h /= ??? s1' hvs; subst rmap2' ii1 i2'.
-  have htyv':= truncate_val_has_type htr.
-  case: ifPn h => [/is_sarrP [n ?]| _ ].
-  + subst ty; apply: add_iinfoP.
+Record wf_arg_pointer m1 m2 pi va p := {
+  wap_align             : is_align p pi.(pp_align);
+    (* [p] is aligned *)
+  wap_no_overflow       : no_overflow p (size_val va);
+    (* [p] is able to store a block as large as [va] *)
+  wap_valid             : forall w, between p (size_val va) w U8 -> validw m2 w U8;
+    (* the bytes in [p ; p + size_val va - 1] are valid *)
+  wap_fresh             : forall w, validw m1 w U8 -> disjoint_zrange p (size_val va) w (wsize_size U8);
+    (* the bytes in [p ; p + size_val va - 1] are disjoint from the valid bytes of [m1] *)
+  wap_writable_not_glob : pi.(pp_writable) -> 0 < glob_size -> disjoint_zrange rip glob_size p (size_val va);
+    (* if the reg ptr is marked as writable, then the bytes in [p ; p + size_val va - 1] are disjoint from
+       the bytes containing the globals *)
+  wap_read              : forall off w, get_val_byte va off = ok w -> read m2 (p + wrepr _ off)%R U8 = ok w
+    (* the memory at address [p] contains [va] *)
+}.
 
+(* Link between the values given as arguments in the source and the target. *)
+Definition wf_arg m1 m2 sao_param va va' :=
+  match sao_param with
+  | None => va' = va (* no reg ptr : both values are equal *)
+  | Some pi => (* reg ptr : [va] is compiled to a pointer [p] that satisfies [wf_arg_pointer] *)
+    exists p,
+      va' = Vword p /\ wf_arg_pointer m1 m2 pi va p
+  end.
 
-    admit.
-  t_xrbindP => e'; apply: add_iinfoP => /(alloc_eP hvs) he [rmap2' x'].
-  apply: add_iinfoP => hax /= ??; subst rmap2' i2.
-  have [s2' [/= hw' hvs']]:= alloc_lvalP hax hvs htyv' hw.
-  exists s2';split => //.
-  apply: Eassgn; eauto; rewrite P'_globs; auto.
-Qed.
-  assert (hx := alloc_lvalP hax).
-Check add_iinfoP.
-
-Search add_iinfo.
-    case:x hv htr Hw => [??| x|???|????]; try by apply: alloc_assgnP.
-(*    case: ifP => hty. last by apply: alloc_assgnP.
-    case he : is_var => [y | ]; last by apply: alloc_assgnP.
-    case: ifP => hsubty; last by apply: alloc_assgnP.
-    case hf : find_gvar => [mp | ]; last by apply: alloc_assgnP.
-    move=> hv htr Hw; have [n htyx] := is_arr_typeP hty; have ? := is_varP he; subst e.
-    set x' := {| v_var := _ |}.
-    t_xrbindP => -[_sm2 _i2] _tt; apply: add_iinfoP=> /check_vfresh_lvalP [hnrsp hnrip] [??] /= ??? s1' hva.
-    subst _sm2 ii1 _i2 i2 sm2; have := valid_s hva y. 
-    rewrite hf => -[h1 h2].
-    set s2' := {| emem := emem s1';
-                  evm := (evm s1').[x' <- ok (@Build_pword U64 U64 
-                                               (wptr (mp_s mp) + wrepr U64 (mp_ofs mp))
-                                               (erefl true))] |}.
-    exists s2'; split.
-    + case hid: mp_id h1 => [idx | ] /= h1.
-      + apply: S.Eassgn => /=;eauto.
-        + by rewrite /truncate_val /= zero_extend_u; auto.
-        done.
-      apply: S.Eopn; rewrite /sem_sopn /= /get_gvar /= (get_vptr hva) /= /s2'. 
-      by do 5! f_equal;rewrite !zero_extend_u wrepr0 wrepr1; ssrring.ssring.
-    move: Hw; apply rbindP =>vm1 /=; apply: set_varP;rewrite /set_var; last by rewrite {1}htyx.
-    move=> t ht ?[?]; subst vm1 s2.
-    move: hv; rewrite /= /s2' /x' => {s2' x'}.
-    case: x hnrsp hnrip hty htyx hsubty t ht => -[xty xn] xi /= hnrsp hnrip hty htyx hsubty t ht /=.
-    subst xty; case: v' htr ht => // n' a'; last first.
-    + by rewrite /pof_val /=; case: (n').
-    rewrite /truncate_val; t_xrbindP; case: ty => //= n1 yt.
-    case: v => //=;last by case.
-    move=> ny ty1 /=; rewrite /WArray.cast; case: ifP => // /ZleP hn1 [?].
-    move=> /Varr_inj [?]; subst n1 => /= ? [?] hgety; subst yt t a'. 
-    have hyty: vtype (gv y) = sarr ny.  
-    + move: hgety; rewrite /get_gvar; case: ifP => ?.
-      + rewrite /get_var; apply on_vuP => //.
-        by case: (gv y) => -[] [] //= p ???? /Varr_inj [?]; subst p. 
-      by rewrite /get_global; case: get_global_value => // ?; case: eqP => // <- [->].
-    move: hsubty; rewrite hyty /= => /ZleP hsubty.
-    case: hva => hd her hdef hvm hrip hrsp htop hfr hs hm hg {h1 he}; split => //=.
-    + move=> z /= /Sv_memP hin; rewrite !Fv.setP_neq; first last.
-      + by apply /eqP; SvD.fsetdec. + by apply /eqP; SvD.fsetdec.
-      by apply: hvm; apply /Sv_memP; SvD.fsetdec.
-    + by rewrite get_var_neq // => h; move: hnrip; rewrite h /is_vrip eq_refl.
-    + by rewrite get_var_neq // => h; move: hnrsp; rewrite h /is_vrsp eq_refl.
-    + move=> z; case heq: find_gvar => [mpz | //]; move: heq.
-      rewrite find_gvar_set; case: andP => [ [hlv /eqP heq] [?]| hna].
-      + subst mpz => /=; split; first by rewrite /get_var Fv.setP_eq.
-        move: h2; rewrite -heq /= hyty => h off hoff.
-        have hoff' : 0 <= off ∧ off < ny by lia.
-        have [h1 /(_ _ _ hgety) h2]:= h _ hoff'; split => //.
-        rewrite /get_gvar hlv -heq /get_var Fv.setP_eq /= => s' a hok. 
-        have /Varr_inj [? {hok}]:= ok_inj hok.
-        subst s' => /= ? v hv; subst a; apply h2. 
-        apply: WArray.uincl_get hv; split => // i vi hi.
-        by rewrite WArray.zget_inject //=; case: ifP.
-      move=> /find_gvar_keep [hz hdiff] /=.
-      have := hs z; rewrite hz => -[hz1 hz2]; split.
-      + case: mp_id hdiff hz1 => // id hne.
-        by rewrite get_var_neq // => -[eid]; apply hne;rewrite eid.
-      case: vtype hz2 => //.
-      + move=> p hp off; rewrite get_gvar_neq; first by apply hp.
-        by move=> his; apply /negP => he;auto.
-      move=> w [hw1 hw2]; split => // v; rewrite get_gvar_neq; first by apply hw2.
-      by move=> his; apply /negP => he;auto.
-    move=> z mpz; have := hm _ _ hf; rewrite hyty => -[nn [[?]]]; subst nn.
-    move=> [hmp1 hmp2 hmp3 hmp4].
-    rewrite find_gvar_set;case: andP => [ [hlv /eqP heq] [?]| hna].
-    + subst mpz => /=; exists n; rewrite -heq /=; split => //; split => //; first by lia.
-      move=> z1 mpz1 sz1;rewrite find_gvar_set;case: andP => [ [hlv1 /eqP heq1] [?]| hna1].
-      + by subst mpz1; rewrite /= eq_refl -heq1 /= => ?? [].
-      move=> /find_gvar_keep [hz1 hdiff] /= hsz hms. 
-      have := hmp4 _ _ _ hz1 hsz hms; case:eqP;last by lia.
-      move=> ? h1 [ //| hh1]; have heq1 := h1 (or_intror hh1).
-      by move: hh1; rewrite -heq1 hyty.
-    move=> /find_gvar_keep [hz1 hdiff].
-    have [sz1 [hsz1 [hmpz1 hmpz2 hmpz3 hmpz4]]]:= hm _ _ hz1; exists sz1; split => //; split => //.
-    move => s mps ss;rewrite find_gvar_set;case: andP => [ [hlv1 /eqP heq1] [?]| hna1].
-    + subst mps => /=; rewrite -heq1 /= => -[?] h1; subst ss.
-      have := hmp4 _ _ _ hz1 hsz1; rewrite h1 => /(_ erefl); rewrite eq_sym.
-      case: eqP => ?; last lia.
-      move=> h [ hh1| //]; have heq2 := h (or_intror hh1).
-      by move: hh1; rewrite -heq2 hyty.
-    move=> /find_gvar_keep [hh1 hh2 hh3 hh4].
-    by apply: hmpz4 hh1 hh3 hh4. *)
-  Qed.
-  
-  Local Lemma Hopn : sem_Ind_opn P Pi_r.
-  Proof.
-    move => s1 s2 t o xs es.
-    rewrite /sem_sopn;t_xrbindP => vs va He Hop Hw sm1 sm2 ii1 ii2 i2 /=.
-    t_xrbindP => -[sm3 i'] es'; apply: add_iinfoP => he [sm4 x']; apply: add_iinfoP => ha /= [??] ??? s1' hv.
-    subst i' sm3 sm4 ii1 i2.
-    have [va' [He' Uvv']] := (alloc_esP he hv He). 
-    have [w' [Hop' Uww']]:= vuincl_exec_opn Uvv' Hop.
-    have [s2' [Hw' Hvalid']] := alloc_lvalsP ha hv (sopn_toutP Hop) Uww' Hw.
-    exists s2'; split=> //.
-    by apply: Eopn;rewrite /sem_sopn He' /= Hop'.
-  Qed.
-
-  Lemma valid_incl sm1 sm2 s s' :
-    incl sm1 sm2 -> valid sm2 s s' -> valid sm1 s s'.
-  Proof.
-    rewrite /incl => /andP [] /allP hall 
-      /Sv.subset_spec hsub [hd her hdef hvm hrip hrsp htopf hs hm hg].
-    have h: forall x mpx, find_gvar gm sm1 x = Some mpx -> find_gvar gm sm2 x = Some mpx.
-    + move=> x mpx; rewrite /find_gvar; case: ifP => //.
-      case heq: (Mvar.get sm1 (gv x)) => [ap | //].
-      have /hall : (v_var (gv x), ap) \in Mvar.elements sm1.(mstk) by apply /Mvar.elementsP.
-      by rewrite /incl_alloc_pos /=; case : Mvar.get => // ap' /eqP <-.
-    split => //.
-    + by move=> x /Sv_memP hin; apply hvm; apply /Sv_memP; SvD.fsetdec.
-    + move=> x; have := hs x; case heq : (find_gvar gm sm1 x) => [mp |// ].
-      by rewrite (h _ _ heq).
-    move=> x mpx /h hf; have [sx [? [??? h1]]]:= hm x mpx hf.
-    by exists sx;split => //;split => // y mpy sy /h; apply h1.
-  Qed.
-    
-  Lemma incl_merge_l sm1 sm2 : incl (merge sm1 sm2) sm1.
-  Proof.
-    rewrite /merge; apply /andP => /=; split; last by apply SvP.inter_subset_1.
-    apply /allP => -[x ap] /Mvar.elementsP.
-    rewrite Mvar.map2P //= /incl_alloc_pos.
-    case: Mvar.get => [ap1| //]; case: Mvar.get => [ap2 | ] //=.
-    by case: eqP => [-> | //] [->].
-  Qed.
-
-  Lemma incl_merge_r sm1 sm2 : incl (merge sm1 sm2) sm2.
-  Proof.
-    rewrite /merge; apply /andP => /=; split; last by apply SvP.inter_subset_2.
-    apply /allP => -[x ap] /Mvar.elementsP.
-    rewrite Mvar.map2P //= /incl_alloc_pos.
-    case: Mvar.get => [ap1| //]; case: Mvar.get => [ap2 | ] //=.
-    by case: eqP => [-> | //] [->].
-  Qed.
-
-  Lemma incl_refl sm : incl sm sm.
-  Proof.
-    apply /andP; split; last by apply SvP.subset_refl.
-    apply /allP => -[x ap] /Mvar.elementsP /= h.
-    by rewrite /incl_alloc_pos h.
-  Qed.
-
-  Lemma incl_trans sm1 sm2 sm3: incl sm1 sm2 -> incl sm2 sm3 -> incl sm1 sm3.
-  Proof.
-    move=> /andP [/allP a1 s1] /andP [/allP a2 s2]; apply /andP; split.
-    + apply /allP => -[x ap] /a1 /=; rewrite /incl_alloc_pos.
-      case heq :  Mvar.get => [ap2| //] /eqP ?;subst ap2.
-      by apply: (a2 (x, ap)); apply /Mvar.elementsP.
-    apply: SvP.subset_trans s1 s2.
-  Qed.
-
-  Local Lemma Hif_true : sem_Ind_if_true P ev Pc Pi_r.
-  Proof.
-    move=> s1 s2 e c1 c2 Hse ? Hc sm1 sm2 ii1 ii2 i2 /=.
-    t_xrbindP => -[sm3 i'] e'; apply: add_iinfoP => he [sm4 c1'] hc1 [sm5 c2'] hc2 /= [??]??? s1' hv.
-    subst sm3 i' sm2 ii1 i2.
-    have [b [he']]:= alloc_eP he hv Hse.
-    move=> /value_uincl_bool /= -/(_ _ erefl) [_ ?];subst b.
-    have [s2' [Hsem Hvalid']] := Hc _ _ _ hc1 _ hv.
-    exists s2'; split; first by apply: Eif_true.
-    by apply: valid_incl Hvalid'; apply incl_merge_l.
-  Qed.
-
-  Local Lemma Hif_false : sem_Ind_if_false P ev Pc Pi_r.
-  Proof.
-    move=> s1 s2 e c1 c2 Hse ? Hc sm1 sm2 ii1 ii2 i2 /=.
-    t_xrbindP => -[sm3 i'] e'; apply: add_iinfoP => he [sm4 c1'] hc1 [sm5 c2'] hc2 /= [??]??? s1' hv.
-    subst sm3 i' sm2 ii1 i2.
-    have [b [he']]:= alloc_eP he hv Hse.
-    move=> /value_uincl_bool /= -/(_ _ erefl) [_ ?];subst b.
-    have [s2' [Hsem Hvalid']] := Hc _ _ _ hc2 _ hv.
-    exists s2'; split; first by apply: Eif_false.
-    by apply: valid_incl Hvalid'; apply incl_merge_r.
-  Qed.
-
-  Lemma loop2P ii check_c2 n sm sm' e' c1' c2': 
-    loop2 ii check_c2 n sm = ok (sm', (e', (c1', c2'))) ->
-    exists sm1 sm2, incl sm1 sm /\ check_c2 sm1 = ok ((sm', sm2), (e', (c1', c2'))) /\ incl sm1 sm2.
-  Proof.
-    elim: n sm => //= n hrec sm; t_xrbindP => -[[sm1 sm2] [e1 [c11 c12]]] hc2 /=; case: ifP.
-    + move=> hi [] ????;subst.
-      by exists sm; exists sm2;split => //; apply incl_refl.
-    move=> _ /hrec [sm3 [sm4 [h1 [h2 h3]]]]; exists sm3, sm4; split => //.
-    by apply: (incl_trans h1); apply incl_merge_l.
-  Qed.
-
-  Local Lemma Hwhile_true : sem_Ind_while_true P ev Pc Pi_r.
-  Proof.
-    move=> s1 s2 s3 s4 a c1 e c2 _ Hc1 Hv ? Hc2 ? Hwhile sm1 sm2 ii1 ii2 i2 /=.
-    t_xrbindP => -[sm3 i'] [sm4 [e' [c1' c2']]] /loop2P [sm5 [sm6 [hincl1 []]]].
-    t_xrbindP => -[sm7 c11] hc1 /= e1; apply: add_iinfoP => he [sm8 c22] /= hc2 ????? hincl2 [??]???.
-    subst i2 ii1 sm3 sm4 i' sm7 sm8 e1 c11 c22 => s1' /(valid_incl hincl1) hv. 
-    have [s2' [hs1 hv2]]:= Hc1 _ _ _ hc1 _ hv.
-    have [b [he']] := alloc_eP he hv2 Hv.
-    move=> /value_uincl_bool /= -/(_ _ erefl) [_ ?];subst b.
-    have [s3' [hs2 /(valid_incl hincl2) hv3]]:= Hc2 _ _ _ hc2 _ hv2.
-    have /= := Hwhile sm5 sm2 ii2 ii2 (Cwhile a c1' e' c2').
-    rewrite Loop.nbP /= hc1 /= he /= hc2 /= hincl2 /= => /(_ erefl _ hv3) [s4'] [hs3 hv4].
-    by exists s4';split => //; apply: Ewhile_true; eauto.
-  Qed.
-
-  Local Lemma Hwhile_false : sem_Ind_while_false P ev Pc Pi_r.
-  Proof.
-    move=> s1 s2 a c1 e c2 _ Hc1 Hv sm1 sm2 ii1 ii2 i2 /=.
-    t_xrbindP => -[sm3 i'] [sm4 [e' [c1' c2']]] /loop2P [sm5 [sm6 [hincl1 []]]].
-    t_xrbindP => -[sm7 c11] hc1 /= e1; apply: add_iinfoP => he [sm8 c22] /= hc2 ????? hincl2 [??]???.
-    subst i2 ii1 sm3 sm4 i' sm7 sm8 e1 c11 c22 => s1' /(valid_incl hincl1) hv. 
-    have [s2' [hs1 hv2]]:= Hc1 _ _ _ hc1 _ hv.
-    have [b [he']] := alloc_eP he hv2 Hv.
-    move=> /value_uincl_bool /= -/(_ _ erefl) [_ ?];subst b.
-    by exists s2';split => //; apply: Ewhile_false; eauto.
-  Qed.
-
-  Local Lemma Hfor : sem_Ind_for P ev Pi_r Pfor.
-  Proof. by []. Qed.
-
-  Local Lemma Hfor_nil : sem_Ind_for_nil Pfor.
-  Proof. by []. Qed.
-
-  Local Lemma Hfor_cons : sem_Ind_for_cons P ev Pc Pfor.
-  Proof. by []. Qed.
-
-  Local Lemma Hcall : sem_Ind_call P ev Pi_r Pfun.
-  Proof. by []. Qed.
-
-  Local Lemma Hproc : sem_Ind_proc P ev Pc Pfun.
-  Proof. by []. Qed.
-
-  Lemma check_cP s1 c s2: sem P ev s1 c s2 -> Pc s1 c s2.
-  Proof.
-    apply (@sem_Ind _ _ _ P ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn
-             Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc).
-  Qed.
-End PROOF.
-
-Definition valid_map1 (m:Mvar.t Z) (size:Z) :=
-  forall x px, Mvar.get m x = Some px -> 
-     exists sx, size_of (vtype x) = ok sx /\
-     [/\ 0 <= px, px + sx <= size,
-      aligned_for (vtype x) px &
-         forall y py sy, x != y -> 
-           Mvar.get m y = Some py -> size_of (vtype y) = ok sy ->
-           px + sx <= py \/ py + sy <= px].
-
-Lemma init_mapP l sz m :
-  init_map sz l = ok m -> 
-  valid_map1 m sz.
-Proof.
-  rewrite /init_map.
-  set f1 := (f in foldM f _ _ ).
-  set g := (g in foldM _ _ _ >>= g). 
-  have : forall p p',
-    foldM f1 p l = ok p' -> 
-    valid_map1 p.1 p.2 -> 0 <= p.2 ->
-    (forall y py sy, Mvar.get p.1 y = Some py ->
-        size_of (vtype y) = ok sy -> py + sy <= p.2) ->
-    (p.2 <= p'.2 /\ valid_map1 p'.1 p'.2).
-  + elim:l => [|[v pn] l Hrec] p p'//=.
-    + by move=>[] <- ???;split=>//;omega.
-    case:ifPn=> //= /Z.leb_le Hle.
-    case: ifP => // Hal.
-    case Hs : size_of=> [svp|]//= /Hrec /= {Hrec}Hrec H2 H3 H4. 
-    have Hpos := size_of_pos Hs.
-    case:Hrec.
-    + move=> x px;rewrite Mvar.setP;case:ifPn => /eqP Heq.
-      + move=> [] ?;subst;exists svp;split=>//;split => //.
-        + omega. + omega.
-        move=> y py sy Hne.
-        by rewrite Mvar.setP_neq // => /H4 H /H ?;omega.
-      move=> /H2 [sx] [Hsx] [] Hle0 Hpx Hal' Hy;exists sx;split=>//;split=>//.
-      + omega.
-      move=> y py sy Hne;rewrite Mvar.setP;case:eqP=> [?[]? |].
-      + subst;rewrite Hs => -[] ?;subst; omega.
-      by move=> Hney;apply Hy.
-    + omega.
-    + move=> y py sy;rewrite Mvar.setP;case:eqP=> [?[]?|].
-      + subst;rewrite Hs => -[] ->;omega.
-      move=> ? /H4 H /H ?;omega.
-    move=> Hle2 H';split=>//;first by omega.
-  move=> H;case Heq : foldM => [p'|]//=.
-  case: (H _ _ Heq)=> //= Hp' Hv.
-  rewrite /g; case:ifP => //= /Z.leb_le Hp [<-].
-  move=> x px Hx.
-  case :(Hv x px Hx) => //= sx [] Hsx [] H1 H2 H3 H4.
-  by exists sx;split=>//;split=>//;omega.
-Qed.
-
-Lemma getfun_alloc nrsp oracle oracle_g (P:uprog) (SP:sprog) :
-  alloc_prog nrsp oracle oracle_g P = ok SP ->
-  exists lg mglob, 
-    [/\ init_map (Z.of_nat (size SP.(p_extra).(sp_globs))) lg = ok mglob,
-        check_globs (p_globs P) mglob SP.(p_extra).(sp_globs) &
-        forall fn fd,
-        get_fundef (p_funcs P) fn = Some fd ->
-        exists fd', 
-           get_fundef SP.(p_funcs) fn = Some fd' /\
-           alloc_fd nrsp SP.(p_extra).(sp_rip) mglob oracle (fn, fd) = ok (fn,fd')].
-Proof.
-  rewrite /alloc_prog.
-  case: (oracle_g P) => -[data rip] l.
-  t_xrbindP => mglob; apply: add_err_msgP => heq.
-  case heq1: check_globs => //; t_xrbindP => sfd hm ?; subst SP => /=.
-  exists l, mglob;split => //.
-  elim: (p_funcs P) sfd hm => [ | [fn1 fd1] fs hrec sfd] //=.
-  t_xrbindP => -[fn2 fd2] fd2' H [??]; subst fn2 fd2'.
-  move => sfds /hrec hm ?; subst sfd.
-  move=> fn3 fd3 /=.
-  case: eqP => ? .
-  + by move=> [?]; subst fn3 fd3; exists fd2; rewrite H.
-  by move=> /hm.
-Qed.
+(* We consider two reg ptr values in the list [va] of source values and the
+   corresponding pointers in the list [va'] of target values.
+   If one of the reg ptr is writable, the zones in the target memory pointed to
+   by the two pointers are disjoint.
 *)
-Definition extend_mem (m1:mem) (m2:mem) (rip:pointer) (data: seq u8) :=
-  let glob_size := Z.of_nat (size data) in
-  [/\ wunsigned rip + glob_size <= wbase U64 /\
-      (forall ofs s, is_align (rip + wrepr _ ofs)%R s = is_align (wrepr _ ofs) s), 
-      (forall w sz, validw m1 w sz -> read m1 w sz = read m2 w sz),
-      (forall w sz, validw m1 w sz ->
-          ~((wunsigned rip <? wunsigned w + wsize_size sz) && (wunsigned w <? wunsigned rip + glob_size))),
-      (forall w sz, validw m2 w sz = 
-         validw m1 w sz || (between rip glob_size w sz && is_align w sz)) &
-      (forall i, 
-         0 <= i < glob_size ->
-         read m2 (rip + wrepr U64 i)%R U8 = ok (nth (wrepr U8 0) data (Z.to_nat i)))].
-(*
-Lemma all_In (T:Type) (P: T -> bool) (l:seq T) x :
-  all P l ->
-  List.In x l -> P x.
-Proof. by elim: l => //= x' l hi /andP [] hp /hi h -[<- | /h]. Qed.
+Definition disjoint_values (sao_params:seq (option param_info)) va va' :=
+  forall i1 pi1 w1 i2 pi2 w2,
+    nth None sao_params i1 = Some pi1 ->
+    nth (Vbool true) va' i1 = @Vword Uptr w1 ->
+    nth None sao_params i2 = Some pi2 ->
+    nth (Vbool true) va' i2 = @Vword Uptr w2 ->
+    i1 <> i2 -> pi1.(pp_writable) ->
+    disjoint_zrange w1 (size_val (nth (Vbool true) va i1)) w2 (size_val (nth (Vbool true) va i2)).
 
-Lemma valid_top (P : uprog) nrsp (stk_size : Z) (rsp : u64) (glob_size : Z) 
-         (rip : u64) (data : seq u8) (gm : gmap) (sm : smap) 
-         s1 s2 :
-         valid P nrsp stk_size rsp glob_size rip data gm sm s1 s2 ->
- top_stack (emem s2) = rsp.
+(* Link between a reg ptr result value [vr] in the source and the corresponding pointer
+   [p] in the target. [m1] is the source memory. The reg ptr is associated to
+   the [i]-th elements of [vargs1] and [vargs2] (the arguments in the source and
+   the target).
+*)
+Record wf_result_pointer m1 vargs1 vargs2 i vr p := {
+  wrp_args    : nth (Vbool true) vargs2 i = Vword p;
+    (* the pointer [p] that is returned is the same that was taken as argument (in the target) *)
+  wrp_subtype : subtype (type_of_val vr) (type_of_val (nth (Vbool true) vargs1 i));
+    (* [vr] is smaller than the value taken as argument (in the source) *)
+    (* actually, size_of_val vr <= size_of_val (nth (Vbool true) vargs1 i) is enough to do the proofs,
+       but this is true and we have lemmas about [subtype] (e.g. [wf_sub_region_subtype] *)
+  wrp_read    : forall off w, get_val_byte vr off = ok w -> read m1 (p + wrepr _ off)%R U8 = ok w
+    (* the memory at address [p] contains [vr] *)
+}.
+
+(* Link between the values returned by the function in the source and the target. *)
+Definition wf_result m1 vargs1 vargs2 (i : option nat) vr vr' :=
+  match i with
+  | None => vr' = vr (* no reg ptr : both values are equal *)
+  | Some i => (* reg ptr : [va] is compiled to a pointer [p] that satisfies [wf_arg_pointer] *)
+    exists p, vr' = Vword p /\ wf_result_pointer m1 vargs1 vargs2 i vr p
+  end.
+
+Lemma get_PvarP e x : get_Pvar e = ok x -> e = Pvar x.
+Proof. by case: e => //= _ [->]. Qed.
+
+Lemma alloc_call_arg_aux_not_None rmap0 rmap opi e rmap2 bsr e' :
+  alloc_call_arg_aux pmap rmap0 rmap opi e = ok (rmap2, (bsr, e')) ->
+  forall pi, opi = Some pi -> exists sr, bsr = Some (pi.(pp_writable), sr).
 Proof.
-  by move=> /valid_top_frame; rewrite /top_stack; case: frames => //= ?? [->].
+  move=> halloc pi ?; subst opi.
+  move: halloc; rewrite /alloc_call_arg_aux.
+  t_xrbindP=> x _ _ _.
+  case: get_local => [pk|//].
+  case: pk => // p.
+  t_xrbindP=> -[sr ?] _ _ _ _ _ _ /= <- _.
+  by eexists.
 Qed.
 
-Lemma alloc_prog_stk_id nrsp oracle oracle_g P SP :
-  alloc_prog nrsp oracle oracle_g P = ok SP →
-  sp_stk_id SP.(p_extra) = nrsp.
+Lemma alloc_call_args_aux_not_None rmap sao_params args rmap2 l :
+  alloc_call_args_aux pmap rmap sao_params args = ok (rmap2, l) ->
+  List.Forall2 (fun opi bsr => forall pi, opi = Some pi ->
+    exists sr, bsr = Some (pi.(pp_writable), sr)) sao_params (map fst l).
 Proof.
-  by rewrite /alloc_prog; case: (oracle_g _) => - []; t_xrbindP => ?????; case: ifP => // _; t_xrbindP => ?? <-.
+  rewrite /alloc_call_args_aux.
+  elim: sao_params args {2}rmap rmap2 l.
+  + move=> [|//] _ _ _ /= [_ <-]; constructor.
+  move=> opi sao_params ih [//|arg args] rmap0 /=.
+  t_xrbindP=> _ _ [rmap1 [bsr e]] halloc [rmap2 l] /= /ih{ih}ih _ <-.
+  constructor=> //.
+  by apply (alloc_call_arg_aux_not_None halloc).
 Qed.
 
-Lemma alloc_fdP nrsp oracle oracle_g (P:uprog) SP fn fd fd':
-  alloc_prog nrsp oracle oracle_g P = ok SP ->
-  get_fundef (p_funcs P) fn = Some fd ->
-  get_fundef (p_funcs SP) fn = Some fd' ->
-  forall ev m1 va m1' vr rip, 
-    sem_call P ev m1 fn va m1' vr ->
-    forall m2, extend_mem m1 m2 rip SP.(p_extra).(sp_globs) ->
-    (exists p, alloc_stack m2 (sf_stk_sz fd'.(f_extra)) = ok p) ->
-    exists m2' vr',
-      List.Forall2 value_uincl vr vr' /\
-      extend_mem m1' m2' rip SP.(p_extra).(sp_globs) /\
-      sem_call (sCP:=sCP_stack) SP rip m2 fn va m2' vr'.
-Proof.
-  move=> hap get Sget. 
-  have ? := alloc_prog_stk_id hap; subst nrsp.
-  have [lg [mglob [higlob hcheck hf]]]:= getfun_alloc hap.
-  have [fd1 [] {hf}]:= hf _ _ get.
-  rewrite Sget => -[?];subst fd1.
-  rewrite /alloc_fd.
-  case: (oracle (fn, fd)) => -[stk_size lv] ptrreg_of_reg .
-  t_xrbindP => fd1 mstk; rewrite /add_err_fun.
-  case histk : init_map => [mstk1 | //] [?]; subst mstk1.
-  set gm := {| rip := _ |}; set sm0 := {| mstk := _ |}.
-  move=> sm1; case hfold : foldM => [sm1' | //] [?]; subst sm1'.
-  move=> [sme c]; apply: add_finfoP => hc /=.
-  case: andP => // -[] hneq hres [?] ?;subst fd1 fd' => /=.
-  move=> ev m1 vargs m1' vres rip hcall m2 hm2 [m2s ha].
-  pose glob_size := Z.of_nat (size (sp_globs SP.(p_extra))).
-  have Hstk: ptr_ok (top_stack m2s) stk_size.
-  + by move: ha=> /Memory.alloc_stackP [].
-  have Hglob: ptr_ok rip (Z.of_nat (size (sp_globs SP.(p_extra)))).
-  + by rewrite /ptr_ok; case hm2.
+Lemma set_clearP rmap sr ofs len rmap2 :
+  set_clear rmap sr ofs len = ok rmap2 ->
+  sr.(sr_region).(r_writable) /\
+  rmap2 = set_clear_pure rmap sr ofs len.
+Proof. by rewrite /set_clear; t_xrbindP=> _ /assertP -> <-. Qed.
 
-  have hv : valid_map gm sm0 stk_size glob_size.
-  + rewrite /sm0 => x mpx; rewrite /find_gvar /=; case:ifP => his.
-    + rewrite Mvar.mapP; case heq: Mvar.get => [ofsx | // ] [?]; subst mpx.
-      have [sx [h1 [h2 h3 h4 h5]]] := init_mapP histk heq.
-      exists sx;split => //; split => //.
-      move=> y mpy sy; case: ifP => his'.
-      + rewrite  Mvar.mapP; case heq': Mvar.get => [ofsy | // ] [?]; subst mpy => /=.
-        move=> hsy _; case: (v_var (gv x) =P gv y).
-        + by move => heq1; move: heq'; rewrite -heq1 heq => -[->]; rewrite eq_refl.
-        move=> /eqP => heq1; have := h5 _ _ _ heq1 heq' hsy; case: eqP => //.
-        by have := size_of_pos h1; have := size_of_pos hsy; lia.
-      by case: Mvar.get => [ofsy | //] [<-].
-    case heq: Mvar.get => [ofsx' | // ] [?]; subst mpx => /=.
-    have [sx [h1 [h2 h3 h4 h5]]] := init_mapP higlob heq.
-    exists sx;split => //; split => //.
-    move=> y mpy sy; case: ifP => his'.
-    + by rewrite  Mvar.mapP; case heq': Mvar.get => [ofsy | // ] [?]; subst mpy.
-    case heq': Mvar.get => [ofsy | //] [?] hsy _; subst mpy => /=.
-    case: (v_var (gv x) =P gv y).
-    + by move => heq1; move: heq'; rewrite -heq1 heq => -[->]; rewrite eq_refl.
-    move=> /eqP => heq1; have := h5 _ _ _ heq1 heq' hsy; case: eqP => //.
-    by have := size_of_pos h1; have := size_of_pos hsy; lia.
-  have heq_init :
-    init_state (semCallParams := sCP_stack) {| sf_stk_sz := stk_size; sf_extra := ptrreg_of_reg |} 
-                          SP.(p_extra) rip {| emem := m2; evm := vmap0 |} = 
-    ok {| emem := m2s; evm := vmap0.[vrsp (sp_stk_id SP.(p_extra)) <- ok (pword_of_word (top_stack m2s))]
-                                             .[vrip gm <- ok (pword_of_word rip)] |}.
-  + rewrite /init_state /= /init_stk_state ha /= /with_vm //=. 
-    f_equal; f_equal; f_equal; [f_equal | ]; f_equal; rewrite /pword_of_word;
-    f_equal; apply (Eqdep_dec.UIP_dec Bool.bool_dec).
-    
-  have hvalid : 
-    valid P (sp_stk_id SP.(p_extra)) stk_size (top_stack m2s) 
-            (Z.of_nat (size (sp_globs SP.(p_extra)))) rip (sp_globs SP.(p_extra)) gm sm0
-              {| emem := m1; evm := vmap0 |}
-              {| emem := m2s; evm := vmap0.[vrsp (sp_stk_id SP.(p_extra)) <- ok (pword_of_word (top_stack m2s))]
-                                             .[vrip gm <- ok (pword_of_word rip)] |}.
-  + case: hm2 => halign2 hread_eq hdisj hval hglob.
-    have [hin hread_eqs hvals hal hdisjs htopf]:= Memory.alloc_stackP ha.
-    constructor => //=.
-    + move=> w sz hw; split; last by apply hdisj.
-      by have := hdisjs w sz; rewrite hval hw /= => /(_ erefl) -[] h; apply /negP /nandP;
-        [left|right];apply /ZltP; lia.
-    + by move=> w sz hw; rewrite (hread_eq _ _ hw) hread_eqs // hval hw.
-    + by move=> w sz; rewrite hvals hval -orbA (orbC (_ && _)) orbA.
-(*    + by move=> x hnin hnrsp hnrip;rewrite !Fv.setP_neq // eq_sym. *)
-    + by rewrite /get_var Fv.setP_eq.
-    + rewrite /get_var Fv.setP_neq ? Fv.setP_eq //.
-      by apply/eqP => -[k]; move/eqP: hneq; rewrite k.
-    + by rewrite htopf. 
-    + move=> x; rewrite /find_gvar.
-      case: ifP => his. 
-      + rewrite Mvar.mapP; case heq: Mvar.get => [ofs /=| //];split => //.
-        have := init_mapP histk heq. 
-        case Htype: (vtype (gv x))=> [| |n| sz] // [sx /= [[?] [h1 h2 h3 h4]]]; subst sx.
-        + move=> off hoff; rewrite hvals; split.
-          + apply /orP; right; rewrite is_align8 andbT.
-            rewrite /between wsize8 /ptr_size /wptr /= (wunsigned_rsp_add Hstk); [ | nia | nia ].
-            by apply/andP; split; apply/ZleP; nia.
-          move=> s' a; rewrite /get_gvar his /get_var Fv.get0 /on_vu /pundef_addr Htype /= => hok.
-          by have /Varr_inj [e ?]:= ok_inj hok; subst s' a; rewrite WArray.get0.
-        split.
-        + rewrite hvals; apply /orP; right.
-          have heq2 : v_var (gv x) = {| vtype := sword sz; vname := vname (gv x) |}.
-          + by case: (v_var (gv x)) Htype => /= ?? ->.
-          rewrite heq2 in heq. have /(_ sz (vname (gv x)) ofs):= valid_get_w Hstk Hglob hv. 
-          by rewrite /sm0 /= Mvar.mapP heq /= /wptr /= => /(_ erefl).
-        by move=> ?;rewrite /get_gvar his /get_var Fv.get0 /on_vu /pundef_addr Htype.
-      rewrite /gm /=; case heq: Mvar.get => [ofs /=| //]; split => //.
-      have := init_mapP higlob heq. 
-      case Htype: (vtype (gv x))=> [| |n| sz] // [sx /= [[?] [h1 h2 h3 h4]]]; subst sx.
-      + move=> off hoff; rewrite hvals.
-        have hvalid : valid_pointer m2 (wptr (top_stack m2s) rip MSglob + wrepr U64 (off + ofs)) U8.
-        + rewrite hval; apply /orP; right; rewrite is_align8 andbT.
-          rewrite /between wsize8 /ptr_size /wptr (wunsigned_rip_add Hglob).
-          + by apply/andP; split; apply/ZleP; nia.
-          + nia.
-          by move: (size _) hoff h2 h1; clear=> *;lia. 
-        split; first by rewrite hvalid.
-        move=> s' a; rewrite /get_gvar his /get_global /get_global_value.
-        case heq1 : xseq.assoc => [ []//= | //]; case: eqP => //.
-(*
-        rewrite Htype => -[?] heq2; subst n'; have /Varr_inj [e ?] := ok_inj heq2; subst n a => /=.
-        have := all_In hcheck (xseq.assoc_mem' heq1).
-        rewrite /check_glob /= heq => /andP [hle /allP hall] v hget. 
-        have := hall (Z.to_nat off); rewrite mem_iota /= Z2Nat.id; last by lia.
-        rewrite hget.
-        match goal with |- (?A -> _) -> _ => have hh: A end.
-        + by apply /ltP; case: hoff => ? /Z2Nat.inj_lt;apply.
-        move=> /(_ hh) {hh} /eqP <-.
-        rewrite /wptr -hread_eqs;last by move: hvalid; rewrite /wptr /=.
-        rewrite hglob; last by lia. 
-        rewrite Z.add_comm Z2Nat.z2nD;first last.
-        + by apply /lezP;rewrite -ssrring.z0E;lia.
-        + by apply /lezP;rewrite -ssrring.z0E;lia. 
-        by rewrite -nth_drop wrepr0. *)
-      rewrite /valid_ptr_word /get_gvar /wptr his.
-      have hvalid : valid_pointer m2 (rip + wrepr U64 ofs) sz.
-      + rewrite hval; apply /orP; right.
-        case: halign2 => hh1 hh2; rewrite /between hh2 h3 andbT.
-        rewrite (wunsigned_rip_add Hglob) //.
-        + apply /andP;split; apply /ZleP;lia.
-        move: (size _) (@wsize_size_pos sz) h2 => *; lia. 
-      rewrite hvals hvalid;split => // v. 
-      rewrite -hread_eqs // /get_global /get_global_value Htype.
-      case heq1 : xseq.assoc => [[ sz' w] //= | //]; case: eqP => // -[?] [?]; subst sz' v.
-      exists w => //; rewrite Memory.readP /CoreMem.read.
-      have := validr_valid_pointer m2 (rip + wrepr U64 ofs)%R sz.
-      rewrite hvalid => /is_okP => -[? ->] /=.
-      have := all_In hcheck (xseq.assoc_mem' heq1).
-Opaque Z.to_nat.
-      rewrite /check_glob heq /= => /andP [hh1 /eqP hh2];subst w.
-      f_equal; f_equal.
-      rewrite /CoreMem.uread; apply: (@eq_from_nth _ (wrepr U8 0)).
-      have hw := @le0_wsize_size sz.
-      + rewrite size_map size_ziota size_take size_drop.
-        case: ifPn => // /ltP; rewrite Nat2Z.inj_lt Z2Nat.id // Nat2Z.n2zB; last first. 
-        rewrite -(Nat2Z.id (size _)); apply /leP; rewrite -Z2Nat.inj_le; lia.
-        rewrite -subZE Z2Nat.id // => hh. 
-        have -> : (wsize_size sz) = Z.of_nat (size (sp_globs SP.(p_extra))) - ofs.
-        + by move:(size _) h2 hh => *; lia.
-        by rewrite Z2Nat.inj_sub // Nat2Z.id.
-      move=> i; rewrite size_map size_ziota => hi.
-      rewrite (nth_map 0) ?size_ziota // nth_take // nth_drop nth_ziota // Memory.addP /=.
-      rewrite -GRing.addrA -wrepr_add.
-      move /ltP: hi; rewrite Nat2Z.inj_lt Z2Nat.id // => hi.
-      have : 0 <= ofs + Z.of_nat i ∧ ofs + Z.of_nat i < Z.of_nat (size (sp_globs SP.(p_extra))).
-      + by move:(size _) h2 => *; lia.
-      move=> /hglob; rewrite Memory.readP /CoreMem.read CoreMem.uread8_get. 
-      t_xrbindP => ?? ->; rewrite Z2Nat.inj_add //; last by apply Zle_0_nat.
-      by rewrite Nat2Z.id addP.
-    move=> i [hi1 hi2]; rewrite -hread_eqs; first by apply hglob.
-    rewrite hval is_align8 andbT;apply /orP;right.
-    apply /andP;rewrite (wunsigned_rip_add Hglob) // wsize8;split;apply /ZleP; lia.
-Transparent Z.to_nat.
-  inversion_clear hcall.
-  case: H1 (* init_state ... *) => ?;subst s0.
-  move: H;rewrite get => -[?];subst f.
-  have uvargs0 : List.Forall2 value_uincl vargs0 vargs0.
-  + by apply List_Forall2_refl.
-  have [s1' [hwargs hvalid2 ]] := check_lvarsP hvalid hfold uvargs0 H2.
-  have hdisj : 0 < stk_size -> 0 < Z.of_nat (size (sp_globs SP.(p_extra))) ->
-       ((wunsigned (top_stack m2s) + stk_size <=? wunsigned rip)
-                || (wunsigned rip + Z.of_nat (size (sp_globs SP.(p_extra))) <=? wunsigned (top_stack m2s))).
-  + case: hm2 =>  _ _ _ hvm2 _ hss hsg. 
-    have [_ _ _ _ hh _]:= Memory.alloc_stackP ha.
-    have /hh : valid_pointer m2 rip U8.
-    + rewrite hvm2 is_align8 andbT;apply /orP;right.
-      rewrite /between Z.leb_refl /= wsize8; apply /ZleP. 
-      by move: (size _) hsg => *;lia.
-    have /hh : valid_pointer m2 (rip + wrepr Uptr (Z.of_nat (size (sp_globs SP.(p_extra))) - 1)) U8.
-    + rewrite hvm2 is_align8 andbT;apply /orP;right.
-      rewrite /between (wunsigned_rip_add Hglob); [ | lia | lia]. 
-      by rewrite wsize8; apply /andP; split; apply /ZleP; by move: (size _) hsg => *; lia.
-    rewrite wsize8 (wunsigned_rip_add Hglob); [ | lia | lia]. 
-    move=> a1 a2;apply /orP.
-    rewrite /is_true !Z.leb_le. 
-    case: a1; first by lia.
-    case: a2; last by lia.
-    move=> h_1 h_2.
-    have u1 : stk_size < Z.of_nat (size (sp_globs SP.(p_extra))) by lia.
-    have /hh : valid_pointer m2 (top_stack m2s) U8.
-    + rewrite hvm2 is_align8 andbT;apply /orP;right.
-      rewrite /between wsize8; apply /andP.
-      move: (size _) h_1 h_2 => *; split; apply /ZleP; lia.
-    by rewrite wsize8; lia.   
-  have [s3 [hssem hvalid3]] := check_cP (P:= P) SP.(p_funcs) Hstk Hglob hdisj H3 hc hvalid2.
-  have [vres1 [H1' uincl1]]:= check_varsP hres (valid_vm hvalid3) H4.
-  have [vres2 htr uincl2]:= mapM2_truncate_val H5 uincl1.
-  exists (free_stack (emem s3) stk_size), vres2.
-  split => //; split.
-  + have /Memory.free_stackP [h1 h2 h3 h4 (* h5 *)]: 
-     omap snd (ohead (frames(emem s3))) = Some stk_size.
-    + by rewrite (valid_top_frame hvalid3).
-    have [u1 u2 u3 u4 u5] := hm2.
-    have vdisj: forall w sz, valid_pointer m1' w sz ->  disjoint_zrange (top_stack m2s) stk_size w (wsize_size sz).
-    + subst m1'; move=> w sz hw; have [ /negP /andP] := valid_disj hvalid3 hw.
-      rewrite {1 2}/is_true !Z.ltb_lt => ??; split.
-      + by apply /ZleP; case: Hstk.
-      + by apply is_align_no_overflow; apply (Memory.valid_align hw).
-      lia.
-    subst m1';split => //.
-    + move=> w sz hw.
-      rewrite (valid_eq hvalid3) // h1 // h2 (valid_def hvalid3) /= hw /=; split=> //.
-      by rewrite (valid_top hvalid3); apply vdisj.
-    + by move=> w sz /(valid_disj hvalid3) [].
-    + move=> w sz. 
-      apply Bool.eq_iff_eq_true; have := h2 w sz.
-      rewrite {1}/is_true => ->.
-      rewrite (valid_def hvalid3) /= (valid_top hvalid3); split.
-      + move=> [] /orP [].
-        + move=> /orP [-> //| ].
-          move=> /andP [] /andP [] /ZleP ? /ZleP ?? [???].
-          by have := wsize_size_pos sz;lia.
-        by move=> /andP [-> ->] /=;rewrite orbT.         
-      move=> /orP [ hw | /andP [hb hal]]. 
-      + by rewrite hw /=;split => //; apply: vdisj.
-      rewrite hb hal !orbT;split => //; split.
-      + by apply /ZleP; case: Hstk.
-      + by apply is_align_no_overflow.
-      have : valid_pointer m2 w sz by rewrite u4 hb hal /= orbT.
-      have [_ _ _ _ h _]:= Memory.alloc_stackP ha.
-      by move=> /h; lia.
-    move=> i [hi1 hi2].
-    rewrite -h1.
-    + by rewrite (valid_glob hvalid3).
-    rewrite h2 (valid_top hvalid3) (valid_def hvalid3) is_align8 !andbT; split.
-    + apply /orP;right; apply /andP.
-      rewrite (wunsigned_rip_add Hglob) // wsize8;split;apply /ZleP.
-      lia. move: hi1 hi2; rewrite /h4; move: (size _) => *;lia.
+Lemma alloc_call_arg_aux_writable rmap0 rmap opi e rmap2 bsr e' :
+  alloc_call_arg_aux pmap rmap0 rmap opi e = ok (rmap2, (bsr, e')) ->
+  forall sr, bsr = Some (true, sr) ->
+  sr.(sr_region).(r_writable).
+Proof.
+  move=> halloc sr ?; subst bsr.
+  move: halloc; rewrite /alloc_call_arg_aux.
+  t_xrbindP=> x _ _ _.
+  case: opi => [pi|].
+  + case: get_local => [pk|//].
+    case: pk => // p.
+    t_xrbindP=> -[{sr}sr _] /= _ tt hclear _ _ _ hw <- _.
+    by move: hclear; rewrite hw => /set_clearP [? _].
+  case: get_local => //.
+  by t_xrbindP.
+Qed.
+
+Lemma alloc_call_args_aux_writable rmap sao_params args rmap2 l :
+  alloc_call_args_aux pmap rmap sao_params args = ok (rmap2, l) ->
+  List.Forall (fun bsr => forall sr, bsr = Some (true, sr) ->
+    sr.(sr_region).(r_writable)) (map fst l).
+Proof.
+  rewrite /alloc_call_args_aux.
+  elim: sao_params args {2}rmap rmap2 l.
+  + by move=> [|//] _ _ _ [_ <-]; constructor.
+  move=> opi sao_params ih [//|arg args] rmap0 /=.
+  t_xrbindP=> _ _ [rmap1 [bsr e]] halloc [rmap2 l] /= /ih{ih}ih _ <-.
+  constructor=> //.
+  by apply (alloc_call_arg_aux_writable halloc).
+Qed.
+
+Lemma incl_bytes_map_refl r bm : incl_bytes_map r bm bm.
+Proof.
+  apply Mvar.inclP => x.
+  case: Mvar.get => [bytes|//].
+  by apply subset_refl.
+Qed.
+
+Lemma incl_refl rmap : incl rmap rmap.
+Proof.
+  apply /andP; split.
+  + apply Mvar.inclP => x.
+    case: Mvar.get => [sr|//].
+    by apply eq_refl.
+  apply Mr.inclP => r.
+  case: Mr.get => [bm|//].
+  by apply incl_bytes_map_refl.
+Qed.
+
+Lemma incl_bytes_map_trans r bm1 bm2 bm3 :
+  incl_bytes_map r bm1 bm2 -> incl_bytes_map r bm2 bm3 -> incl_bytes_map r bm1 bm3.
+Proof.
+  move=> /Mvar.inclP h1 /Mvar.inclP h2.
+  apply Mvar.inclP => x.
+  case heq1: Mvar.get => [bytes1|//].
+  have := h1 x; rewrite heq1.
+  case heq2: Mvar.get => [bytes2|//] hsubset.
+  have := h2 x; rewrite heq2.
+  case heq3: Mvar.get => [bytes3|//].
+  by apply (subset_trans hsubset).
+Qed.
+
+Lemma incl_trans rmap1 rmap2 rmap3: incl rmap1 rmap2 -> incl rmap2 rmap3 -> incl rmap1 rmap3.
+Proof.
+  move=> /andP [] /Mvar.inclP h12 /Mr.inclP h12'.
+  move=> /andP [] /Mvar.inclP h23 /Mr.inclP h23'.
+  apply /andP; split.
+  + apply Mvar.inclP => x.
+    case heq1: Mvar.get => [sr1|//].
+    have := h12 x; rewrite heq1.
+    case heq2: Mvar.get => [sr2|//] /eqP ->.
+    have := h23 x; rewrite heq2.
+    by apply.
+  apply Mr.inclP => r.
+  case heq1: Mr.get => [bm1|//].
+  have := h12' r; rewrite heq1.
+  case heq2: Mr.get => [bm2|//] hincl.
+  have := h23' r; rewrite heq2.
+  case heq3: Mr.get => [bm3|//].
+  by apply (incl_bytes_map_trans hincl).
+Qed.
+
+Lemma get_var_bytes_None rv r x :
+  Mr.get rv r = None ->
+  get_var_bytes rv r x = ByteSet.empty.
+Proof.
+  move=> hget.
+  rewrite /get_var_bytes /get_bytes_map hget /=.
+  by rewrite /get_bytes /empty_bytes_map Mvar.get0.
+Qed.
+
+Lemma incl_var_region rmap1 rmap2 x sr :
+  incl rmap1 rmap2 ->
+  Mvar.get rmap1.(var_region) x = Some sr ->
+  Mvar.get rmap2.(var_region) x = Some sr.
+Proof.
+  move=> /andP [hincl _] hget1.
+  have /Mvar.inclP -/(_ x) := hincl.
+  rewrite hget1.
+  by case: Mvar.get => // _ /eqP <-.
+Qed.
+
+Lemma incl_get_var_bytes rmap1 rmap2 r x :
+  incl rmap1 rmap2 ->
+  ByteSet.subset (get_var_bytes rmap1 r x) (get_var_bytes rmap2 r x).
+Proof.
+  move=> /andP [] _ /Mr.inclP /(_ r).
+  rewrite /get_var_bytes /get_bytes_map /get_bytes.
+  case: Mr.get => [bm1|_]; last by apply (subset_is_empty _ is_empty_empty).
+  case: Mr.get => [bm2|//].
+  move=> /Mvar.inclP /(_ x).
+  case: Mvar.get => [bytes1|_]; last by apply (subset_is_empty _ is_empty_empty).
+  by case: Mvar.get => [bytes2|//].
+Qed.
+
+Lemma incl_check_gvalid rmap1 rmap2 x sr bytes :
+  incl rmap1 rmap2 ->
+  check_gvalid rmap1 x = Some (sr, bytes) ->
+  exists bytes2,
+  check_gvalid rmap2 x = Some (sr, bytes2) /\ ByteSet.subset bytes bytes2.
+Proof.
+  move=> hincl.
+  rewrite /check_gvalid.
+  case: is_glob.
+  + move=> ->.
+    exists bytes; split=> //.
+    by apply subset_refl.
+  case heq1: Mvar.get=> [sr'|//] [? <-]; subst sr'.
+  rewrite (incl_var_region hincl heq1).
+  eexists; split; first by reflexivity.
+  apply: incl_get_var_bytes hincl.
+Qed.
+
+Lemma wf_rmap_incl rmap1 rmap2 s1 s2 :
+  incl rmap1 rmap2 ->
+  wf_rmap rmap2 s1 s2 ->
+  wf_rmap rmap1 s1 s2.
+Proof.
+  move=> hincl hwfr.
+  case: (hwfr) => hwfsr hval hptr; split.
+  + move=> x sr /(incl_var_region hincl).
+    by apply hwfsr.
+  + move=> x sr bytes v /(incl_check_gvalid hincl) [bytes2 [hgvalid2 hsubset]] hget.
+    have [hread hty] := hval _ _ _ _ hgvalid2 hget.
+    split=> //.
+    move=> off hmem.
+    apply hread.
+    by apply: ByteSet.subsetP hmem.
+  move=> x sr /(incl_var_region hincl) /hptr [pk [hlx hpk]].
+  exists pk; split=> //.
+  case: pk hlx hpk => //= sl ofs ws z f hlx hpk hstkptr.
+  apply hpk.
+  by apply (mem_incl_l (incl_get_var_bytes _ _ hincl)).
+Qed.
+
+Lemma valid_state_incl rmap1 rmap2 m0 s s' :
+  incl rmap1 rmap2 ->
+  valid_state rmap2 m0 s s' ->
+  valid_state rmap1 m0 s s'.
+Proof.
+  move=> hincl hvs.
+  case:(hvs) => hvalid hdisj hvincl hvincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  constructor=> //.
+  by apply (wf_rmap_incl hincl hwfr).
+Qed.
+
+Lemma incl_bytes_map_merge_bytes_l r bm1 bm2 :
+  incl_bytes_map r (Mvar.map2 merge_bytes bm1 bm2) bm1.
+Proof.
+  apply Mvar.inclP => x.
+  rewrite Mvar.map2P //.
+  rewrite /merge_bytes.
+  case: Mvar.get => [bytes1|//].
+  case: Mvar.get => [bytes2|//].
+  case: ByteSet.is_empty => //.
+  by apply subset_inter_l.
+Qed.
+
+Lemma incl_bytes_map_merge_bytes_r r bm1 bm2 :
+  incl_bytes_map r (Mvar.map2 merge_bytes bm1 bm2) bm2.
+Proof.
+  apply Mvar.inclP => x.
+  rewrite Mvar.map2P //.
+  rewrite /merge_bytes.
+  case: Mvar.get => [bytes1|//].
+  case: Mvar.get => [bytes2|//].
+  case: ByteSet.is_empty => //.
+  by apply subset_inter_r.
+Qed.
+
+Lemma incl_merge_l rmap1 rmap2 : incl (merge rmap1 rmap2) rmap1.
+Proof.
+  rewrite /merge; apply /andP => /=; split.
+  + apply Mvar.inclP => x.
+    rewrite Mvar.map2P //.
+    case: Mvar.get => [sr1|//].
+    case: Mvar.get => [sr2|//].
+    by case: ifP.
+  apply Mr.inclP => r.
+  rewrite Mr.map2P //.
+  rewrite /merge_bytes_map.
+  case: Mr.get => [bm1|//].
+  case: Mr.get => [bm2|//].
+  case: Mvar.is_empty => //.
+  by apply incl_bytes_map_merge_bytes_l.
+Qed.
+
+Lemma incl_merge_r rmap1 rmap2 : incl (merge rmap1 rmap2) rmap2.
+Proof.
+  rewrite /merge; apply /andP => /=; split.
+  + apply Mvar.inclP => x.
+    rewrite Mvar.map2P //.
+    case: Mvar.get => [sr1|//].
+    case: Mvar.get => [sr2|//].
+    by case: ifP.
+  apply Mr.inclP => r.
+  rewrite Mr.map2P //.
+  rewrite /merge_bytes_map.
+  case: Mr.get => [bm1|//].
+  case: Mr.get => [bm2|//].
+  case: Mvar.is_empty => //.
+  by apply incl_bytes_map_merge_bytes_r.
+Qed.
+
+Lemma subset_clear_bytes_compat bytes1 bytes2 i :
+  ByteSet.subset bytes1 bytes2 ->
+  ByteSet.subset (clear_bytes i bytes1) (clear_bytes i bytes2).
+Proof.
+  move=> /ByteSet.subsetP hsubset.
+  apply /ByteSet.subsetP => z.
+  rewrite /clear_bytes !ByteSet.removeE.
+  move=> /andP [hmem hnmem].
+  apply /andP; split=> //.
+  by apply hsubset.
+Qed.
+
+Lemma incl_bytes_map_clear_bytes_map_compat r bm1 bm2 i :
+  incl_bytes_map r bm1 bm2 ->
+  incl_bytes_map r (clear_bytes_map i bm1) (clear_bytes_map i bm2).
+Proof.
+  move=> /Mvar.inclP hincl.
+  apply /Mvar.inclP => x.
+  rewrite /clear_bytes_map !Mvar.mapP.
+  case heq1: (Mvar.get bm1 x) (hincl x) => [bytes1|//] /=.
+  case: Mvar.get => [bytes2|//] /=.
+  by apply subset_clear_bytes_compat.
+Qed.
+
+(* not sure whether this is a good name *)
+Lemma incl_set_clear_pure_compat rmap1 rmap2 sr ofs len :
+  incl rmap1 rmap2 ->
+  incl (set_clear_pure rmap1 sr ofs len) (set_clear_pure rmap2 sr ofs len).
+Proof.
+  move=> /andP [] hincl1 /Mr.inclP hincl2.
+  apply /andP; split=> //=.
+  apply /Mr.inclP => r.
+  rewrite /set_clear_bytes !Mr.setP.
+  case: eqP => [<-|//].
+  apply incl_bytes_map_clear_bytes_map_compat.
+  rewrite /get_bytes_map.
+  case heq1: Mr.get (hincl2 sr.(sr_region)) => [r1|] /=.
+  + by case: Mr.get.
+  move=> _.
+  apply /Mvar.inclP => x.
+  by rewrite Mvar.get0.
+Qed.
+
+Lemma subset_clear_bytes i bytes :
+  ByteSet.subset (clear_bytes i bytes) bytes.
+Proof.
+  apply /ByteSet.subsetP => z.
+  by rewrite /clear_bytes ByteSet.removeE => /andP [? _].
+Qed.
+
+Lemma incl_bytes_map_clear_bytes_map r i bm :
+  incl_bytes_map r (clear_bytes_map i bm) bm.
+Proof.
+  apply /Mvar.inclP => x.
+  rewrite /clear_bytes_map Mvar.mapP.
+  case: Mvar.get => [bytes|//] /=.
+  by apply subset_clear_bytes.
+Qed.
+
+(* If we used the optim "do not put empty bytesets in the map", then I think
+   we could remove the condition. *)
+Lemma incl_set_clear_pure (rmap:region_map) sr ofs len :
+  Mr.get rmap sr.(sr_region) <> None ->
+  incl (set_clear_pure rmap sr ofs len) rmap.
+Proof.
+  move=> hnnone.
+  apply /andP; split=> /=.
+  + apply Mvar.inclP => x.
+    by case: Mvar.get.
+  apply /Mr.inclP => r.
+  rewrite /set_clear_bytes Mr.setP.
+  case: eqP => [<-|_].
+  + rewrite /get_bytes_map.
+    case heq: Mr.get hnnone => [bm|//] _ /=.
+    by apply incl_bytes_map_clear_bytes_map.
+  case: Mr.get => // bm.
+  by apply incl_bytes_map_refl.
+Qed.
+
+Lemma get_var_bytes_set_clear_bytes rv sr ofs len r y :
+  get_var_bytes (set_clear_bytes rv sr ofs len) r y =
+    let bytes := get_var_bytes rv r y in
+    if sr.(sr_region) != r then bytes
+    else
+      let i := interval_of_zone (sub_zone_at_ofs sr.(sr_zone) ofs len) in
+      ByteSet.remove bytes i.
+Proof.
+  rewrite /set_clear_bytes /get_var_bytes.
+  rewrite get_bytes_map_setP.
+  case: eqP => [->|] //=.
+  by rewrite get_bytes_clear.
+Qed.
+
+Lemma check_gvalid_set_clear rmap sr ty ofs len rmap2 y sry bytes :
+  wf_sub_region sr ty ->
+  set_clear rmap sr ofs len = ok rmap2 ->
+  check_gvalid rmap2 y = Some (sry, bytes) ->
+  exists bytes',
+    check_gvalid rmap y = Some (sry, bytes') /\
+    bytes =
+      if sr_region sr != sr_region sry then bytes' else
+      ByteSet.remove bytes' (interval_of_zone (sub_zone_at_ofs sr.(sr_zone) ofs len)).
+Proof.
+  move=> hwf /set_clearP [hw ->]; rewrite /check_gvalid.
+  case: (@idP (is_glob y)) => hg.
+  + case heq: Mvar.get => [[ofs' ws]|//] [<- <-].
+    eexists; split; first by reflexivity.
+    case: eqP => heqr //=.
+    by rewrite -hwf.(wfr_writable) heqr (sub_region_glob_wf (wf_globals heq)).(wfr_writable) in hw.
+  case heq': Mvar.get => [sr'|//] [? <-]; subst sr'.
+  eexists; split; first by reflexivity.
+  by rewrite get_var_bytes_set_clear_bytes.
+Qed.
+
+Lemma alloc_call_arg_aux_incl (rmap0 rmap:region_map) opi e rmap2 bsr e2 :
+  (forall r, Mr.get rmap0 r <> None -> Mr.get rmap r <> None) ->
+  alloc_call_arg_aux pmap rmap0 rmap opi e = ok (rmap2, (bsr, e2)) ->
+  incl rmap2 rmap /\ (forall r, Mr.get rmap0 r <> None -> Mr.get rmap2 r <> None).
+Proof.
+  move=> hincl.
+  rewrite /alloc_call_arg_aux.
+  t_xrbindP=> x _ _ _.
+  case: opi => [pi|].
+  + case: get_local => [pk|//].
+    case: pk => // p.
+    t_xrbindP=> -[sr _] /check_validP [bytes [hgvalid -> hmem]] /= {rmap2}rmap2 hclear _ _ <- _ _.
+    case: pp_writable hclear; last first.
+    + move=> [<-]; split=> //.
+      by apply incl_refl.
+    move=> /set_clearP [hw ->].
     split.
-    + by apply /ZleP; case: Hstk.
-    + by apply is_align_no_overflow; apply is_align8.
-    have :  valid_pointer m2 (rip + wrepr U64 i) U8.
-    + rewrite u4 is_align8 andbT; apply /orP;right.
-      by apply /andP; rewrite (wunsigned_rip_add Hglob) // wsize8;split;apply /ZleP;lia.
-    have [_ _ _ _ h _]:= Memory.alloc_stackP ha.
-    by move=> /h;lia.
-  econstructor;eauto.
-  move: hap hssem => /=; rewrite /alloc_prog.
-  by case: oracle_g => -[???]; t_xrbindP => ??; case:ifP => // ?; t_xrbindP => ?? <-.
+    + apply incl_set_clear_pure.
+      apply hincl.
+      move: hgvalid; rewrite /check_gvalid /=.
+      case: Mvar.get => [_|//] [-> hget] hnone.
+      move: hmem; rewrite -hget (get_var_bytes_None _ hnone) /=.
+      move=> /mem_is_empty_l -/(_ is_empty_empty).
+      apply /negP.
+      apply interval_of_zone_wf.
+      by apply size_of_gt0.
+    move=> r /=.
+    rewrite /set_clear_bytes Mr.setP.
+    case: eqP => [//|_].
+    by apply hincl.
+  case: get_local => [//|].
+  t_xrbindP=> _ _ <- _ _.
+  split=> //.
+  by apply incl_refl.
 Qed.
-*)
 
-Definition alloc_ok (SP:sprog) fn m2 :=
-  forall fd, get_fundef (p_funcs SP) fn = Some fd ->
-  allocatable_stack m2 fd.(f_extra).(sf_stk_max).
-
-Lemma alloc_progP nrip data oracle_g oracle (P: uprog) (SP: sprog) fn:
-  alloc_prog nrip data oracle_g oracle P = ok SP ->
-  forall ev m1 va m1' vr rip, 
-    sem_call (sCP := sCP_unit) P ev m1 fn va m1' vr ->
-    forall m2, extend_mem m1 m2 rip SP.(p_extra).(sp_globs) ->
-    alloc_ok SP fn m2 ->
-    exists m2' vr',
-      List.Forall2 value_uincl vr vr' /\
-      extend_mem m1' m2' rip SP.(p_extra).(sp_globs) /\
-      sem_call (sCP := sCP_stack) SP rip m2 fn va m2' vr'.
+Lemma alloc_call_args_aux_incl_aux (rmap0 rmap:region_map) err sao_params args rmap2 l :
+  (forall r, Mr.get rmap0 r <> None -> Mr.get rmap r <> None) ->
+  fmapM2 err (alloc_call_arg_aux pmap rmap0) rmap sao_params args = ok (rmap2, l) ->
+  incl rmap2 rmap.
 Proof.
-Admitted.
-(*
-  move=> Hcheck ev m1 va m1' vr rip hsem m2 he ha.
-  have [fd hget]: exists fd, get_fundef (p_funcs P) fn = Some fd.
-  + by case: hsem=> ??? fd *;exists fd.
-  have [lg [mglob [higlob hcheck hf]]]:= getfun_alloc Hcheck.
-  have [fd' [hgetS ?]]:= hf _ _ hget.
-  by apply: (alloc_fdP Hcheck hget hgetS hsem he (ha _ hgetS)).
+  elim: sao_params args rmap rmap2 l.
+  + by move=> [|//] rmap _ _ _ [<- _]; apply incl_refl.
+  move=> opi sao_params ih [//|arg args] rmap /=.
+  t_xrbindP=> _ _ hnnone [rmap1 [bsr e]] halloc [rmap2 l] /= /ih{ih}ih <- _.
+  have [hincl hnnone2] := alloc_call_arg_aux_incl hnnone halloc.
+  apply: (incl_trans _ hincl).
+  by apply ih.
 Qed.
+
+Lemma alloc_call_args_aux_incl rmap sao_params args rmap2 l :
+  alloc_call_args_aux pmap rmap sao_params args = ok (rmap2, l) ->
+  incl rmap2 rmap.
+Proof. by apply alloc_call_args_aux_incl_aux. Qed.
+
+Lemma alloc_call_arg_auxP m0 rmap0 rmap s1 s2 opi e1 rmap2 bsr e2 v1 :
+  valid_state rmap0 m0 s1 s2 ->
+  alloc_call_arg_aux pmap rmap0 rmap opi e1 = ok (rmap2, (bsr, e2)) ->
+  sem_pexpr gd s1 e1 = ok v1 ->
+  exists v2, [/\
+    sem_pexpr [::] s2 e2 = ok v2,
+    wf_arg (emem s1) (emem s2) opi v1 v2,
+    forall b sr, bsr = Some (b, sr) ->
+      v2 = Vword (sub_region_addr sr) /\ wf_sub_region sr (type_of_val v1) &
+    forall sr, bsr = Some (true, sr) ->
+      incl rmap2 (set_clear_pure rmap sr (Some 0%Z) (size_val v1))].
+Proof.
+  move=> hvs.
+  rewrite /alloc_call_arg_aux.
+  t_xrbindP=> x /get_PvarP -> _ /assertP.
+  case: x => x [] //= _.
+  case: opi => [pi|]; last first.
+  + case hlx: get_local => //.
+    t_xrbindP=> _ /check_diffP hnnew _ <- <- /= hget.
+    have hkind: get_var_kind pmap (mk_lvar x) = ok None.
+    + by rewrite /get_var_kind /= hlx.
+    rewrite (get_var_kindP hvs hkind hnnew hget).
+    by eexists.
+  case hlx: get_local => [pk|//].
+  case: pk hlx => // p hlx.
+  t_xrbindP=> -[sr _] /check_validP [bytes [hgvalid -> hmem]] /=.
+  have /(check_gvalid_wf wfr_wf) /= hwf := hgvalid.
+  move=> {rmap2}rmap2 hclear _ /(check_alignP hwf) halign <- <- <- hget /=.
+  have /wfr_gptr := hgvalid.
+  rewrite /get_var_kind /= hlx => -[_ [[<-] /=]].
+  rewrite get_gvar_nglob // => ->.
+  (* We have [size_val v1 <= size_slot x] by [have /= hle := size_of_le (type_of_get_gvar hget)].
+     The inequality is sufficient for most of the proof.
+     But we even have the equality, so let's use it.
+  *)
+  have /(wfr_val hgvalid) [_ /= hty] := hget.
+  eexists; split; first by reflexivity.
+  + eexists; split; first by reflexivity.
+    split=> //.
+    + have /= := no_overflow_sub_region_addr hwf.
+      by rewrite hty.
+    + move=> w hb.
+      apply (vs_slot_valid hwf.(wfr_slot)).
+      apply (zbetween_trans (zbetween_sub_region_addr hwf)).
+      by rewrite -hty.
+    + move=> w hvalid.
+      apply: disjoint_zrange_incl_l (vs_disjoint hwf.(wfr_slot) hvalid).
+      rewrite hty.
+      by apply (zbetween_sub_region_addr hwf).
+    + move=> hw hgsize.
+      move: hclear; rewrite hw => /set_clearP [hwritable _].
+      apply: disjoint_zrange_incl_r (writable_not_glob hwf.(wfr_slot) _ hgsize);
+        last by rewrite hwf.(wfr_writable).
+      rewrite hty.
+      by apply (zbetween_sub_region_addr hwf).
+    move=> off w /dup[] /get_val_byte_bound; rewrite hty => hoff.
+    have /(wfr_val hgvalid) [hread _] := hget.
+    apply hread.
+    rewrite memi_mem_U8; apply: mem_incl_r hmem; rewrite subset_interval_of_zone.
+    rewrite -(Z.add_0_l off).
+    rewrite -(sub_zone_at_ofs_compose _ _ _ (size_slot x)).
+    apply zbetween_zone_byte => //.
+    by apply zbetween_zone_refl.
+  + move=> _ _ [_ <-].
+    split=> //.
+    by rewrite hty.
+  move=> _ [hw <-].
+  move: hclear; rewrite hw => /set_clearP [_ ->].
+  by rewrite hty; apply incl_refl.
+Qed.
+
+Lemma alloc_call_args_auxP rmap m0 s1 s2 sao_params args rmap2 l vargs1 :
+  valid_state rmap m0 s1 s2 ->
+  alloc_call_args_aux pmap rmap sao_params args = ok (rmap2, l) ->
+  sem_pexprs gd s1 args = ok vargs1 ->
+  exists vargs2, [/\
+    sem_pexprs [::] s2 (map snd l) = ok vargs2,
+    Forall3 (wf_arg (emem s1) (emem s2)) sao_params vargs1 vargs2,
+    Forall3 (fun bsr varg1 varg2 => forall (b:bool) (sr:sub_region), bsr = Some (b, sr) ->
+      varg2 = Vword (sub_region_addr sr) /\ wf_sub_region sr (type_of_val varg1)) (map fst l) vargs1 vargs2 &
+    List.Forall2 (fun bsr varg1 => forall sr, bsr = Some (true, sr) ->
+      incl rmap2 (set_clear_pure rmap sr (Some 0%Z) (size_val varg1))) (map fst l) vargs1].
+Proof.
+  move=> hvs.
+  have: forall r, Mr.get rmap r <> None -> Mr.get rmap r <> None by done.
+  rewrite /alloc_call_args_aux.
+  elim: sao_params args {2 4 5}rmap rmap2 l vargs1.
+  + move=> [|//] /= rmap0 _ _ _ _ [<- <-] [<-].
+    by eexists; (split; first by reflexivity); constructor.
+  move=> opi sao_params ih [//|arg args] rmap0 /=.
+  t_xrbindP=> _ _ _ hnnone [rmap1 [bsr e]] halloc [rmap2 l] /= hallocs <- <- varg1 hvarg1 vargs1 hvargs1 <-.
+  have [varg2 [hvarg2 harg haddr hclear]] := alloc_call_arg_auxP hvs halloc hvarg1.
+  have [hincl hnnone2] := alloc_call_arg_aux_incl hnnone halloc.
+  have [vargs2 [hvargs2 hargs haddrs hclears]] := ih _ _ _ _ _ hnnone2 hallocs hvargs1.
+  rewrite /= hvarg2 /= hvargs2 /=.
+  eexists; (split; first by reflexivity); constructor=> //.
+  + move=> sr /hclear.
+    apply: incl_trans.
+    by apply (alloc_call_args_aux_incl_aux hnnone2 hallocs).
+  apply: Forall2_impl hclears.
+  move=> _ v1 hincl' sr /hincl'{hincl'}hincl'.
+  apply (incl_trans hincl').
+  by apply: incl_set_clear_pure_compat hincl.
+Qed.
+
+(* TODO: all2 defined in seq, oseq and utils... -> to be cleaned *)
+(* we could benefit from [seq.allrel] but it exists only in recent versions *)
+Lemma check_all_disjP notwritables writables srs :
+  check_all_disj notwritables writables srs -> [/\
+  forall b1 sr1 sr2, Some (b1, sr1) \in (map fst srs) -> sr2 \in writables -> disj_sub_regions sr1 sr2,
+  forall sr1 sr2, Some (true, sr1) \in (map fst srs) -> sr2 \in notwritables -> disj_sub_regions sr1 sr2 &
+  forall i1 sr1 i2 b2 sr2, nth None (map fst srs) i1 = Some (true, sr1) -> nth None (map fst srs) i2 = Some (b2, sr2) ->
+    i1 <> i2 -> disj_sub_regions sr1 sr2].
+Proof.
+  elim: srs notwritables writables.
+  + move=> notwritables writables _.
+    split=> // i1 b1 sr1 i2 b2 sr2.
+    by rewrite nth_nil.
+  move=> [bsr e] srs ih notwritables writables /=.
+  case: bsr => [[b sr]|]; last first.
+  + move=> /ih [ih1 ih2 ih3].
+    split.
+    + move=> b1 sr1 sr2.
+      rewrite in_cons /=.
+      by apply ih1.
+    + move=> sr1 sr2.
+      rewrite in_cons /=.
+      by apply ih2.
+    move=> [//|i1] sr1 [//|i2] b2 sr2 /= hnth1 hnth2 hneq.
+    by apply: ih3 hnth1 hnth2 ltac:(congruence).
+  case: allP => // hdisj.
+  case: b; last first.
+  + move=> /ih [ih1 ih2 ih3].
+    split.
+    + move=> b1 sr1 sr2.
+      rewrite in_cons => /orP [/eqP [_ ->]|hin1] hin2.
+      + by apply hdisj.
+      by apply: ih1 hin1 hin2.
+    + move=> sr1 sr2.
+      rewrite in_cons /= => hin1 hin2.
+      apply ih2 => //.
+      rewrite in_cons.
+      by apply /orP; right.
+    move=> [//|i1] sr1 [|i2] b2 sr2 /=.
+    + move=> hnth1 [_ <-] _.
+      apply ih2; last by apply mem_head.
+      rewrite -hnth1.
+      apply mem_nth.
+      by apply (nth_not_default hnth1 ltac:(discriminate)).
+    move=> hnth1 hnth2 hneq.
+    by apply: ih3 hnth1 hnth2 ltac:(congruence).
+  case: allP => // hdisj2.
+  move=> /ih [ih1 ih2 ih3].
+  split.
+  + move=> b1 sr1 sr2.
+    rewrite in_cons => /orP [/eqP [_ ->]|hin1] hin2.
+    + by apply hdisj.
+    apply (ih1 _ _ _ hin1).
+    rewrite in_cons.
+    by apply /orP; right.
+  + move=> sr1 sr2.
+    rewrite in_cons => /orP [/eqP [->]|hin1] hin2.
+    + by apply hdisj2.
+    by apply ih2.
+  move=> i1 sr1 i2 b2 sr2.
+  case: i1 => [|i1].
+  + case: i2 => [//|i2].
+    move=> /= [<-] hnth2 _.
+    rewrite disj_sub_regions_sym.
+    apply (ih1 b2); last by apply mem_head.
+    rewrite -hnth2.
+    apply mem_nth.
+    by apply (nth_not_default hnth2 ltac:(discriminate)).
+  move=> /= hnth1.
+  case: i2 => [|i2].
+  + move=> [_ <-] _.
+    apply (ih1 true); last by apply mem_head.
+    rewrite -hnth1.
+    apply mem_nth.
+    by apply (nth_not_default hnth1 ltac:(discriminate)).
+  move=> /= hnth2 hneq.
+  apply: ih3 hnth1 hnth2 ltac:(congruence).
+Qed.
+
+Lemma disj_sub_regions_disjoint_zrange sr1 sr2 ty1 ty2 :
+  wf_sub_region sr1 ty1 ->
+  wf_sub_region sr2 ty2 ->
+  disj_sub_regions sr1 sr2 ->
+  sr1.(sr_region).(r_writable) ->
+  disjoint_zrange (sub_region_addr sr1) (size_of ty1) (sub_region_addr sr2) (size_of ty2).
+Proof.
+  move=> hwf1 hwf2 hdisj hw.
+  move: hdisj; rewrite /disj_sub_regions /region_same.
+  case: eqP => heqr /=.
+  + move=> hdisj.
+    apply (disjoint_zones_disjoint_zrange hwf1 hwf2).
+    + by apply (wf_region_slot_inj hwf1 hwf2).
+    apply: disjoint_zones_incl hdisj.
+    + by apply (zbetween_zone_sub_zone_at_ofs_0 hwf1).
+    by apply (zbetween_zone_sub_zone_at_ofs_0 hwf2).
+  move=> _.
+  by apply (distinct_regions_disjoint_zrange hwf1 hwf2 ltac:(congruence) hw).
+Qed.
+
+Lemma disj_sub_regions_disjoint_values (srs:seq (option (bool * sub_region))) sao_params vargs1 vargs2 :
+  (forall i1 sr1 i2 b2 sr2, nth None srs i1 = Some (true, sr1) -> nth None srs i2 = Some (b2, sr2) ->
+    i1 <> i2 -> disj_sub_regions sr1 sr2) ->
+  List.Forall2 (fun opi bsr => forall pi, opi = Some pi -> exists sr, bsr = Some (pi.(pp_writable), sr)) sao_params srs ->
+  List.Forall (fun bsr => forall sr, bsr = Some (true, sr) -> sr.(sr_region).(r_writable)) srs ->
+  Forall3 (fun bsr varg1 varg2 => forall (b:bool) (sr:sub_region), bsr = Some (b, sr) ->
+    varg2 = Vword (sub_region_addr sr) /\ wf_sub_region sr (type_of_val varg1)) srs vargs1 vargs2 ->
+  disjoint_values sao_params vargs1 vargs2.
+Proof.
+  move=> hdisj hnnone hwritable haddr.
+  move=> i1 pi1 w1 i2 pi2 w2 hpi1 hw1 hpi2 hw2 hneq hwritable1.
+  have := Forall2_nth hnnone None None.
+  move=> /dup[].
+  move=> /(_ _ (nth_not_default hpi1 ltac:(discriminate)) _ hpi1); rewrite hwritable1 => -[sr1 hsr1].
+  move=> /(_ _ (nth_not_default hpi2 ltac:(discriminate)) _ hpi2) [sr2 hsr2].
+  have /InP hin1 := mem_nth None (nth_not_default hsr1 ltac:(discriminate)).
+  have /List.Forall_forall -/(_ _ hin1 _ hsr1) hwritable1' := hwritable.
+  have := Forall3_nth haddr None (Vbool true) (Vbool true).
+  move=> /dup[].
+  move=> /(_ _ (nth_not_default hsr1 ltac:(discriminate)) _ _ hsr1).
+  rewrite hw1 => -[[?] hwf1]; subst w1.
+  move=> /(_ _ (nth_not_default hsr2 ltac:(discriminate)) _ _ hsr2).
+  rewrite hw2 => -[[?] hwf2]; subst w2.
+  apply (disj_sub_regions_disjoint_zrange hwf1 hwf2) => //.
+  by apply: hdisj hsr1 hsr2 hneq.
+Qed.
+
+(* TODO: is it a good name? *)
+Lemma alloc_call_argsE rmap sao_params args rmap2 l :
+  alloc_call_args pmap rmap sao_params args = ok (rmap2, l) ->
+  alloc_call_args_aux pmap rmap sao_params args = ok (rmap2, l) /\
+  check_all_disj [::] [::] l.
+Proof.
+  rewrite /alloc_call_args.
+  by t_xrbindP=> -[{rmap2}rmap2 {l}l] halloc _ /assertP hdisj [<- <-].
+Qed.
+
+(* Full spec including [disjoint_values] *)
+Lemma alloc_call_argsP rmap m0 s1 s2 sao_params args rmap2 l vargs1 :
+  valid_state rmap m0 s1 s2 ->
+  alloc_call_args pmap rmap sao_params args = ok (rmap2, l) ->
+  sem_pexprs gd s1 args = ok vargs1 ->
+  exists vargs2, [/\
+    sem_pexprs [::] s2 (map snd l) = ok vargs2,
+    Forall3 (wf_arg (emem s1) (emem s2)) sao_params vargs1 vargs2,
+    disjoint_values sao_params vargs1 vargs2,
+    Forall3 (fun bsr varg1 varg2 => forall (b:bool) (sr:sub_region), bsr = Some (b, sr) ->
+      varg2 = Vword (sub_region_addr sr) /\ wf_sub_region sr (type_of_val varg1)) (map fst l) vargs1 vargs2 &
+    List.Forall2 (fun bsr varg1 => forall sr, bsr = Some (true, sr) ->
+      incl rmap2 (set_clear_pure rmap sr (Some 0%Z) (size_val varg1))) (map fst l) vargs1].
+Proof.
+  move=> hvs /alloc_call_argsE [halloc hdisj] hvargs1.
+  have [vargs2 [hvargs2 hargs haddr hclear]] := alloc_call_args_auxP hvs halloc hvargs1.
+  exists vargs2; split=> //.
+  apply: disj_sub_regions_disjoint_values (alloc_call_args_aux_not_None halloc) (alloc_call_args_aux_writable halloc) haddr.
+  by have [_ _ ?] := check_all_disjP hdisj.
+Qed.
+
+Lemma mem_unchanged_holed_rmap m0 s1 s2 mem1 mem2 l :
+  valid_incl m0 (emem s2) ->
+  validw (emem s1) =2 validw mem1 ->
+  List.Forall (fun '(sr, ty) => wf_sub_region sr ty /\ sr.(sr_region).(r_writable)) l ->
+  (forall p,
+    validw (emem s2) p U8 -> ~ validw (emem s1) p U8 ->
+    List.Forall (fun '(sr, ty) => disjoint_zrange (sub_region_addr sr) (size_of ty) p (wsize_size U8)) l ->
+    read mem2 p U8 = read (emem s2) p U8) ->
+  mem_unchanged (emem s1) m0 (emem s2) ->
+  mem_unchanged mem1 m0 mem2.
+Proof.
+  move=> hincl hvalideq1 hlwf hlunch hunch p hvalid1 hvalid2 hdisj.
+  rewrite -hvalideq1 in hvalid2.
+  rewrite (hunch _ hvalid1 hvalid2 hdisj).
+  symmetry; apply hlunch => //.
+  + by apply hincl.
+  apply List.Forall_forall => -[sr ty] hin.
+  have /List.Forall_forall -/(_ _ hin) [hwf hw] := hlwf.
+  apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf)).
+  apply (hdisj _ hwf.(wfr_slot)).
+  by rewrite hwf.(wfr_writable).
+Qed.
+
+(* "holed" because [rmap.(region_var)] does not contain any information about the sub-regions in [l]. *)
+Lemma eq_read_holed_rmap rmap m0 s1 s2 mem2 l sr ty off :
+  valid_state rmap m0 s1 s2 ->
+  List.Forall (fun '(sr, ty) => wf_sub_region sr ty /\ sr.(sr_region).(r_writable)) l ->
+  (forall p,
+    validw (emem s2) p U8 -> ~ validw (emem s1) p U8 ->
+    List.Forall (fun '(sr, ty) => disjoint_zrange (sub_region_addr sr) (size_of ty) p (wsize_size U8)) l ->
+    read mem2 p U8 = read (emem s2) p U8) ->
+  List.Forall (fun '(sr, ty) => forall x,
+    ByteSet.disjoint (get_var_bytes rmap sr.(sr_region) x) (ByteSet.full (interval_of_zone (sr.(sr_zone))))) l ->
+  wf_sub_region sr ty ->
+  0 <= off /\ off < size_of ty ->
+  (sr.(sr_region).(r_writable) -> exists x, ByteSet.memi (get_var_bytes rmap sr.(sr_region) x) (z_ofs (sr_zone sr) + off)) ->
+  read mem2 (sub_region_addr sr + wrepr _ off)%R U8 = read (emem s2) (sub_region_addr sr + wrepr _ off)%R U8.
+Proof.
+  move=> hvs hlwf hlunch hldisj hwf hoff hmem.
+  case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  apply hlunch.
+  + apply (hvalid _ _ hwf.(wfr_slot)).
+    apply: between_byte hoff.
+    + by apply (no_overflow_sub_region_addr hwf).
+    by apply (zbetween_sub_region_addr hwf).
+  + move=> hval.
+    have := hdisj _ _ hwf.(wfr_slot) hval.
+    apply zbetween_not_disjoint_zrange => //.
+    apply: between_byte hoff.
+    + by apply (no_overflow_sub_region_addr hwf).
+    by apply (zbetween_sub_region_addr hwf).
+  apply List.Forall_forall => -[sr2 ty2] hin2.
+  have /List.Forall_forall -/(_ _ hin2) hdisj2 := hldisj.
+  have /List.Forall_forall -/(_ _ hin2) [hwf2 hw2] := hlwf.
+  rewrite (sub_region_addr_offset (size_of sword8)).
+  change (wsize_size U8) with (size_of sword8).
+  have hwf' := sub_region_at_ofs_wf_byte hwf hoff.
+  case: (sr2.(sr_region) =P sr.(sr_region)) => heqr.
+  + apply (disjoint_zones_disjoint_zrange hwf2 hwf') => //.
+    move: hmem; rewrite -heqr => /(_ hw2) [x hmem].
+    move: (hdisj2 x) => /ByteSet.disjointP /(_ _ hmem).
+    rewrite ByteSet.fullE /I.memi /disjoint_zones /= !zify wsize8.
+    by have := hwf2.(wfz_len); lia.
+  by apply (distinct_regions_disjoint_zrange hwf2 hwf').
+Qed.
+
+Lemma wfr_VAL_holed_rmap rmap m0 s1 s2 mem1 mem2 l :
+  valid_state rmap m0 s1 s2 ->
+  List.Forall (fun '(sr, ty) => wf_sub_region sr ty /\ sr.(sr_region).(r_writable)) l ->
+  (forall p,
+    validw (emem s2) p U8 -> ~ validw (emem s1) p U8 ->
+    List.Forall (fun '(sr, ty) => disjoint_zrange (sub_region_addr sr) (size_of ty) p (wsize_size U8)) l ->
+    read mem2 p U8 = read (emem s2) p U8) ->
+  List.Forall (fun '(sr, ty) => forall x,
+    ByteSet.disjoint (get_var_bytes rmap sr.(sr_region) x) (ByteSet.full (interval_of_zone (sr.(sr_zone))))) l ->
+  wfr_VAL rmap (with_mem s1 mem1) (with_mem s2 mem2).
+Proof.
+  move=> hvs hlwf hlunch hldisj.
+  move=> x sr bytes v /= hgvalid /(wfr_val hgvalid) [hread hty].
+  have /(check_gvalid_wf wfr_wf) /= hwf := hgvalid.
+  split=> // off hmem w /dup[] /get_val_byte_bound; rewrite hty => hoff hget.
+  rewrite -(hread _ hmem _ hget).
+  apply (eq_read_holed_rmap hvs hlwf hlunch hldisj hwf hoff).
+  move=> hw.
+  by exists x.(gv); move: hmem; have -> := check_gvalid_writable hw hgvalid.
+Qed.
+
+Lemma wfr_PTR_holed_rmap rmap m0 s1 s2 mem2 l :
+  valid_state rmap m0 s1 s2 ->
+  List.Forall (fun '(sr, ty) => wf_sub_region sr ty /\ sr.(sr_region).(r_writable)) l ->
+  (forall p,
+    validw (emem s2) p U8 -> ~ validw (emem s1) p U8 ->
+    List.Forall (fun '(sr, ty) => disjoint_zrange (sub_region_addr sr) (size_of ty) p (wsize_size U8)) l ->
+    read mem2 p U8 = read (emem s2) p U8) ->
+  List.Forall (fun '(sr, ty) => forall x,
+    ByteSet.disjoint (get_var_bytes rmap sr.(sr_region) x) (ByteSet.full (interval_of_zone (sr.(sr_zone))))) l ->
+  wfr_PTR rmap (with_mem s2 mem2).
+Proof.
+  move=> hvs hlwf hlunch hldisj.
+  move=> x sr /wfr_ptr [pk [hlx hpk]].
+  exists pk; split=> //.
+  case: pk hlx hpk => // s ofs ws z f hlx /= hpk hcheck.
+  rewrite -(hpk hcheck).
+  apply eq_read => i hi; rewrite addE.
+  have /wf_locals /= hlocal := hlx.
+  have hwfs := sub_region_stkptr_wf hlocal.
+  apply (eq_read_holed_rmap hvs hlwf hlunch hldisj hwfs hi).
+  move=> _; exists f.
+  rewrite memi_mem_U8; apply: mem_incl_r hcheck; rewrite subset_interval_of_zone.
+  rewrite -(Z.add_0_l i).
+  rewrite -(sub_zone_at_ofs_compose _ _ _ (size_of sword64)).
+  apply zbetween_zone_byte => //.
+  by apply zbetween_zone_refl.
+Qed.
+
+Lemma valid_state_holed_rmap rmap m0 s1 s2 mem1 mem2 l :
+  valid_state rmap m0 s1 s2 ->
+  validw (emem s1) =2 validw mem1 ->
+  stack_stable (emem s2) mem2 ->
+  validw (emem s2) =2 validw mem2 ->
+  eq_mem_source mem1 mem2 ->
+  List.Forall (fun '(sr, ty) => wf_sub_region sr ty /\ sr.(sr_region).(r_writable)) l ->
+  (forall p,
+    validw (emem s2) p U8 -> ~ validw (emem s1) p U8 ->
+    List.Forall (fun '(sr, ty) => disjoint_zrange (sub_region_addr sr) (size_of ty) p (wsize_size U8)) l ->
+    read mem2 p U8 = read (emem s2) p U8) ->
+  List.Forall (fun '(sr, ty) => forall x,
+    ByteSet.disjoint (get_var_bytes rmap sr.(sr_region) x) (ByteSet.full (interval_of_zone (sr.(sr_zone))))) l ->
+  valid_state rmap m0 (with_mem s1 mem1) (with_mem s2 mem2).
+Proof.
+  move=> hvs hvalideq1 hss2 hvalideq2 heqmem_ hlwf hlunch hldisj.
+  case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  constructor=> //=.
+  + by move=> ??; rewrite -hvalideq2; apply hvalid.
+  + by move=> ??; rewrite -hvalideq1; apply hdisj.
+  + by move=> ?; rewrite -hvalideq1 -hvalideq2; apply hincl.
+  + by move=> ?; rewrite -hvalideq2; apply hincl2.
+  + by apply (mem_unchanged_holed_rmap hincl2 hvalideq1 hlwf hlunch hunch).
+  + case: (hwfr) => hwfsr hval hptr; split=> //.
+    + by apply (wfr_VAL_holed_rmap hvs hlwf hlunch hldisj).
+    by apply (wfr_PTR_holed_rmap hvs hlwf hlunch hldisj).
+  by rewrite -hss2.(ss_top_stack).
+Qed.
+
+Lemma check_lval_reg_callP r tt :
+  check_lval_reg_call pmap r = ok tt ->
+    (exists ii ty, r = Lnone ii ty) \/
+    exists x,
+      [/\ r = Lvar x, Mvar.get pmap.(locals) x = None & ~ Sv.In x pmap.(vnew)].
+Proof.
+  rewrite /check_lval_reg_call.
+  case: r => //.
+  + move=> ii ty _.
+    by left; exists ii, ty.
+  move=> x.
+  case heq: get_local => [//|].
+  t_xrbindP=> _ /check_diffP ? _.
+  by right; exists x.
+Qed.
+
+(* Another lemma on [set_sub_region].
+   See [valid_state_set_move_regptr].
 *)
+Lemma valid_state_set_sub_region_regptr rmap m0 s1 s2 x sr ofs ty v p rmap2 :
+  valid_state rmap m0 s1 s2 ->
+  wf_sub_region sr x.(vtype) ->
+  (forall zofs, ofs = Some zofs -> 0 <= zofs /\ zofs + size_of ty <= size_of x.(vtype)) ->
+  get_local pmap x = Some (Pregptr p) ->
+  set_sub_region rmap x sr ofs (size_of ty) = ok rmap2 ->
+  eq_sub_region_val x.(vtype) (emem s2) sr (get_var_bytes rmap2 sr.(sr_region) x) v ->
+  valid_state rmap2 m0 (with_vm s1 (evm s1).[x <- pof_val x.(vtype) v])
+                       (with_vm s2 (evm s2).[p <- pof_val p.(vtype) (Vword (sub_region_addr sr))]).
+Proof.
+  move=> hvs hwf hofs hlx hset heqval.
+  have hwf' := sub_region_at_ofs_wf hwf hofs.
+  have /wf_locals /= hlocal := hlx.
+  case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  constructor=> //=.
+  + rewrite get_var_neq //.
+    by apply hlocal.(wfr_not_vrip).
+  + rewrite get_var_neq //.
+    by apply hlocal.(wfr_not_vrsp).
+  + move=> y hget hnnew.
+    rewrite get_var_neq; last by rewrite /get_local in hlx; congruence.
+    rewrite get_var_neq; last by have := hlocal.(wfr_new); congruence.
+    by apply heqvm.
+  case: (hwfr) => hwfsr hval hptr; split.
+  + apply (wfr_WF_set hwfsr hwf).
+    by have [_ ->] := set_sub_regionP hset.
+  + move=> y sry bytesy vy.
+    move=> /(check_gvalid_set_sub_region hwf hset) [].
+    + move=> [? ? <- ->]; subst x.
+      rewrite get_gvar_eq //.
+      case: heqval => hread hty'.
+      apply on_vuP => //; rewrite -hty'.
+      by move => ? hof hto; rewrite -hto (pto_val_pof_val hof) hty'.
+    move=> [? [bytes [hgvalid ->]]].
+    rewrite get_gvar_neq => // /(wfr_val hgvalid).
+    assert (hwfy := check_gvalid_wf wfr_wf hgvalid).
+    case: eqP => heqr /=.
+    + by apply (eq_sub_region_val_same_region hwf' hwfy heqr).
+    apply: (eq_sub_region_val_distinct_regions hwf' hwfy heqr) => //.
+    by case /set_sub_regionP : hset.
+  move=> y sry.
+  have /set_sub_regionP [_ ->] /= := hset.
+  rewrite Mvar.setP; case: eqP.
+  + move=> <- [<-].
+    exists (Pregptr p); split=> //=.
+    by rewrite get_var_eq hlocal.(wfr_rtype).
+  move=> hneq /hptr [pk [hly hpk]].
+  exists pk; split=> //.
+  case: pk hly hpk => //=.
+  + move=> py hly.
+    have ? := hlocal.(wfr_distinct) hly hneq.
+    by rewrite get_var_neq.
+  move=> s osf ws z f hly hpk.
+  rewrite /check_stack_ptr get_var_bytes_set_pure_bytes.
+  case: eqP => [_|//].
+  case: eqP => [heq|_].
+  + have /wf_locals /wfs_new := hly.
+    by have /wf_vnew := hlx; congruence.
+  by move=> /(mem_remove_interval_of_zone (wf_zone_len_gt0 hwf')) -/(_ ltac:(done)) [/hpk ? _].
+Qed.
+
+Lemma get_regptrP x p :
+  get_regptr pmap x = ok p ->
+  Mvar.get pmap.(locals) x = Some (Pregptr p).
+Proof. by rewrite /get_regptr; case heq: get_local => [[]|] // [<-]. Qed.
+
+Lemma alloc_lval_callP rmap m0 s1 s2 srs r oi rmap2 r2 vargs1 vargs2 vres1 vres2 s1' :
+  valid_state rmap m0 s1 s2 ->
+  alloc_lval_call pmap srs rmap r oi = ok (rmap2, r2) ->
+  Forall3 (fun bsr varg1 varg2 => forall (b:bool) (sr:sub_region), bsr = Some (b, sr) ->
+    varg2 = Vword (sub_region_addr sr) /\ wf_sub_region sr (type_of_val varg1)) (map fst srs) vargs1 vargs2 ->
+  wf_result (emem s2) vargs1 vargs2 oi vres1 vres2 ->
+  write_lval gd r vres1 s1 = ok s1' ->
+  exists s2', [/\
+    write_lval [::] r2 vres2 s2 = ok s2' &
+    valid_state rmap2 m0 s1' s2'].
+Proof.
+  move=> hvs halloc haddr hresult hs1'.
+  move: halloc; rewrite /alloc_lval_call.
+  case: oi hresult => [i|]; last first.
+  + move=> ->.
+    t_xrbindP=> _ /check_lval_reg_callP hcheck <- <-.
+    case: hcheck.
+    + move=> [ii [ty ?]]; subst r.
+      move: hs1' => /= /write_noneP [->] h; exists s2; split => //.
+      by rewrite /write_none; case: h => [ [? ->]| [-> ->]].
+    move=> [x [? hlx hnnew]]; subst r.
+    move: hs1'; rewrite /= /write_var.
+    t_xrbindP=> vm1 hvm1 <- /=.
+    by apply: set_varP hvm1=> [v' hv <- | hb hv <-]; rewrite /set_var hv /= ?hb /=;
+      eexists;(split;first by reflexivity) => //; apply valid_state_set_var.
+  move=> [w [-> hresp]].
+  case hnth: nth => [[[b sr]|//] ?].
+  have {hnth}hnth: nth None (map fst srs) i = Some (b, sr).
+  + rewrite (nth_map (None, Pconst 0)) ?hnth //.
+    by apply (nth_not_default hnth ltac:(discriminate)).
+  case: r hs1' => //.
+  + move=> ii ty /= /write_noneP [-> _] [<- <-] /=; rewrite /write_none /=.
+    by eexists.
+  t_xrbindP=> x hs1' p /get_regptrP hlx {rmap2}rmap2 hset <- <-.
+  have /wf_locals hlocal := hlx.
+  move: hs1'; rewrite /= /write_var; t_xrbindP=> vm1.
+  have /is_sarrP [nx hty] := hlocal.(wfr_type).
+  apply: set_varP; last by rewrite {1}hty.
+  case: x hty hset hlx hlocal => -[_ xn] xii /= -> /= hset hlx hlocal.
+  move=> ax /to_arrI [nr [ar [? hcast]]] <- <-; subst vres1.
+  have :=
+    Forall3_nth haddr None (Vbool true) (Vbool true) (nth_not_default hnth ltac:(discriminate)) _ _ hnth.
+  rewrite hresp.(wrp_args) => -[[?] hwf]; subst w.
+
+  set vp := pof_val p.(vtype) (Vword (sub_region_addr sr)).
+  exists (with_vm s2 (evm s2).[p <- vp]).
+  split.
+  + rewrite /set_var /vp.
+    by case: (p) hlocal.(wfr_rtype) => -[_ pn] pii /= ->.
+  rewrite -(WArray.castK ax).
+  apply: (valid_state_set_sub_region_regptr hvs _ _ hlx hset (v:=Varr ax)) => /=.
+  + apply: wf_sub_region_subtype hwf.
+    apply: subtype_trans hresp.(wrp_subtype).
+    apply /ZleP.
+    by apply (WArray.cast_len hcast).
+  + by move=> _ [<-] /=; lia.
+  split=> //.
+  move=> off hmem w /= /(cast_get8 hcast).
+  by apply hresp.(wrp_read).
+Qed.
+
+Lemma alloc_lval_call_lv_write_mem srs rmap r oi rmap2 r2 :
+  alloc_lval_call pmap srs rmap r oi = ok (rmap2, r2) ->
+  ~~ lv_write_mem r2.
+Proof.
+  rewrite /alloc_lval_call.
+  case: oi => [i|].
+  + case: nth => [[[b sr]|//] e].
+    case: r => //.
+    + by move=> ii ty [_ <-].
+    by t_xrbindP=> _ p _ _ _ _ <-.
+  t_xrbindP=> _ /check_lval_reg_callP hcheck _ <-.
+  case: hcheck.
+  + by move=> [_ [_ ->]] /=.
+  by move=> [x [-> _ _]].
+Qed.
+
+Lemma alloc_call_resP rmap m0 s1 s2 srs ret_pos rs rmap2 rs2 vargs1 vargs2 vres1 vres2 s1' :
+  valid_state rmap m0 s1 s2 ->
+  alloc_call_res pmap rmap srs ret_pos rs = ok (rmap2, rs2) ->
+  Forall3 (fun bsr varg1 varg2 => forall (b:bool) (sr:sub_region), bsr = Some (b, sr) ->
+    varg2 = Vword (sub_region_addr sr) /\ wf_sub_region sr (type_of_val varg1)) (map fst srs) vargs1 vargs2 ->
+  Forall3 (wf_result (emem s2) vargs1 vargs2) ret_pos vres1 vres2 ->
+  write_lvals gd s1 rs vres1 = ok s1' ->
+  exists s2',
+    write_lvals [::] s2 rs2 vres2 = ok s2' /\
+    valid_state rmap2 m0 s1' s2'.
+Proof.
+  move=> hvs halloc haddr.
+  move hmem: (emem s2) => m2 hresults.
+  elim: {ret_pos vres1 vres2} hresults rmap s1 s2 hvs hmem rs rmap2 rs2 halloc s1'.
+  + move=> rmap s1 s2 hvs _ [|//] _ _ /= [<- <-] _ [<-].
+    by eexists; split; first by reflexivity.
+  move=> oi vr1 vr2 ret_pos vres1 vres2 hresult _ ih rmap0 s1 s2 hvs ? [//|r rs] /=; subst m2.
+  t_xrbindP=> _ _ [rmap1 r2] hlval [rmap2 rs2] /= halloc <- <- s1'' s1' hs1' hs1''.
+  have [s2' [hs2' hvs']] := alloc_lval_callP hvs hlval haddr hresult hs1'.
+  have heqmem := esym (lv_write_memP (alloc_lval_call_lv_write_mem hlval) hs2').
+  have [s2'' [hs2'' hvs'']] := ih _ _ _ hvs' heqmem _ _ _ halloc _ hs1''.
+  rewrite /= hs2' /= hs2'' /=.
+  by eexists; split; first by reflexivity.
+Qed.
+
+Lemma check_resultP rmap m0 s1 s2 srs params (sao_return:option nat) res1 res2 vres1 vargs1 vargs2 :
+  valid_state rmap m0 s1 s2 ->
+  Forall3 (fun osr (x : var_i) v => osr <> None -> subtype x.(vtype) (type_of_val v)) srs params vargs1 ->
+  List.Forall2 (fun osr varg2 => forall sr, osr = Some sr -> varg2 = Vword (sub_region_addr sr)) srs vargs2 ->
+  check_result pmap rmap srs params sao_return res1 = ok res2 ->
+  get_var (evm s1) res1 = ok vres1 ->
+  exists vres2,
+    get_var (evm s2) res2 = ok vres2 /\
+    wf_result (emem s2) vargs1 vargs2 sao_return vres1 vres2.
+Proof.
+  move=> hvs hsize haddr hresult hget.
+  move: hresult; rewrite /check_result.
+  case: sao_return => [i|].
+  + case heq: nth => [sr|//].
+    t_xrbindP=> _ /assertP /eqP heqty -[sr' _] /check_validP [bytes [hgvalid -> hmem]].
+    move=> /= _ /assertP /eqP ? p /get_regptrP hlres1 <-; subst sr'.
+    have /wfr_gptr := hgvalid.
+    rewrite /get_var_kind /= /get_local hlres1 => -[_ [[<-] /= ->]].
+    eexists; split; first by reflexivity.
+    eexists; split; first by reflexivity.
+    split.
+    + by apply (Forall2_nth haddr None (Vbool true) (nth_not_default heq ltac:(discriminate))).
+    + apply (subtype_trans (type_of_get_var hget)).
+      rewrite heqty.
+      apply (Forall3_nth hsize None res1 (Vbool true) (nth_not_default heq ltac:(discriminate))).
+      by rewrite heq.
+    assert (hval := wfr_val hgvalid hget).
+    case: hval => hread hty.
+    move=> off w /dup[] /get_val_byte_bound; rewrite hty => hoff.
+    apply hread.
+    rewrite memi_mem_U8; apply: mem_incl_r hmem; rewrite subset_interval_of_zone.
+    rewrite -(Z.add_0_l off).
+    rewrite -(sub_zone_at_ofs_compose _ _ _ (size_slot res1)).
+    apply zbetween_zone_byte => //.
+    by apply zbetween_zone_refl.
+  t_xrbindP=> _ /check_varP hlres1 _ /check_diffP hnnew <-.
+  exists vres1; split=> //.
+  by have := get_var_kindP hvs hlres1 hnnew hget.
+Qed.
+
+Lemma check_resultsP rmap m0 s1 s2 srs params sao_returns res1 res2 vargs1 vargs2 :
+  valid_state rmap m0 s1 s2 ->
+  Forall3 (fun osr (x : var_i) v => osr <> None -> subtype x.(vtype) (type_of_val v)) srs params vargs1 ->
+  List.Forall2 (fun osr varg2 => forall sr, osr = Some sr -> varg2 = Vword (sub_region_addr sr)) srs vargs2 ->
+  check_results pmap rmap srs params sao_returns res1 = ok res2 ->
+  forall vres1,
+  mapM (λ x : var_i, get_var (evm s1) x) res1 = ok vres1 ->
+  exists vres2,
+    mapM (λ x : var_i, get_var (evm s2) x) res2 = ok vres2 /\
+    Forall3 (wf_result (emem s2) vargs1 vargs2) sao_returns vres1 vres2.
+Proof.
+  move=> hvs hsize haddr.
+  rewrite /check_results.
+  t_xrbindP=> _ _.
+  elim: sao_returns res1 res2.
+  + move=> [|//] _ [<-] _ [<-] /=.
+    eexists; split; first by reflexivity.
+    by constructor.
+  move=> sao_return sao_returns ih [//|x1 res1] /=.
+  t_xrbindP=> _ x2 hresult res2 /ih{ih}ih <-.
+  move=> _ v1 hget1 vres1 hgets1 <-.
+  have [v2 [hget2 hrout]] := check_resultP hvs hsize haddr hresult hget1.
+  have [vres2 [hgets2 hrouts]] := ih _ hgets1.
+  rewrite /= hget2 /= hgets2 /=.
+  eexists; split; first by reflexivity.
+  by constructor.
+Qed.
+
+Lemma check_results_alloc_params_not_None rmap srs params sao_returns res1 res2 :
+  check_results pmap rmap srs params sao_returns res1 = ok res2 ->
+  List.Forall (fun oi => forall i, oi = Some i -> nth None srs i <> None) sao_returns.
+Proof.
+  rewrite /check_results.
+  t_xrbindP=> _ _.
+  elim: sao_returns res1 res2 => //.
+  move=> oi sao_returns ih [//|x1 res1] /=.
+  t_xrbindP => _ x2 hresult res2 /ih{ih}ih _.
+  constructor=> //.
+  move=> i ?; subst oi.
+  move: hresult => /=.
+  by case: nth.
+Qed.
+
+End Section.

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -1,0 +1,2775 @@
+(* ** License
+ * -----------------------------------------------------------------------
+ * Copyright 2016--2017 IMDEA Software Institute
+ * Copyright 2016--2017 Inria
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ----------------------------------------------------------------------- *)
+
+(* This file is the second part of [stack_alloc_proof.v] that was split to
+   ease the development process.
+*)
+
+(* ** Imports and settings *)
+From mathcomp Require Import all_ssreflect all_algebra.
+From CoqWord Require Import ssrZ.
+Require Import psem psem_facts compiler_util constant_prop_proof.
+Require Export psem stack_alloc stack_alloc_proof.
+Require Import byteset.
+Require Import Psatz.
+Import Utf8.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Local Open Scope vmap.
+Local Open Scope seq_scope.
+Local Open Scope Z_scope.
+
+Import Region.
+
+(* When the boolean is set to false, some checks are disable. On the Coq side,
+   we want to perform all the checks, so we set it to true.
+*)
+Notation alloc_fd   := (alloc_fd true).
+Notation alloc_i    := (alloc_i true).
+Notation alloc_prog := (alloc_prog true).
+
+Section INIT.
+
+Variable global_data : seq u8.
+Variable global_alloc : seq (var * wsize * Z).
+
+Let glob_size := Z.of_nat (size global_data).
+
+Variable rip : u64.
+Hypothesis no_overflow_glob_size : no_overflow rip glob_size.
+
+Variable mglob : Mvar.t (Z * wsize).
+
+Hypothesis hmap : init_map (Z.of_nat (size global_data)) global_alloc = ok mglob.
+
+Lemma init_mapP : forall x1 ofs1 ws1,
+  Mvar.get mglob x1 = Some (ofs1, ws1) -> [/\
+    ofs1 mod wsize_size ws1 = 0,
+    0 <= ofs1 /\ ofs1 + size_slot x1 <= glob_size &
+    (forall x2 ofs2 ws2,
+      Mvar.get mglob x2 = Some (ofs2, ws2) -> x1 <> x2 ->
+      ofs1 + size_slot x1 <= ofs2 \/ ofs2 + size_slot x2 <= ofs1)].
+Proof.
+  move: hmap; rewrite /init_map.
+  t_xrbindP=> -[mglob' size] hfold /=.
+  case: ZleP => [hle|//] [?] x1 ofs1 ws1 hget; subst mglob'.
+  have: [/\ ofs1 mod wsize_size ws1 = 0,
+    0 <= ofs1 /\ ofs1 + size_slot x1 <= size &
+    ∀ x2 ofs2 ws2,
+      Mvar.get mglob x2 = Some (ofs2, ws2) -> x1 ≠ x2 ->
+      ofs1 + size_slot x1 <= ofs2 ∨ ofs2 + size_slot x2 <= ofs1];
+  last first.
+  + by move=> [h1 h2 h3]; split=> //; lia.
+  move: hfold x1 ofs1 ws1 hget.
+  have: 0 <= (Mvar.empty (Z * wsize), 0).2 /\
+    forall x1 ofs1 ws1,
+    Mvar.get (Mvar.empty (Z * wsize), 0).1 x1 = Some (ofs1, ws1) -> [/\
+    ofs1 mod wsize_size ws1 = 0,
+    0 <= ofs1 /\ ofs1 + size_slot x1 <= (Mvar.empty (Z * wsize), 0).2 &
+      (forall x2 ofs2 ws2,
+        Mvar.get (Mvar.empty (Z * wsize), 0).1 x2 = Some (ofs2, ws2) -> x1 <> x2 ->
+        ofs1 + size_slot x1 <= ofs2 \/ ofs2 + size_slot x2 <= ofs1)].
+  + done.
+  elim: global_alloc (Mvar.empty _, 0).
+  + by move=> [mglob0 size0] [_ hbase2] /= [<- <-].
+  move=> [[x wsx] ofsx] l ih [mglob0 size0] /= [hbase1 hbase2].
+  t_xrbindP=> -[mglob1 size1].
+  case: ZleP => [h1|//].
+  case: eqP => [h2|//].
+  move=> [<- <-].
+  apply ih.
+  split=> /=.
+  + by have := size_slot_gt0 x; lia.
+  move=> x1 ofs1 ws1.
+  rewrite Mvar.setP.
+  case: eqP => [|_].
+  + move=> <- [<- <-].
+    split.
+    + by rewrite -Zland_mod.
+    + by lia.
+    move=> x2 ofs2 ws2.
+    rewrite Mvar.setP.
+    case: eqP => [//|_].
+    by move=> /hbase2 [_ ? _] _; right; lia.
+  move=> /hbase2 [???]; split=> //.
+  + by have := size_slot_gt0 x; lia.
+  move=> x2 ofs2 ws2.
+  rewrite Mvar.setP.
+  case: eqP; last by eauto.
+  by move=> <- [<- _] _; left; lia.
+Qed.
+
+Lemma init_map_align x1 ofs1 ws1 :
+  Mvar.get mglob x1 = Some (ofs1, ws1) -> ofs1 mod wsize_size ws1 = 0.
+Proof. by move=> /init_mapP [? _ _]. Qed.
+
+Lemma init_map_bounded x1 ofs1 ws1 :
+  Mvar.get mglob x1 = Some (ofs1, ws1) ->
+  0 <= ofs1 /\ ofs1 + size_slot x1 <= glob_size.
+Proof. by move=> /init_mapP [_ ? _]. Qed.
+
+Lemma init_map_disjoint x1 ofs1 ws1 :
+  Mvar.get mglob x1 = Some (ofs1, ws1) ->
+  forall x2 ofs2 ws2,
+    Mvar.get mglob x2 = Some (ofs2, ws2) -> x1 <> x2 ->
+    ofs1 + size_slot x1 <= ofs2 \/ ofs2 + size_slot x2 <= ofs1.
+Proof. by move=> /init_mapP [_ _ ?]. Qed.
+
+
+Variable (P : uprog) (ev: extra_val_t (progT := progUnit)).
+Notation gd := (p_globs P).
+
+Hypothesis hglobs : check_globs gd mglob global_data.
+
+Lemma check_globP gd :
+  check_glob mglob global_data gd ->
+  exists ofs ws,
+    Mvar.get mglob gd.1 = Some (ofs, ws) /\
+    forall k w,
+      get_val_byte (gv2val gd.2) k = ok w ->
+      nth 0%R global_data (Z.to_nat (ofs + k)) = w.
+Proof.
+  rewrite /check_glob.
+  case heq: Mvar.get => [[ofs ws]|//].
+  move=> h; eexists _, _; (split; first by reflexivity); move: h.
+  move /init_map_bounded in heq.
+  case: gd.2.
+  + move=> ws' w /andP [] /leP; rewrite size_drop => hle /eqP hw.
+    move=> k u /=.
+    case: andP => //; rewrite !zify => hbound [<-].
+    rewrite Z2Nat.inj_add; try lia.
+    rewrite -nth_drop -(@nth_take (Z.to_nat (wsize_size ws')));
+      last by apply /ltP; apply Z2Nat.inj_lt; lia.
+    rewrite /LE.wread8.
+    f_equal.
+    apply (LE.decode_inj (sz:=ws')).
+    + rewrite size_take size_drop LE.size_encode.
+      by case: ltP; lia.
+    + rewrite size_take size_drop.
+      by case: ltP; lia.
+    by rewrite -hw LE.decodeK.
+  move=> len a /andP [] /leP; rewrite size_drop => hle /allP hread.
+  move=> k w /dup[] /get_val_byte_bound /= hbound hw.
+  apply /eqP; rewrite Z2Nat.inj_add; try lia.
+  move: (hread (Z.to_nat k)).
+  rewrite Z2Nat.id; last by lia.
+  rewrite hw nth_drop.
+  apply.
+  rewrite mem_iota; apply /andP; split; first by apply /leP; lia.
+  by apply /ltP; apply Z2Nat.inj_lt; lia.
+Qed.
+
+Lemma check_globsP g gv :
+  get_global_value gd g = Some gv ->
+  exists ofs ws,
+    Mvar.get mglob g = Some (ofs, ws) /\
+    forall k w,
+      get_val_byte (gv2val gv) k = ok w ->
+      nth 0%R global_data (Z.to_nat (ofs + k)) = w.
+Proof.
+  move: hglobs; rewrite /check_globs.
+  elim: gd => // -[g' gv'] gd ih /= /andP [/check_globP h1 /ih h2].
+  case: eqP => [|//].
+  by move=> -> [<-].
+Qed.
+
+Section LOCAL.
+
+Variable fn : funname.
+Variable sao : stk_alloc_oracle_t.
+Variable stack : Mvar.t (Z * wsize).
+
+Hypothesis hlayout : init_stack_layout fn mglob sao = ok stack.
+
+Lemma init_stack_layoutP :
+  0 <= sao.(sao_size) /\
+  forall x1 ofs1 ws1,
+    Mvar.get stack x1 = Some (ofs1, ws1) -> [/\
+      (ws1 <= sao.(sao_align))%CMP,
+      ofs1 mod wsize_size ws1 = 0,
+      0 <= ofs1 /\ ofs1 + size_slot x1 <= sao.(sao_size),
+      (forall x2 ofs2 ws2,
+        Mvar.get stack x2 = Some (ofs2, ws2) -> x1 <> x2 ->
+        ofs1 + size_slot x1 <= ofs2 \/ ofs2 + size_slot x2 <= ofs1) &
+      Mvar.get mglob x1 = None].
+Proof.
+  move: hlayout; rewrite /init_stack_layout.
+  t_xrbindP=> -[stack' size] hfold.
+  rewrite zify.
+  case: ZleP => [hle|//] [?]; subst stack'.
+  have: 0 <= size /\
+    forall x1 ofs1 ws1,
+    Mvar.get stack x1 = Some (ofs1, ws1) -> [/\
+      (ws1 ≤ sao_align sao)%CMP, ofs1 mod wsize_size ws1 = 0,
+      0 <= ofs1 /\ ofs1 + size_slot x1 <= size,
+      (forall x2 ofs2 ws2,
+        Mvar.get stack x2 = Some (ofs2, ws2) -> x1 <> x2 ->
+        ofs1 + size_slot x1 <= ofs2 \/ ofs2 + size_slot x2 <= ofs1) &
+      Mvar.get mglob x1 = None];
+  last first.
+  + move=> [h1 h2]; split; first by lia.
+    by move=> x1 ofs1 ws1 /h2 [?????]; split=> //; lia.
+  move: hfold.
+  have: 0 <= (Mvar.empty (Z * wsize), 0).2 /\
+    forall x1 ofs1 ws1,
+    Mvar.get (Mvar.empty (Z * wsize), 0).1 x1 = Some (ofs1, ws1) -> [/\
+      (ws1 <= sao.(sao_align))%CMP,
+      ofs1 mod wsize_size ws1 = 0,
+      0 <= ofs1 /\ ofs1 + size_slot x1 <= (Mvar.empty (Z * wsize), 0).2,
+      (forall x2 ofs2 ws2,
+        Mvar.get (Mvar.empty (Z * wsize), 0).1 x2 = Some (ofs2, ws2) -> x1 <> x2 ->
+        ofs1 + size_slot x1 <= ofs2 \/ ofs2 + size_slot x2 <= ofs1) &
+      Mvar.get mglob x1 = None].
+  + done.
+  elim: sao.(sao_slots) (Mvar.empty _, 0).
+  + by move=> [stack0 size0] /= hbase [<- <-].
+  move=> [[x wsx] ofsx] l ih [stack0 size0] /= [hbase1 hbase2].
+  t_xrbindP=> -[stack1 size1].
+  case: Mvar.get => //.
+  case heq: Mvar.get => //.
+  case: ifP => [|//]; rewrite zify => /ZleP h1.
+  case: ifP => [h2|//].
+  case: eqP => [h3|//].
+  move=> [<- <-].
+  apply ih.
+  split=> /=.
+  + by have := size_slot_gt0 x; lia.
+  move=> x1 ofs1 ws1.
+  rewrite Mvar.setP.
+  case: eqP => [|_].
+  + move=> <- [<- <-].
+    split=> //.
+    + by rewrite -Zland_mod.
+    + by lia.
+    move=> x2 ofs2 ws2.
+    rewrite Mvar.setP.
+    case: eqP => [|_]; first by congruence.
+    by move=> /hbase2 [_ _ ? _]; lia.
+  move=> /hbase2 /= [????]; split=> //.
+  + by have := size_slot_gt0 x; lia.
+  move=> x2 ofs2 ws2.
+  rewrite Mvar.setP.
+  case: eqP; last by eauto.
+  by move=> <- [<- _]; lia.
+Qed.
+
+Lemma init_stack_layout_size_ge0 : 0 <= sao.(sao_size).
+Proof. by have [? _] := init_stack_layoutP. Qed.
+
+Lemma init_stack_layout_stack_align x1 ofs1 ws1 :
+  Mvar.get stack x1 = Some (ofs1, ws1) -> (ws1 <= sao.(sao_align))%CMP.
+Proof. by have [_ h] := init_stack_layoutP => /h [? _ _ _ _]. Qed.
+
+Lemma init_stack_layout_align x1 ofs1 ws1 :
+  Mvar.get stack x1 = Some (ofs1, ws1) -> ofs1 mod wsize_size ws1 = 0.
+Proof. by have [_ h] := init_stack_layoutP => /h [_ ? _ _ _]. Qed.
+
+Lemma init_stack_layout_bounded x1 ofs1 ws1 :
+  Mvar.get stack x1 = Some (ofs1, ws1) ->
+  0 <= ofs1 /\ ofs1 + size_slot x1 <= sao.(sao_size).
+Proof. by have [_ h] := init_stack_layoutP => /h [_ _ ? _ _]. Qed.
+
+Lemma init_stack_layout_disjoint x1 ofs1 ws1 :
+  Mvar.get stack x1 = Some (ofs1, ws1) ->
+  forall x2 ofs2 ws2,
+    Mvar.get stack x2 = Some (ofs2, ws2) -> x1 <> x2 ->
+    ofs1 + size_slot x1 <= ofs2 \/ ofs2 + size_slot x2 <= ofs1.
+Proof. by have [_ h] := init_stack_layoutP => /h [_ _ _ ? _]. Qed.
+
+Lemma init_stack_layout_not_glob x1 ofs1 ws1 :
+  Mvar.get stack x1 = Some (ofs1, ws1) -> Mvar.get mglob x1 = None.
+Proof. by have [_ h] := init_stack_layoutP => /h [_ _ _ _ ?]. Qed.
+
+(* We pack the hypotheses about slots in a record for the sake of simplicity. *)
+Record wf_Slots (Slots : Sv.t) Addr (Writable:slot-> bool) Align := {
+  wfsl_no_overflow : forall s, Sv.In s Slots -> no_overflow (Addr s) (size_slot s);
+  wfsl_disjoint : forall s1 s2, Sv.In s1 Slots -> Sv.In s2 Slots -> s1 <> s2 ->
+    Writable s1 -> disjoint_zrange (Addr s1) (size_slot s1) (Addr s2) (size_slot s2);
+  wfsl_align : forall s, Sv.In s Slots -> is_align (Addr s) (Align s);
+  wfsl_not_glob : forall s, Sv.In s Slots -> Writable s ->
+    0 < glob_size -> disjoint_zrange rip glob_size (Addr s) (size_slot s)
+}.
+
+Variable rsp : u64.
+Hypothesis no_overflow_size : no_overflow rsp sao.(sao_size).
+Hypothesis disjoint_zrange_globals_locals :
+  0 < glob_size -> 0 < sao.(sao_size) ->
+  disjoint_zrange rip glob_size rsp sao.(sao_size).
+Hypothesis rip_align : is_align rip U256.
+  (* could be formulated [forall ws, is_align rip ws] (cf. extend_mem) *)
+Hypothesis rsp_align : is_align rsp sao.(sao_align).
+
+Definition Slots_slots (m : Mvar.t (Z * wsize)) :=
+  SvP.MP.of_list (map fst (Mvar.elements m)).
+
+Lemma in_Slots_slots m s :
+  Sv.In s (Slots_slots m) <-> Mvar.get m s <> None.
+Proof.
+  rewrite /Slots_slots; split.
+  + move=> /SvP.MP.of_list_1 /SetoidList.InA_alt.
+    move=> [_ [<- /InP /mapP]].
+    move=> [[s' ?]] /Mvar.elementsP /= ??; subst s'.
+    by congruence.
+  move=> hget.
+  apply SvP.MP.of_list_1; apply SetoidList.InA_alt.
+  exists s; split=> //.
+  apply /InP; apply /mapP.
+  case heq: (Mvar.get m s) => [ofs_align|//].
+  exists (s, ofs_align) => //.
+  by apply /Mvar.elementsP.
+Qed.
+
+Definition Offset_slots (m : Mvar.t (Z * wsize)) s :=
+  match Mvar.get m s with
+  | Some (ofs, _) => ofs
+  | _ => 0
+  end.
+
+Definition Align_slots (m : Mvar.t (Z * wsize)) s :=
+  match Mvar.get m s with
+  | Some (_, ws) => ws
+  | _ => U8
+  end.
+
+Definition Slots_globals := Slots_slots mglob.
+Definition Addr_globals s := (rip + wrepr _ (Offset_slots mglob s))%R.
+Definition Writable_globals (s:slot) := false.
+Definition Align_globals := Align_slots mglob.
+
+Definition Slots_locals := Slots_slots stack.
+Definition Addr_locals s := (rsp + wrepr _ (Offset_slots stack s))%R.
+Definition Writable_locals (s:slot) := true.
+Definition Align_locals := Align_slots stack.
+
+Variable params : seq var_i.
+Variables vargs1 vargs2 : seq value.
+Variable m1 m2 : mem.
+
+Hypothesis Hargs : Forall3 (wf_arg glob_size rip m1 m2) sao.(sao_params) vargs1 vargs2.
+Hypothesis Hdisj : disjoint_values sao.(sao_params) vargs1 vargs2.
+Hypothesis Hsub : Forall3 (fun opi (x:var_i) v => opi <> None -> subtype x.(vtype) (type_of_val v)) sao.(sao_params) params vargs1.
+
+(* [param_info] is registered as [eqType], so that we can use all operators of
+   the [seq] library on sequences containing [param_info]s.
+   Is it the right place to perform this registration?
+*)
+Definition param_info_beq pi1 pi2 :=
+  [&& pi1.(pp_ptr) == pi2.(pp_ptr),
+      pi1.(pp_writable) == pi2.(pp_writable) &
+      pi1.(pp_align) == pi2.(pp_align)].
+
+Lemma param_info_axiom : Equality.axiom param_info_beq.
+Proof.
+  move=> [ptr1 w1 al1] [ptr2 w2 al2].
+  by apply:(iffP and3P) => /= [[/eqP -> /eqP -> /eqP ->] | [-> -> ->]].
+Qed.
+
+Definition param_info_eqMixin := Equality.Mixin param_info_axiom.
+Canonical  param_info_eqType  := EqType param_info param_info_eqMixin.
+
+(* We would have liked to do the same for values, but this is impossible
+   because of arrays, thus we still have non-eqType in our sequences, which is painful.
+*)
+
+Definition param_tuples :=
+  let s := zip params (zip sao.(sao_params) (zip vargs1 vargs2)) in
+  pmap (fun '(x, (opi, (v1, v2))) =>
+    omap (fun pi => (x.(v_var), (pi, (v1, v2)))) opi) s.
+
+Definition Slots_params := SvP.MP.of_list (map fst param_tuples).
+
+(* For a parameter slot [s], [get_pi] returns the param_info and the two values
+   (in the source and in the target) that correspond to it.
+*)
+Definition get_pi s := assoc param_tuples s.
+
+Definition Addr_params s :=
+  match get_pi s with
+  | Some (_, (_, Vword Uptr w)) => w
+  | _                           => 0%R
+  end.
+
+Definition Writable_params s :=
+  match get_pi s with
+  | Some (pi, _) => pi.(pp_writable)
+  | None         => false
+  end.
+
+Definition Align_params s :=
+  match get_pi s with
+  | Some (pi, _) => pi.(pp_align)
+  | None         => U8
+  end.
+
+(* Slots : glob + stack + params *)
+Definition Slots :=
+  Sv.union Slots_globals (Sv.union Slots_locals Slots_params).
+
+Lemma in_Slots s :
+  Sv.In s Slots <->
+    Sv.In s Slots_globals \/ Sv.In s Slots_locals \/ Sv.In s Slots_params.
+Proof. by rewrite /Slots; rewrite !Sv.union_spec. Qed.
+
+Definition pick_slot A (f_globals f_locals f_params : slot -> A) s :=
+  if Sv.mem s Slots_globals then f_globals s
+  else if Sv.mem s Slots_locals then f_locals s
+  else f_params s.
+
+Definition Addr := pick_slot Addr_globals Addr_locals Addr_params.
+Definition Writable := pick_slot Writable_globals Writable_locals Writable_params.
+Definition Align := pick_slot Align_globals Align_locals Align_params.
+
+Lemma wunsigned_Addr_globals s ofs ws :
+  Mvar.get mglob s = Some (ofs, ws) ->
+  wunsigned (Addr_globals s) = wunsigned rip + ofs.
+Proof.
+  move=> hget.
+  rewrite /Addr_globals /Offset_slots hget.
+  rewrite wunsigned_add //.
+  have hbound := init_map_bounded hget.
+  move: no_overflow_glob_size; rewrite /no_overflow zify => hover.
+  have := wunsigned_range rip.
+  have := size_slot_gt0 s.
+  by lia.
+Qed.
+
+Lemma zbetween_Addr_globals s :
+  Sv.In s Slots_globals ->
+  zbetween rip glob_size (Addr_globals s) (size_slot s).
+Proof.
+  move=> /in_Slots_slots.
+  case heq: Mvar.get => [[ofs ws]|//] _.
+  rewrite /zbetween !zify (wunsigned_Addr_globals heq).
+  have hbound := init_map_bounded heq.
+  by lia.
+Qed.
+
+Lemma wunsigned_Addr_locals s ofs ws :
+  Mvar.get stack s = Some (ofs, ws) ->
+  wunsigned (Addr_locals s) = wunsigned rsp + ofs.
+Proof.
+  move=> hget.
+  rewrite /Addr_locals /Offset_slots hget.
+  rewrite wunsigned_add //.
+  have hbound := init_stack_layout_bounded hget.
+  move: no_overflow_size; rewrite /no_overflow zify => hover.
+  have := wunsigned_range rsp.
+  have := size_slot_gt0 s.
+  by lia.
+Qed.
+
+Lemma zbetween_Addr_locals s :
+  Sv.In s Slots_locals ->
+  zbetween rsp sao.(sao_size) (Addr_locals s) (size_slot s).
+Proof.
+  move=> /in_Slots_slots.
+  case heq: Mvar.get => [[ofs ws]|//] _.
+  rewrite /zbetween !zify (wunsigned_Addr_locals heq).
+  have hbound := init_stack_layout_bounded heq.
+  by lia.
+Qed.
+
+Lemma disjoint_globals_locals : disjoint Slots_globals Slots_locals.
+Proof.
+  apply /disjointP => s /in_Slots_slots ? /in_Slots_slots.
+  case heq: Mvar.get => [[ofs ws]|//].
+  by move /init_stack_layout_not_glob in heq.
+Qed.
+
+Lemma pick_slot_globals s :
+  Sv.In s Slots_globals ->
+  forall A (f_globals f_locals f_params : slot -> A),
+  pick_slot f_globals f_locals f_params s = f_globals s.
+Proof. by rewrite /pick_slot => /Sv_memP ->. Qed.
+
+Lemma pick_slot_locals s :
+  Sv.In s Slots_locals ->
+  forall A (f_globals f_locals f_params : slot -> A),
+  pick_slot f_globals f_locals f_params s = f_locals s.
+Proof.
+  rewrite /pick_slot.
+  case: Sv_memP => [|_].
+  + by move /disjointP : disjoint_globals_locals => h /h.
+  by move=> /Sv_memP ->.
+Qed.
+
+
+Variable vripn : Ident.ident.
+Let vrip0 := {| vtype := spointer; vname := vripn |}.
+Variable vrspn : Ident.ident.
+Let vrsp0 := {| vtype := spointer; vname := vrspn |}.
+Variable locals1 : Mvar.t ptr_kind.
+Variable rmap1 : region_map.
+Variable vnew1 : Sv.t.
+Hypothesis hlocal_map : init_local_map vrip0 vrsp0 fn mglob stack sao = ok (locals1, rmap1, vnew1).
+Variable vnew2 : Sv.t.
+Variable locals2 : Mvar.t ptr_kind.
+Variable rmap2 : region_map.
+Variable alloc_params : seq (option sub_region * var_i).
+Hypothesis hparams : init_params mglob stack vnew1 locals1 rmap1 sao.(sao_params) params = ok (vnew2, locals2, rmap2, alloc_params).
+
+Lemma uniq_param_tuples : uniq (map fst param_tuples).
+Proof.
+  have: uniq (map fst param_tuples) /\
+    forall x, x \in map fst param_tuples -> Mvar.get locals1 x = None;
+  last by move=> [].
+  rewrite /param_tuples.
+  move: hparams; rewrite /init_params.
+  elim: sao.(sao_params) params vargs1 vargs2 vnew1 locals1 rmap1 vnew2 locals2 rmap2 alloc_params;
+    first by move=> [|??] [|??] [|??].
+  move=> opi sao_params ih [|x params'] [|varg1 vargs1'] [|varg2 vargs2'] //.
+  move=> vnew0 locals0 rmap0 vnew2' locals2' rmap2' alloc_params' /=.
+  t_xrbindP=> -[[[vnew1' locals1'] rmap1'] alloc_param'] _ _.
+  case heq: Mvar.get => //.
+  case: opi => [pi|]; last first.
+  + by move=> [<- <- <- <-] [[[??]?]?] /ih -/(_ vargs1' vargs2') [ih1 ih2] _ _.
+  t_xrbindP=> _ _ _ _ _ _.
+  case: Mvar.get => //.
+  case: Mvar.get => //.
+  case: Mvar.get => //.
+  move=> [_ ? _ _]; subst locals1'.
+  move=> [[[_ _] _] _] /ih -/(_ vargs1' vargs2') [ih1 ih2] _ _.
+  split=> /=.
+  + apply /andP; split=> //.
+    apply /negP => /ih2.
+    by rewrite Mvar.setP_eq.
+  move=> y; rewrite in_cons => /orP.
+  case.
+  + by move=> /eqP ->.
+  move=> /ih2.
+  by rewrite Mvar.setP; case: eqP.
+Qed.
+
+Lemma in_Slots_params s :
+  Sv.In s Slots_params <-> get_pi s <> None.
+Proof.
+  rewrite /Slots_params /get_pi SvP.MP.of_list_1 SetoidList.InA_alt.
+  split.
+  + move=> [] _ [<-] /InP /in_map [[x [opi v]] hin ->].
+    by have -> := mem_uniq_assoc hin uniq_param_tuples.
+  case heq: assoc => [[pi [v1 v2]]|//] _.
+  exists s; split=> //.
+  apply /InP; apply /in_map.
+  exists (s, (pi, (v1, v2))) => //.
+  by apply assoc_mem'.
+Qed.
+
+Lemma init_params_not_glob_nor_stack s pi :
+  get_pi s = Some pi ->
+  Mvar.get mglob s = None /\ Mvar.get stack s = None.
+Proof.
+  rewrite /get_pi /param_tuples.
+  move: hparams; rewrite /init_params.
+  elim: params sao.(sao_params) vargs1 vargs2 vnew1 locals1 rmap1 vnew2 locals2 rmap2 alloc_params;
+    first by move=> [|??] [|??] [|??].
+  move=> x params' ih [|opi2 sao_params] [|varg1 vargs1'] [|varg2 vargs2'] //.
+  move=> vnew0 locals0 rmap0 vnew2' locals2' rmap2' alloc_params' /=.
+  t_xrbindP=> -[[[??]?]?] _ _.
+  case: Mvar.get => //.
+  case: opi2 => [pi2|]; last first.
+  + by move=> [<- <- <- <-] [[[??]?]?] /ih{ih}ih _ _; apply ih.
+  t_xrbindP=> _ _ _ _ _ _.
+  case: Mvar.get => //.
+  case heq1: Mvar.get => //.
+  case heq2: Mvar.get => //.
+  move=> _ [[[_ _] _] _] /ih{ih}ih _ _ /=.
+  case: eqP => [-> //|_].
+  by apply ih.
+Qed.
+
+Lemma get_pi_Forall :
+  List.Forall (fun '(x, (opi, (v1, v2))) =>
+    forall pi, opi = Some pi -> get_pi x.(v_var) = Some (pi, (v1, v2)))
+    (zip params (zip sao.(sao_params) (zip vargs1 vargs2))).
+Proof.
+  apply List.Forall_forall.
+  move=> [x [opi [v1 v2]]] hin pi ?; subst opi.
+  rewrite /get_pi.
+  apply: mem_uniq_assoc uniq_param_tuples.
+  rewrite /param_tuples.
+  have [s1 [s2 ->]] := List.in_split _ _ hin.
+  rewrite pmap_cat.
+  by apply List.in_app_iff; right; left.
+Qed.
+
+(* We perform an induction while we could use properties of zip and List.In,
+   but it seems simpler in this case.
+*)
+Lemma get_pi_wf_arg s pi v1 v2 :
+  get_pi s = Some (pi, (v1, v2)) -> wf_arg glob_size rip m1 m2 (Some pi) v1 v2.
+Proof.
+  rewrite /get_pi => -/(assoc_mem' (w:=_)).
+  rewrite /param_tuples.
+  elim: Hargs params; first by move=> [].
+  move=> opi varg1 varg2 sao_params vargs1' vargs2' hrin _ ih [//|param params'].
+  case: opi hrin => [pi'|] hrin; last by apply ih.
+  by move=> [[_ <- <- <-] //|]; apply ih.
+Qed.
+
+Lemma get_pi_size_le s pi v1 v2 :
+  get_pi s = Some (pi, (v1, v2)) -> size_slot s <= size_val v1.
+Proof.
+  rewrite /get_pi => -/(assoc_mem' (w:=_)).
+  rewrite /param_tuples.
+  elim: Hsub vargs2; first by move=> [].
+  move=> opi x varg1 sao_params params' vargs1' hsub _ ih [//|varg2 vargs2'].
+  case: opi hsub => [pi'|] hsub; last by apply ih.
+  move=> [[<- _ <- _] //|]; last by apply ih.
+  apply size_of_le.
+  by apply hsub.
+Qed.
+
+(* TODO: move (and cf. dummy_info in array_init.v) *)
+(* We need a var to give to nth as a default value *)
+Definition dummy_var := {| vtype := sbool; vname := ""%string |}.
+
+Lemma get_pi_nth s pi v1 v2 :
+  get_pi s = Some (pi, (v1, v2)) ->
+  exists k,
+    [/\ nth dummy_var (map v_var params) k = s,
+        nth None sao.(sao_params) k = Some pi,
+        nth (Vbool true) vargs1 k = v1 &
+        nth (Vbool true) vargs2 k = v2].
+Proof.
+  rewrite /get_pi => -/(assoc_mem' (w:=_)).
+  rewrite /param_tuples.
+  elim: sao.(sao_params) params vargs1 vargs2; first by move=> [|??] [|??] [|??].
+  move=> opi sao_params ih [|x params'] [|varg1 vargs1'] [|varg2 vargs2'] //.
+  case: opi => [pi'|].
+  + move=> /=.
+    case.
+    + by move=> [-> -> -> ->]; exists 0%nat.
+    by move=> /ih{ih} [k ih]; exists (S k).
+  by move=> /ih{ih} [k ih]; exists (S k).
+Qed.
+
+Lemma disjoint_globals_params : disjoint Slots_globals Slots_params.
+Proof.
+  apply /disjointP => s /in_Slots_slots ? /in_Slots_params.
+  case heq: get_pi => [pi|//].
+  by have [] := init_params_not_glob_nor_stack heq; congruence.
+Qed.
+
+Lemma disjoint_locals_params : disjoint Slots_locals Slots_params.
+Proof.
+  apply /disjointP => s /in_Slots_slots ? /in_Slots_params.
+  case heq: get_pi => [pi|//].
+  by have [] := init_params_not_glob_nor_stack heq; congruence.
+Qed.
+
+Lemma pick_slot_params s :
+  Sv.In s Slots_params ->
+  forall A (f_globals f_locals f_params : slot -> A),
+  pick_slot f_globals f_locals f_params s = f_params s.
+Proof.
+  rewrite /pick_slot.
+  case: Sv_memP => [|_].
+  + by move /disjointP : disjoint_globals_params => h /h.
+  case: Sv_memP => //.
+  by move /disjointP : disjoint_locals_params => h /h.
+Qed.
+
+Lemma disjoint_zrange_globals_params :
+  forall s, Sv.In s Slots_params -> Writable_params s ->
+  0 < glob_size -> disjoint_zrange rip glob_size (Addr_params s) (size_slot s).
+Proof.
+  move=> s hin hw hgsize.
+  have /in_Slots_params := hin.
+  case hpi: get_pi => [[pi [varg1 varg2]]|//] _.
+  rewrite /Addr_params hpi.
+  have /= := get_pi_wf_arg hpi.
+  move=> [p [? hargp]]; subst varg2.
+  move: hw; rewrite /Writable_params hpi => hw.
+  have := hargp.(wap_writable_not_glob) hw hgsize.
+  apply disjoint_zrange_incl_r.
+  by apply: zbetween_le (get_pi_size_le hpi).
+Qed.
+
+Hypothesis Hdisjoint_zrange_locals :
+  Forall3 (fun opi varg1 varg2 =>
+    forall pi, opi = Some pi ->
+    forall (p:pointer), varg2 = Vword p ->
+    0 < sao.(sao_size) ->
+    disjoint_zrange rsp sao.(sao_size) p (size_val varg1)) sao.(sao_params) vargs1 vargs2.
+
+Lemma disjoint_zrange_locals_params :
+  forall s, Sv.In s Slots_params -> 0 < sao.(sao_size) ->
+  disjoint_zrange rsp sao.(sao_size) (Addr_params s) (size_slot s).
+Proof.
+  move=> s hin hlt.
+  have /in_Slots_params := hin.
+  case hpi: get_pi => [[pi [varg1 varg2]]|//] _.
+  rewrite /Addr_params hpi.
+  have /= := get_pi_wf_arg hpi.
+  move=> [p [? hargp]]; subst varg2.
+  have hle := get_pi_size_le hpi.
+  apply (disjoint_zrange_incl_r (zbetween_le _ hle)).
+  have [k [hnth1 hnth2 hnth3 hnth4]] := get_pi_nth hpi.
+  rewrite -hnth3.
+  by apply (Forall3_nth Hdisjoint_zrange_locals None (Vbool true) (Vbool true)
+    (nth_not_default hnth2 ltac:(discriminate)) _ hnth2 _ hnth4 hlt).
+Qed.
+
+Lemma wf_Slots_params :
+  wf_Slots Slots_params Addr_params Writable_params Align_params.
+Proof.
+  split.
+  + move=> s /in_Slots_params.
+    case hpi: get_pi => [[pi [v1 v2]]|//] _.
+    have [p [? hargp]] := get_pi_wf_arg hpi; subst v2.
+    have hle := get_pi_size_le hpi.
+    rewrite /Addr_params hpi.
+    apply: no_overflow_incl hargp.(wap_no_overflow).
+    by apply zbetween_le.
+  + move=> sl1 sl2 /in_Slots_params hsl1 /in_Slots_params hsl2 hneq.
+    case hpi1: get_pi hsl1 => [[pi1 [v11 v12]]|//] _.
+    case hpi2: get_pi hsl2 => [[pi2 [v21 v22]]|//] _.
+    have [p1 [? hargp1]] := get_pi_wf_arg hpi1; subst v12.
+    have [p2 [? hargp2]] := get_pi_wf_arg hpi2; subst v22.
+    rewrite /Writable_params /Addr_params !hpi1 hpi2 => hw1.
+    have hle1 := get_pi_size_le hpi1.
+    have hle2 := get_pi_size_le hpi2.
+    have [k1 [hnth11 hnth12 hnth13 hnth14]] := get_pi_nth hpi1.
+    have [k2 [hnth21 hnth22 hnth23 hnth24]] := get_pi_nth hpi2.
+    have := Hdisj hnth12 hnth14 hnth22 hnth24 ltac:(congruence) hw1.
+    rewrite hnth13 hnth23.
+    by apply: disjoint_zrange_incl; apply zbetween_le.
+  + move=> s /in_Slots_params.
+    case hpi: get_pi => [[pi [v1 v2]]|//] _.
+    have [p [? hargp]] := get_pi_wf_arg hpi; subst v2.
+    rewrite /Addr_params /Align_params hpi.
+    by apply hargp.(wap_align).
+  by apply disjoint_zrange_globals_params.
+Qed.
+
+Lemma Haddr_no_overflow : forall s, Sv.In s Slots -> no_overflow (Addr s) (size_slot s).
+Proof.
+  move=> s /in_Slots [hin|[hin|hin]].
+  + rewrite /Addr (pick_slot_globals hin).
+    apply: no_overflow_incl no_overflow_glob_size.
+    by apply zbetween_Addr_globals.
+  + rewrite /Addr (pick_slot_locals hin).
+    apply: no_overflow_incl no_overflow_size.
+    by apply zbetween_Addr_locals.
+  rewrite /Addr (pick_slot_params hin).
+  by apply wf_Slots_params.
+Qed.
+
+Lemma Hdisjoint_writable : forall s1 s2, Sv.In s1 Slots -> Sv.In s2 Slots -> s1 <> s2 ->
+  Writable s1 -> disjoint_zrange (Addr s1) (size_slot s1) (Addr s2) (size_slot s2).
+Proof.
+  move=> sl1 sl2 hin1 hin2 hneq hw.
+  have hover1 := Haddr_no_overflow hin1.
+  have hover2 := Haddr_no_overflow hin2.
+  move /in_Slots : hin1 => [hin1|[hin1|hin1]].
+  + by move: hw; rewrite /Writable (pick_slot_globals hin1).
+  + move /in_Slots : hin2 => [hin2|[hin2|hin2]].
+    + apply disjoint_zrange_sym.
+      apply: disjoint_zrange_incl (disjoint_zrange_globals_locals _ _).
+      + rewrite /Addr (pick_slot_globals hin2).
+        by apply (zbetween_Addr_globals hin2).
+      + rewrite /Addr (pick_slot_locals hin1).
+        by apply (zbetween_Addr_locals hin1).
+      + move /in_Slots_slots : hin2.
+        case heq: Mvar.get => [[ofs ws]|//] _.
+        have := init_map_bounded heq.
+        have := size_slot_gt0 sl2.
+        by lia.
+      move /in_Slots_slots : hin1.
+      case heq: Mvar.get => [[ofs ws]|//] _.
+      have := init_stack_layout_bounded heq.
+      have := size_slot_gt0 sl1.
+      by lia.
+    + split=> //.
+      rewrite /Addr (pick_slot_locals hin1) (pick_slot_locals hin2).
+      move /in_Slots_slots : hin1.
+      case heq1 : Mvar.get => [[ofs1 ws1]|//] _.
+      move /in_Slots_slots : hin2.
+      case heq2 : Mvar.get => [[ofs2 ws2]|//] _.
+      rewrite (wunsigned_Addr_locals heq1).
+      rewrite (wunsigned_Addr_locals heq2).
+      have := init_stack_layout_disjoint heq1 heq2 hneq.
+      by lia.
+    rewrite /Addr (pick_slot_locals hin1) (pick_slot_params hin2).
+    apply: disjoint_zrange_incl_l (disjoint_zrange_locals_params hin2 _).
+    + by apply (zbetween_Addr_locals hin1).
+    move /in_Slots_slots : hin1.
+    case heq: Mvar.get => [[ofs ws]|//] _.
+    have := init_stack_layout_bounded heq.
+    have := size_slot_gt0 sl1.
+    by lia.
+  move /in_Slots : hin2 => [hin2|[hin2|hin2]].
+  + rewrite /Addr (pick_slot_params hin1) (pick_slot_globals hin2).
+    rewrite /Writable (pick_slot_params hin1) in hw.
+    apply disjoint_zrange_sym.
+    apply: disjoint_zrange_incl_l (disjoint_zrange_globals_params hin1 hw _).
+    + by apply (zbetween_Addr_globals hin2).
+    move /in_Slots_slots : hin2.
+    case heq: Mvar.get => [[ofs ws]|//] _.
+    have := init_map_bounded heq.
+    have := size_slot_gt0 sl2.
+    by lia.
+  + rewrite /Addr (pick_slot_params hin1) (pick_slot_locals hin2).
+    apply disjoint_zrange_sym.
+    apply: disjoint_zrange_incl_l (disjoint_zrange_locals_params hin1 _).
+    + by apply (zbetween_Addr_locals hin2).
+    move /in_Slots_slots : hin2.
+    case heq: Mvar.get => [[ofs ws]|//] _.
+    have := init_stack_layout_bounded heq.
+    have := size_slot_gt0 sl2.
+    by lia.
+  rewrite /Addr (pick_slot_params hin1) (pick_slot_params hin2).
+  rewrite /Writable (pick_slot_params hin1) in hw.
+  by apply wf_Slots_params.
+Qed.
+
+Lemma Hslot_align : forall s, Sv.In s Slots -> is_align (Addr s) (Align s).
+Proof.
+  move=> s /in_Slots [hin|[hin|hin]].
+  + rewrite /Addr /Align !(pick_slot_globals hin).
+    move /in_Slots_slots : hin.
+    case heq: Mvar.get => [[ofs ws]|//] _.
+    rewrite /Addr_globals /Offset_slots /Align_globals /Align_slots heq.
+    apply is_align_add.
+    + apply: is_align_m rip_align.
+      by apply wsize_ge_U256.
+    rewrite WArray.arr_is_align.
+    by apply /eqP; apply (init_map_align heq).
+  + rewrite /Addr /Align !(pick_slot_locals hin).
+    move /in_Slots_slots : hin.
+    case heq: Mvar.get => [[ofs ws]|//] _.
+    rewrite /Addr_locals /Offset_slots /Align_locals /Align_slots heq.
+    apply is_align_add.
+    + apply: is_align_m rsp_align.
+      by apply (init_stack_layout_stack_align heq).
+    rewrite WArray.arr_is_align.
+    by apply /eqP; apply (init_stack_layout_align heq).
+  rewrite /Addr /Align !(pick_slot_params hin).
+  by apply wf_Slots_params.
+Qed.
+
+Lemma Hwritable_not_glob :
+  forall s, Sv.In s Slots -> Writable s ->
+  0 < glob_size -> disjoint_zrange rip glob_size (Addr s) (size_slot s).
+Proof.
+  move=> s /in_Slots [hin|[hin|hin]].
+  + by rewrite /Writable (pick_slot_globals hin).
+  + move=> _ hlt.
+    apply: disjoint_zrange_incl_r (disjoint_zrange_globals_locals _ _) => //.
+    + rewrite /Addr (pick_slot_locals hin).
+      by apply (zbetween_Addr_locals hin).
+    move /in_Slots_slots : hin.
+    case heq: Mvar.get => [[ofs ws]|//] _.
+    have := init_stack_layout_bounded heq.
+    have := size_slot_gt0 s.
+    by lia.
+  rewrite /Writable /Addr !(pick_slot_params hin).
+  by apply wf_Slots_params.
+Qed.
+
+Lemma Hwf_Slots : wf_Slots Slots Addr Writable Align.
+Proof.
+  split.
+  + by apply Haddr_no_overflow.
+  + by apply Hdisjoint_writable.
+  + by apply Hslot_align.
+  by apply Hwritable_not_glob.
+Qed.
+
+Definition lmap locals' vnew' := {|
+  vrip := vrip0;
+  vrsp := vrsp0;
+  globals := mglob;
+  locals := locals';
+  vnew := vnew'
+|}.
+
+Lemma init_map_wf g ofs ws :
+  Mvar.get mglob g = Some (ofs, ws) ->
+  wf_global rip Slots Addr Writable Align g ofs ws.
+Proof.
+  move=> hget.
+  have hin: Sv.In g Slots_globals.
+  + by apply in_Slots_slots; congruence.
+  split=> /=.
+  + by apply in_Slots; left.
+  + by rewrite /Writable (pick_slot_globals hin).
+  + by rewrite /Align (pick_slot_globals hin) /Align_globals /Align_slots hget.
+  by rewrite /Addr (pick_slot_globals hin) /Addr_globals /Offset_slots hget.
+Qed.
+
+Lemma init_map_wf_rmap vnew' s1 s2 :
+  (forall i, 0 <= i < glob_size ->
+    read (emem s2) (rip + wrepr U64 i)%R U8 = ok (nth 0%R global_data (Z.to_nat i))) ->
+  wf_rmap (lmap (Mvar.empty _) vnew') Slots Addr Writable Align P empty s1 s2.
+Proof.
+  move=> heqvalg.
+  split=> //=.
+  move=> y sry bytesy vy.
+  rewrite /check_gvalid /=.
+  case: (@idP (is_glob y)) => // hg.
+  case heq: Mvar.get => [[ofs ws]|//] [<- <-].
+  rewrite get_gvar_glob // => /get_globalI [v [hv -> hty]].
+  split=> // off _ w hget.
+  rewrite /sub_region_addr /= wrepr0 GRing.addr0.
+  have hin: Sv.In y.(gv) Slots_globals.
+  + by apply in_Slots_slots; congruence.
+  rewrite /Addr (pick_slot_globals hin) /Addr_globals /Offset_slots heq.
+  rewrite -GRing.addrA -wrepr_add.
+  rewrite heqvalg.
+  + f_equal.
+    have /check_globsP := hv.
+    rewrite heq => -[? [? [[<- _]]]].
+    by apply.
+  have := init_map_bounded heq.
+  have := get_val_byte_bound hget; rewrite hty.
+  by lia.
+Qed.
+
+Lemma add_alloc_wf_pmap locals1' rmap1' vnew1' x pki locals2' rmap2' vnew2' :
+  add_alloc fn mglob stack (x, pki) (locals1', rmap1', vnew1') = ok (locals2', rmap2', vnew2') ->
+  wf_pmap (lmap locals1' vnew1') rsp rip Slots Addr Writable Align ->
+  wf_pmap (lmap locals2' vnew2') rsp rip Slots Addr Writable Align.
+Proof.
+  move=> hadd hpmap.
+  case: (hpmap) => /= hrip hrsp hnew1 hnew2 hglobals hlocals hnew.
+  move: hadd => /=.
+  case: Sv_memP => [//|hnnew].
+  case hregx: Mvar.get => //.
+  set wf_pmap := wf_pmap. (* hack due to typeclass interacting badly *)
+  t_xrbindP=> {rmap2'} -[[sv pk] rmap2'] hpki [<- _ <-].
+  case: pki hpki.
+  + move=> s z sc.
+    case heq: Mvar.get => [[ofs ws]|//].
+    case: ifP => [/and3P []|//].
+    rewrite !zify => h1 h2 h3 [<- <- _].
+    split=> //=.
+    + move=> y pky.
+      rewrite Mvar.setP.
+      case: eqP.
+      + move=> <- [<-].
+        case: sc heq => heq.
+        + have hin: Sv.In s Slots_locals.
+          + by apply in_Slots_slots; congruence.
+          split=> //=.
+          + by apply in_Slots; right; left.
+          + by rewrite /Writable (pick_slot_locals hin).
+          + by rewrite /Align (pick_slot_locals hin) /Align_locals /Align_slots heq.
+          by rewrite /Addr (pick_slot_locals hin) /Addr_locals /Offset_slots heq.
+        have hin: Sv.In s Slots_globals.
+        + by apply in_Slots_slots; congruence.
+        split=> //=.
+        + by apply in_Slots; left.
+        + by rewrite /Writable (pick_slot_globals hin).
+        + by rewrite /Align (pick_slot_globals hin) /Align_globals /Align_slots heq.
+        by rewrite /Addr (pick_slot_globals hin) /Addr_globals /Offset_slots heq.
+      move=> hneq /hlocals.
+      case: pky => //=.
+      + move=> p [] hty1 hty2 hrip' hrsp' hnew' hneq'.
+        split=> //=.
+        rewrite /get_local /= => w wr.
+        rewrite Mvar.setP.
+        case: eqP => //.
+        by move=> _; apply hneq'.
+      move=> sy ofsy wsy zy yf [] hslot hty hlen hofs hw hal hcmp hal2 haddr hnew' hneq'.
+      split=> //=.
+      rewrite /get_local /= => w sw ofsw wsw zw wf.
+      rewrite Mvar.setP.
+      case: eqP => //.
+      by move=> _; apply hneq'.
+    move=> y pky.
+    rewrite Mvar.setP.
+    case: eqP.
+    + by move=> <- _.
+    by move=> _; apply hnew.
+  + move=> p.
+    case harr: is_sarr => //=.
+    case: Sv_memP => [//|hnnew2].
+    case heq0: Mvar.get => //.
+    case: eqP => [hty|//] /= [<- <- _].
+    split=> //=.
+    + by apply SvD.F.add_2.
+    + by apply SvD.F.add_2.
+    + move=> y pky.
+      rewrite Mvar.setP.
+      case: eqP.
+      + move=> <- [<-].
+        split=> //=.
+        + by congruence.
+        + by congruence.
+        + by apply SvD.F.add_1.
+        rewrite /get_local /= => w wr.
+        rewrite Mvar.setP.
+        case: eqP => //.
+        by move=> hneq /hlocals /wfr_new /=; congruence.
+      move=> hneq /hlocals.
+      case: pky => //=.
+      + move=> p' [] /= hty1 hty2 hrip' hrsp' hnew' hneq'.
+        split=> //=.
+        + by apply SvD.F.add_2.
+        rewrite /get_local /= => w wr.
+        rewrite Mvar.setP.
+        case: eqP.
+        + by move=> _ [<-]; congruence.
+        by move=> _; apply hneq'.
+      move=> sy ofsy wsy zy yf [] hslot hty' hlen hofs hw hal hcmp hal2 haddr hnew' hneq'.
+      split=> //=.
+      + by apply SvD.F.add_2.
+      move=> w sw ofsw wsw zw wf.
+      rewrite /get_local /= Mvar.setP.
+      case: eqP => //.
+      by move=> _; apply hneq'.
+    move=> y pky.
+    rewrite Mvar.setP.
+    case: eqP.
+    + move=> <- _.
+      have ?: x <> p.
+      + by move /is_sarrP: harr => [n]; congruence.
+      by move=> /SvD.F.add_3; auto.
+    move=> ? /dup[] ? /hnew ?.
+    have ?: p <> y by congruence.
+    by move=> /SvD.F.add_3; auto.
+  move=> s z f.
+  case harr: is_sarr => //.
+  case heq: Mvar.get => [[ofs ws]|//].
+  case: Sv_memP => [//|hnnew2].
+  case: eqP => [//|hneq0].
+  case heqf: Mvar.get => //.
+  case: ifP => [/and5P []|//].
+  move=> h1.
+  rewrite !zify.
+  move=> h2 /eqP; rewrite (Zland_mod _ U64) => h3 h4 h5 [<- <- _].
+  split=> //=.
+  + by apply SvD.F.add_2.
+  + by apply SvD.F.add_2.
+  + move=> y pky.
+    rewrite Mvar.setP.
+    case: eqP.
+    + move=> <- [<-].
+      have hin: Sv.In s Slots_locals.
+      + by apply in_Slots_slots; congruence.
+      split=> //=.
+      + by apply in_Slots; right; left.
+      + by rewrite /Writable (pick_slot_locals hin).
+      + by rewrite /Align (pick_slot_locals hin) /Align_locals /Align_slots heq.
+      + by rewrite WArray.arr_is_align; apply /eqP.
+      + by rewrite /Addr (pick_slot_locals hin) /Addr_locals /Offset_slots heq.
+      + by apply SvD.F.add_1.
+      move=> w sw ofsw wsw zw wf.
+      rewrite /get_local /= Mvar.setP.
+      case: eqP => //.
+      by move=> _ /hlocals /wfs_new /=; congruence.
+    move=> hneq /hlocals.
+    case: pky => //=.
+    + move=> p [] hty1 hty2 hrip' hrsp' hnew' hneq'.
+      split=> //=.
+      + by apply SvD.F.add_2.
+      move=> w wr /=.
+      rewrite /get_local /= Mvar.setP.
+      case: eqP => //.
+      by move=> _; apply hneq'.
+    move=> sy ofsy wsy zy yf [] /= hslot hty' hlen hofs hw hal hcmp hal2 haddr hnew' hneq'.
+    split=> //=.
+    + by apply SvD.F.add_2.
+    move=> w sw ofsw wsw zw wf.
+    rewrite /get_local /= Mvar.setP.
+    case: eqP.
+    + by move=> _ [_ _ _ _ <-]; congruence.
+    by move=> _; apply hneq'.
+  move=> y pky.
+  rewrite Mvar.setP.
+  case: eqP.
+  + move=> <- _.
+    by move=> /SvD.F.add_3; auto.
+  move=> ? /dup[] ? /hnew ?.
+  have ?: f <> y by congruence.
+  by move=> /SvD.F.add_3; auto.
+Qed.
+
+Lemma add_alloc_wf_rmap locals1' rmap1' vnew1' x pki locals2' rmap2' vnew2' s2 :
+  wf_pmap (lmap locals1' vnew1') rsp rip Slots Addr Writable Align ->
+  add_alloc fn mglob stack (x, pki) (locals1', rmap1', vnew1') = ok (locals2', rmap2', vnew2') ->
+  let: s1 := {| emem := m1; evm := vmap0 |} in
+  wf_rmap (lmap locals1' vnew1') Slots Addr Writable Align P rmap1' s1 s2 ->
+  wf_rmap (lmap locals2' vnew2') Slots Addr Writable Align P rmap2' s1 s2.
+Proof.
+  move=> hpmap hadd hrmap.
+  case: (hrmap) => hwfsr hval hptr.
+  move: hadd => /=.
+  case: Sv_memP => [//|hnnew].
+  case hregx: Mvar.get => //.
+  set wf_rmap := wf_rmap. (* hack due to typeclass interacting badly *)
+  t_xrbindP=> {rmap2'} -[[sv pk] rmap2'] hpki [<- <- <-].
+  case: pki hpki.
+  + move=> s z sc.
+    case heq: Mvar.get => [[ofs ws]|//].
+    case: ifP => [/and3P []|//].
+    rewrite !zify => h1 h2 h3 [<- <- <-].
+    case: sc heq => heq.
+    + split.
+      + move=> y sry.
+        rewrite Mvar.setP.
+        case: eqP.
+        + move=> <- [<-].
+          have hin: Sv.In s Slots_locals.
+          + by apply in_Slots_slots; congruence.
+          split; split=> //=.
+          + by apply in_Slots; right; left.
+          + by rewrite /Writable (pick_slot_locals hin).
+          by rewrite /Align (pick_slot_locals hin) /Align_locals /Align_slots heq.
+        by move=> _; apply hwfsr.
+      + move=> y sry bytesy vy /check_gvalid_set_move [].
+        + move=> [hg ? _ _]; subst x.
+          rewrite get_gvar_nglob; last by apply /negP.
+          rewrite /get_var /= Fv.get0.
+          case: vtype => //= len [<-].
+          split=> // off _ w /=.
+          rewrite WArray.get_empty.
+          by case: ifP.
+        by move=> [] _; apply hval.
+      move=> y sry.
+      rewrite /get_local /=.
+      rewrite !Mvar.setP.
+      case: eqP.
+      + move=> _ [<-].
+        by eexists.
+      move=> hneq /hptr [pky [hly hpky]].
+      exists pky; split=> //.
+      case: pky hly hpky => //= sy ofsy wsy zy yf hly hpky.
+      rewrite /check_stack_ptr get_var_bytes_set_move_bytes /=.
+      case: eqP => //=.
+      case: eqP => //.
+      by have /wf_locals /wfs_new /= := hly; congruence.
+    split=> //.
+    move=> y sry /hptr.
+    rewrite /get_local /= => -[pky [hly hpky]].
+    exists pky; split=> //.
+    rewrite Mvar.setP.
+    by case: eqP; first by congruence.
+  + move=> p.
+    case harr: is_sarr => //=.
+    case: Sv_memP => [//|hnnew2].
+    case heq0: Mvar.get => //.
+    case: eqP => [hty|//] /= [<- <- <-].
+    split=> //=.
+    move=> y sry /hptr.
+    rewrite /get_local /= => -[pky [hly hpky]].
+    exists pky; split=> //.
+    rewrite Mvar.setP.
+    by case: eqP; first by congruence.
+  move=> s z f.
+  case harr: is_sarr => //.
+  case heq: Mvar.get => [[ofs ws]|//].
+  case: Sv_memP => [//|hnnew2].
+  case: eqP => [//|hneq0].
+  case heqf: Mvar.get => //.
+  case: ifP => [/and5P []|//].
+  move=> h1.
+  rewrite !zify.
+  move=> h2 /eqP; rewrite (Zland_mod _ U64) => h3 h4 h5 [<- <- <-].
+  split=> //.
+  move=> y sry /hptr.
+  rewrite /get_local /= => -[pky [hly hpky]].
+  exists pky; split=> //.
+  rewrite Mvar.setP.
+  by case: eqP; first by congruence.
+Qed.
+
+Lemma init_local_map_wf_pmap :
+  wf_pmap (lmap locals1 vnew1) rsp rip Slots Addr Writable Align.
+Proof.
+  move: hlocal_map; rewrite /init_local_map.
+  set wf_pmap := wf_pmap. (* hack due to typeclass interacting badly *)
+  t_xrbindP=> -[[locals1' rmap1'] vnew1'] hfold [???]; subst locals1' rmap1' vnew1'.
+  move: hfold.
+  have: wf_pmap (lmap (Mvar.empty ptr_kind, empty, Sv.add vrip0 (Sv.add vrsp0 Sv.empty)).1.1
+                      (Mvar.empty ptr_kind, empty, Sv.add vrip0 (Sv.add vrsp0 Sv.empty)).2) rsp rip
+                      Slots Addr Writable Align.
+  + split=> //=.
+    + by apply SvD.F.add_1.
+    + by apply SvD.F.add_2; apply SvD.F.add_1.
+    by apply init_map_wf.
+  elim: sao.(sao_alloc) (Mvar.empty _, _, _).
+  + by move=> /= [[locals0 rmap0] vnew0] ? [<- _ <-].
+  move=> [x pki] l ih [[locals0 rmap0] vnew0] /= hpmap.
+  t_xrbindP=> -[[locals1' rmap1'] vnew1'] halloc.
+  apply ih.
+  by apply (add_alloc_wf_pmap halloc hpmap).
+Qed.
+
+Lemma init_local_map_wf_rmap s2 :
+  let: s1 := {| emem := m1; evm := vmap0 |} in
+  (forall i, 0 <= i < glob_size ->
+    read (emem s2) (rip + wrepr U64 i)%R U8 = ok (nth 0%R global_data (Z.to_nat i))) ->
+  wf_rmap (lmap locals1 vnew1) Slots Addr Writable Align P rmap1 s1 s2.
+Proof.
+  move=> heqvalg.
+  move: hlocal_map; rewrite /init_local_map.
+  set wf_rmap := wf_rmap. (* hack due to typeclass interacting badly *)
+  t_xrbindP=> -[[locals1' rmap1'] vnew1'] hfold [???]; subst locals1' rmap1' vnew1'.
+  move: hfold.
+  have: wf_pmap (lmap (Mvar.empty ptr_kind, empty, Sv.add vrip0 (Sv.add vrsp0 Sv.empty)).1.1
+                      (Mvar.empty ptr_kind, empty, Sv.add vrip0 (Sv.add vrsp0 Sv.empty)).2) rsp rip
+                      Slots Addr Writable Align
+     /\ wf_rmap (lmap (Mvar.empty ptr_kind, empty, Sv.add vrip0 (Sv.add vrsp0 Sv.empty)).1.1
+                      (Mvar.empty ptr_kind, empty, Sv.add vrip0 (Sv.add vrsp0 Sv.empty)).2)
+                Slots Addr Writable Align P (Mvar.empty ptr_kind, empty, Sv.add vrip0 (Sv.add vrsp0 Sv.empty)).1.2 {| emem := m1; evm := vmap0 |} s2.
+  + split.
+    + split=> //=.
+      + by apply SvD.F.add_1.
+      + by apply SvD.F.add_2; apply SvD.F.add_1.
+      by apply init_map_wf.
+    by apply init_map_wf_rmap.
+  elim: sao.(sao_alloc) (Mvar.empty _, _, _).
+  + by move=> /= [[locals0 rmap0] vnew0] [??] [<- <- <-].
+  move=> [x pki] l ih [[locals0 rmap0] vnew0] /= [hpmap hrmap].
+  t_xrbindP=> -[[locals1' rmap1'] vnew1'] halloc.
+  apply ih.
+  split.
+  + apply (add_alloc_wf_pmap halloc hpmap).
+  by apply (add_alloc_wf_rmap hpmap halloc hrmap).
+Qed.
+
+Lemma init_param_wf_pmap vnew1' locals1' rmap1' sao_param (param:var_i) vnew2' locals2' rmap2' alloc_param :
+  init_param mglob stack (vnew1', locals1', rmap1') sao_param param =
+    ok (vnew2', locals2', rmap2', alloc_param) ->
+  wf_pmap (lmap locals1' vnew1') rsp rip Slots Addr Writable Align ->
+  wf_pmap (lmap locals2' vnew2') rsp rip Slots Addr Writable Align.
+Proof.
+  move=> hparam hpmap.
+  case: (hpmap) => /= hrip hrsp hnew1 hnew2 hglobals hlocals hnew.
+  move: hparam => /=.
+  set wf_pmap := wf_pmap. (* hack due to typeclass interacting badly *)
+  t_xrbindP=> _ /assertP /Sv_memP hnnew.
+  case heq: Mvar.get => //.
+  case: sao_param => [pi|[<- <- _ _] //].
+  t_xrbindP=> _ /assertP /eqP hregty _ /assertP /Sv_memP hnnew2 _ /assertP harrty.
+  case heq1: Mvar.get => //.
+  case heq2: Mvar.get => //.
+  case heq3: Mvar.get => //.
+  move=> [<- <- _ _].
+  split=> //=.
+  + by apply SvD.F.add_2.
+  + by apply SvD.F.add_2.
+  + move=> y pky.
+    rewrite Mvar.setP.
+    case: eqP.
+    + move=> <- [<-] /=.
+      split=> //=.
+      + by congruence.
+      + by congruence.
+      + by apply SvD.F.add_1.
+      move=> w wr.
+      rewrite /get_local /= Mvar.setP.
+      case: eqP => //.
+      by move=> _ /hlocals /wfr_new /=; congruence.
+    move=> ? /hlocals.
+    case: pky => //=.
+    + move=> p [] /= hty1 hty2 hrip' hrsp' hnew' hneq'.
+      split=> //=.
+      + by apply SvD.F.add_2.
+      move=> w wr.
+      rewrite /get_local /= Mvar.setP.
+      case: eqP.
+      + by move=> _ [<-]; congruence.
+      by move=> _; apply hneq'.
+    move=> sy ofsy wsy zy yf [] /= hslot hty' hlen hofs hw hal hcmp hal2 haddr hnew' hneq'.
+    split=> //=.
+    + by apply SvD.F.add_2.
+    move=> w sw ofsw wsw zw wf.
+    rewrite /get_local /= Mvar.setP.
+    case: eqP => //.
+    by move=> _; apply hneq'.
+  move=> y pky.
+  rewrite Mvar.setP.
+  case: eqP.
+  + move=> <- _.
+    have ?: param.(v_var) <> pi.(pp_ptr).
+    + by move /is_sarrP : harrty => [n]; congruence.
+    by move=> /SvD.F.add_3; auto.
+  move=> ? /dup[] ? /hnew ?.
+  have ?: pi.(pp_ptr) <> y by congruence.
+  by move=> /SvD.F.add_3; auto.
+Qed.
+
+Lemma valid_state_init_param rmap m0 s1 s2 vnew1' locals1' sao_param (param:var_i) vnew2' locals2' rmap2' alloc_param :
+  wf_pmap (lmap locals1' vnew1') rsp rip Slots Addr Writable Align ->
+  valid_state (lmap locals1' vnew1') glob_size rsp rip Slots Addr Writable Align P rmap m0 s1 s2 ->
+  init_param mglob stack (vnew1', locals1', rmap) sao_param param = ok (vnew2', locals2', rmap2', alloc_param) ->
+  forall s1' varg1 varg2,
+  write_var param varg1 s1 = ok s1' ->
+  (forall pi, sao_param = Some pi -> get_pi param = Some (pi, (varg1, varg2))) ->
+  wf_arg glob_size rip (emem s1) (emem s2) sao_param varg1 varg2 ->
+  exists s2',
+  write_var alloc_param.2 varg2 s2 = ok s2' /\
+  valid_state (lmap locals2' vnew2') glob_size rsp rip Slots Addr Writable Align P rmap2' m0 s1' s2'.
+Proof.
+  move=> hpmap hvs hparam.
+  have hpmap2 := init_param_wf_pmap hparam hpmap.
+  move: hparam => /=.
+  t_xrbindP=> _ /assertP /Sv_memP hnnew.
+  case heq1: Mvar.get => [//|].
+  case: sao_param => [pi|]; last first.
+  + move=> [<- <- <- <-].
+    move=> s1' varg1 varg2 hw _ ->.
+    move: hw.
+    rewrite /write_var; t_xrbindP => vm1 hvm1 <- /=.
+    by apply: set_varP hvm1 => [v' hv <- | hb hv <-]; rewrite /write_var /set_var hv /= ?hb /=;
+      eexists;(split;first by reflexivity); apply valid_state_set_var.
+  t_xrbindP=> _ /assertP /eqP hty1 _ /assertP /Sv_memP hnnew2 _ /assertP /is_sarrP [n hty2].
+  case heq2: Mvar.get => //.
+  case heq3: Mvar.get => //.
+  case heq4: Mvar.get => //.
+  move=> [? ? <- <-]; subst vnew2' locals2'.
+  move=> s1' varg1 varg2 hw /(_ _ refl_equal) hpi [w [? hargp]]; subst varg2.
+  rewrite /write_var /set_var /=.
+  case: pi.(pp_ptr) hty1 hpmap2 => /= _ pin -> /=.
+  set p := {| vname := pin |} => hpmap2.
+  eexists; split; first by reflexivity.
+  move: hw; rewrite /write_var.
+  set valid_state := valid_state. (* hack due to typeclass interacting badly *)
+  t_xrbindP => vm1 hvm1 <- /=.
+  apply: set_varP hvm1; last by rewrite {1}hty2.
+  case: param hty2 hnnew heq1 heq3 heq4 hpi hpmap2 => -[_ paramn] paramii /= -> /=.
+  set param := {| vname := paramn |} => hnnew heq1 heq3 heq4 hpi hpmap2.
+  move=> a1 /to_arrI [n2 [a2 [? hcast]]] <-; subst varg1.
+  set sr := sub_region_full _ _.
+  have hin: Sv.In sr.(sr_region).(r_slot) Slots_params.
+  + by apply in_Slots_params => /=; congruence.
+  have hwf: wf_sub_region Slots Writable Align sr (sarr n).
+  + split; split=> /=.
+    + by apply in_Slots; right; right.
+    + by rewrite /Writable (pick_slot_params hin) /Writable_params hpi.
+    + by rewrite /Align (pick_slot_params hin) /Align_params hpi.
+    + by lia.
+    by lia.
+  have haddr: w = sub_region_addr Addr sr.
+  + rewrite /sub_region_addr /= wrepr0 GRing.addr0.
+    by rewrite /Addr (pick_slot_params hin) /= /Addr_params hpi.
+  rewrite haddr -(WArray.castK a1).
+  apply (valid_state_set_move_regptr hpmap2 (x := param) (v:=Varr a1) (p:=p)) => //; last first.
+  + split=> //.
+    move=> off _ w' hget.
+    rewrite -haddr.
+    apply hargp.(wap_read).
+    by apply (cast_get8 hcast).
+  + by rewrite /get_local /= Mvar.setP_eq.
+  case:(hvs) => hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
+  split=> //.
+  + move=> x /=.
+    rewrite Mvar.setP.
+    case: eqP => //.
+    move=> ? hlx hnnew3.
+    apply heqvm => //.
+    move=> ?; apply hnnew3.
+    by apply Sv.add_spec; right.
+  case: (hwfr) => hwfsr hval hptr; split=> //.
+  move=> y sry /hptr.
+  rewrite /get_local /= => -[pky [hly hpky]].
+  exists pky; split=> //.
+  rewrite Mvar.setP.
+  by case: eqP => //; congruence.
+Qed.
+
+Lemma init_params_wf_pmap :
+  wf_pmap (lmap locals2 vnew2) rsp rip Slots Addr Writable Align.
+Proof.
+  move: hparams.
+  set wf_pmap := wf_pmap. (* hack due to typeclass interacting badly *)
+  have := init_local_map_wf_pmap.
+  elim: sao.(sao_params) params vnew1 locals1 rmap1 vnew2 locals2 rmap2 alloc_params.
+  + by move=> [|//] ??????? hbase [<- <- _ _].
+  move=> opi sao_params ih [//|param params'].
+  move=> vnew0 locals0 rmap0 vnew2' locals2' rmap2' alloc_params' hpmap.
+  rewrite /init_params /=.
+  apply rbindP => -[[[vnew1' locals1'] rmap1'] alloc_param] hparam.
+  t_xrbindP=> -[[[??]?]?] /ih{ih}ih [<- <- _] _.
+  apply ih.
+  by apply (init_param_wf_pmap hparam).
+Qed.
+
+Lemma valid_state_init_params m0 vm1 vm2 :
+  let: s1 := {| emem := m1; evm := vm1 |} in
+  let: s2 := {| emem := m2; evm := vm2 |} in
+  valid_state (lmap locals1 vnew1) glob_size rsp rip Slots Addr Writable Align P rmap1 m0 s1 s2 ->
+  forall s1',
+  write_vars params vargs1 s1 = ok s1' ->
+  exists s2',
+  write_vars (map snd alloc_params) vargs2 s2  = ok s2' /\
+  valid_state (lmap locals2 vnew2) glob_size rsp rip Slots Addr Writable Align P rmap2 m0 s1' s2'.
+Proof.
+  move=> hvs.
+  have {hvs}:
+     wf_pmap (lmap locals1 vnew1) rsp rip Slots Addr Writable Align /\
+     valid_state (lmap locals1 vnew1) glob_size rsp rip Slots Addr Writable Align P rmap1 m0 {| emem := m1; evm := vm1 |} {| emem := m2; evm := vm2 |}.
+  + split=> //.
+    by apply init_local_map_wf_pmap.
+  elim: Hargs params get_pi_Forall vnew1 locals1 rmap1 vnew2 locals2 rmap2 alloc_params hparams vm1 vm2.
+  + move=> [|//] _ ??????? [<- <- <- <-] vm1 vm2 [_ hvs] _ [<-].
+    by eexists.
+  move=> opi varg1 varg2 sao_params vargs1' vargs2' hrin _ ih [//|x params'].
+  move=> /= /List_Forall_inv [hpi hforall].
+  move=> vnew0 locals0 rmap0 vnew2' locals2' rmap2' alloc_params'.
+  rewrite /init_params /=.
+  apply: rbindP=> -[[[vnew1' locals1'] rmap1'] alloc_param] hparam.
+  t_xrbindP=> -[[[??]?]?] /ih{ih}ih [<- <- <-] <- vm1 vm2 [hpmap hvs].
+  move=> s1'' s1' hs1' hs1''.
+  have [//|s2' [hs2' hvs']] := valid_state_init_param hpmap hvs hparam hs1' _ hrin.
+  rewrite /= hs2'.
+  move: hs1' hs2'.
+  rewrite /write_var.
+  t_xrbindP=> /= vm1' hvm1' ? vm2' hvm2' ?; subst s1' s2'.
+  have hpmap' := init_param_wf_pmap hparam hpmap.
+  have [//|s2'' [hs2'' hvs'']] := ih _ _ _ (conj hpmap' hvs') _ hs1''.
+  rewrite hs2''.
+  by eexists.
+Qed.
+
+Lemma init_param_alloc_param vnew1' locals1' rmap1' sao_param (param:var_i) vnew2' locals2' rmap2' alloc_param :
+  init_param mglob stack (vnew1', locals1', rmap1') sao_param param = ok (vnew2', locals2', rmap2', alloc_param) ->
+  forall varg1 varg2,
+  (forall pi, sao_param = Some pi -> get_pi param = Some (pi, (varg1, varg2))) ->
+  forall sr, fst alloc_param = Some sr ->
+  varg2 = Vword (sub_region_addr Addr sr).
+Proof.
+  rewrite /init_param.
+  t_xrbindP=> _ _.
+  case: Mvar.get => //.
+  case: sao_param => [pi|].
+  + t_xrbindP => _ _ _ _ _ _.
+    case: Mvar.get => //.
+    case: Mvar.get => //.
+    case: Mvar.get => //.
+    move=> [_ _ _ <-] /=.
+    move=> varg1 varg2 /(_ _ refl_equal) hpi sr [<-].
+    rewrite /sub_region_addr /= wrepr0 GRing.addr0.
+    have hin: Sv.In param Slots_params.
+    + by apply in_Slots_params; congruence.
+    rewrite /Addr (pick_slot_params hin) /Addr_params hpi.
+    by have [p [-> _]] := get_pi_wf_arg hpi.
+  by move=> [_ _ _ <-].
+Qed.
+
+Lemma init_params_alloc_params :
+  List.Forall2 (fun osr varg2 => forall sr, osr = Some sr -> varg2 = Vword (sub_region_addr Addr sr)) (map fst alloc_params) vargs2.
+Proof.
+  elim: Hargs params get_pi_Forall vnew1 locals1 rmap1 vnew2 locals2 rmap2 alloc_params hparams.
+  + move=> [|//] _ ??????? [_ _ _ <-].
+    by constructor.
+  move=> opi varg1 varg2 sao_params vargs1' vargs2' _ _ ih [//|param params'].
+  move=> /= /List_Forall_inv [hpi hforall].
+  move=> vnew0 locals0 rmap0 vnew2' locals2' rmap2' alloc_params'.
+  rewrite /init_params /=.
+  apply: rbindP=> -[[[vnew1' locals1'] rmap1'] alloc_param] hparam.
+  t_xrbindP=> -[[[??]?]?] /ih{ih}ih _ <- /=.
+  constructor; last by apply ih.
+  by apply (init_param_alloc_param hparam hpi).
+Qed.
+
+Lemma init_params_alloc_params_not_None :
+  List.Forall2 (fun osr opi => osr <> None -> opi <> None) (map fst alloc_params) sao.(sao_params).
+Proof.
+  elim: sao.(sao_params) params vnew1 locals1 rmap1 vnew2 locals2 rmap2 alloc_params hparams.
+  + move=> [|//] ??????? [_ _ _ <-].
+    by constructor.
+  move=> opi sao_params ih [//|x params'].
+  move=> vnew0 locals0 rmap0 vnew2' locals2' rmap2' alloc_params'.
+  rewrite /init_params /=.
+  apply: rbindP=> -[[[vnew1' locals1'] rmap1'] alloc_param] hparam.
+  t_xrbindP=> -[[[??]?]?] /ih{ih}ih _ <- /=.
+  constructor=> //.
+  move: hparam.
+  t_xrbindP=> _ _.
+  case: Mvar.get => //.
+  case: opi => [//|].
+  by move=> [_ _ _ <-].
+Qed.
+
+Lemma init_params_sarr :
+  List.Forall2 (fun opi (x:var_i) => opi <> None -> is_sarr x.(vtype)) sao.(sao_params) params.
+Proof.
+  elim: sao.(sao_params) params vnew1 locals1 rmap1 vnew2 locals2 rmap2 alloc_params hparams.
+  + by move=> [|//] _ _ _ _ _ _ _ _.
+  move=> opi sao_params ih [//|x params'].
+  move=> vnew0 locals0 rmap0 vnew2' locals2' rmap2' alloc_params'.
+  rewrite /init_params /=.
+  apply: rbindP=> -[[[vnew1' locals1'] rmap1'] alloc_param] hparam.
+  t_xrbindP=> -[[[_ _] _] _] /ih{ih}ih _ _.
+  constructor=> //.
+  move: hparam.
+  t_xrbindP=> _ _.
+  case: Mvar.get => //.
+  case: opi => [pi|//].
+  by t_xrbindP=> _ _ _ _ _ /assertP.
+Qed.
+
+(* [m2] is (at least) [m1] augmented with data [data] at address [rip]. *)
+Record extend_mem (m1 m2:mem) (rip:pointer) (data:seq u8) := {
+  em_no_overflow : no_overflow rip (Z.of_nat (size data));
+    (* [rip] is able to store a block large enough *)
+  em_align       : is_align rip U256;
+    (* [rip] is 32-bytes aligned (and thus is 1,2,4,8,16-bytes aligned) *)
+    (* could be formulated, [forall ws, is_align rip ws] *)
+  em_read_old8   : forall p, validw m1 p U8 -> read m1 p U8 = read m2 p U8;
+    (* [m2] contains [m1] *)
+  em_fresh       : forall p, validw m1 p U8 -> disjoint_zrange rip (Z.of_nat (size data)) p (wsize_size U8);
+   (* the bytes in [rip; rip + Z.of_nat (size data) - 1] are disjoint from the valid bytes of [m1] *)
+  em_valid       : forall p, validw m1 p U8 || between rip (Z.of_nat (size data)) p U8 -> validw m2 p U8;
+    (* [m2] contains at least [m1] and [rip; rip + Z.of_nat (size data) - 1] *)
+  em_read_new    : forall i, 0 <= i < Z.of_nat (size data) ->
+                     read m2 (rip + wrepr _ i)%R U8 = ok (nth 0%R data (Z.to_nat i))
+    (* the memory at address [rip] contains [data] *)
+}.
+
+(* TODO: should we assume init_stk_state = ok ... as section hypothesis and reason about it,
+   it would in particular ease the proof of params <> locals, since we would have the properties
+   of alloc_stack_spec to reason with. The advantages are not clear. For now, I leave it like this.
+*)
+(* cf. init_stk_stateI in merge_varmaps_proof *)
+Lemma init_stk_state_valid_state m3 sz' ws :
+  extend_mem m1 m2 rip global_data ->
+  alloc_stack_spec m2 ws sao.(sao_size) sz' m3 ->
+  rsp = top_stack m3 ->
+  vripn <> vrspn ->
+  let s2 := {| emem := m3; evm := vmap0.[vrsp0 <- ok (pword_of_word rsp)].[vrip0 <- ok (pword_of_word rip)] |} in
+  valid_state (lmap locals1 vnew1) glob_size rsp rip Slots Addr Writable Align P rmap1 m2 {| evm := vmap0; emem := m1 |} s2.
+Proof.
+  move=> hext hass hrsp hneq /=.
+  constructor=> //=.
+  + move=> s w hin hb.
+    rewrite hass.(ass_valid); apply /orP.
+    case /in_Slots : hin => [hin|[hin|hin]].
+    + left.
+      apply hext.(em_valid).
+      apply /orP; right.
+      apply: zbetween_trans hb.
+      rewrite /Addr (pick_slot_globals hin).
+      by apply (zbetween_Addr_globals hin).
+    + right.
+      apply: zbetween_trans hb.
+      rewrite /Addr (pick_slot_locals hin).
+      have := zbetween_Addr_locals hin.
+      by rewrite hrsp.
+    left.
+    have /in_Slots_params := hin.
+    case hpi: get_pi => [[pi [v1 v2]]|//] _.
+    have [p [? hargp]] := get_pi_wf_arg hpi; subst v2.
+    apply hargp.(wap_valid).
+    apply: zbetween_trans hb.
+    rewrite /Addr (pick_slot_params hin) /Addr_params hpi.
+    by apply (zbetween_le _ (get_pi_size_le hpi)).
+  + move=> s w hin hvalid.
+    case /in_Slots : hin => [hin|[hin|hin]].
+    + rewrite /Addr (pick_slot_globals hin).
+      apply (disjoint_zrange_incl_l (zbetween_Addr_globals hin)).
+      by apply: hext.(em_fresh) hvalid.
+    + rewrite /Addr (pick_slot_locals hin).
+      apply: (disjoint_zrange_incl_l (zbetween_Addr_locals hin)).
+      have hvalid2: validw m2 w U8.
+      + apply hext.(em_valid).
+        by rewrite hvalid.
+      have hdisj := hass.(ass_fresh) hvalid2.
+      split.
+      + by apply no_overflow_size.
+      + by apply is_align_no_overflow; apply is_align8.
+      by rewrite hrsp; apply or_comm.
+    have /in_Slots_params := hin.
+    case hpi: get_pi => [[pi [v1 v2]]|//] _.
+    have [p [? hargp]] := get_pi_wf_arg hpi; subst v2.
+    apply: disjoint_zrange_incl_l (hargp.(wap_fresh) hvalid).
+    rewrite /Addr (pick_slot_params hin) /Addr_params hpi.
+    by apply (zbetween_le _ (get_pi_size_le hpi)).
+  + move=> p hvalid.
+    rewrite hass.(ass_valid); apply /orP; left.
+    by apply hext.(em_valid); apply /orP; left.
+  + move=> p hvalid.
+    by rewrite hass.(ass_valid); apply /orP; left.
+  + by move=> p hvalid1 hvalid2 hdisj; apply hass.(ass_read_old8).
+  + by rewrite get_var_eq.
+  + rewrite get_var_neq; first by rewrite get_var_eq.
+    by rewrite /vrip0 /vrsp0; congruence.
+  + move=> x /= hget hnnew.
+    rewrite !get_var_neq //.
+    + by have /rsp_in_new /= := init_local_map_wf_pmap; congruence.
+    by have /rip_in_new /= := init_local_map_wf_pmap; congruence.
+  + apply init_local_map_wf_rmap.
+    move=> i hi /=.
+    rewrite -hass.(ass_read_old8); first by apply hext.(em_read_new).
+    apply hext.(em_valid); apply /orP; right.
+    apply: between_byte hi.
+    + by apply hext.(em_no_overflow).
+    by apply zbetween_refl.
+  + move=> w hvalid.
+    rewrite -hass.(ass_read_old8); first by apply hext.(em_read_old8).
+    by apply hext.(em_valid); apply /orP; left.
+  + move=> p hb.
+    by apply hext.(em_valid); apply /orP; right.
+Qed.
+
+(* It is not clear whether we should use the size of the value [varg1] or the
+   size of the corresponding parameter [x] in this definition. Initially,
+   we used the latter, but at one point it seemed easier to use the former.
+   Since several proofs have been reworked since, this choice could be rethought.
+   At least, it works with the current formulation.
+*)
+Definition disjoint_from_writable_param p opi varg1 varg2 :=
+  forall pi p2, opi = Some pi -> varg2 = @Vword Uptr p2 -> pi.(pp_writable) ->
+  disjoint_zrange p2 (size_val varg1) p (wsize_size U8).
+
+(* [disjoint_from_writable_params] correctly captures the notion of being
+   disjoint from writable param slots
+*)
+Lemma disjoint_from_writable_params_param_slots p :
+  Forall3 (disjoint_from_writable_param p) sao.(sao_params) vargs1 vargs2 ->
+  forall s, Sv.In s Slots_params -> Writable_params s ->
+  disjoint_zrange (Addr_params s) (size_slot s) p (wsize_size U8).
+Proof.
+  move=> hdisj s hin.
+  have /in_Slots_params := hin.
+  case hpi: get_pi => [[pi [v1 v2]]|//] _.
+  have [p2 [? hargp]] := get_pi_wf_arg hpi; subst v2.
+  rewrite /Writable_params /Addr_params hpi => hw.
+  have [i [hnth1 hnth2 hnth3 hnth4]] := get_pi_nth hpi.
+  have hi := nth_not_default hnth2 ltac:(discriminate).
+  have := Forall3_nth hdisj None (Vbool true) (Vbool true) hi.
+  move: hi; have [-> _] := size_fmapM2 hparams => hi.
+  rewrite hnth2 hnth4 => /(_ _ _ refl_equal refl_equal hw).
+  apply disjoint_zrange_incl_l.
+  apply: zbetween_le.
+  rewrite hnth3.
+  by apply: get_pi_size_le hpi.
+Qed.
+
+(* If p is [disjoint_from_writable_params] and from local variables, it is
+   disjoint from all writable params.
+*)
+Corollary disjoint_from_writable_params_all_slots p :
+  Forall3 (disjoint_from_writable_param p) sao.(sao_params) vargs1 vargs2 ->
+  disjoint_zrange rsp sao.(sao_size) p (wsize_size U8) ->
+  forall s, Sv.In s Slots -> Writable s ->
+  disjoint_zrange (Addr s) (size_slot s) p (wsize_size U8).
+Proof.
+  move=> hdisj1 hdisj2 s hin hw.
+  case /in_Slots : hin => [hin|[hin|hin]].
+  + by move: hw; rewrite /Writable (pick_slot_globals hin).
+  + rewrite /Addr (pick_slot_locals hin).
+    by apply (disjoint_zrange_incl_l (zbetween_Addr_locals hin)).
+  rewrite /Writable (pick_slot_params hin) in hw.
+  rewrite /Addr (pick_slot_params hin).
+  by apply (disjoint_from_writable_params_param_slots hdisj1).
+Qed.
+
+End LOCAL.
+
+Lemma valid_state_extend_mem pmap rsp Slots Addr Writable Align rmap m0 s1 s2 :
+  wf_Slots Slots Addr Writable Align ->
+  valid_state pmap glob_size rsp rip Slots Addr Writable Align P rmap m0 s1 s2 ->
+  extend_mem (emem s1) (emem s2) rip global_data ->
+  forall rmap' s1' s2',
+  valid_state pmap glob_size rsp rip Slots Addr Writable Align P rmap' m0 s1' s2' ->
+  validw (emem s1) =2 validw (emem s1') ->
+  validw (emem s2) =2 validw (emem s2') ->
+  extend_mem (emem s1') (emem s2') rip global_data.
+Proof.
+  move=> hwf hvs hext rmap' s1' s2' hvs' hvalideq1 hvalideq2.
+  case:(hext) => hover halign hold hfresh hvalid hnew.
+  split=> //=.
+  + by apply (vs_eq_mem (valid_state := hvs')).
+  + by move=> p hvalidp; apply hfresh; rewrite hvalideq1.
+  + by move=> p; rewrite -hvalideq1 -hvalideq2; apply hvalid.
+  move=> i hi.
+  have hb: between rip glob_size (rip + wrepr _ i)%R U8.
+  + apply: between_byte hi => //.
+    by apply zbetween_refl.
+  have hvalid0: validw m0 (rip + wrepr _ i)%R U8.
+  + by apply (vs_glob_valid (valid_state := hvs)).
+  have hnvalid1: ~ validw (emem s1) (rip + wrepr _ i)%R U8.
+  + move=> /hfresh.
+    by apply zbetween_not_disjoint_zrange.
+  have hdisjoint: forall s, Sv.In s Slots -> Writable s ->
+    disjoint_zrange (Addr s) (size_slot s) (rip + wrepr U64 i) (wsize_size U8).
+  + move=> s hin hw.
+    apply disjoint_zrange_sym.
+    apply (disjoint_zrange_incl_l hb).
+    apply hwf.(wfsl_not_glob) => //.
+    by lia.
+  rewrite -(vs_unchanged (valid_state:=hvs')) //; last by rewrite -hvalideq1.
+  rewrite (vs_unchanged (valid_state:=hvs)) //.
+  by apply hnew.
+Qed.
+
+Section PROC.
+
+Variable (P' : sprog).
+Hypothesis P'_globs : P'.(p_globs) = [::].
+
+Variable (local_alloc : funname -> stk_alloc_oracle_t).
+
+Hypothesis Halloc_fd : forall fn fd,
+  get_fundef P.(p_funcs) fn = Some fd ->
+  exists2 fd', alloc_fd P'.(p_extra) mglob local_alloc (fn, fd) = ok (fn, fd') &
+               get_fundef P'.(p_funcs) fn = Some fd'.
+
+(* RAnone -> export function (TODO: rename RAexport?) *)
+Definition enough_size m sao :=
+  let sz :=
+    if is_RAnone sao.(sao_return_address) then
+      sao.(sao_size) + sao.(sao_extra_size) + wsize_size sao.(sao_align) - 1
+    else
+      round_ws sao.(sao_align) (sao.(sao_size) + sao.(sao_extra_size))
+  in
+  allocatable_stack m (sao.(sao_max_size) - sz).
+
+Record wf_sao rsp m sao := {
+  wf_sao_size     : enough_size m sao;
+  wf_sao_align    : is_align rsp sao.(sao_align);
+}.
+
+Lemma stack_stable_wf_sao rsp m1 m2 sao :
+  stack_stable m1 m2 ->
+  wf_sao rsp m1 sao ->
+  wf_sao rsp m2 sao.
+Proof.
+  move=> hss [hsize halign]; split=> //.
+  rewrite /enough_size /allocatable_stack.
+  by rewrite -(ss_top_stack hss) -(ss_limit hss).
+Qed.
+
+Let Pi_r s1 (i1:instr_r) s2 :=
+  forall pmap rsp Slots Addr Writable Align rmap1 rmap2 ii1 ii2 i2,
+  wf_pmap pmap rsp rip Slots Addr Writable Align ->
+  wf_Slots Slots Addr Writable Align ->
+  forall sao,
+  alloc_i pmap local_alloc sao rmap1 (MkI ii1 i1) = ok (rmap2, MkI ii2 i2) ->
+  forall m0 s1', valid_state pmap glob_size rsp rip Slots Addr Writable Align P rmap1 m0 s1 s1' ->
+  extend_mem (emem s1) (emem s1') rip global_data ->
+  wf_sao rsp (emem s1') sao ->
+  exists s2', sem_i (sCP:= sCP_stack) P' rip s1' i2 s2' /\
+              valid_state pmap glob_size rsp rip Slots Addr Writable Align P rmap2 m0 s2 s2'.
+
+Let Pi s1 (i1:instr) s2 :=
+  forall pmap rsp Slots Addr Writable Align rmap1 rmap2 i2,
+  wf_pmap pmap rsp rip Slots Addr Writable Align ->
+  wf_Slots Slots Addr Writable Align ->
+  forall sao,
+  alloc_i pmap local_alloc sao rmap1 i1 = ok (rmap2, i2) ->
+  forall m0 s1', valid_state pmap glob_size rsp rip Slots Addr Writable Align P rmap1 m0 s1 s1' ->
+  extend_mem (emem s1) (emem s1') rip global_data ->
+  wf_sao rsp (emem s1') sao ->
+  exists s2', sem_I (sCP:= sCP_stack) P' rip s1' i2 s2' /\
+              valid_state pmap glob_size rsp rip Slots Addr Writable Align P rmap2 m0 s2 s2'.
+
+Let Pc s1 (c1:cmd) s2 :=
+  forall pmap rsp Slots Addr Writable Align rmap1 rmap2 c2,
+  wf_pmap pmap rsp rip Slots Addr Writable Align ->
+  wf_Slots Slots Addr Writable Align ->
+  forall sao,
+  fmapM (alloc_i pmap local_alloc sao) rmap1 c1 = ok (rmap2, c2) ->
+  forall m0 s1', valid_state pmap glob_size rsp rip Slots Addr Writable Align P rmap1 m0 s1 s1' ->
+  extend_mem (emem s1) (emem s1') rip global_data ->
+  wf_sao rsp (emem s1') sao ->
+  exists s2', sem (sCP:= sCP_stack) P' rip s1' c2 s2' /\
+              valid_state pmap glob_size rsp rip Slots Addr Writable Align P rmap2 m0 s2 s2'.
+
+Let Pfor (i1: var_i) (vs: seq Z) (s1: estate) (c: cmd) (s2: estate) := True.
+
+Definition alloc_ok (SP:sprog) fn m2 :=
+  forall fd, get_fundef (p_funcs SP) fn = Some fd ->
+  allocatable_stack m2 fd.(f_extra).(sf_stk_max) /\
+  (~ is_RAnone fd.(f_extra).(sf_return_address) -> is_align (top_stack m2) fd.(f_extra).(sf_align)).
+
+(* [glob_size] and [rip] were section variables in stack_alloc_proof.v, they
+   are section variables in this file too. Can we put everything in the same
+   section? Probably not if the file is split.
+*)
+Definition wf_args m1 m2 fn :=
+  Forall3 (wf_arg glob_size rip m1 m2) (local_alloc fn).(sao_params).
+Definition wf_results m vargs1 vargs2 fn :=
+  Forall3 (wf_result m vargs1 vargs2) (local_alloc fn).(sao_return).
+
+Definition disjoint_from_writable_params fn p :=
+  Forall3 (disjoint_from_writable_param p) (local_alloc fn).(sao_params).
+Definition mem_unchanged_params fn ms m0 m vargs1 vargs2 :=
+  forall p, validw m0 p U8 -> ~ validw ms p U8 -> disjoint_from_writable_params fn p vargs1 vargs2 ->
+  read m0 p U8 = read m p U8.
+
+Let Pfun (m1: mem) (fn: funname) (vargs: seq value) (m2: mem) (vres: seq value) :=
+  forall m1' vargs',
+    extend_mem m1 m1' rip global_data ->
+    wf_args m1 m1' fn vargs vargs' ->
+    disjoint_values (local_alloc fn).(sao_params) vargs vargs' ->
+    alloc_ok P' fn m1' ->
+    exists m2' vres',
+      sem_call (sCP := sCP_stack) P' rip m1' fn vargs' m2' vres' /\
+      extend_mem m2 m2' rip global_data /\
+      wf_results m2' vargs vargs' fn vres vres' /\
+      mem_unchanged_params fn m1 m1' m2' vargs vargs'.
+
+Local Lemma Hskip : sem_Ind_nil Pc.
+Proof.
+  move=> s pmap rsp Slots Addr Writable Align rmap1 rmap2 /= c2 hpmap hwf sao [??] m0 s' hv hext hsao;subst rmap1 c2.
+  exists s'; split => //; exact: Eskip.
+Qed.
+
+Local Lemma Hcons : sem_Ind_cons P ev Pc Pi.
+Proof.
+  move=> s1 s2 s3 i c hhi Hi hhc Hc pmap rsp Slots Addr Writable Align rmap1 rmap3 c1 hpmap hwf sao /=.
+  t_xrbindP => -[rmap2 i'] hi {rmap3} [rmap3 c'] hc /= <- <- m0 s1' hv hext hsao.
+  have [s2' [si hv2]]:= Hi _ _ _ _ _ _ _ _ _ hpmap hwf _ hi _ _ hv hext hsao.
+  have hsao2 := stack_stable_wf_sao (sem_I_stack_stable_sprog si) hsao.
+  have hext2 := valid_state_extend_mem hwf hv hext hv2 (sem_I_validw_stable_uprog hhi) (sem_I_validw_stable_sprog si).
+  have [s3' [sc hv3]]:= Hc _ _ _ _ _ _ _ _ _ hpmap hwf _ hc _ _ hv2 hext2 hsao2.
+  by exists s3'; split => //; apply: Eseq; [exact: si|exact: sc].
+Qed.
+
+Local Lemma HmkI : sem_Ind_mkI P ev Pi_r Pi.
+Proof.
+  move=> ii i s1 s2 _ Hi pmap rsp Slots Addr Writable Align rmap1 rmap2 [ii' ir'] hpmap hwf sao ha m0 s1' hv hext hsao.
+  by have [s2' [Hs2'1 [Hs2'2 Hs2'3]]] := Hi _ _ _ _ _ _ _ _ _ _ _ hpmap hwf _ ha _ _ hv hext hsao; exists s2'; split.
+Qed.
+
+Local Lemma Hassgn : sem_Ind_assgn P Pi_r.
+Proof.
+  move=> s1 s1' r tag ty e v v' hv htr hw pmap rsp Slots Addr Writable Align rmap1 rmap2 ii1 ii2 i2 hpmap hwf sao /=.
+  t_xrbindP => -[rmap2' i2'] h /= ??? m0 s2 hvs hext hsao; subst rmap2' ii1 i2'.
+  case: ifPn h => [/is_sarrP [n ?]| _ ].
+  + subst ty; apply: add_iinfoP.
+    move=> halloc.
+    have [s2' [hs2' hvs']] := alloc_array_move_initP hwf.(wfsl_no_overflow) hwf.(wfsl_disjoint) hwf.(wfsl_align) hpmap P'_globs hvs hv htr hw halloc.
+    by exists s2'.
+  t_xrbindP => e'; apply: add_iinfoP => /(alloc_eP hwf.(wfsl_no_overflow) hwf.(wfsl_align) hpmap hvs) he [rmap2' x'].
+  apply: add_iinfoP => hax /= ??; subst rmap2' i2.
+  have htyv':= truncate_val_has_type htr.
+  have [s2' [/= hw' hvs']]:= alloc_lvalP hwf.(wfsl_no_overflow) hwf.(wfsl_disjoint) hwf.(wfsl_align) hpmap hax hvs htyv' hw.
+  exists s2'; split=> //.
+  by apply: Eassgn; eauto; rewrite P'_globs; auto.
+Qed.
+
+Local Lemma Hopn : sem_Ind_opn P Pi_r.
+Proof.
+  move=> s1 s2 t o xs es.
+  rewrite /sem_sopn; t_xrbindP=> vs va hes hop hw pmap rsp Slots Addr Writable Align rmap1 rmap2 ii1 ii2 i2 hpmap hwf sao /=.
+  t_xrbindP=> -[rmap3 i'] es'; apply: add_iinfoP => he [rmap4 x'];
+    apply: add_iinfoP => ha /= [<- <-] <- _ <- m0 s1' hvs hext hsao.
+  have [s2' [hw' hvalid']] := alloc_lvalsP hwf.(wfsl_no_overflow) hwf.(wfsl_disjoint) hwf.(wfsl_align) hpmap ha hvs (sopn_toutP hop) hw.
+  exists s2'; split=> //.
+  by constructor;
+    rewrite /sem_sopn P'_globs (alloc_esP hwf.(wfsl_no_overflow) hwf.(wfsl_align) hpmap hvs he hes) /= hop.
+Qed.
+
+Local Lemma Hif_true : sem_Ind_if_true P ev Pc Pi_r.
+Proof.
+  move=> s1 s2 e c1 c2 Hse _ Hc pmap rsp Slots Addr Writable Align rmap1 rmap2 ii1 ii2 i2 hpmap hwf sao /=.
+  t_xrbindP => -[rmap3 i'] e'; apply: add_iinfoP => he [rmap4 c1'] hc1 [rmap5 c2'] hc2 /= [??]??? m0 s1' hv hext hsao.
+  subst rmap3 i' rmap2 ii1 i2.
+  have := alloc_eP hwf.(wfsl_no_overflow) hwf.(wfsl_align) hpmap hv he Hse; rewrite -P'_globs => he'.
+  have [s2' [Hsem Hvalid']] := Hc _ _ _ _ _ _ _ _ _ hpmap hwf _ hc1 _ _ hv hext hsao.
+  exists s2'; split; first by apply: Eif_true.
+  by apply: valid_state_incl Hvalid'; apply incl_merge_l.
+Qed.
+
+Local Lemma Hif_false : sem_Ind_if_false P ev Pc Pi_r.
+Proof.
+  move=> s1 s2 e c1 c2 Hse _ Hc pmap rsp Slots Addr Writable Align rmap1 rmap2 ii1 ii2 i2 hpmap hwf sao /=.
+  t_xrbindP => -[rmap3 i'] e'; apply: add_iinfoP => he [rmap4 c1'] hc1 [rmap5 c2'] hc2 /= [??]??? m0 s1' hv hext hsao.
+  subst rmap3 i' rmap2 ii1 i2.
+  have := alloc_eP hwf.(wfsl_no_overflow) hwf.(wfsl_align) hpmap hv he Hse; rewrite -P'_globs => he'.
+  have [s2' [Hsem Hvalid']] := Hc _ _ _ _ _ _ _ _ _ hpmap hwf _ hc2 _ _ hv hext hsao.
+  exists s2'; split; first by apply: Eif_false.
+  by apply: valid_state_incl Hvalid'; apply incl_merge_r.
+Qed.
+
+Lemma loop2P ii check_c2 n rmap rmap' e' c1' c2': 
+  loop2 ii check_c2 n rmap = ok (rmap', (e', (c1', c2'))) ->
+  exists rmap1 rmap2, incl rmap1 rmap /\ check_c2 rmap1 = ok ((rmap', rmap2), (e', (c1', c2'))) /\ incl rmap1 rmap2.
+Proof.
+  elim: n rmap => //= n hrec rmap; t_xrbindP => -[[rmap1 rmap2] [e1 [c11 c12]]] hc2 /=; case: ifP.
+  + move=> hi [] ????;subst.
+    by exists rmap; exists rmap2;split => //; apply incl_refl.
+  move=> _ /hrec [rmap3 [rmap4 [h1 [h2 h3]]]]; exists rmap3, rmap4; split => //.
+  by apply: (incl_trans h1); apply incl_merge_l.
+Qed.
+
+Local Lemma Hwhile_true : sem_Ind_while_true P ev Pc Pi_r.
+Proof.
+  move=> s1 s2 s3 s4 a c1 e c2 hhi Hc1 Hv hhi2 Hc2 _ Hwhile pmap rsp Slots Addr Writable Align
+    rmap1 rmap2 ii1 ii2 i2 hpmap hwf sao /=.
+  t_xrbindP => -[rmap3 i'] [rmap4 [e' [c1' c2']]] /loop2P [rmap5 [rmap6 [hincl1 []]]].
+  t_xrbindP => -[rmap7 c11] hc1 /= e1; apply: add_iinfoP => he [rmap8 c22] /= hc2 ????? hincl2 [??]???.
+  subst i2 ii1 rmap3 rmap4 i' rmap7 rmap8 e1 c11 c22 => m0 s1' /(valid_state_incl hincl1) hv hext hsao.
+  have [s2' [hs1 hv2]]:= Hc1 _ _ _ _ _ _ _ _ _ hpmap hwf _ hc1 _ _ hv hext hsao.
+  have := alloc_eP hwf.(wfsl_no_overflow) hwf.(wfsl_align) hpmap hv2 he Hv; rewrite -P'_globs => he'.
+  have hsao2 := stack_stable_wf_sao (sem_stack_stable_sprog hs1) hsao.
+  have hext2 := valid_state_extend_mem hwf hv hext hv2 (sem_validw_stable_uprog hhi) (sem_validw_stable_sprog hs1).
+  have [s3' [hs2 /(valid_state_incl hincl2) hv3]]:= Hc2 _ _ _ _ _ _ _ _ _ hpmap hwf _ hc2 _ _ hv2 hext2 hsao2.
+  have /= := Hwhile _ _ _ _ _ _ rmap5 rmap2 ii2 ii2 (Cwhile a c1' e' c2') hpmap hwf sao.
+  have hsao3 := stack_stable_wf_sao (sem_stack_stable_sprog hs2) hsao2.
+  have hext3 := valid_state_extend_mem hwf hv2 hext2 hv3 (sem_validw_stable_uprog hhi2) (sem_validw_stable_sprog hs2).
+  rewrite Loop.nbP /= hc1 /= he /= hc2 /= hincl2 /= => /(_ erefl _ _ hv3 hext3 hsao3) [s4'] [hs3 hv4].
+  by exists s4';split => //; apply: Ewhile_true; eassumption.
+Qed.
+
+Local Lemma Hwhile_false : sem_Ind_while_false P ev Pc Pi_r.
+Proof.
+  move=> s1 s2 a c1 e c2 _ Hc1 Hv pmap rsp Slots Addr Writable Align rmap1 rmap2 ii1 ii2 i2 hpmap hwf sao /=.
+  t_xrbindP => -[rmap3 i'] [rmap4 [e' [c1' c2']]] /loop2P [rmap5 [rmap6 [hincl1 []]]].
+  t_xrbindP => -[rmap7 c11] hc1 /= e1; apply: add_iinfoP => he [rmap8 c22] /= hc2 ????? hincl2 [??]???.
+  subst i2 ii1 rmap3 rmap4 i' rmap7 rmap8 e1 c11 c22 => m0 s1' /(valid_state_incl hincl1) hv hext hsao.
+  have [s2' [hs1 hv2]]:= Hc1 _ _ _ _ _ _ _ _ _ hpmap hwf _ hc1 _ _ hv hext hsao.
+  have := alloc_eP hwf.(wfsl_no_overflow) hwf.(wfsl_align) hpmap hv2 he Hv; rewrite -P'_globs => he'.
+  by exists s2';split => //; apply: Ewhile_false; eassumption.
+Qed.
+
+Local Lemma Hfor : sem_Ind_for P ev Pi_r Pfor.
+Proof. by []. Qed.
+
+Local Lemma Hfor_nil : sem_Ind_for_nil Pfor.
+Proof. by []. Qed.
+
+Local Lemma Hfor_cons : sem_Ind_for_cons P ev Pc Pfor.
+Proof. by []. Qed.
+
+Lemma get_var_bytes_set_clear_bytes rv sr ofs len r y :
+  get_var_bytes (set_clear_bytes rv sr ofs len) r y =
+    let bytes := get_var_bytes rv r y in
+    if sr.(sr_region) != r then bytes
+    else
+      let i := interval_of_zone (sub_zone_at_ofs sr.(sr_zone) ofs len) in
+      ByteSet.remove bytes i.
+Proof.
+  rewrite /set_clear_bytes /get_var_bytes.
+  rewrite get_bytes_map_setP.
+  case: eqP => [->|] //=.
+  by rewrite get_bytes_clear.
+Qed.
+
+Lemma alloc_fd_max_size_ge0 pex fn fd fd' :
+  alloc_fd pex mglob local_alloc (fn, fd) = ok (fn, fd') ->
+  0 <= (local_alloc fn).(sao_max_size).
+Proof.
+  rewrite /alloc_fd /=.
+  t_xrbindP=> ?? hlayout [[??]?] hlocal_map.
+  t_xrbindP=> -[[[??]?]?] hparams.
+  t_xrbindP=> _ /assertP /ZleP hextra _ /assertP /ZleP hmax _ _ _ _.
+  have hsize := init_stack_layout_size_ge0 hlayout.
+  case: is_RAnone hmax.
+  + have := wsize_size_pos (local_alloc fn).(sao_align).
+    by lia.
+  have := round_ws_range (local_alloc fn).(sao_align) ((local_alloc fn).(sao_size) + (local_alloc fn).(sao_extra_size)).
+  by lia.
+Qed.
+
+Lemma disjoint_set_clear rmap sr ofs len x :
+  ByteSet.disjoint (get_var_bytes (set_clear_pure rmap sr ofs len) sr.(sr_region) x) (ByteSet.full (interval_of_zone (sub_zone_at_ofs sr.(sr_zone) ofs len))).
+Proof.
+  rewrite get_var_bytes_set_clear_bytes eq_refl /=.
+  apply /ByteSet.disjointP => n.
+  by rewrite ByteSet.fullE ByteSet.removeE => /andP [_ /negP ?].
+Qed.
+
+(* TODO: in [vundef_type], we could maybe change the [sarr] case, now [is_sarr t = false] is an argument of Vundef *)
+Local Lemma Hcall : sem_Ind_call P ev Pi_r Pfun.
+Proof.
+  move=> s1 m1 s1' ii rs fn args vargs1 vres1 hvargs1 hsem1 Hf hs1'.
+  move=> pmap rsp Slots Addr Writable Align rmap0 rmap2 ii1 ii2 i2 hpmap hwfsl sao /=.
+  t_xrbindP=> -[rmap2' i2']; apply: add_iinfoP => /= halloc ? {ii1 ii2} _ ? m0 s2 hvs hext hsao; subst rmap2' i2'.
+  move: halloc; rewrite /alloc_call.
+  t_xrbindP=> -[rmap1 es] hcargs.
+  t_xrbindP=> -[{rmap2}rmap2 rs2] hcres _ /assertP /ZleP hsize _ /assertP hle /= <- <-.
+
+  (* evaluation of the arguments *)
+  have [vargs2 [hvargs2 hargs hdisj haddr hclear]] :=
+    alloc_call_argsP hwfsl.(wfsl_no_overflow) hwfsl.(wfsl_disjoint) hwfsl.(wfsl_align) hwfsl.(wfsl_not_glob) hpmap hvs hcargs hvargs1.
+
+  (* function call *)
+  have [fd1 hfd1]: exists fd, get_fundef P.(p_funcs) fn = Some fd.
+  + have /sem_callE [fd1 [hfd1 _]] := hsem1.
+    by exists fd1.
+  have [fd2 halloc hfd2] := Halloc_fd hfd1.
+  have hmax := alloc_fd_max_size_ge0 halloc.
+  move: halloc hfd2; rewrite /alloc_fd.
+  t_xrbindP=> {fd2}fd2 _ <- hfd2.
+  have halloc_ok: alloc_ok P' fn (emem s2).
+  + rewrite /alloc_ok hfd2 => _ [<-] /=.
+    split.
+    + rewrite /allocatable_stack.
+      move: hsao.(wf_sao_size); rewrite /enough_size /allocatable_stack.
+      by lia.
+    move=> _.
+    have := hsao.(wf_sao_align).
+    have /vs_top_stack -> := hvs.
+    by apply is_align_m.
+  have [m2 [vres2 [hsem2 [hext' [hresults hunch]]]]] := Hf _ _ hext hargs hdisj halloc_ok.
+
+  (* after function call, we have [valid_state] for [rmap1] where all writable arguments
+     have been cleared.
+  *)
+  have hvs': valid_state pmap glob_size rsp rip Slots Addr Writable Align P rmap1 m0 (with_mem s1 m1) (with_mem s2 m2).
+  + have [hcargsx _] := alloc_call_argsE hcargs.
+    set l :=
+      seq.pmap (fun '(bsr, ty) =>
+        match bsr with
+        | Some (true, sr) => Some (sub_region_at_ofs sr (Some 0) (size_of ty), ty)
+        | _               => None
+        end) (zip (map fst es) (map type_of_val vargs1)).
+    have hlin: forall sr ty, (sr, ty) \in l <->
+      exists k sr', [/\ ty = type_of_val (nth (Vbool true) vargs1 k),
+                        nth None (map fst es) k = Some (true, sr') &
+                        sr = sub_region_at_ofs sr' (Some 0) (size_of ty)].
+    + move=> sr ty.
+      rewrite /l mem_pmap -(rwP mapP) /=.
+      have heqsize: size (map fst es) = size (map type_of_val vargs1).
+      + rewrite 2!size_map.
+        have [_ <-] := size_fmapM2 hcargsx.
+        by have [? _] := Forall3_size hargs.
+      split.
+      + move=> [[[[[|//] sr']|//] ty'] hin [??]]; subst sr ty'.
+        move: hin.
+        move=> /nthP -/(_ (None, sbool)).
+        rewrite size1_zip heqsize // => -[k hk].
+        rewrite (nth_zip _ _ _ heqsize) => -[hsr' <-].
+        exists k, sr'; split=> //.
+        rewrite (nth_map (Vbool true)) //.
+        by move: hk; rewrite size_map.
+      move=> [k [sr' [-> hsr' ->]]].
+      exists (Some (true, sr'), type_of_val (nth (Vbool true) vargs1 k)) => //.
+      apply /(nthP (None, sbool)).
+      exists k.
+      + rewrite size1_zip -?heqsize //.
+        apply (nth_not_default hsr' ltac:(discriminate)).
+      rewrite (nth_zip _ _ _ heqsize) hsr' (nth_map (Vbool true)) //.
+      move: heqsize; rewrite (size_map _ vargs1) => <-.
+      apply (nth_not_default hsr' ltac:(discriminate)).
+
+    have hvs' := valid_state_incl (alloc_call_args_aux_incl hcargsx) hvs.
+    apply (valid_state_holed_rmap hwfsl.(wfsl_no_overflow) hwfsl.(wfsl_disjoint) hpmap hvs'
+             (sem_call_validw_stable_uprog hsem1) (sem_call_stack_stable_sprog hsem2)
+             (sem_call_validw_stable_sprog hsem2) hext'.(em_read_old8) (l:=l)).
+    + apply List.Forall_forall => -[sr ty] /InP.
+      rewrite hlin => -[k [sr' [-> hsr' ->]]] /=.
+      split.
+      + have [_ hwf'] := Forall3_nth haddr None (Vbool true) (Vbool true) (nth_not_default hsr' ltac:(discriminate)) _ _ hsr'.
+        apply (sub_region_at_ofs_wf hwf' (ofs:=Some 0)).
+        by move=> _ [<-]; lia.
+      by apply (Forall_nth (alloc_call_args_aux_writable hcargsx) None (nth_not_default hsr' ltac:(discriminate)) _ hsr').
+    + move=> p hvalid1 hvalid2 hdisj'.
+      symmetry; apply hunch => //.
+      apply (nth_Forall3 None (Vbool true) (Vbool true)).
+      + by have [? _] := Forall3_size hargs.
+      + by have [_ ?] := Forall3_size hargs.
+      move=> i hi pi p2 hpi hp2 hw.
+      have [sr hsr] := Forall2_nth (alloc_call_args_aux_not_None hcargsx) None None hi _ hpi.
+      rewrite hw in hsr.
+      have := Forall3_nth haddr None (Vbool true) (Vbool true) (nth_not_default hsr ltac:(discriminate)) _ _ hsr.
+      rewrite hp2 => -[[?] hwf']; subst p2.
+      have {hw}hw := Forall_nth (alloc_call_args_aux_writable hcargsx) None (nth_not_default hsr ltac:(discriminate)) _ hsr.
+      have /List.Forall_forall -/(_ (sub_region_at_ofs sr (Some 0) (size_val (nth (Vbool true) vargs1 i)), type_of_val (nth (Vbool true) vargs1 i))) := hdisj'.
+      rewrite -sub_region_addr_offset wrepr0 GRing.addr0.
+      apply.
+      apply /InP /hlin.
+      by exists i, sr.
+    apply List.Forall_forall => -[sr ty] /InP /hlin [i [sr' [-> hsr' ->]]] x.
+    have hincl := Forall2_nth hclear None (Vbool true) (nth_not_default hsr' ltac:(discriminate)) _ hsr'.
+    apply (disjoint_incl_l (incl_get_var_bytes _ _ hincl)) => /=.
+    by apply disjoint_set_clear.
+
+  (* writing of the returned values *)
+  have [s2' [hs2' hvs'']] := alloc_call_resP hwfsl.(wfsl_no_overflow) hwfsl.(wfsl_disjoint) hpmap hvs' hcres haddr hresults hs1'.
+
+  exists s2'; split=> //.
+  by econstructor; try eassumption; rewrite P'_globs.
+Qed.
+
+Lemma add_err_funP A (a:A) (e:cexec A) P0 fn :
+  (e = ok a -> P0) -> add_err_fun fn e = ok a -> P0.
+Proof.
+  case: e => //= a' h [?]; subst a'.
+  by apply h.
+Qed.
+
+(* Not sure at all if this is the right way to do the proof. *)
+Lemma wbit_subword (ws ws' : wsize) i (w : word ws) k :
+  wbit_n (word.subword i ws' w) k = (k < ws')%nat && wbit_n w (k + i).
+Proof.
+  rewrite /wbit_n.
+  case: ltP.
+  + move=> /ltP hlt.
+    by rewrite word.subwordE word.wbit_t2wE (nth_map 0%R) ?size_enum_ord // nth_enum_ord.
+  rewrite /nat_of_wsize => hle.
+  rewrite word.wbit_word_ovf //.
+  by apply /ltP; lia.
+Qed.
+
+(* TODO: is this result generic enough to be elsewhere ? *)
+Lemma zero_extend_wread8 (ws ws' : wsize) (w : word ws) :
+  (ws' <= ws)%CMP ->
+  forall off,
+    0 <= off < wsize_size ws' ->
+    LE.wread8 (zero_extend ws' w) off = LE.wread8 w off.
+Proof.
+  move=> /wsize_size_le /(Z.divide_pos_le _ _ (wsize_size_pos _)) hle off hoff.
+  rewrite /LE.wread8 /LE.encode /split_vec.
+  have hmod: forall (ws:wsize), ws %% U8 = 0%nat.
+  + by move=> [].
+  have hdiv: forall (ws:wsize), ws %/ U8 = Z.to_nat (wsize_size ws).
+  + by move=> [].
+  have hlt: (Z.to_nat off < Z.to_nat (wsize_size ws))%nat.
+  + by apply /ltP /Z2Nat.inj_lt; lia.
+  have hlt': (Z.to_nat off < Z.to_nat (wsize_size ws'))%nat.
+  + by apply /ltP /Z2Nat.inj_lt; lia.
+  rewrite !hmod !addn0.
+  rewrite !(nth_map 0%nat) ?size_iota ?hdiv // !nth_iota // !add0n.
+  apply /eqP/eq_from_wbit_n => i.
+  rewrite !wbit_subword; f_equal.
+  rewrite wbit_zero_extend.
+  have -> //: (i + Z.to_nat off * U8 <= wsize_size_minus_1 ws')%nat.
+  rewrite -ltnS -/(nat_of_wsize ws').
+  apply /ltP.
+  have := ltn_ord i; rewrite -/(nat_of_wsize _) => /ltP hi.
+  have /ltP ? := hlt'.
+  have <-: (Z.to_nat (wsize_size ws') * U8 = ws')%nat.
+  + by case: (ws').
+  by rewrite -!multE -!plusE; nia.
+Qed.
+
+(* Actually, I think we could have proved something only for arrays, since we
+   use this result when the target value is a pointer, in which case the source
+   value is an array. But it is not clear whether we know that the source value
+   is an array at the point where we need this lemma. And now that we have this
+   more general version...
+*)
+Lemma value_uincl_get_val_byte v1 v2 :
+  value_uincl v1 v2 ->
+  forall off w,
+    get_val_byte v1 off = ok w ->
+    get_val_byte v2 off = ok w.
+Proof.
+  move=> /value_uinclE; case: v1 => //=.
+  + move=> len a [len2 [a2 -> [_ hincl]]].
+    by apply hincl.
+  + move=> ws w [ws2 [w2 [-> /andP [hle /eqP ->]]]].
+    move=> off w' /=.
+    case: ifP => //; rewrite !zify => hoff.
+    have hle' := Z.divide_pos_le _ _ (wsize_size_pos _) (wsize_size_le hle).
+    case: ifPn => [_|]; last by rewrite !zify; lia.
+    move=> <-; f_equal; symmetry.
+    by apply zero_extend_wread8.
+Qed.
+
+(* We don't need the hypothesis that [varg1] and [varg1'] are arrays, since
+   we have the powerful [value_uincl_get_val_byte]. If we had a weaker version,
+   we should probably add this hypothesis.
+*)
+Lemma value_uincl_wf_arg_pointer m1 m2 pi varg1 varg1' p :
+  value_uincl varg1' varg1 ->
+  wf_arg_pointer glob_size rip m1 m2 pi varg1 p ->
+  wf_arg_pointer glob_size rip m1 m2 pi varg1' p.
+Proof.
+  move=> huincl [halign hover hvalid hfresh hwnglob hread].
+  have hle := size_of_le (value_uincl_subtype huincl).
+  split=> //.
+  + by apply (no_overflow_incl (zbetween_le _ hle)).
+  + move=> w hb; apply hvalid.
+    apply: zbetween_trans hb.
+    by apply zbetween_le.
+  + move=> w /hfresh.
+    apply disjoint_zrange_incl_l.
+    by apply zbetween_le.
+  + move=> hw hgsize.
+    apply: disjoint_zrange_incl_r (hwnglob hw hgsize).
+    by apply zbetween_le.
+  by move=> off w /(value_uincl_get_val_byte huincl) /hread.
+Qed.
+
+Lemma mapM2_truncate_val_wf_args m1 m2 fn vargs1 vargs2 :
+  wf_args m1 m2 fn vargs1 vargs2 ->
+  forall tyin vargs1',
+  mapM2 ErrType truncate_val tyin vargs1 = ok vargs1' ->
+  exists vargs2',
+    mapM2 ErrType truncate_val
+      (map2 (fun o ty =>
+        match o with
+        | Some _ => sword64
+        | None => ty
+        end) (sao_params (local_alloc fn)) tyin) vargs2 = ok vargs2' /\
+    wf_args m1 m2 fn vargs1' vargs2'.
+Proof.
+  rewrite /wf_args.
+  elim {vargs1 vargs2}.
+  + move=> [|//] /= _ [<-].
+    eexists; split; first by reflexivity.
+    by constructor.
+  move=> opi varg1 varg2 sao_params vargs1 vargs2 harg _ ih [//|ty tyin] /=.
+  t_xrbindP=> _ varg1' hvarg1' vargs1' /ih{ih}[vargs2' [htr hargs]] <-.
+  rewrite htr /=.
+  case: opi harg => [pi|].
+  + move=> [p [-> hargp]].
+    rewrite /= zero_extend_u.
+    eexists; split; first by reflexivity.
+    constructor=> //.
+    exists p; split=> //.
+    apply: value_uincl_wf_arg_pointer hargp.
+    by apply (truncate_value_uincl hvarg1').
+  move=> /= ->.
+  rewrite hvarg1' /=.
+  eexists; split; first by reflexivity.
+  by constructor.
+Qed.
+
+(* If the parameter is a reg ptr, [varg2] is a pointer, and is equal to [varg2']. *)
+Lemma mapM2_truncate_val_ptr_eq m1 m2 fn vargs1 vargs2 :
+  wf_args m1 m2 fn vargs1 vargs2 ->
+  forall tyin vargs2',
+  mapM2 ErrType truncate_val
+    (map2 (fun o ty =>
+          match o with
+          | Some _ => sword64
+          | None => ty
+          end) (sao_params (local_alloc fn)) tyin) vargs2 = ok vargs2' ->
+  Forall3 (fun opi varg varg' => opi <> None -> varg = varg') (local_alloc fn).(sao_params) vargs2 vargs2'.
+Proof.
+  elim {vargs1 vargs2}.
+  + by move=> /= _ _ [<-]; constructor.
+  move=> opi varg1 varg2 sao_params vargs1 vargs2 harg _ ih [//|ty tyin] /=.
+  t_xrbindP=> _ varg2' hvarg2' vargs2' /ih{ih}ih <-.
+  constructor=> //.
+  case: opi harg hvarg2' => [pi|//] [p [-> ?]].
+  rewrite /truncate_val /= zero_extend_u.
+  by move=> [<-].
+Qed.
+
+Lemma value_uincl_disjoint_values m1 m2 fn vargs1 vargs2 :
+  wf_args m1 m2 fn vargs1 vargs2 ->
+  disjoint_values (local_alloc fn).(sao_params) vargs1 vargs2 ->
+  forall vargs1' vargs2',
+  List.Forall2 value_uincl vargs1' vargs1 ->
+  Forall3 (fun opi varg varg' => opi <> None -> varg = varg') (local_alloc fn).(sao_params) vargs2 vargs2' ->
+  disjoint_values (local_alloc fn).(sao_params) vargs1' vargs2'.
+Proof.
+  move=> hargs hdisj vargs1' vargs2' hincl hptreq.
+  move=> i1 pi1 w1 i2 pi2 w2 hpi1 hw1 hpi2 hw2 hneq hw.
+  have := Forall3_nth hptreq None (Vbool true) (Vbool true).
+  move=> /dup[].
+  move=> /(_ _ (nth_not_default hpi1 ltac:(discriminate))); rewrite hpi1 => /(_ ltac:(discriminate)); rewrite hw1 => hw1'.
+  move=> /(_ _ (nth_not_default hpi2 ltac:(discriminate))); rewrite hpi2 => /(_ ltac:(discriminate)); rewrite hw2 => hw2'.
+  have := hdisj _ _ _ _ _ _ hpi1 hw1' hpi2 hw2' hneq hw.
+  have := Forall2_nth hincl (Vbool true) (Vbool true).
+  have -> := Forall2_size hincl.
+  have [<- _] := Forall3_size hargs.
+  move=> /dup[].
+  move=> /(_ _ (nth_not_default hpi1 ltac:(discriminate))) /value_uincl_subtype /size_of_le hle1.
+  move=> /(_ _ (nth_not_default hpi2 ltac:(discriminate))) /value_uincl_subtype /size_of_le hle2.
+  by apply disjoint_zrange_incl; apply zbetween_le.
+Qed.
+
+Lemma value_uincl_wf_result_pointer m vargs1 vargs2 i vr1 vr1' p :
+  value_uincl vr1' vr1 ->
+  wf_result_pointer m vargs1 vargs2 i vr1 p ->
+  wf_result_pointer m vargs1 vargs2 i vr1' p.
+Proof.
+  move=> huincl [hargs hsub hread].
+  have hsub' := value_uincl_subtype huincl.
+  split=> //.
+  + by apply: subtype_trans hsub.
+  by move=> off w /(value_uincl_get_val_byte huincl) /hread.
+Qed.
+
+Lemma mapM2_truncate_val_wf_results m vargs1 vargs2 fn vres1 vres2 :
+  wf_results m vargs1 vargs2 fn vres1 vres2 ->
+  forall tyout vres1',
+  mapM2 ErrType truncate_val tyout vres1 = ok vres1' ->
+  exists vres2',
+    mapM2 ErrType truncate_val
+      (map2 (fun o ty =>
+        match o with
+        | Some _ => sword64
+        | None => ty
+        end) (sao_return (local_alloc fn)) tyout) vres2 = ok vres2' /\
+    wf_results m vargs1 vargs2 fn vres1' vres2'.
+Proof.
+  rewrite /wf_results.
+  elim {vres1 vres2}.
+  + move=> [|//] /= _ [<-].
+    eexists; split; first by reflexivity.
+    by constructor.
+  move=> i vr1 vr2 sao_returns vres1 vres2 hresult _ ih [//|ty tyout] /=.
+  t_xrbindP=> _ vr1' hvr1' vres1' /ih{ih}[vres2' [htr hresults]] <-.
+  rewrite htr /=.
+  case: i hresult => [i|].
+  + move=> [p [-> hresultp]].
+    rewrite /= zero_extend_u.
+    eexists; split; first by reflexivity.
+    constructor=> //.
+    eexists; split; first by reflexivity.
+    apply: value_uincl_wf_result_pointer hresultp.
+    by apply (truncate_value_uincl hvr1').
+  move=> /= ->.
+  rewrite hvr1' /=.
+  eexists; split; first by reflexivity.
+  by constructor.
+Qed.
+
+Hypothesis rip_rsp_neq : P'.(p_extra).(sp_rip) <> x86_variables.string_of_register RSP.
+
+(* could probably be written
+   Forall2 (fun x v2 => is_sarr x.(vtype) -> size_slot x <= size_val v) l params
+   But maybe more complex to use?
+*)
+Lemma write_vars_subtype A (l:seq (option A)) params :
+  List.Forall2 (fun o (x:var_i) => o <> None -> is_sarr x.(vtype)) l params ->
+  forall vargs1 s1 s2,
+  write_vars params vargs1 s1 = ok s2 ->
+  Forall3 (fun o (x:var_i) v => o <> None -> subtype x.(vtype) (type_of_val v)) l params vargs1.
+Proof.
+  elim {l params}.
+  + by move=> [|//] _ _ _; constructor.
+  move=> o x l params harr _ ih [//|varg1 vargs1] /=.
+  t_xrbindP=> s1 s3 s2 hw /ih{ih}ih.
+  constructor=> //.
+  move=> /harr /is_sarrP [n hty].
+  move: hw; rewrite /write_var.
+  t_xrbindP=> vm1 hvm1 _.
+  apply: set_varP hvm1; last by rewrite {1}hty.
+  move=> t h _; move: t h; rewrite hty /=.
+  by move=> _ /to_arrI [n' [_ [-> /WArray.cast_len /ZleP]]] /=.
+Qed.
+
+Lemma alloc_stack_spec_wf_args m1 m2 fn vargs1 vargs2 ws sz sz' m3 :
+  wf_args m1 m2 fn vargs1 vargs2 ->
+  alloc_stack_spec m2 ws sz sz' m3 ->
+  wf_args m1 m3 fn vargs1 vargs2.
+Proof.
+  move=> hargs hass.
+  apply: Forall3_impl hargs.
+  move=> [pi|//] varg1 _ [p [-> hargp]].
+  eexists; split; first by reflexivity.
+  case: hargp => halign hover hvalid hfresh hwnglob hread.
+  split=> //.
+  + by move=> ??; rewrite hass.(ass_valid) hvalid.
+  move=> off w /dup[] /get_val_byte_bound hoff /hread.
+  rewrite hass.(ass_read_old8) //.
+  apply hvalid.
+  apply: between_byte hoff => //.
+  by apply zbetween_refl.
+Qed.
+
+Lemma alloc_stack_spec_extend_mem m1 m2 ws sz sz' m3 :
+  extend_mem m1 m2 rip global_data ->
+  alloc_stack_spec m2 ws sz sz' m3 ->
+  extend_mem m1 m3 rip global_data.
+Proof.
+  move=> hext hass.
+  case:(hext) => hover halign hold hfresh hvalid hnew.
+  split=> //.
+  + move=> ??; rewrite hold //.
+    apply hass.(ass_read_old8).
+    by apply hvalid; apply /orP; left.
+  + move=> ? /hvalid.
+    by rewrite hass.(ass_valid) => ->.
+  move=> i hi; rewrite -hnew //.
+  symmetry.
+  apply hass.(ass_read_old8).
+  apply hvalid; apply /orP; right.
+  apply: between_byte hi => //.
+  by apply zbetween_refl.
+Qed.
+
+Lemma free_stack_spec_extend_mem m1 m2 m3 :
+  extend_mem m1 m2 rip global_data ->
+  free_stack_spec m2 m3 ->
+  (forall p, validw m1 p U8 || between rip (Z.of_nat (size global_data)) p U8 -> validw m3 p U8) ->
+  extend_mem m1 m3 rip global_data.
+Proof.
+  move=> hext hfss hincl.
+  case:(hext) => hover halign hold hfresh hvalid hnew.
+  split=> //.
+  + move=> p ?.
+    rewrite -hfss.(fss_read_old8); first by apply hold.
+    apply hincl.
+    by apply /orP; left.
+  move=> i hi.
+  rewrite -hfss.(fss_read_old8); first by apply hnew.
+  apply hincl.
+  apply /orP; right.
+  apply: between_byte hi => //.
+  by apply zbetween_refl.
+Qed.
+
+Lemma value_uincl_wf_results m1 m2 fn vargs1 vargs2 vargs1' vargs2' m vres1 vres2 :
+  wf_args m1 m2 fn vargs1 vargs2 ->
+  List.Forall2 value_uincl vargs1' vargs1 ->
+  Forall3 (fun opi varg varg' => opi <> None -> varg = varg') (local_alloc fn).(sao_params) vargs2 vargs2' ->
+  List.Forall (fun oi => forall i, oi = Some i -> nth None (local_alloc fn).(sao_params) i <> None) (local_alloc fn).(sao_return) ->
+  wf_results m vargs1' vargs2' fn vres1 vres2 ->
+  wf_results m vargs1 vargs2 fn vres1 vres2.
+Proof.
+  move=> hargs hincl hptreq hnnone.
+  apply Forall3_impl_in.
+  move=> [i|//] vr1 vr2 hoi _ _ [p [-> hresultp]].
+  exists p; split; first by reflexivity.
+  have /List.Forall_forall -/(_ _ hoi _ refl_equal) := hnnone.
+  case hpi: nth => [pi|//] _.
+  case: (hresultp) => hrargs hsub hread.
+  split=> //.
+  + by rewrite (Forall3_nth hptreq None (Vbool true) (Vbool true)
+      (nth_not_default hpi ltac:(discriminate)) ltac:(congruence)).
+  have := Forall2_nth hincl (Vbool true) (Vbool true).
+  have -> := Forall2_size hincl.
+  have [<- _] := Forall3_size hargs.
+  move=> /(_ _ (nth_not_default hpi ltac:(discriminate))).
+  move=> /value_uincl_subtype.
+  by apply subtype_trans.
+Qed.
+
+Lemma free_stack_spec_wf_results m1 m2 fn vargs1 vargs2 m3 m3' vres1 vres2 :
+  wf_args m1 m3 fn vargs1 vargs2 ->
+  validw m3 =2 validw m3' ->
+  free_stack_spec m2 m3' ->
+  List.Forall (fun oi => forall i, oi = Some i -> nth None (local_alloc fn).(sao_params) i <> None) (local_alloc fn).(sao_return) ->
+  wf_results m2 vargs1 vargs2 fn vres1 vres2 ->
+  wf_results m3' vargs1 vargs2 fn vres1 vres2.
+Proof.
+  move=> hargs hvalid hfss hforall.
+  apply Forall3_impl_in.
+  move=> [i|//] vr1 vr2 hoi _ _ [p [-> hresultp]].
+  exists p; split; first by reflexivity.
+  have /List.Forall_forall -/(_ _ hoi _ refl_equal) := hforall.
+  case hpi: nth => [pi|//] _.
+  case: (hresultp) => hrargs hsub hread.
+  split=> //.
+  move=> off w /dup[] /get_val_byte_bound hoff.
+  rewrite -hfss.(fss_read_old8); first by apply hread.
+  have := Forall3_nth hargs None (Vbool true) (Vbool true) (nth_not_default hpi ltac:(discriminate)).
+  rewrite hpi /= hrargs.
+  move=> [_ [[<-] hargp]].
+  rewrite -hvalid.
+  apply hargp.(wap_valid).
+  apply: between_byte hoff.
+  + by apply (no_overflow_incl (zbetween_le _ (size_of_le hsub)) hargp.(wap_no_overflow)).
+  by apply: zbetween_le (size_of_le hsub).
+Qed.
+
+Lemma value_uincl_disjoint_from_writable_params fn vargs1 vargs1' vargs2 vargs2' p :
+  List.Forall2 value_uincl vargs1' vargs1 ->
+  Forall3 (fun opi varg varg' => opi <> None -> varg = varg') (local_alloc fn).(sao_params) vargs2 vargs2' ->
+  disjoint_from_writable_params fn p vargs1 vargs2 ->
+  disjoint_from_writable_params fn p vargs1' vargs2'.
+Proof.
+  rewrite /disjoint_from_writable_params.
+  move=> hincl hptreq hdisj.
+  elim: {vargs1 vargs2} hdisj vargs1' hincl vargs2' hptreq.
+  + move=> _ /List_Forall2_inv_r -> [|??] /List_Forall3_inv // _.
+    by constructor.
+  move=> opi varg1 varg2 sao_params vargs1 vargs2 hdisj _ ih.
+  move=> _ /List_Forall2_inv_r [varg1' [vargs1' [-> [hincl /ih{ih}ih]]]].
+  move=> [|varg2' vargs2'] /List_Forall3_inv // [hptreq /ih{ih}ih].
+  constructor=> //.
+  move=> pi p2 ?? hw; subst opi varg2'.
+  apply (disjoint_zrange_incl_l (zbetween_le _ (size_of_le (value_uincl_subtype hincl)))).
+  rewrite /disjoint_from_writable_param in hdisj.
+  by apply (hdisj _ _ refl_equal (hptreq ltac:(discriminate)) hw).
+Qed.
+
+(* sem_call has 7 steps that are reflected in this proof:
+  - truncate_val of args,
+  - init_state,
+  - write_vars of args,
+  - execution of the body,
+  - get_var of results,
+  - truncate_val of results,
+  - finalize.
+*)
+Local Lemma Hproc : sem_Ind_proc P ev Pc Pfun.
+Proof.
+  move=> m1 _ fn fd vargs1' vargs1 _ s1 s1' vres1 vres1' hfd hvargs1' /= [<-] hs1 hsem1 Hc hvres1 hvres1' ->.
+  move=> m2 vargs2 hext hargs hdisjv hok.
+  have [fd2 halloc hfd2] := Halloc_fd hfd.
+  move: halloc; rewrite /alloc_fd /=.
+  t_xrbindP=> fd2' stack hlayout [[locals1 rmap1] vnew1] hlocal_map.
+  t_xrbindP=> -[[[vnew2 locals2] rmap2] alloc_params].
+  apply: add_err_funP => hparams.
+  t_xrbindP=> _ /assertP /ZleP hextra _ /assertP /ZleP hmax.
+  move=> [rmap3 c].
+  apply: add_finfoP => halloc.
+  t_xrbindP=> res.
+  apply: add_err_funP => hcresults ??; subst fd2 fd2'.
+
+  (* truncate_val of args *)
+  have [vargs2' [hvargs2' hargs']] := mapM2_truncate_val_wf_args hargs hvargs1'.
+  have huincl := mapM2_truncate_value_uincl hvargs1'.
+  have hptreq := mapM2_truncate_val_ptr_eq hargs hvargs2'.
+  have hdisjv' := value_uincl_disjoint_values hargs hdisjv huincl hptreq.
+
+  (* init_state *)
+  have [m2' halloc_stk]: exists m2',
+    alloc_stack m2 (sao_align (local_alloc fn)) (sao_size (local_alloc fn)) (sao_extra_size (local_alloc fn)) = ok m2'.
+  + apply Memory.alloc_stack_complete.
+    apply /and3P; split.
+    + apply /ZleP.
+      by apply (init_stack_layout_size_ge0 hlayout).
+    + by apply /ZleP.
+    move: hok; rewrite /alloc_ok => /(_ _ hfd2) /=; rewrite /allocatable_stack => -[hallocatable hal].
+    case: is_RAnone hal hmax => [_|-> //] hmax; last by apply /ZleP; lia.
+    case: is_align; last by apply /ZleP; lia.
+    apply /ZleP.
+    have := round_ws_range (sao_align (local_alloc fn)) (sao_size (local_alloc fn) + sao_extra_size (local_alloc fn)).
+    by lia.
+  have hass := Memory.alloc_stackP halloc_stk.
+  set fex := {| sf_align := _ |} in hfd2.
+  set rsp := top_stack m2'.
+  have hinit: init_stk_state fex (p_extra P') rip {| emem := m2; evm := vmap0 |} =
+    ok {| emem := m2';
+          evm  := vmap0.[x86_variables.var_of_register RSP <- ok (pword_of_word rsp)]
+                       .[{|vtype := sword64; vname := P'.(p_extra).(sp_rip)|} <- ok (pword_of_word rip)] |}.
+  + by rewrite /init_stk_state halloc_stk /= !pword_of_wordE.
+  have hover := ass_no_overflow hass.
+  have hargs'' := alloc_stack_spec_wf_args hargs' hass.
+  have hext' := alloc_stack_spec_extend_mem hext hass.
+
+  have hdisj_glob_locals: 0 < glob_size -> 0 < (local_alloc fn).(sao_size) ->
+    disjoint_zrange rip glob_size rsp (sao_size (local_alloc fn)).
+  + move=> hlt1 hlt2.
+    apply disjoint_zrange_sym.
+    apply disjoint_zrange_U8 => //.
+    move=> k hk.
+    have hb: between rip glob_size (rip + wrepr _ k)%R U8.
+    + apply: between_byte hk => //.
+      by apply zbetween_refl.
+    (* TODO: use disjoint_zrange in ass_fresh? *)
+    have /hass.(ass_fresh) hfresh: validw m2 (rip + wrepr _ k)%R U8.
+    + apply hext.(em_valid).
+      by rewrite hb orbT.
+    apply disjoint_zrange_sym.
+    split=> //.
+    by apply: (no_overflow_incl hb).
+  have hdisj_locals_params:
+    Forall3 (fun opi varg1 varg2 => forall pi, opi = Some pi ->
+      forall (p:pointer), varg2 = Vword p -> 0 < (local_alloc fn).(sao_size) -> disjoint_zrange rsp (local_alloc fn).(sao_size) p (size_val varg1))
+    (sao_params (local_alloc fn)) vargs1' vargs2'.
+  + apply: Forall3_impl hargs'.
+    move=> opi varg1 varg2 harg pi ? p ? hlt; subst opi varg2.
+    case: harg => _ [[<-] hargp].
+    apply disjoint_zrange_U8 => //.
+    + by apply size_of_gt0.
+    + by apply hargp.(wap_no_overflow).
+    move=> k hk.
+    have hb: between p (size_val varg1) (p + wrepr _ k) U8.
+    + apply: between_byte hk.
+      + by apply hargp.(wap_no_overflow).
+      by apply zbetween_refl.
+    have hfresh := hass.(ass_fresh) (hargp.(wap_valid) hb).
+    apply disjoint_zrange_sym.
+    split=> //.
+    by apply: no_overflow_incl hb hargp.(wap_no_overflow).
+
+  have hsub := write_vars_subtype (init_params_sarr hparams) hs1. (* 'backported' from write_vars of args *)
+  have /= hvs := init_stk_state_valid_state hlayout hover hdisj_glob_locals
+    hargs' hsub hlocal_map hparams hext hass refl_equal rip_rsp_neq.
+  have hpmap := init_params_wf_pmap hlayout rsp vargs1' vargs2' hlocal_map hparams.
+  have hslots := Hwf_Slots hlayout hover hdisj_glob_locals hext.(em_align)
+    hass.(ass_align_stk) hargs' hdisjv' hsub hparams hdisj_locals_params.
+
+  (* write_vars of args *)
+  have [s2 [hs2 hvs']] := valid_state_init_params hlayout hargs'' hlocal_map hparams hvs hs1.
+  have hext'': extend_mem (emem s1) (emem s2) rip global_data.
+  + have /= <- := write_vars_emem hs1.
+    by have /= <- := write_vars_emem hs2.
+
+  have hsao: wf_sao rsp (emem s2) (local_alloc fn).
+  + have /= <- := write_vars_emem hs2.
+    split.
+    + rewrite /enough_size /allocatable_stack.
+      split; first by lia.
+      rewrite /top_stack hass.(ass_frames) /= hass.(ass_limit).
+      move: hok; rewrite /alloc_ok => /(_ _ hfd2) /= []; rewrite /allocatable_stack.
+      have hsize := init_stack_layout_size_ge0 hlayout.
+      assert (hge := wunsigned_range (stack_limit m2)).
+      have hpos := wsize_size_pos (sao_align (local_alloc fn)).
+      case: is_RAnone hmax.
+      + move=> hmax hok _.
+        have hbound: 0 <= sao_size (local_alloc fn) + sao_extra_size (local_alloc fn)
+                  /\ sao_size (local_alloc fn) + sao_extra_size (local_alloc fn) <= wunsigned (top_stack m2).
+        + by lia.
+        have := @top_stack_after_alloc_bounded _ (local_alloc fn).(sao_align) _ hbound.
+        by lia.
+      move=> hmax hok1 hok2.
+      rewrite (top_stack_after_aligned_alloc _ (hok2 _)) //.
+      rewrite wunsigned_add; first by lia.
+      split; first by lia.
+      assert (hrange := wunsigned_range (top_stack m2)).
+      have [? _] := round_ws_range (sao_align (local_alloc fn)) (sao_size (local_alloc fn) + sao_extra_size (local_alloc fn)).
+      by lia.
+   by apply hass.(ass_align_stk).
+
+  (* execution of the body *)
+  have [s2' [hsem2 hvs''']] := Hc _ _ _ _ _ _ _ _ _ hpmap hslots _ halloc _ _ hvs' hext'' hsao.
+  have hext''' := valid_state_extend_mem hslots hvs' hext'' hvs''' (sem_validw_stable_uprog hsem1) (sem_validw_stable_sprog hsem2).
+
+  (* get_var of results *)
+  have harr: List.Forall2 (fun osr (x : var_i) => osr <> None -> is_sarr (vtype x)) (map fst alloc_params) (f_params fd).
+  + by apply: (Forall2_trans _ (init_params_alloc_params_not_None hparams) (init_params_sarr hparams)); auto.
+  have hsub' := write_vars_subtype harr hs1.
+  have haddr := init_params_alloc_params rsp hargs'' hparams.
+  have [vres2 [hvres2 hresults]] := check_resultsP hvs''' hsub' haddr hcresults hvres1.
+
+  (* truncate_val of results *)
+  have [vres2' [hvres2' hresults']] := mapM2_truncate_val_wf_results hresults hvres1'.
+  have hnnone: List.Forall (fun oi => forall i, oi = Some i -> nth None (sao_params (local_alloc fn)) i <> None)
+                           (sao_return (local_alloc fn)).
+  + apply: List.Forall_impl (check_results_alloc_params_not_None hcresults).
+    move=> oi hnnone i ?; subst oi.
+    move: hnnone => /(_ _ refl_equal).
+    case hsr: nth => [sr|//] _.
+    apply (Forall2_nth (init_params_alloc_params_not_None hparams) None None (nth_not_default hsr ltac:(discriminate))).
+    by rewrite hsr.
+  have hresults'' := value_uincl_wf_results hargs huincl hptreq hnnone hresults'.
+
+  (* finalize *)
+  have hfss := Memory.free_stackP (emem s2').
+  have hvalideq1: validw m1 =2 validw (emem s1').
+  + have /= -> := write_vars_emem hs1.
+    by apply (sem_validw_stable_uprog hsem1).
+  have hvalideq2: validw m2 =2 validw (free_stack (emem s2')).
+  + apply: (alloc_free_validw_stable hass _ _ hfss);
+      have /= -> := write_vars_emem hs2.
+    + by apply (sem_stack_stable_sprog hsem2).
+    by apply (sem_validw_stable_sprog hsem2).
+  have hresults''' := free_stack_spec_wf_results hargs hvalideq2 hfss hnnone hresults''.
+
+  exists (free_stack (emem s2')), vres2'.
+  split.
+  + by econstructor; try eassumption.
+  split.
+  + apply (free_stack_spec_extend_mem hext''' hfss).
+    move=> p.
+    rewrite -hvalideq1 -hvalideq2.
+    by apply hext.(em_valid).
+  split=> //.
+  rewrite /mem_unchanged_params.
+  move=> p hvalid1 hvalid2 hdisjp.
+  rewrite -hfss.(fss_read_old8) -?hvalideq2 //.
+  have /vs_unchanged := hvs'''; apply => //.
+  + by rewrite -hvalideq1.
+  apply (disjoint_from_writable_params_all_slots hlayout hover hdisj_glob_locals hargs'' hsub hparams).
+  + by apply (value_uincl_disjoint_from_writable_params huincl hptreq hdisjp).
+  have ? := hass.(ass_fresh) hvalid1.
+  split.
+  + by apply hover.
+  + apply is_align_no_overflow.
+    by apply is_align8.
+  by apply or_comm.
+Qed.
+
+Lemma check_cP m1 fn vargs m2 vres : sem_call P ev m1 fn vargs m2 vres -> Pfun m1 fn vargs m2 vres.
+Proof.
+  apply (@sem_call_Ind _ _ _ _ _ Pc Pi_r Pi Pfor Pfun
+                       Hskip
+                       Hcons
+                       HmkI
+                       Hassgn
+                       Hopn
+                       Hif_true
+                       Hif_false
+                       Hwhile_true
+                       Hwhile_false
+                       Hfor
+                       Hfor_nil
+                       Hfor_cons
+                       Hcall
+                       Hproc).
+Qed.
+
+End PROC.
+
+End INIT.
+
+Lemma mapM_alloc_fd_get_fundef p_extra mglob oracle fds1 fds2 :
+  mapM (alloc_fd p_extra mglob oracle) fds1 = ok fds2 ->
+  forall fn fd1,
+  get_fundef fds1 fn = Some fd1 ->
+  exists2 fd2, alloc_fd p_extra mglob oracle (fn, fd1) = ok (fn, fd2) &
+               get_fundef fds2 fn = Some fd2.
+Proof.
+  move=> hmap fn fd1.
+  apply: (mapM_assoc _ hmap).
+  move=> {fn fd1} [fn fd1] [fn' fd2]; rewrite /alloc_fd.
+  by t_xrbindP.
+Qed.
+
+(* Here are informal descriptions of the predicates used in the theorem.
+
+   - extend_mem m1 m2 rip data: [m2] is a memory that contains at least [m1]
+       and (disjointly) data [data] at adress [rip];
+
+   - wf_args: link between the values taken as arguments in the source and the target
+       (complex predicate if the argument is a reg ptr, just equality otherwise);
+
+   - disjoint_values: the writable [reg ptr]s taken as arguments point to memory zones
+       that are pairwise disjoint and disjoint from the zones pointed to by
+       non writable [reg ptr]s;
+
+   - alloc_ok: the call is possible in the target (there is enough space in the
+       stack, and the top of the stack is aligned if the callee is not an export function);
+
+   - wf_results: link between the values returned in the source and the target
+       (complex predicate if the result is a reg ptr, just equality otherwise);
+
+   - mem_unchanged_params: the function call does not modify the stack region,
+      except for the regions pointed to by the writable [reg ptr]s given as arguments.
+*)
+Theorem alloc_progP nrip data oracle_g oracle (P: uprog) (SP: sprog) fn:
+  alloc_prog nrip data oracle_g oracle P = ok SP ->
+  forall ev m1 vargs1 m1' vres1,
+    sem_call (sCP := sCP_unit) P ev m1 fn vargs1 m1' vres1 ->
+    forall rip m2 vargs2,
+      extend_mem m1 m2 rip data ->
+      wf_args data rip oracle m1 m2 fn vargs1 vargs2 ->
+      disjoint_values (oracle fn).(sao_params) vargs1 vargs2 ->
+      alloc_ok SP fn m2 ->
+      exists m2' vres2,
+        sem_call (sCP := sCP_stack) SP rip m2 fn vargs2 m2' vres2 /\
+        extend_mem m1' m2' rip data /\
+        wf_results oracle m2' vargs1 vargs2 fn vres1 vres2 /\
+        mem_unchanged_params oracle fn m1 m2 m2' vargs1 vargs2.
+Proof.
+  move=> hprog ev m1 vargs1 m1' vres1 hsem1 rip m2 vargs2 hext hargs hdisj halloc.
+  move: hprog; rewrite /alloc_prog.
+  t_xrbindP=> mglob.
+  apply: add_err_msgP => hmap.
+  case: eqP => [//|hneq].
+  case: ifP => [hcheck|//].
+  t_xrbindP=> fds hfds.
+  set P' := {| p_funcs := _ |} => ?; subst SP.
+
+  have [fd1 hfd1]: exists fd, get_fundef (p_funcs P) fn = Some fd.
+  + have /sem_callE [fd1 [hfd1 _]]  := hsem1.
+    by exists fd1.
+
+  by apply (check_cP hext.(em_no_overflow) hmap hcheck (P':=P') refl_equal (mapM_alloc_fd_get_fundef hfds)
+              hneq hsem1 hext hargs hdisj halloc).
+Qed.

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -393,6 +393,9 @@ Definition mk_lvar x := {| gv := x; gs := Slocal |}.
 Definition is_lvar (x:gvar) := x.(gs) == Slocal.
 Definition is_glob (x:gvar) := x.(gs) == Sglob.
 
+Lemma is_lvar_is_glob x : is_lvar x = ~~is_glob x.
+Proof. by case: x => ? []. Qed.
+
 Definition gvar_beq (x1 x2:gvar) := 
   (x1.(gs) == x2.(gs)) && (x1.(gv) == x2.(gv)).
 

--- a/proofs/lang/low_memory.v
+++ b/proofs/lang/low_memory.v
@@ -29,6 +29,7 @@ From Coq Require Import RelationClasses.
 Require memory_example.
 
 Import all_ssreflect all_algebra.
+From CoqWord Require Import ssrZ.
 Import Utf8 ZArith.
 Import type word utils.
 Import memory_example.
@@ -80,6 +81,40 @@ Proof.
   move => hw; apply /writeV; exists m'; exact hw.
 Qed.
 
+(* An alternate form of [CoreMem.writeP_neq] that should be easier to use. *)
+Lemma writeP_neq mem1 mem2 p ws (v : word ws) p2 ws2 :
+  write mem1 p v = ok mem2 ->
+  disjoint_range p ws p2 ws2 ->
+  read mem2 p2 ws2 = read mem1 p2 ws2.
+Proof.
+  move=> hmem2 hdisj.
+  apply (writeP_neq hmem2).
+  by apply disjoint_range_alt.
+Qed.
+
+Lemma disjoint_range_valid_not_valid_U8 m p1 ws1 p2 :
+  validw m p1 ws1 ->
+  ~ validw m p2 U8 ->
+  disjoint_range p1 ws1 p2 U8.
+Proof.
+  move=> /validwP [hal1 hval1] hnval.
+  split.
+  + by apply is_align_no_overflow.
+  + by apply is_align_no_overflow; apply is_align8.
+  rewrite wsize8.
+  case: (Z_le_gt_dec (wunsigned p1 + wsize_size ws1) (wunsigned p2)); first by left.
+  case: (Z_le_gt_dec (wunsigned p2 + 1) (wunsigned p1)); first by right.
+  move=> hgt1 hgt2.
+  case: hnval.
+  apply /validwP; split.
+  + by apply is_align8.
+  move=> k; rewrite wsize8 => hk; have ->: k = 0%Z by Lia.lia.
+  rewrite add_0.
+  have ->: p2 = (p1 + wrepr _ (wunsigned p2 - wunsigned p1))%R.
+  + by rewrite wrepr_sub !wrepr_unsigned; ssrring.ssring.
+  by apply hval1; Lia.lia.
+Qed.
+
 Lemma alloc_stack_top_stack m ws sz sz' m' :
   alloc_stack m ws sz sz' = ok m' →
   top_stack m' = top_stack_after_alloc (top_stack m) ws (sz + sz').
@@ -111,13 +146,13 @@ Proof.
   - have [L _] := round_ws_range ws (sz + sz').
     Lia.lia.
   etransitivity; last exact: (proj2 (Memory.alloc_stackP A).(ass_above_limit)).
-  rewrite (alloc_stack_top_stack A) (Memory.top_stack_after_aligned_alloc _ AL) wrepr_opp.
+  rewrite (alloc_stack_top_stack A) (top_stack_after_aligned_alloc _ AL) wrepr_opp.
   Lia.lia.
 Qed.
 
 (* -------------------------------------------------------------- *)
 Definition allocatable_stack (m : mem) (z : Z) :=
-  True. (* TODO *)
+  (0 <= z <= wunsigned (top_stack m) - wunsigned (stack_limit m))%Z.
 
 (*
   Record allocatable_spec : Prop := {

--- a/proofs/lang/psem_facts.v
+++ b/proofs/lang/psem_facts.v
@@ -1,8 +1,8 @@
 (*
 *)
+From mathcomp Require Import all_ssreflect all_algebra.
 Require Import psem.
 Import Utf8.
-Import all_ssreflect all_algebra.
 Import Memory low_memory.
 
 Set Implicit Arguments.
@@ -23,20 +23,12 @@ Proof.
   by move => v vs a /=; t_xrbindP => b /write_var_emem -> /ih.
 Qed.
 
-Lemma pword_of_wordE sz (w: word sz) e :
-  {| pw_size := sz ; pw_word := w ; pw_proof := e |} = pword_of_word w.
-Proof.
-    by rewrite (Eqdep_dec.UIP_dec Bool.bool_dec e (cmp_le_refl _)).
-Qed.
-
-(** Running a program with stack preserves said stack *)
-Section STACK_STABLE.
-
-Infix "≡" := stack_stable (at level 40).
+(* sem_stack_stable and sem_validw_stable both for uprog and sprog *)
+Section STACK_VALIDW_STABLE. (* inspired by sem_one_varmap_facts *)
 
 Lemma write_lval_stack_stable gd x v s s' :
   write_lval gd x v s = ok s' →
-  emem s ≡ emem s'.
+  stack_stable (emem s) (emem s').
 Proof.
   case: x => [ vi ty | x | ws x e | aa ws x e | aa ws len x e ].
   - apply: on_vuP; first by move => _ _ ->.
@@ -49,42 +41,134 @@ Qed.
 
 Lemma write_lvals_stack_stable gd xs vs s s' :
   write_lvals gd s xs vs = ok s' →
-  emem s ≡ emem s'.
+  stack_stable (emem s) (emem s').
 Proof.
   elim: xs vs s => [ | x xs ih ] [] //; first by move => ? [<-].
   by move => v vs s /=; t_xrbindP => ? /write_lval_stack_stable -> /ih.
 Qed.
 
-Context (p: sprog) (gd: pointer).
+Lemma write_lval_validw gd x v s s' :
+  write_lval gd x v s = ok s' ->
+  validw (emem s) =2 validw (emem s').
+Proof.
+  case: x => /=.
+  - by move => _ ty /write_noneP [] <-.
+  - by move => x /write_var_emem <-.
+  - t_xrbindP => /= ????? ?? ?? ? ? ? ? ? h <- /=.
+    by move=> ??; rewrite (write_validw_eq h).
+  - move => aa sz x e.
+    by apply: on_arr_varP; t_xrbindP => ?????????????? <-.
+  move => aa sz ty x e.
+  by apply: on_arr_varP; t_xrbindP => ?????????????? <-.
+Qed.
 
-Let Pc (s1: estate) (c: cmd) (s2: estate) : Prop := emem s1 ≡ emem s2.
-Let Pi_r (s1: estate) (ir: instr_r) (s2: estate) : Prop := emem s1 ≡ emem s2.
-Let Pi (s1: estate) (i: instr) (s2: estate) : Prop := emem s1 ≡ emem s2.
-Let Pfor (x: var_i) (dom: seq Z) (s1: estate) (c: cmd) (s2: estate) : Prop := emem s1 ≡ emem s2.
-Let Pfun (m1: mem) (fn: funname) (args: seq value) (m2: mem) (res: seq value) : Prop := m1 ≡ m2.
+Lemma write_lvals_validw gd xs vs s s' :
+  write_lvals gd s xs vs = ok s' ->
+  validw (emem s) =2 validw (emem s').
+Proof.
+  elim: xs vs s.
+  - by case => // ? [] ->.
+  move => x xs ih [] // v vs s /=; t_xrbindP => ? /write_lval_validw h /ih.
+  by move=> h1 p ws; rewrite h h1.
+Qed.
 
-Local Lemma Hnil : sem_Ind_nil Pc.
+Lemma alloc_free_stack_stable m1 ws sz sz' m2 m2' m3 :
+  alloc_stack_spec m1 ws sz sz' m2 ->
+  stack_stable m2 m2' ->
+  free_stack_spec m2' m3 ->
+  stack_stable m1 m3.
+Proof.
+  move=> hass hss hfss.
+  split.
+  + by rewrite hfss.(fss_root) -hss.(ss_root) hass.(ass_root).
+  + by rewrite hfss.(fss_limit) -hss.(ss_limit) hass.(ass_limit).
+  by rewrite hfss.(fss_frames) -hss.(ss_frames) hass.(ass_frames).
+Qed.
+
+Lemma alloc_free_validw_stable m1 ws sz sz' m2 m2' m3 :
+  alloc_stack_spec m1 ws sz sz' m2 ->
+  stack_stable m2 m2' ->
+  validw m2 =2 validw m2' ->
+  free_stack_spec m2' m3 ->
+  validw m1 =2 validw m3.
+Proof.
+  move=> hass hss hvalid hfss.
+  move=> p ws'.
+  congr (_ && _).
+  apply: all_ziota => i hi.
+  rewrite !valid8_validw.
+  rewrite hfss.(fss_valid) -hvalid hass.(ass_valid).
+  rewrite -hss.(ss_top_stack) -(alloc_free_stack_stable hass hss hfss).(ss_top_stack).
+  rewrite /pointer_range.
+  have [L H] := ass_above_limit hass.
+  case: (@andP (_ <=? _)%Z); rewrite !zify.
+  - case => ptr_i_lo ptr_i_hi.
+    rewrite andbF; apply/negbTE; apply: stack_region_is_free.
+    split; last exact: ptr_i_hi.
+    etransitivity; last exact: ptr_i_lo.
+    exact: L.
+  rewrite andbT => ptr_not_fresh.
+  set X := (X in _ || X).
+  suff /negbTE -> : ~~ X; first by rewrite orbF.
+  subst X; rewrite !zify => - [].
+  change (wsize_size U8) with 1%Z.
+  move => ptr_i_lo ptr_i_hi.
+  apply: ptr_not_fresh.
+  split; first exact: ptr_i_lo.
+  move: H ptr_i_hi; clear => n.
+  by Lia.lia.
+Qed.
+
+Section MEM_EQUIV.
+
+Context {T:eqType} {pT:progT T} {sCP: semCallParams}.
+
+Variable P : prog.
+Variable ev : extra_val_t.
+
+Definition mem_equiv m1 m2 := stack_stable m1 m2 /\ validw m1 =2 validw m2.
+Infix "≡" := mem_equiv (at level 40).
+
+Hypothesis init_finalize_mem_equiv : forall s1 s2 m2 ef,
+  init_state ef P.(p_extra) ev s1 = ok s2 ->
+  emem s2 ≡ m2 ->
+  emem s1 ≡ finalize ef m2.
+
+Instance mem_equiv_trans : Transitive mem_equiv.
+Proof.
+  move => m1 m2 m3 [hss1 hvalid1] [hss2 hvalid2].
+  split; first by transitivity m2.
+  by move=> p ws; transitivity (validw m2 p ws).
+Qed.
+
+Let Pc s1 (_: cmd) s2 : Prop := emem s1 ≡ emem s2.
+Let Pi s1 (_: instr) s2 : Prop := emem s1 ≡ emem s2.
+Let Pi_r s1 (_: instr_r) s2 : Prop := emem s1 ≡ emem s2.
+Let Pfor (_: var_i) (_: seq Z) s1 (_: cmd) s2 : Prop := emem s1 ≡ emem s2.
+Let Pfun m1 (_: funname) (_: seq value) m2 (_: seq value) : Prop := m1 ≡ m2.
+
+Lemma mem_equiv_nil : sem_Ind_nil Pc.
 Proof. by []. Qed.
 
-Local Lemma Hcons : sem_Ind_cons p gd Pc Pi.
-Proof. move => x y z i c _ xy _ yz; red; transitivity (emem y); assumption. Qed.
+Lemma mem_equiv_cons : sem_Ind_cons P ev Pc Pi.
+Proof. by move => x y z i c _ xy _ yz; red; etransitivity; eassumption. Qed.
 
-Local Lemma HmkI : sem_Ind_mkI p gd Pi_r Pi.
+Lemma mem_equiv_mkI : sem_Ind_mkI P ev Pi_r Pi.
 Proof. by []. Qed.
 
-Local Lemma Hassgn : sem_Ind_assgn p Pi_r.
-Proof. by move => s1 s2 x tg ty e v v' ok_v ok_v' /write_lval_stack_stable. Qed.
+Lemma mem_equiv_assgn : sem_Ind_assgn P Pi_r.
+Proof. by move => s1 s2 x tg ty e v v' ok_v ok_v' /dup[] /write_lval_validw ? /write_lval_stack_stable. Qed.
 
-Local Lemma Hopn : sem_Ind_opn p Pi_r.
-Proof. by move => s1 s2 tg op xs es; rewrite /sem_sopn; t_xrbindP => ???? /write_lvals_stack_stable. Qed.
+Lemma mem_equiv_opn : sem_Ind_opn P Pi_r.
+Proof. by move => s1 s2 tg op xs es; rewrite /sem_sopn; t_xrbindP => ???? /dup[] /write_lvals_validw ? /write_lvals_stack_stable. Qed.
 
-Local Lemma Hif_true : sem_Ind_if_true p gd Pc Pi_r.
+Lemma mem_equiv_if_true : sem_Ind_if_true P ev Pc Pi_r.
 Proof. by []. Qed.
 
-Local Lemma Hif_false : sem_Ind_if_false p gd Pc Pi_r.
+Lemma mem_equiv_if_false : sem_Ind_if_false P ev Pc Pi_r.
 Proof. by []. Qed.
 
-Local Lemma Hwhile_true : sem_Ind_while_true p gd Pc Pi_r.
+Lemma mem_equiv_while_true : sem_Ind_while_true P ev Pc Pi_r.
 Proof.
   move => s1 s2 s3 s4 aa c e c' _ A _ _ B _ C; red.
   etransitivity; first exact: A.
@@ -92,58 +176,278 @@ Proof.
   exact: C.
 Qed.
 
-Local Lemma Hwhile_false : sem_Ind_while_false p gd Pc Pi_r.
+Lemma mem_equiv_while_false : sem_Ind_while_false P ev Pc Pi_r.
 Proof. by []. Qed.
 
-Local Lemma Hfor : sem_Ind_for p gd Pi_r Pfor.
+Lemma mem_equiv_for : sem_Ind_for P ev Pi_r Pfor.
 Proof. by []. Qed.
 
-Local Lemma Hfor_nil : sem_Ind_for_nil Pfor.
+Lemma mem_equiv_for_nil : sem_Ind_for_nil Pfor.
 Proof. by []. Qed.
 
-Local Lemma Hfor_cons : sem_Ind_for_cons p gd Pc Pfor.
+Lemma mem_equiv_for_cons : sem_Ind_for_cons P ev Pc Pfor.
 Proof.
   move => ???????? /write_var_emem A _ B _ C; red.
   rewrite A; etransitivity; [ exact: B | exact: C ].
 Qed.
 
-Local Lemma Hcall : sem_Ind_call p gd Pi_r Pfun.
+Lemma mem_equiv_call : sem_Ind_call P ev Pi_r Pfun.
+Proof. move=> s1 m2 s2 ii xs fn args vargs vres _ _ ? /dup[] /write_lvals_validw ? /write_lvals_stack_stable ?; red; etransitivity; [|split]; eassumption. Qed.
+
+Lemma mem_equiv_proc : sem_Ind_proc P ev Pc Pfun.
 Proof.
-  move => s1 m2 s2 ii xs fn args vargs vs _ _ A /write_lvals_stack_stable B; red.
-  etransitivity; [ exact: A | exact: B ].
+  move=> m1 m2 fn fd vargs vargs' s0 s1 s2 vres vres' ok_fd ok_vargs ok_s0 ok_s1 _ Hc _ _ ->.
+  rewrite /Pc -(write_vars_emem ok_s1) in Hc.
+  by apply (init_finalize_mem_equiv ok_s0 Hc).
 Qed.
 
-Local Lemma Hproc : sem_Ind_proc p gd Pc Pfun.
+Lemma sem_mem_equiv s1 c s2 :
+  sem P ev s1 c s2 → emem s1 ≡ emem s2.
 Proof.
-  red.
-  move => m _ fn fd vargs vargs' s0 s1 s2 vres vres' _ _ A /write_vars_emem B _ C _ _ ->; red.
-  move: A; rewrite /= /init_stk_state /finalize_stk_mem; t_xrbindP => /= m' ok_m' [?]; subst s0.
-  move: B => /= ?; subst m'.
-  have ok_free := free_stackP (emem s2).
-  split; last by rewrite (fss_frames ok_free) -C.(ss_frames) (alloc_stackP ok_m').(ass_frames).
-  + rewrite (fss_root ok_free) -(alloc_stackP ok_m').(ass_root).
-    exact: ss_root C.
-  rewrite (fss_limit ok_free) -(alloc_stackP ok_m').(ass_limit).
-  exact: ss_limit C.
+  by apply
+    (@sem_Ind _ _ _ _ _ Pc Pi_r Pi Pfor Pfun
+              mem_equiv_nil
+              mem_equiv_cons
+              mem_equiv_mkI
+              mem_equiv_assgn
+              mem_equiv_opn
+              mem_equiv_if_true
+              mem_equiv_if_false
+              mem_equiv_while_true
+              mem_equiv_while_false
+              mem_equiv_for
+              mem_equiv_for_nil
+              mem_equiv_for_cons
+              mem_equiv_call
+              mem_equiv_proc).
 Qed.
 
-Lemma sem_stack_stable s1 c s2 :
-  sem p gd s1 c s2 → stack_stable (emem s1) (emem s2).
+Lemma sem_I_mem_equiv s1 i s2 :
+  sem_I P ev s1 i s2 → emem s1 ≡ emem s2.
 Proof.
-  exact:
-    (@sem_Ind _ _ _ p gd Pc Pi_r Pi Pfor Pfun
-              Hnil Hcons HmkI Hassgn Hopn Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc).
+  by apply
+    (@sem_I_Ind _ _ _ _ _ Pc Pi_r Pi Pfor Pfun
+                mem_equiv_nil
+                mem_equiv_cons
+                mem_equiv_mkI
+                mem_equiv_assgn
+                mem_equiv_opn
+                mem_equiv_if_true
+                mem_equiv_if_false
+                mem_equiv_while_true
+                mem_equiv_while_false
+                mem_equiv_for
+                mem_equiv_for_nil
+                mem_equiv_for_cons
+                mem_equiv_call
+                mem_equiv_proc).
 Qed.
 
-Lemma sem_I_stack_stable s1 i s2 :
-  sem_I p gd s1 i s2 → stack_stable (emem s1) (emem s2).
+Lemma sem_i_mem_equiv s1 i s2 :
+  sem_i P ev s1 i s2 → emem s1 ≡ emem s2.
 Proof.
-  exact:
-    (@sem_I_Ind _ _ _ p gd Pc Pi_r Pi Pfor Pfun
-              Hnil Hcons HmkI Hassgn Hopn Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc).
+  by apply
+    (@sem_i_Ind _ _ _ _ _ Pc Pi_r Pi Pfor Pfun
+                mem_equiv_nil
+                mem_equiv_cons
+                mem_equiv_mkI
+                mem_equiv_assgn
+                mem_equiv_opn
+                mem_equiv_if_true
+                mem_equiv_if_false
+                mem_equiv_while_true
+                mem_equiv_while_false
+                mem_equiv_for
+                mem_equiv_for_nil
+                mem_equiv_for_cons
+                mem_equiv_call
+                mem_equiv_proc).
 Qed.
 
-End STACK_STABLE.
+Lemma sem_call_mem_equiv m1 fn vargs m2 vres :
+  sem_call P ev m1 fn vargs m2 vres → m1 ≡ m2.
+Proof.
+  by apply
+    (@sem_call_Ind _ _ _ _ _ Pc Pi_r Pi Pfor Pfun
+                   mem_equiv_nil
+                   mem_equiv_cons
+                   mem_equiv_mkI
+                   mem_equiv_assgn
+                   mem_equiv_opn
+                   mem_equiv_if_true
+                   mem_equiv_if_false
+                   mem_equiv_while_true
+                   mem_equiv_while_false
+                   mem_equiv_for
+                   mem_equiv_for_nil
+                   mem_equiv_for_cons
+                   mem_equiv_call
+                   mem_equiv_proc).
+Qed.
+
+End MEM_EQUIV.
+
+Lemma sem_stack_stable_uprog (p : uprog) (ev : unit) s1 c s2 :
+  sem p ev s1 c s2 -> stack_stable (emem s1) (emem s2).
+Proof.
+  apply sem_mem_equiv => {s1 c s2}.
+  by move=> s1 s2 m2 ef /= [<-].
+Qed.
+
+Lemma sem_validw_stable_uprog (p : uprog) (ev : unit) s1 c s2 :
+  sem p ev s1 c s2 → validw (emem s1) =2 validw (emem s2).
+Proof.
+  apply sem_mem_equiv => {s1 c s2}.
+  by move=> s1 s2 m2 ef /= [<-].
+Qed.
+
+Lemma sem_i_stack_stable_uprog (p : uprog) (ev : unit) s1 c s2 :
+  sem_i p ev s1 c s2 → stack_stable (emem s1) (emem s2).
+Proof.
+  apply sem_i_mem_equiv => {s1 c s2}.
+  by move=> s1 s2 m2 ef /= [<-].
+Qed.
+
+Lemma sem_i_validw_stable_uprog (p : uprog) (ev : unit) s1 c s2 :
+  sem_i p ev s1 c s2 → validw (emem s1) =2 validw (emem s2).
+Proof.
+  apply sem_i_mem_equiv => {s1 c s2}.
+  by move=> s1 s2 m2 ef /= [<-].
+Qed.
+
+Lemma sem_I_stack_stable_uprog (p : uprog) (ev : unit) s1 c s2 :
+  sem_I p ev s1 c s2 → stack_stable (emem s1) (emem s2).
+Proof.
+  apply sem_I_mem_equiv => {s1 c s2}.
+  by move=> s1 s2 m2 ef /= [<-].
+Qed.
+
+Lemma sem_I_validw_stable_uprog (p : uprog) (ev : unit) s1 c s2 :
+  sem_I p ev s1 c s2 → validw (emem s1) =2 validw (emem s2).
+Proof.
+  apply sem_I_mem_equiv => {s1 c s2}.
+  by move=> s1 s2 m2 ef /= [<-].
+Qed.
+
+Lemma sem_call_stack_stable_uprog (p : uprog) (ev : unit) m1 fn vargs m2 vres :
+  sem_call p ev m1 fn vargs m2 vres -> stack_stable m1 m2.
+Proof.
+  apply sem_call_mem_equiv => {m1 fn vargs m2 vres}.
+  by move=> s1 s2 m2 ef /= [<-].
+Qed.
+
+Lemma sem_call_validw_stable_uprog (p : uprog) (ev : unit) m1 fn vargs m2 vres :
+  sem_call p ev m1 fn vargs m2 vres -> validw m1 =2 validw m2.
+Proof.
+  apply sem_call_mem_equiv => {m1 fn vargs m2 vres}.
+  by move=> s1 s2 m2 ef /= [<-].
+Qed.
+
+Lemma sem_stack_stable_sprog (p : sprog) (gd : pointer) s1 c s2 :
+  sem p gd s1 c s2 -> stack_stable (emem s1) (emem s2).
+Proof.
+  apply sem_mem_equiv => {s1 c s2}.
+  move=> s1 s2 m2 ef /=; rewrite /init_stk_state /finalize_stk_mem.
+  t_xrbindP=> m1 /Memory.alloc_stackP hass [<-] /= [hss hvalid].
+  have hfss := Memory.free_stackP m2.
+  split.
+  + by apply (alloc_free_stack_stable hass hss hfss).
+  by apply (alloc_free_validw_stable hass hss hvalid).
+Qed.
+
+Lemma sem_validw_stable_sprog (p : sprog) (gd : pointer) s1 c s2 :
+  sem p gd s1 c s2 -> validw (emem s1) =2 validw (emem s2).
+Proof.
+  apply sem_mem_equiv => {s1 c s2}.
+  move=> s1 s2 m2 ef /=; rewrite /init_stk_state /finalize_stk_mem.
+  t_xrbindP=> m1 /Memory.alloc_stackP hass [<-] /= [hss hvalid].
+  have hfss := Memory.free_stackP m2.
+  split.
+  + by apply (alloc_free_stack_stable hass hss hfss).
+  by apply (alloc_free_validw_stable hass hss hvalid).
+Qed.
+
+Lemma sem_i_stack_stable_sprog (p : sprog) (gd : pointer) s1 c s2 :
+  sem_i p gd s1 c s2 -> stack_stable (emem s1) (emem s2).
+Proof.
+  apply sem_i_mem_equiv => {s1 c s2}.
+  move=> s1 s2 m2 ef /=; rewrite /init_stk_state /finalize_stk_mem.
+  t_xrbindP=> m1 /Memory.alloc_stackP hass [<-] /= [hss hvalid].
+  have hfss := Memory.free_stackP m2.
+  split.
+  + by apply (alloc_free_stack_stable hass hss hfss).
+  by apply (alloc_free_validw_stable hass hss hvalid).
+Qed.
+
+Lemma sem_i_validw_stable_sprog (p : sprog) (gd : pointer) s1 c s2 :
+  sem_i p gd s1 c s2 -> validw (emem s1) =2 validw (emem s2).
+Proof.
+  apply sem_i_mem_equiv => {s1 c s2}.
+  move=> s1 s2 m2 ef /=; rewrite /init_stk_state /finalize_stk_mem.
+  t_xrbindP=> m1 /Memory.alloc_stackP hass [<-] /= [hss hvalid].
+  have hfss := Memory.free_stackP m2.
+  split.
+  + by apply (alloc_free_stack_stable hass hss hfss).
+  by apply (alloc_free_validw_stable hass hss hvalid).
+Qed.
+
+Lemma sem_I_stack_stable_sprog (p : sprog) (gd : pointer) s1 c s2 :
+  sem_I p gd s1 c s2 -> stack_stable (emem s1) (emem s2).
+Proof.
+  apply sem_I_mem_equiv => {s1 c s2}.
+  move=> s1 s2 m2 ef /=; rewrite /init_stk_state /finalize_stk_mem.
+  t_xrbindP=> m1 /Memory.alloc_stackP hass [<-] /= [hss hvalid].
+  have hfss := Memory.free_stackP m2.
+  split.
+  + by apply (alloc_free_stack_stable hass hss hfss).
+  by apply (alloc_free_validw_stable hass hss hvalid).
+Qed.
+
+Lemma sem_I_validw_stable_sprog (p : sprog) (gd : pointer) s1 c s2 :
+  sem_I p gd s1 c s2 -> validw (emem s1) =2 validw (emem s2).
+Proof.
+  apply sem_I_mem_equiv => {s1 c s2}.
+  move=> s1 s2 m2 ef /=; rewrite /init_stk_state /finalize_stk_mem.
+  t_xrbindP=> m1 /Memory.alloc_stackP hass [<-] /= [hss hvalid].
+  have hfss := Memory.free_stackP m2.
+  split.
+  + by apply (alloc_free_stack_stable hass hss hfss).
+  by apply (alloc_free_validw_stable hass hss hvalid).
+Qed.
+
+Lemma sem_call_stack_stable_sprog (p : sprog) (gd : pointer) m1 fn vargs m2 vres :
+  sem_call p gd m1 fn vargs m2 vres -> stack_stable m1 m2.
+Proof.
+  apply sem_call_mem_equiv => {m1 fn vargs m2 vres}.
+  move=> s1 s2 m2 ef /=; rewrite /init_stk_state /finalize_stk_mem.
+  t_xrbindP=> m1 /Memory.alloc_stackP hass [<-] /= [hss hvalid].
+  have hfss := Memory.free_stackP m2.
+  split.
+  + by apply (alloc_free_stack_stable hass hss hfss).
+  by apply (alloc_free_validw_stable hass hss hvalid).
+Qed.
+
+Lemma sem_call_validw_stable_sprog (p : sprog) (gd : pointer) m1 fn vargs m2 vres :
+  sem_call p gd m1 fn vargs m2 vres ->
+  validw m1 =2 validw m2.
+Proof.
+  apply sem_call_mem_equiv => {m1 fn vargs m2 vres}.
+  move=> s1 s2 m2 ef /=; rewrite /init_stk_state /finalize_stk_mem.
+  t_xrbindP=> m1 /Memory.alloc_stackP hass [<-] /= [hss hvalid].
+  have hfss := Memory.free_stackP m2.
+  split.
+  + by apply (alloc_free_stack_stable hass hss hfss).
+  by apply (alloc_free_validw_stable hass hss hvalid).
+Qed.
+
+End STACK_VALIDW_STABLE.
+
+(* TODO: move? *)
+Lemma pword_of_wordE sz (w: word sz) e :
+  {| pw_size := sz ; pw_word := w ; pw_proof := e |} = pword_of_word w.
+Proof.
+    by rewrite (Eqdep_dec.UIP_dec Bool.bool_dec e (cmp_le_refl _)).
+Qed.
 
 (** The semantics is deterministic. *)
 Section DETERMINISM.

--- a/proofs/lang/type.v
+++ b/proofs/lang/type.v
@@ -232,6 +232,12 @@ Definition is_sarr t :=
   | _      => false
   end.
 
+Lemma is_sarrP ty : reflect (exists n, ty = sarr n) (is_sarr ty).
+Proof.
+  case: ty => /= [||n|ws]; constructor; try by move => -[].
+  by exists n.
+Qed.
+
 Definition is_word_type (t:stype) :=
   if t is sword sz then Some sz else None.
 

--- a/proofs/lang/var.v
+++ b/proofs/lang/var.v
@@ -514,6 +514,18 @@ Proof.
   SvD.fsetdec.
 Qed.
 
+Lemma disjointP s1 s2 :
+  reflect (forall x, Sv.In x s1 -> ~ Sv.In x s2) (disjoint s1 s2).
+Proof.
+  case: (@idP (disjoint s1 s2)) => hdisj; constructor.
+  + move=> x h1 h2.
+    move: hdisj; rewrite /disjoint => /Sv.is_empty_spec /(_ x) /Sv.inter_spec.
+    by apply.
+  move=> h; apply: hdisj.
+  rewrite /disjoint.
+  by apply /Sv.is_empty_spec => x /Sv.inter_spec []; apply h.
+Qed.
+
 Lemma disjoint_diff A B :
   disjoint A B →
   Sv.Equal (Sv.diff B A) B.


### PR DESCRIPTION
Here it is!

Apart from the main changes (in stack_alloc.v, stack_alloc_proof.v and stack_alloc_proof_2.v), I pushed changes in common files (psem.v, memory_model.v, ...). These changes are probably more important to review than the main ones.

Here are a few questions and points to closely look at:
- there are two files stack_alloc_proof.v and stack_alloc_proof_2.v only because the initial file was becoming too big (cf. paragraph at the top of stack_alloc_proof_2.v). Should we keep two different files or should I merge them?
- I performed a renaming `pointer` -> `ptr` for the sake of uniformity with `Uptr` and `sptr` (introduced in stack_alloc_proof.v because I don't know where to put it). But is it worth the trouble?
- Among the changes I made to memory_model.v, I proved `top_stack_after_aligned_alloc` instead of assuming it and proving it in `memory_example.v` because it turned out the definition of `top_stack_after_alloc` was precise enough to make the proof directly. I also moved `top_stack_after_alloc_bounded` from memory_example.v to memory_model.v. Actually, I wonder whether there are other parts that could be proved instead of assumed (`ass_above_limit`, `ass_fresh`)?
- I added a `-1` to `alloc_stack_complete` and `top_stack_after_alloc_bounded` because this is true and more precise.
- there are now two proofs called `writeP_neq` (in memory_model.v and low_memory.v). The one in low_memory.v should be easier to use (and shadows the other one). File linear_proof.v was using `writeP_neq` from memory_model.v. I chose the simple solution of using the longer name `CoreMem.writeP_neq` to still use this one, but maybe the right fix would be to use the other `writeP_neq`.
- I changed the priority of some type class instances, so that they do not hide more natural instances.

I can of course explain some points if some choices seem questionable (actually, until the end of week, because I'm going on vacation on Saturday). But this is not urgent, so take the time needed to review this. It can wait until I am back from vacation if needed. I have already rebased this PR a few times, so I can do it again, the effort is small.