### PR TITLE
Do not export global variables

### DIFF
--- a/compiler/scripts/compile-and-assemble
+++ b/compiler/scripts/compile-and-assemble
@@ -5,6 +5,7 @@ set -e
 DIR=$(mktemp -d jasminXXXXXX)
 ASM=${DIR}/jasmin.s
 OBJ=${DIR}/jasmin.o
+DLL=${DIR}/jasmin.so
 
 trap "rm -r ${DIR}" EXIT
 
@@ -12,3 +13,4 @@ set -x
 
 $(dirname $0)/../jasminc.native -o ${ASM} "$@"
 cc -c -o ${OBJ} ${ASM}
+cc -shared -o ${DLL} ${OBJ}

--- a/compiler/src/ppasm.ml
+++ b/compiler/src/ppasm.ml
@@ -335,8 +335,6 @@ let pp_glob_def fmt (gd:Global.glob_decl) : unit =
   let z = Prog.clamp ws z in
   let m = mangle n in
   pp_gens fmt ([
-    `Instr (".globl", [m]);
-    `Instr (".globl", [n]);
     `Instr (".p2align", [pp_align ws]);
     `Label m;
     `Label n


### PR DESCRIPTION
Currently, Jasmin programs that use global variables cannot be dynamically linked (at least on Linux with GCC and GNU binutils). I don’t understand all the details, but the linker complains: “relocation R_X86_64_PC32 against symbol `g' can not be used when making a shared object”.

Maybe we could allow global data to be tagged as `export` to get the current behavior (name is accessible from other compilation units, but only static linking is possible).