### PR TITLE
Update EC semantics for VPEXTR instruction

### DIFF
--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -132,13 +132,6 @@ op mulu64 (w1 w2 : W64.t) =
   (W2u32.zeroextu64 (W2u32.truncateu32 w2)).
 
 (* -------------------------------------------------------------------- *)
-
-(* FIXME it is really the semantics? In particular the last if *)
-op VPEXTR_64 (w:W128.t) (i:W8.t) =
-  if W8.to_uint i = 0 then (w \bits64 0)
-  else if W8.to_uint i = 1 then (w \bits64 1)
-  else W64.of_int 0.
-
 op VMOV_32 (v:W32.t) =
   pack4 [v; W32.zero; W32.zero; W32.zero].
 

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -2233,7 +2233,9 @@ abstract theory W_WS.
 
    op VPMINS_'Ru'S (w1 : WB.t) (w2 : WB.t) = 
      map2 (fun x y => if WS.to_sint x < WS.to_sint y then x else y) w1 w2.
- 
+
+  op VPEXTR_'S (w: WB.t) (i: W8.t) = w \bits'S (W8.to_uint i).
+
    (** TODO CHECKME : still x86 **)
    lemma x86_'Ru'S_rol_xor i w : 0 < i < sizeS =>
       VPSLL_'Ru'S w (W8.of_int i) +^ VPSRL_'Ru'S w (W8.of_int (sizeS - i)) =


### PR DESCRIPTION
- Update EC semantics specification for the VPEXTR instruction 
- Add support for `VPEXTRB` (VPEXTR_8) and `VPEXTRD` (VPEXTR_32)