### PR TITLE
EC semantics

### DIFF
--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -367,16 +367,21 @@ abbrev [-printing] VPBLEND_16u16 = VPBLENDW_256.
 abbrev [-printing] VPBLEND_8u32 = VPBLENDD_256.
 
 (* ------------------------------------------------------------------- *)
-op VPMOVMSKB_128 (v: W128.t) : W16.t =
-  let vb = W16u8.to_list v in
-  W16.bits2w (map W8.msb vb).
+op VPMOVMSKB_u128_u32 (v: W128.t) =
+   let vb = W16u8.to_list v in
+   W32.bits2w (map W8.msb vb).
 
-op VPMOVMSKB_256 (v: W256.t) : W32.t =
+op VPMOVMSKB_u128_u64 (v: W128.t) =
+   let vb = W16u8.to_list v in
+   W64.bits2w (map W8.msb vb).
+
+op VPMOVMSKB_u256_u32 (v: W256.t) =
   let vb = W32u8.to_list v in
   W32.bits2w (map W8.msb vb).
 
-abbrev [-printing] VPMOVMSKB_u128_u16 = VPMOVMSKB_128.
-abbrev [-printing] VPMOVMSKB_u256_u32 = VPMOVMSKB_256.
+op VPMOVMSKB_u256_u64 (v: W256.t) =
+  let vb = W32u8.to_list v in
+  W64.bits2w (map W8.msb vb).
 
 (* ------------------------------------------------------------------- *)
 op VMOVLPD (v: W128.t) : W64.t =

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -190,8 +190,14 @@ op permd (v: W256.t) (i: W32.t) : W32.t =
 op VPERMD (w: W256.t) (i: W256.t) : W256.t =
   map (permd w) i.
 
+(* ------------------------------------------------------------------- *)
 op VEXTRACTI128 (w:W256.t) (i:W8.t) : W128.t =
   w \bits128 b2i i.[0].
+
+
+op VINSERTI128 (w:W256.t) (x: W128.t) (i:W8.t): W256.t =
+  let i = W8.to_uint i %% 2 in
+  pack2 (map (fun j => if j = i then x else w \bits128 j) [0;1]).
 
 (* ------------------------------------------------------------------- *)
 op interleave_gen ['elem]

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -1683,6 +1683,8 @@ theory W8.
 
   op (`|>>`) (w1 w2 : W8.t) = sar w1 (to_uint w2 %% size).
 
+  op SETcc (b: bool) = b ? W8.one : W8.zero.
+
   theory SHIFT.
 
   op shift_mask i = to_uint i %% 32.

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -2236,7 +2236,7 @@ abstract theory W_WS.
    op VPMINS_'Ru'S (w1 : WB.t) (w2 : WB.t) = 
      map2 (fun x y => if WS.to_sint x < WS.to_sint y then x else y) w1 w2.
 
-  op VPEXTR_'S (w: WB.t) (i: W8.t) = w \bits'S (W8.to_uint i).
+   op VPEXTR_'S (w: WB.t) (i: W8.t) = w \bits'S (W8.to_uint i).
 
    (** TODO CHECKME : still x86 **)
    lemma x86_'Ru'S_rol_xor i w : 0 < i < sizeS =>


### PR DESCRIPTION
- EC semantics for the `SETcc` instruction
- Update EC semantics for the `VPMOVMSKB`  instruction to support more destination sizes
- EC semantics for the `VINSERTI128` instruction