### PR TITLE
Use Coq 8.12 and Mathcomp 1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ compiler/src/CIL/*.mli
 *.cmx[as]
 *.annot
 *.vo
+*.vok
+*.vos
 *.vio
 *.cache
 *.bak

--- a/coqword.nix
+++ b/coqword.nix
@@ -9,7 +9,7 @@ let mathcomp =
  ).algebra
 ; in
 
-let rev = "7c650450e03310ca67bdccb64c95be82116945c7"; in
+let rev = "131bee8a1c14a67a4925534e455ea0b870ee0615"; in
 
 stdenv.mkDerivation rec {
   version = "0.0-git-${builtins.substring 0 8 rev}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "jasmin-lang";
     repo = "coqword";
     inherit rev;
-    sha256 = "1b4p67599s6cqbs3r1pd736dq5zivvi3w8wbl4dhcg6mnzbgvkyg";
+    sha256 = "196w51biq9wagbr0dkjd2v2z16nf6sz0yy5r4q1mgnpdld0rs9m1";
   };
 
   buildInputs = [ coq ];

--- a/coqword.nix
+++ b/coqword.nix
@@ -4,12 +4,12 @@ let inherit (coqPackages) coq; in
 
 let mathcomp =
  (if coqPackages ? mathcomp_
-  then coqPackages.mathcomp_ "1.10.0"
-  else coqPackages.mathcomp.override { version = "1.10.0"; }
+  then coqPackages.mathcomp_ "1.11.0"
+  else coqPackages.mathcomp.override { version = "1.11.0"; }
  ).algebra
 ; in
 
-let rev = "4b83cbe911364a39b4f87ea2451b5a6119cbca06"; in
+let rev = "7c650450e03310ca67bdccb64c95be82116945c7"; in
 
 stdenv.mkDerivation rec {
   version = "0.0-git-${builtins.substring 0 8 rev}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "jasmin-lang";
     repo = "coqword";
     inherit rev;
-    sha256 = "0235qgjzdjjci1b8h85y16g8akrl0mgdm799lnhf4givx0d90hzv";
+    sha256 = "1b4p67599s6cqbs3r1pd736dq5zivvi3w8wbl4dhcg6mnzbgvkyg";
   };
 
   buildInputs = [ coq ];

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ with pkgs;
 
 let inherit (lib) optionals; in
 
-let coqPackages = coqPackages_8_9; in
+let coqPackages = coqPackages_8_12; in
 
 let coqword = callPackage ./coqword.nix { inherit coqPackages; }; in
 

--- a/proofs/3rdparty/ssrring.v
+++ b/proofs/3rdparty/ssrring.v
@@ -21,6 +21,8 @@ Local Notation simpm := Monoid.simpm.
 Require Import NArith ZArith BinPos Ring_polynom Field_theory.
 
 (* -------------------------------------------------------------------- *)
+Declare Scope ssring.
+
 Reserved Notation "x %:S" (at level 2, left associativity, format "x %:S").
 
 Notation "c %:S"   := (PEc c)     : ssring.
@@ -37,6 +39,8 @@ Notation "1" := PEI : ssring.
 Delimit Scope ssring with S.
 
 (* -------------------------------------------------------------------- *)
+Declare Scope ssfield.
+
 Notation "c %:S"   := (FEc c)     : ssfield.
 Notation "''X_' i" := (FEX _ i)   : ssfield.
 Notation "x + y"   := (FEadd x y) : ssfield.

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -4,6 +4,12 @@
 -arg -extraction-reserved-identifier
 -arg -w
 -arg -extraction-opaque-accessed
+-arg -w
+-arg -ambiguous-paths
+-arg -w
+-arg -duplicate-clear
+-arg -w
+-arg -omega-is-deprecated
 
 -R 3rdparty Jasmin
 -R compiler Jasmin

--- a/proofs/compiler/lowering.v
+++ b/proofs/compiler/lowering.v
@@ -553,7 +553,7 @@ Variant opn_5flags_cases_t (a: pexprs) : Type :=
 | Opn5f_other.
 
 Arguments Opn5f_large_immed [a] {x y n z} _ _.
-Arguments Opn5f_other [a].
+Arguments Opn5f_other {a}.
 
 Definition check_signed_range (m: option wsize) sz' (n: Z) : bool :=
   if m is Some ws then (

--- a/proofs/compiler/lowering_proof.v
+++ b/proofs/compiler/lowering_proof.v
@@ -388,7 +388,7 @@ Section PROOF.
   by case: o => // -[] // => [ | | [] | [] | [] | [] ] sz [] _ <- <-.
   Qed.
 
-  Lemma between_ZR (a b c: ssrZ.Z_numType) :
+  Lemma between_ZR (a b c: Z) :
     (a <= b < c)%R →
     (a <= b < c)%Z.
   Proof. by case/andP => /ssrZ.lezP ? /ssrZ.ltzP. Qed.
@@ -397,7 +397,7 @@ Section PROOF.
     wle Unsigned β α = (wunsigned (β - α) != (wunsigned β - wunsigned α)%Z) || (β == α).
   Proof.
   case: (β =P α).
-  + by move => <-; rewrite orbT /= Num.Theory.lerr.
+  + by move => <-; rewrite orbT /= Order.POrderTheory.lexx.
   rewrite orbF /wunsigned /=.
   case: α β => α hα [] β hβ ne'.
   Transparent word.
@@ -527,7 +527,7 @@ Section PROOF.
       rewrite /vsf /SF_of_word /vof; f_equal.
       set α := zero_extend _ w1; set β := zero_extend _ w2.
       case: (α =P β).
-      - by move => <-; rewrite GRing.subrr msb0 wsigned0 Z.sub_diag /= Num.Theory.lerr.
+      - by move => <-; rewrite GRing.subrr msb0 wsigned0 Z.sub_diag /= Order.POrderTheory.lexx.
       exact: wlesE.
     (* Cond2 CondNeq *)
     + case: o He => // [] // [] // [] sz' //=.
@@ -544,7 +544,7 @@ Section PROOF.
       rewrite /vsf /SF_of_word /vof; f_equal.
       set α := zero_extend _ w1; set β := zero_extend _ w2.
       case: (α =P β).
-      + by move => <-; rewrite /= Num.Theory.ltrr GRing.subrr Z.sub_diag wsigned0 msb0.
+      + by move => <-; rewrite /= Order.POrderTheory.ltxx GRing.subrr Z.sub_diag wsigned0 msb0.
       exact: wltsE.
     (* Cond2 CondOr *)
     + case: o He => // [] // [] // [] sz' //=.
@@ -589,7 +589,7 @@ Section PROOF.
       rewrite /vzf /ZF_of_word /vsf /SF_of_word /vof GRing.subr_eq0; f_equal.
       set α := zero_extend _ w1; set β := zero_extend _ w2.
       case: (α =P β).
-      - move => ->; exact: Num.Theory.lerr.
+      - move => ->; exact: Order.POrderTheory.lexx.
       exact: wlesE'.
     (* Cond3 CondAndNotEq *)
     + case: o He => // [] // [] // [] sz' //=.
@@ -607,7 +607,7 @@ Section PROOF.
       + rewrite /vzf /vsf /vof /ZF_of_word /SF_of_word GRing.subr_eq0; f_equal.
         set α := zero_extend _ w1; set β := zero_extend _ w2.
         case: (α =P _).
-        * by move => -> /=; exact: Num.Theory.ltrr.
+        * by move => -> /=; exact: Order.POrderTheory.ltxx.
         exact: wltsE'.
   Qed.
 

--- a/proofs/lang/strings.v
+++ b/proofs/lang/strings.v
@@ -210,6 +210,7 @@ Module CmpString.
 End CmpString.
 
 Module Ms := Mmake CmpString.
+Declare Scope mstring_scope.
 Delimit Scope mstring_scope with ms.
 Notation "m .[ x ]" := (@Ms.get _ m x) : mstring_scope.
 Notation "m .[ x  <- v ]" := (@Ms.set _ m x v) : mstring_scope.

--- a/proofs/lang/type.v
+++ b/proofs/lang/type.v
@@ -208,6 +208,7 @@ Proof. by elim: n=> // p0 /= ->. Qed.
 
 Module Mt := DMmake CmpStype CEDecStype.
 
+Declare Scope mtype_scope.
 Delimit Scope mtype_scope with mt.
 Notation "m .[ x ]" := (@Mt.get _ m x) : mtype_scope.
 Notation "m .[ x  <- v ]" := (@Mt.set _ m x v) : mtype_scope.

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -698,6 +698,7 @@ Section CMP.
 
 End CMP.
 
+Declare Scope cmp_scope.
 Notation "m < n" := (cmp_lt m n) : cmp_scope.
 Notation "m <= n" := (cmp_le m n) : cmp_scope.
 Notation "m ≤ n" := (cmp_le m n) : cmp_scope.

--- a/proofs/lang/var.v
+++ b/proofs/lang/var.v
@@ -335,6 +335,7 @@ Definition pair2var (p:stype * ident) := Var (fst p) (snd p).
 
 Lemma codeK_var : cancel var2pair pair2var. Proof. by rewrite /cancel; case => //. Qed.
 
+Declare Scope mvar_scope.
 Delimit Scope mvar_scope with mv.
 Notation "vm .[ x ]" := (@Mv.get _ vm x) : mvar_scope.
 Notation "vm .[ x  <- v ]" := (@Mv.set _ vm x v) : mvar_scope.
@@ -401,6 +402,7 @@ Module Fv : FvT.
 
 End Fv.
 
+Declare Scope vmap_scope.
 Delimit Scope vmap_scope with vmap.
 Notation "vm .[ id ]" := (Fv.get vm id) : vmap_scope.
 Notation "vm .[ k  <- v ]" := (@Fv.set _ vm k v) : vmap_scope.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -40,7 +40,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GRing.Theory Num.Theory.
+Import GRing.Theory Num.Theory Order.POrderTheory Order.TotalTheory.
+Import ssrnat.
 
 Local Open Scope Z_scope.
 
@@ -425,13 +426,13 @@ Proof. by rewrite /wsar /asr Z.shiftr_0_r sreprK. Qed.
 Lemma wltuE' sz (α β: word sz) :
   wlt Unsigned α β = (wunsigned (β - α) == (wunsigned β - wunsigned α)%Z) && (β != α).
 Proof.
-by rewrite -[X in X && _]negbK -wltuE /= -lerNgt andbC eq_sym -ltr_neqAle.
+by rewrite -[X in X && _]negbK -wltuE /= -leNgt andbC eq_sym -lt_neqAle.
 Qed.
 
 Lemma wleuE sz (w1 w2: word sz) :
   wle Unsigned w1 w2 = (wunsigned (w2 - w1) == (wunsigned w2 - wunsigned w1))%Z.
 Proof.
-rewrite /= ler_eqVlt -/(wlt Unsigned _ _) wltuE'.
+rewrite /= le_eqVlt -/(wlt Unsigned _ _) wltuE'.
 rewrite orb_andr /= [w2 == w1]eq_sym orbN andbT.
 by rewrite orb_idl // => /eqP /val_inj ->; rewrite subZE !subrr.
 Qed.
@@ -447,42 +448,42 @@ rewrite !CoqWord.word.msbE /= !subZE; set w := (_ sz);
 + rewrite ltr_add2r eq_sym eqb_id negbK opprB !addrA subrK.
   rewrite [val (α - β)%R]subw_modE /urepr /= -/w.
   case: ltrP; first by rewrite addrK eqxx.
-  by rewrite addr0 ltr_eqF // ltr_subl_addr ltr_addl modulus_gt0.
+  by rewrite addr0 lt_eqF // ltr_subl_addr ltr_addl modulus_gt0.
 + rewrite ltr_add2r opprB !addrA subrK eq_sym eqbF_neg negbK.
   rewrite [val (α - β)%R]subw_modE /urepr -/w /=; case: ltrP.
-  + by rewrite mulr1n gtr_eqF // ltr_addl modulus_gt0.
+  + by rewrite mulr1n gt_eqF // ltr_addl modulus_gt0.
   + by rewrite addr0 eqxx.
-+ rewrite ltr_subl_addr (ltr_le_trans (urepr_ltmod _)); last first.
++ rewrite ltr_subl_addr (lt_le_trans (urepr_ltmod _)); last first.
     by rewrite ler_addr urepr_ge0.
   rewrite eq_sym eqb_id negbK; apply/esym.
-  rewrite [val _]subw_modE /urepr -/w /= ltrNge ltrW /=.
+  rewrite [val _]subw_modE /urepr -/w /= ltNge ltW /=.
   * by rewrite addr0 addrAC eqxx.
-  * by rewrite (ltr_le_trans hb).
-+ rewrite ltr_subl_addr (ltr_le_trans (urepr_ltmod _)); last first.
+  * by rewrite (lt_le_trans hb).
++ rewrite ltr_subl_addr (lt_le_trans (urepr_ltmod _)); last first.
     by rewrite ler_addr urepr_ge0.
   rewrite eq_sym eqbF_neg negbK [val _]subw_modE /urepr -/w /=.
-  rewrite ltrNge ltrW ?addr0; last first.
-    by rewrite (ltr_le_trans hb).
-  by rewrite addrAC gtr_eqF // ltr_subl_addr ltr_addl modulus_gt0.
-+ rewrite ltr_subr_addl ltrNge ltrW /=; last first.
-    by rewrite (ltr_le_trans (urepr_ltmod _)) // ler_addl urepr_ge0.
+  rewrite ltNge ltW ?addr0; last first.
+    by rewrite (lt_le_trans hb).
+  by rewrite addrAC gt_eqF // ltr_subl_addr ltr_addl modulus_gt0.
++ rewrite ltr_subr_addl ltNge ltW /=; last first.
+    by rewrite (lt_le_trans (urepr_ltmod _)) // ler_addl urepr_ge0.
   apply/esym/negbTE; rewrite negbK; apply/eqP/esym.
   rewrite [val _]subw_modE /urepr /= -/w; have ->/=: (val α < val β)%R.
     by have := ltr_le_add ha hb; rewrite addrC ltr_add2l.
-  rewrite mulr1n addrK opprD addrA ltr_eqF //= opprK.
+  rewrite mulr1n addrK opprD addrA lt_eqF //= opprK.
   by rewrite ltr_addl modulus_gt0.
-+ rewrite ltr_subr_addl ltrNge ltrW /=; last first.
-    by rewrite (ltr_le_trans (urepr_ltmod _)) // ler_addl urepr_ge0.
++ rewrite ltr_subr_addl ltNge ltW /=; last first.
+    by rewrite (lt_le_trans (urepr_ltmod _)) // ler_addl urepr_ge0.
   apply/esym/negbTE; rewrite negbK eq_sym eqbF_neg negbK.
   rewrite [val _]subw_modE /urepr -/w /= opprD addrA opprK.
-  by have ->//: (val α < val β)%R; apply/(ltr_le_trans ha).
+  by have ->//: (val α < val β)%R; apply/(lt_le_trans ha).
 + rewrite [val (α - β)%R](subw_modE α β) -/w /urepr /=.
   rewrite eq_sym eqb_id negbK; case: ltrP.
   * by rewrite mulr1n addrK eqxx.
-  * by rewrite addr0 ltr_eqF // ltr_subl_addr ltr_addl modulus_gt0.
+  * by rewrite addr0 lt_eqF // ltr_subl_addr ltr_addl modulus_gt0.
 + rewrite [val (α - β)%R](subw_modE α β) -/w /urepr /=.
   rewrite eq_sym eqbF_neg negbK; case: ltrP.
-  * by rewrite mulr1n gtr_eqF // ltr_addl modulus_gt0.
+  * by rewrite mulr1n gt_eqF // ltr_addl modulus_gt0.
   * by rewrite addr0 eqxx.
 Qed.
 
@@ -490,13 +491,13 @@ Lemma wlesE' sz (α β: word sz) : α ≠ β →
   wle Signed α β = (msb (α - β) != (wsigned (α - β) != (wsigned α - wsigned β)%Z)).
 Proof.
 move=> ne_ab; suff ->: wle Signed α β = wlt Signed α β by rewrite wltsE.
-by move=> /=; rewrite ler_eqVlt orb_idl // => /eqP /srepr_inj.
+by move=> /=; rewrite le_eqVlt orb_idl // => /eqP /srepr_inj.
 Qed.
 
 Lemma wltsE' sz (α β: word sz) : α ≠ β →
   wlt Signed β α = (msb (α - β) == (wsigned (α - β) != (wsigned α - wsigned β)%Z)).
 Proof.
-have ->: wlt Signed β α = ~~ (wle Signed α β) by rewrite /= ltrNge.
+have ->: wlt Signed β α = ~~ (wle Signed α β) by rewrite /= ltNge.
 by move=> ne_ab; rewrite wlesE' // negbK.
 Qed.
 
@@ -504,7 +505,7 @@ Lemma wlesE sz (α β: word sz) : α ≠ β →
   wle Signed β α = (msb (α - β) == (wsigned (α - β) != (wsigned α - wsigned β)%Z)).
 Proof.
 move=> ne_ab; suff ->: wle Signed β α = wlt Signed β α by rewrite wltsE'.
-by move=> /=; rewrite ler_eqVlt orb_idl // => /eqP /srepr_inj /esym.
+by move=> /=; rewrite le_eqVlt orb_idl // => /eqP /srepr_inj /esym.
 Qed.
 
 (* -------------------------------------------------------------------*)
@@ -787,7 +788,7 @@ Proof.
   rewrite {1}/wbit_n /wunsigned mkwordK.
   rewrite /CoqWord.word.wbit /modulus two_power_nat_equiv.
   rewrite Z.mod_pow2_bits_low //.
-  have /ssrnat.leP := ltn_ord i.
+  have /leP := ltn_ord i.
   lia.
 Qed.
 

--- a/proofs/ssrmisc/oseq.v
+++ b/proofs/ssrmisc/oseq.v
@@ -187,6 +187,7 @@ Qed.
 
 (* -------------------------------------------------------------------- *)
 
+Declare Scope option_scope.
 Delimit Scope option_scope with O.
 
 Notation "m >>= f" := (ssrfun.Option.bind f m)


### PR DESCRIPTION
This updates Jasmin to make it compatible with Coq 8.12 and math-comp 1.11 (and only these versions). It implicitly updates the OCaml dependency to 4.10.

Using math-comp 1.12 is not currently possible due to a bug affecting all released versions of Coq (https://github.com/coq/coq/issues/13581). Said bug shall be fixed in future version 8.14.0 of Coq (https://github.com/coq/coq/pull/13624). Note that the patch that fixes the Coq bug can be applied as-is to Coq 8.12.2.