### PR TITLE
Arrays in pretyping

### DIFF
--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1337,9 +1337,7 @@ let rec tt_instr (env : Env.env) (pi : S.pinstr) : unit P.pinstr  =
       let ety =
         match vty with
         | None -> ety
-        | Some vty -> match max_ty ety vty with
-          | Some ty -> ty
-          | None -> rs_tyerror ~loc:(L.loc pi) (TypeMismatch (ety, vty))
+        | Some vty -> vty
       in
       let v = flv ety in
       let tg =


### PR DESCRIPTION
A strange piece of code in pretyping was making a program fail to typecheck too early (i.e. before param expansion). Moreover it was also rejecting such an example:
```
fn f () -> reg u32 {
  reg u32 r;
  inline int r2;
  r = 17;
  r2 = r;
  return r;
}
```
by mistyping the equality `r2 = r`. So it seems it is really buggy.