### PR TITLE
Pretyping: keep the error when OnlyParam

### DIFF
--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -582,9 +582,8 @@ let tt_var_global (mode:tt_mode) (env : Env.env) v =
   let lc = v.L.pl_loc in
   let x, k = 
     try tt_var mode env v, E.Slocal
-    with TyError _ -> 
+    with TyError _ when mode <> `OnlyParam ->
       let x = v.L.pl_desc in
-      if mode = `OnlyParam then rs_tyerror ~loc:lc (UnknownVar x);
       match Env.Globals.find x env with
       | Some v -> v, E.Sglob
       | None -> rs_tyerror ~loc:lc (UnknownVar x) in

--- a/compiler/tests/fail/typing/only_param.jazz
+++ b/compiler/tests/fail/typing/only_param.jazz
@@ -1,0 +1,4 @@
+export fn main () {
+  reg u64 x;
+  reg u64[x] a;
+}


### PR DESCRIPTION
We catch an exception and in some cases reemit a different one. I think it is better not to catch it in these cases (which means the original exception is displayed to the user).