### PR TITLE
Safety checker: fix alignment constraints for direct array accesses

### DIFF
--- a/compiler/safety/success/array-direct.jazz
+++ b/compiler/safety/success/array-direct.jazz
@@ -1,0 +1,28 @@
+export
+fn array_direct() -> reg u256 {
+
+  stack u8[32] a;
+  reg u8 b;
+  reg u64 q;
+  reg u256 y;
+  inline int i;
+  i = 0;
+  b = 0;
+  q = 0;
+  y = #set0_256();
+  a.[u256 0] = y;
+  a.[u8 0] = b;
+  a.[u8 i] = b;
+  a.[u64 0] = q;
+  a.[u64 i] = q;
+  a.[u8 (int)q] = b;
+  a.[u64 i + 8] = q;
+  a.[u64 8 * (i + 1)] = q;
+  a.[u64 (i + 1) * 8] = q;
+  a.[u64 i * 8 + 8] = q;
+  a.[u8 (int)(q + 1)] = b;
+  a.[u8 (int)q + 1] = b;
+
+  y = a.[u256 0];
+  return y;
+}

--- a/compiler/src/safety/safetyInterpreter.ml
+++ b/compiler/src/safety/safetyInterpreter.ml
@@ -226,7 +226,7 @@ let arr_aligned access ws e = match access with
   | Warray_.AAdirect ->
      begin match e with
      | Papp1 (Oint_of_word U64, e) -> [AlignedExpr (ws, e)]
-     | _ -> [AlignedExpr (ws, e)]
+     | _ -> [AlignedExpr (ws, Papp1 (Oword_of_int U64, e))]
      end
 
 (*------------------------------------------------------------*)


### PR DESCRIPTION
Currently, the safety checker crashes when verifying alignment constraints of “direct” (not scaled) array accesses.
