### PR TITLE
Reject programs that attempt to write a constant pointer during typing

### DIFF
--- a/compiler/tests/fail/typing/write_constant_pointer_direct_array.jazz
+++ b/compiler/tests/fail/typing/write_constant_pointer_direct_array.jazz
@@ -1,0 +1,8 @@
+export
+fn main() -> reg u64{
+  reg u64 a;
+  reg const ptr u64[1] p;
+  p[0] = 1;
+  a = p[0];
+  return a;
+}

--- a/compiler/tests/fail/typing/write_constant_pointer_direct_var.jazz
+++ b/compiler/tests/fail/typing/write_constant_pointer_direct_var.jazz
@@ -1,0 +1,10 @@
+export
+fn main() -> reg u64{
+  reg u64 a;
+  stack u64[1] s;
+  reg const ptr u64[1] p;
+  s[0] = 42;
+  p = s;
+  a = s[0];
+  return a;
+}

--- a/compiler/tests/fail/typing/write_constant_pointer_subproc_array.jazz
+++ b/compiler/tests/fail/typing/write_constant_pointer_subproc_array.jazz
@@ -1,0 +1,17 @@
+fn foo (reg ptr u64[3] px) -> reg u64 {
+  px[0] = 1;
+  px[1] = 0;
+  px[2] = 8;
+  reg u64 res_x;
+  res_x = px[0];
+  return res_x;
+}
+
+export fn main () -> reg u64 {
+  stack u64[3] x;
+  reg u64 res;
+  x[0] = 41;
+  _ = foo(x);
+  res = x[0];
+  return res;
+}

--- a/compiler/tests/fail/typing/write_constant_pointer_subproc_var.jazz
+++ b/compiler/tests/fail/typing/write_constant_pointer_subproc_var.jazz
@@ -1,0 +1,17 @@
+fn foo (reg ptr u64[3] px) -> reg u64 {
+  reg u64 res_x;
+  stack u64[3] y;
+  px = y;
+  y[0] = 666;
+  res_x = px[0];
+  return res_x;
+}
+
+export fn main () -> reg u64 {
+  stack u64[3] x;
+  reg u64 res;
+  x[0] = 41;
+  _ = foo(x);
+  res = x[0];
+  return res;
+}


### PR DESCRIPTION
Pointers that aren't returned are inferred to be constant; any attempt at
writing to such a pointer should be considered an error.

Closes #81.