### PR TITLE
Pretty-print intermediate programs in correct Jasmin syntax

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -20,7 +20,7 @@ JSJOBS    ?= 2
 CHECKPY   ?=
 CHECK     := $(CHECKPY) scripts/runtest --jobs="$(JSJOBS)"
 CHECK     += config/tests.config
-CHECKCATS ?= all safety nolea
+CHECKCATS ?= all safety nolea print
 
 # --------------------------------------------------------------------
 PREFIX ?= /usr/local

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -13,3 +13,7 @@ kodirs = !safety/fail
 [test-all]
 okdirs = examples examples/gimli tests/success
 kodirs = tests/fail
+
+[test-print]
+bin = ./scripts/parse-print-parse
+okdirs = tests/success

--- a/compiler/scripts/parse-print-parse
+++ b/compiler/scripts/parse-print-parse
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+DIR=$(mktemp -d jasminXXXXXX)
+OUT=${DIR}/jasmin.jazz
+
+trap "rm -r ${DIR}" EXIT
+
+set -x
+
+# Check that no printer crashes
+$(dirname $0)/../jasminc.native -pall "$@" >/dev/null
+# Pretty-print the program before compilation
+$(dirname $0)/../jasminc.native -ptyping "$@" > ${OUT}
+# Try to parse it and type-check it again
+$(dirname $0)/../jasminc.native -typeonly ${OUT}

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -97,6 +97,6 @@ let eprint step pp_prog p =
   if List.mem step !print_list then
     let (_, msg) = print_strings step in
     Format.eprintf
-"(* -------------------------------------------------------------------- *)@.";
-    Format.eprintf "(* After %s *)@.@." msg;
+"/* -------------------------------------------------------------------- */@.";
+    Format.eprintf "/* After %s */@.@." msg;
     Format.eprintf "%a@.@.@." pp_prog p

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -96,7 +96,7 @@ let usage_msg = "Usage : jasminc [option] filename"
 let eprint step pp_prog p =
   if List.mem step !print_list then
     let (_, msg) = print_strings step in
-    Format.eprintf
+    Format.printf
 "/* -------------------------------------------------------------------- */@.";
-    Format.eprintf "/* After %s */@.@." msg;
-    Format.eprintf "%a@.@.@." pp_prog p
+    Format.printf "/* After %s */@.@." msg;
+    Format.printf "%a@.@.@." pp_prog p

--- a/compiler/src/liveness.ml
+++ b/compiler/src/liveness.ml
@@ -4,7 +4,7 @@ open Prog
 let dep_lv s_o x =
   match x with
   | Lvar x -> Sv.remove (L.unloc x) s_o
-  | _      -> rvars_lv s_o x
+  | _      -> vars_lv s_o x
 
 (* Variables live before a write_lvals:
    this is tricky when a variable occurs several times,

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -252,7 +252,7 @@ let main () =
           try
             let pp_range fmt (ptr, sz) =
               Format.fprintf fmt "%a:%a" Z.pp_print ptr Z.pp_print sz in
-            Format.printf "Evaluation of %s (@[<h>%a@]):@." f.fn_name
+            Format.printf "/* Evaluation of %s (@[<h>%a@]):@." f.fn_name
               (pp_list ",@ " pp_range) m;
             let _m, vs =
               (** TODO: allow to configure the initial stack pointer *)
@@ -260,7 +260,8 @@ let main () =
               (match Low_memory.Memory.coq_M.init live (Conv.int64_of_z (Z.of_string "1024")) with Utils0.Ok m -> m | Utils0.Error err -> raise (Evaluator.Eval_error (Coq_xH, err))) |>
               Evaluator.exec cprog (Conv.cfun_of_fun tbl f) in
             Format.printf "@[<v>%a@]@."
-              (pp_list "@ " Evaluator.pp_val) vs
+              (pp_list "@ " Evaluator.pp_val) vs;
+            Format.printf "*/@."
           with Evaluator.Eval_error (ii,err) ->
             hierror "%a" Evaluator.pp_error (tbl, ii, err)
         in

--- a/compiler/src/printLinear.ml
+++ b/compiler/src/printLinear.ml
@@ -37,7 +37,7 @@ let rec pp_expr tbl fmt =
   | E.Pload (sz, x, e) -> F.fprintf fmt "(%a)[%a + %a]" pp_wsize sz (pp_var_i tbl) x pp_expr e
   | E.Papp1 (op, e) -> F.fprintf fmt "(%s %a)" (Pr.string_of_op1 op) pp_expr e
   | E.Papp2 (op, e1, e2) -> F.fprintf fmt "(%a %s %a)" pp_expr e1 (Pr.string_of_op2 op) pp_expr e2
-  | E.PappN (op, es) -> F.fprintf fmt "@[(%s [%a])@]" (Pr.string_of_opN op) (Pr.pp_list ",@ " pp_expr) es
+  | E.PappN (_op, _es) -> assert false
   | E.Pif (_, c, e1, e2) -> F.fprintf fmt "(%a ? %a : %a)" pp_expr c pp_expr e1 pp_expr e2
 
 let pp_lval tbl fmt =

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -94,7 +94,7 @@ let string_of_op2 = function
 
 
 let string_of_op1 = function
-  | E.Oint_of_word sz -> F.sprintf "(int of u%d)" (int_of_ws sz)
+  | E.Oint_of_word sz -> F.sprintf "(int /* of u%d */)" (int_of_ws sz)
   | E.Osignext (szo, _) -> F.sprintf "(%ds)" (int_of_ws szo)
   | E.Oword_of_int szo
   | E.Ozeroext (szo, _) -> F.sprintf "(%du)" (int_of_ws szo)
@@ -130,7 +130,7 @@ let pp_ge pp_var =
 
 (* -------------------------------------------------------------------- *)
 let pp_glv pp_var fmt = function
-  | Lnone (_, ty) -> F.fprintf fmt "_{%a}" (pp_gtype (fun fmt _ -> F.fprintf fmt "?")) ty
+  | Lnone (_, ty) -> F.fprintf fmt "_ /* %a */" (pp_gtype (fun fmt _ -> F.fprintf fmt "?")) ty
   | Lvar x  -> pp_gvar_i pp_var fmt x
   | Lmem (ws, x, e) ->
     F.fprintf fmt "@[(%a)[%a@ +@ %a]@]"
@@ -169,10 +169,11 @@ let rec pp_gi pp_info pp_ty pp_var fmt i =
   F.fprintf fmt "%a" pp_info i.i_info;
   match i.i_desc with
   | Cassgn(x , tg, ty, e) ->
-    F.fprintf fmt "@[<hov 2>%a %s=(%a)@ %a;@]"
-      (pp_glv pp_var) x (pp_tag tg)
-      pp_ty ty
+    F.fprintf fmt "@[<hov 2>%a =@ %a; /* %a%s */@]"
+      (pp_glv pp_var) x
       (pp_ge pp_var) e
+      pp_ty ty
+      (pp_tag tg)
 
   | Copn(x, t, o, e) -> (* FIXME *)
     F.fprintf fmt "@[<hov 2>%a %s=@ #%s(%a);@]"

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -102,13 +102,6 @@ let string_of_op1 = function
   | E.Onot    -> "!"
   | E.Oneg _ -> "-"
 
-let string_of_opN =
-  function
-  | E.Opack (sz, pe) ->
-    F.sprintf "Opack<%d, %d>"
-      (int_of_ws sz)
-      (int_of_pe pe)
-
 (* -------------------------------------------------------------------- *)
 let pp_ge pp_var =
   let pp_var_i = pp_gvar_i pp_var in

--- a/compiler/src/printer.mli
+++ b/compiler/src/printer.mli
@@ -26,7 +26,6 @@ val pp_var   : debug:bool -> Format.formatter -> var -> unit
 
 val string_of_op1 : Expr.sop1 -> string
 val string_of_op2 : Expr.sop2 -> string
-val string_of_opN : Expr.opN -> string
 val pp_opn : Expr.sopn -> string
 
 val pp_ty : Format.formatter -> ty -> unit

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -238,7 +238,8 @@ module Hf : Hash.S with type key = funname
 (* -------------------------------------------------------------------- *)
 (* used variables                                                       *)
 
-val rvars_lv : Sv.t -> lval -> Sv.t
+val fold_vars_fc : ('ty gvar -> 'acc -> 'acc) -> 'acc -> ('ty, 'info) gfunc -> 'acc
+val vars_lv : Sv.t -> lval -> Sv.t
 val vars_e  : expr -> Sv.t
 val vars_es : expr list -> Sv.t
 val vars_i  : 'info instr -> Sv.t

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -253,8 +253,8 @@ let collect_variables (allvars: bool) (f: 'info func) : int Hv.t * int =
       Hv.add tbl v n
   in
   let collect_sv = Sv.iter get in
-  let collect_lv lv = rvars_lv Sv.empty lv |> collect_sv in
-  let collect_lvs lvs = List.fold_left rvars_lv Sv.empty lvs |> collect_sv in
+  let collect_lv lv = vars_lv Sv.empty lv |> collect_sv in
+  let collect_lvs lvs = List.fold_left vars_lv Sv.empty lvs |> collect_sv in
   let collect_expr e = vars_e e |> collect_sv in
   let collect_exprs es = vars_es es |> collect_sv in
   let rec collect_instr_r =


### PR DESCRIPTION
This PR tries to ensure that Jasmin programs printed by the compiler are indeed written in Jasmin syntax. In particular, the output of `-pcstexp` is always syntactically valid (and usually well-typed); this is now checked by the test-suite.

This is a breaking change (in particular printed programs are now displayed on `stdout` instead of `stderr`).

Feature requested by Tiago (@tfaoliveira).