### PR TITLE
Migrate CI to Github Actions

### DIFF
--- a/.github/actions/nix/action.yml
+++ b/.github/actions/nix/action.yml
@@ -1,0 +1,15 @@
+name: 'Nix'
+description: 'Prepares nix shell'
+runs:
+  using: "composite"
+  steps:
+    - run: nix-shell -p nix-info --run 'nix-info -m'
+      shell: sh
+    - name: Compute version
+      id: version
+      run: echo "::set-output name=version::development version at commit $GITHUB_SHA on branch $GITHUB_REF_NAME"
+      shell: sh
+    - run: nix-shell --extra-substituters "$EXTRA_SUBSTITUTERS" --trusted-public-keys "$NIXOS_PUBLIC_KEY $EXTRA_PUBLIC_KEYS" --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'echo done'
+      shell: sh
+    - run: nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'sed -i -e "s|@VERSION@|${{ steps.version.outputs.version }}|" compiler/src/glob_options.ml'
+      shell: sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,236 @@
+name: Jasmin CI
+
+on: [push, pull_request]
+
+env:
+  NIX_PATH: nixpkgs=channel:nixpkgs-unstable
+  EXTRA_SUBSTITUTERS: https://jasmin.cachix.org
+  EXTRA_PUBLIC_KEYS: jasmin.cachix.org-1:aA5r1ovq4HYKUa+8QHVvIP7K6Fi9L75b0SaN/sooWSY=
+  NIXOS_PUBLIC_KEY: cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+  NIXPKGS_ALLOW_UNFREE: 1
+
+jobs:
+  coq:
+    runs-on: ubuntu-latest
+    container: nixos/nix:2.3.12
+    env:
+      EXTRA_NIX_ARGUMENTS: --arg coqDeps true
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/nix
+    - run: |
+        nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs'
+        nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C compiler CIL'
+        apk add --no-cache tar # Needed for cache action
+    - uses: actions/cache@v3
+      with:
+        path: compiler/CIL
+        key: artifacts-coq-${{ github.run_id }}-${{ github.run_number }}
+
+  ocaml:
+    runs-on: ubuntu-latest
+    container: nixos/nix:2.3.12
+    needs: coq
+    env:
+      EXTRA_NIX_ARGUMENTS: --arg ocamlDeps true
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/nix
+    - run: apk add --no-cache tar # Needed for cache action
+    - uses: actions/cache@v3
+      with:
+        path: compiler/CIL
+        key: artifacts-coq-${{ github.run_id }}-${{ github.run_number }}
+    - run: nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C compiler'
+    - uses: actions/cache@v3
+      with:
+        path: |
+          compiler/_build
+          compiler/jasminc.native
+        key: artifacts-ocaml-${{ github.run_id }}-${{ github.run_number }}
+
+  eclib:
+    runs-on: ubuntu-latest
+    container: nixos/nix:2.3.12
+    env:
+      EXTRA_NIX_ARGUMENTS: --arg ecDeps true
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/nix
+    - run: |
+        nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt why3config -why3 eclib/why3.conf'
+        nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt     config -why3 eclib/why3.conf'
+        nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make ECARGS="-why3 why3.conf" -C eclib'
+
+  #TODO: cache opam root
+  opam:
+    runs-on: ubuntu-latest
+    container: nixos/nix:2.3.12
+    env:
+      OPAMROOTISOK: 'true'
+      OPAMROOT: ~/mapo
+    steps:
+    - uses: actions/checkout@v2
+    - name: Compute prefix
+      id: prefix
+      run: echo "::set-output name=prefix::jasmin-$GITHUB_REF_NAME-${GITHUB_SHA::7}"
+    - run: |
+        apk add --no-cache rsync # Needed for OPAM sync
+        nix-shell -p opam git pkg-config perl ppl mpfr --run 'echo Let’s go!'
+        nix-shell -p opam --run 'opam init --disable-sandboxing --no-setup --compiler=4.12.1'
+        nix-shell -p opam --run 'opam repo add coq-released https://coq.inria.fr/opam/released'
+        nix-shell -p opam git --run 'opam pin --yes --no-action add coq-mathcomp-word https://github.com/jasmin-lang/coqword.git'
+        nix-shell -p opam git --run 'opam pin --yes --no-depexts --no-action add .'
+        nix-shell -p opam git pkg-config perl ppl mpfr --run 'opam install --yes --no-depexts --deps-only jasmin'
+        nix-shell -p opam ppl mpfr --run 'export PREFIX="${{ steps.prefix.outputs.prefix }}" && eval $(opam env) && make -j$NIX_BUILD_CORES && make install'
+    - uses: actions/upload-artifact@v2
+      with:
+        name: opam-build
+        path: ${{ steps.prefix.outputs.prefix }}
+
+  tarball:
+    runs-on: ubuntu-latest
+    container: nixos/nix:2.3.12
+    needs: coq
+    env:
+      EXTRA_NIX_ARGUMENTS: --arg testDeps true
+    steps:
+    - uses: actions/checkout@v2
+    - name: Compute tarball name
+      id: tarball
+      run: echo "::set-output name=tarball::jasmin-compiler-${GITHUB_SHA::7}"
+    - uses: ./.github/actions/nix
+    - run: nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -C compiler dist DISTDIR=${{ steps.tarball.outputs.tarball }}'
+    - uses: actions/upload-artifact@v2
+      with:
+        name: tarball
+        path: compiler/${{ steps.tarball.outputs.tarball }}.tgz
+
+  check:
+    runs-on: ubuntu-latest
+    container: nixos/nix:2.3.12
+    needs: [coq, ocaml]
+    env:
+      EXTRA_NIX_ARGUMENTS: --arg testDeps true
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/nix
+    - run: apk add --no-cache tar # Needed for cache action
+    - uses: actions/cache@v3
+      with:
+        path: compiler/CIL
+        key: artifacts-coq-${{ github.run_id }}-${{ github.run_number }}
+    - uses: actions/cache@v3
+      with:
+        path: |
+          compiler/_build
+          compiler/jasminc.native
+        key: artifacts-ocaml-${{ github.run_id }}-${{ github.run_number }}
+    - run: |
+        nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './compiler/jasminc.native -version'
+        nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C compiler check-ci'
+
+  cryptolib:
+    strategy:
+      matrix:
+        include:
+          - CASE: crypto_hash/sha256/amd64/ref
+          - CASE: crypto_hash/sha3-224/amd64/avx2
+          - CASE: crypto_hash/sha3-224/amd64/ref
+          - CASE: crypto_hash/sha3-256/amd64/avx2
+          - CASE: crypto_hash/sha3-256/amd64/ref
+          - CASE: crypto_hash/sha3-384/amd64/avx2
+          - CASE: crypto_hash/sha3-384/amd64/ref
+          - CASE: crypto_hash/sha3-512/amd64/avx2
+          - CASE: crypto_hash/sha3-512/amd64/ref
+          #- CASE: crypto_kem/kyber/kyber512/amd64/avx2 # Need randombytes
+          #- CASE: crypto_kem/kyber/kyber768/amd64/avx2
+          - CASE: crypto_onetimeauth/poly1305/amd64/ref
+          - CASE: crypto_stream/chacha/chacha12/amd64/avx2
+          - CASE: crypto_stream/chacha/chacha12/amd64/avx
+          - CASE: crypto_stream/chacha/chacha12/amd64/ref
+          - CASE: crypto_stream/chacha/chacha20/amd64/avx2
+          - CASE: crypto_stream/chacha/chacha20/amd64/avx
+          - CASE: crypto_stream/chacha/chacha20/amd64/ref
+          - CASE: crypto_stream/chacha/chacha20-ietf/amd64/avx2
+          - CASE: crypto_stream/chacha/chacha20-ietf/amd64/avx
+          - CASE: crypto_stream/chacha/chacha20-ietf/amd64/ref
+          - CASE: crypto_stream/salsa20/salsa2012/amd64/avx2
+          - CASE: crypto_stream/salsa20/salsa2012/amd64/avx
+          - CASE: crypto_stream/salsa20/salsa2012/amd64/ref
+          - CASE: crypto_stream/salsa20/salsa20/amd64/avx2
+          - CASE: crypto_stream/salsa20/salsa20/amd64/avx
+          - CASE: crypto_stream/salsa20/salsa20/amd64/ref
+          - CASE: crypto_stream/xsalsa20/amd64/avx2
+          - CASE: crypto_stream/xsalsa20/amd64/avx
+          - CASE: crypto_stream/xsalsa20/amd64/ref
+          - CASE: crypto_xof/shake128/amd64/avx2
+          - CASE: crypto_xof/shake128/amd64/ref
+          - CASE: crypto_xof/shake256/amd64/avx2
+          - CASE: crypto_xof/shake256/amd64/ref1
+          - CASE: crypto_xof/shake256/amd64/ref
+          - CASE: crypto_xof/shake256/amd64/spec
+    runs-on: ubuntu-latest
+    container: nixos/nix:2.3.12
+    needs: [coq, ocaml]
+    env:
+      EXTRA_NIX_ARGUMENTS: --arg testDeps true
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/nix
+    - run: apk add --no-cache tar # Needed for cache action
+    - uses: actions/cache@v3
+      with:
+        path: compiler/CIL
+        key: artifacts-coq-${{ github.run_id }}-${{ github.run_number }}
+    - uses: actions/cache@v3
+      with:
+        path: |
+          compiler/_build
+          compiler/jasminc.native
+        key: artifacts-ocaml-${{ github.run_id }}-${{ github.run_number }}
+    - run: |
+        nix-env -iA nixpkgs.git
+        nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'echo done'
+        git clone --depth 1 --branch master https://github.com/jasmin-lang/cryptolib.git
+        echo ${{ matrix.CASE }}
+        nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -C cryptolib/src/${{ matrix.CASE }} JASMIN=$PWD/compiler/jasminc.native'
+
+  push-compiler-code:
+    runs-on: ubuntu-latest
+    container: nixos/nix:2.3.12
+    needs: tarball
+    steps:
+    - name: Compute tarball name
+      id: tarball
+      run: echo "::set-output name=tarball::jasmin-compiler-${GITHUB_SHA::7}"
+    - name: Download tarball
+      uses: actions/download-artifact@v3
+      with:
+        name: tarball
+        path: compiler
+    - name: Push changes to compiler repository
+      # TODO: switch to final repo URL
+      env:
+        COMPILER_DEPLOY_KEY: ${{ secrets.COMPILER_DEPLOY_KEY }}
+        GIT_SSH_COMMAND: "ssh -o UserKnownHostsFile=/github/home/.ssh/known_hosts"
+      run: |
+        nix-env -iA nixpkgs.git
+        nix-env -iA nixpkgs.openssh
+        eval $(ssh-agent -s)
+        mkdir -p ~/.ssh
+        chmod 700 ~/.ssh
+        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
+        chmod 600 ~/.ssh/known_hosts
+        git config --global user.name "Jasmin Contributors"
+        git config --global user.email "nobody@noreply.example.com"
+        echo "$COMPILER_DEPLOY_KEY" | tr -d '\r' | ssh-add - > /dev/null
+        git clone git@gitlab.com:jasmin-lang/jasmin-compiler.git _deploy
+        cd _deploy
+        git checkout $GITHUB_REF_NAME || git checkout --orphan $GITHUB_REF_NAME
+        rm -rf compiler
+        tar xzvf ../compiler/${{ steps.tarball.outputs.tarball }}.tgz
+        mv ${{ steps.tarball.outputs.tarball }}/ compiler
+        git add compiler
+        git commit -m "Jasmin compiler on branch “$GITHUB_REF_NAME” at $GITHUB_SHA" || true
+        git push --set-upstream origin $GITHUB_REF_NAME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
         nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt     config -why3 eclib/why3.conf'
         nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make ECARGS="-why3 why3.conf" -C eclib'
 
-  #TODO: cache opam root
   opam:
     runs-on: ubuntu-latest
     container: nixos/nix:2.3.12
@@ -71,11 +70,16 @@ jobs:
       OPAMROOT: ~/mapo
     steps:
     - uses: actions/checkout@v2
+    - name: Install system dependencies
+      run: apk add --no-cache tar xz rsync # Needed for cache action and OPAM
+    - uses: actions/cache@v3
+      with:
+        path: ${{ env.OPAMROOT }}
+        key: opam-cache-key-v1
     - name: Compute prefix
       id: prefix
       run: echo "::set-output name=prefix::jasmin-$GITHUB_REF_NAME-${GITHUB_SHA::7}"
     - run: |
-        apk add --no-cache rsync # Needed for OPAM sync
         nix-shell -p opam git pkg-config perl ppl mpfr --run 'echo Let’s go!'
         nix-shell -p opam --run 'opam init --disable-sandboxing --no-setup --compiler=4.12.1'
         nix-shell -p opam --run 'opam repo add coq-released https://coq.inria.fr/opam/released'


### PR DESCRIPTION
We migrate all CI steps except pushing to cachix.

The main motivation is a better integration in the development workflow (PRs, etc) since the main Jasmin repository is on GitHub.

Note: before merging, a deploy key should be set up to target the jasmin-compiler repo, and the URL should be updated accordingly.