### PR TITLE
fix Let notation

### DIFF
--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -175,7 +175,7 @@ Notation rmap  := Result.map.
 Notation ok    := (@Ok _).
 
 Notation "m >>= f" := (rbind f m) (at level 25, left associativity).
-Notation "'Let' x ':=' m 'in' body" := (m >>= (fun x => body)) (x ident, at level 25).
+Notation "'Let' x ':=' m 'in' body" := (m >>= (fun x => body)) (x name, at level 25).
 Notation "'Let:' x ':=' m 'in' body" := (m >>= (fun x => body)) (x strict pattern, at level 25).
 Notation "m >> n" := (rbind (λ _, n) m) (at level 25, left associativity).
 


### PR DESCRIPTION
We recently merged https://github.com/coq/coq/pull/15754 which removed support for `_` in `ident`, after a period of deprecation. Since Jasmin was recently added to the CI, the CI run for that PR missed the fact that the `Let` notation defined here is using ident. This PR changes `ident` to the correct `name`, which allows for underscores.