### PR TITLE
opam: relax version constraints

### DIFF
--- a/opam
+++ b/opam
@@ -26,8 +26,8 @@ depends: [
   "yojson"
   "ocamlbuild"
   "ocamlfind"
-  "coq" {>= "8.14.0" & < "8.15"}
-  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.14"}
+  "coq" {>= "8.14.0" & < "8.16"}
+  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.15"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-word"
 ]


### PR DESCRIPTION
Jasmin is compatible with Coq 8.15 & mathcomp 1.14