### PR TITLE
CI: refactor opam job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ cache dependencies:
   stage: prepare
   extends: .common
   variables:
-    EXTRA_NIX_ARGUMENTS: --arg coqDeps true --arg ocamlDeps true --arg testDeps true --arg ecDeps true
+    EXTRA_NIX_ARGUMENTS: --arg coqDeps true --arg ocamlDeps true --arg testDeps true --arg ecDeps true --arg opamDeps true
   environment: cachix
   only:
     variables:
@@ -90,19 +90,16 @@ opam:
     OPAMROOTISOK: 'true'
     OPAMROOT: mapo
     PREFIX: jasmin-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA
+    EXTRA_NIX_ARGUMENTS: --arg opamDeps true
+  extends: .common
   cache:
     paths:
       - $OPAMROOT
   before_script:
-  - nix-shell -p opam git pkg-config perl ppl mpfr --run 'echo Let’s go!'
-  - nix-shell -p opam --run 'opam init --no-setup --compiler=4.12.1'
-  - nix-shell -p opam --run 'opam repo add coq-released https://coq.inria.fr/opam/released'
-  - nix-shell -p opam git --run 'opam pin --yes --no-action add coq-mathcomp-word https://github.com/jasmin-lang/coqword.git'
-  - nix-shell -p opam git --run 'opam pin --yes --no-depexts --no-action add .'
-  - nix-shell -p opam git pkg-config perl ppl mpfr --run 'opam install --yes --no-depexts --deps-only jasmin'
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'scripts/opam-setup.sh'
   script:
   - >-
-    nix-shell -p opam ppl mpfr --run
+    nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run
     'eval $(opam env) &&
      make -j$NIX_BUILD_CORES &&
      make install'

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@
 , testDeps ? !inCI
 , devTools ? !inCI
 , ecDeps ? false
+, opamDeps ? false
 , enableFramePointers ? false
 }:
 
@@ -47,5 +48,6 @@ stdenv.mkDerivation {
          menhir (oP.menhirLib or null) zarith camlidl apron yojson ]))
     ++ optionals devTools (with oP; [ merlin ])
     ++ optionals ecDeps [ easycrypt easycrypt.runtest alt-ergo z3.out ]
+    ++ optionals opamDeps [ git pkg-config perl ppl mpfr opam ]
     ;
 }

--- a/scripts/nixpkgs.nix
+++ b/scripts/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/6896623f630ce8703e2201625eabd9f01dfcc5e0.tar.gz";
-  sha256 = "sha256:18avv8pknx0bzhphqfkxgzvavh9jsa3pp75kdfz64yl9nwlyxhxx";
+  url = "https://github.com/NixOS/nixpkgs/archive/bd4dffcdb7c577d74745bd1eff6230172bd176d5.tar.gz";
+  sha256 = "sha256:18zacrykj2k5x42d0grr7g1y7xhy5ppq7j0gm3lrghwflyrdkslj";
 })

--- a/scripts/opam-setup.sh
+++ b/scripts/opam-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+opam init --no-setup --compiler=4.12.1
+opam repo add coq-released https://coq.inria.fr/opam/released
+opam pin --yes --no-action add coq-mathcomp-word https://github.com/jasmin-lang/coqword.git
+opam pin --yes --no-depexts --no-action add .
+opam install --yes --no-depexts --deps-only jasmin
+


### PR DESCRIPTION
This should prevent the cache of the OPAM root to rot, as long as it stays in sync with the pinned nixpkgs.

(The update of nixpkgs is not related.)