### PR TITLE
opam: mark easy-format-1.3.3 as conflicting

### DIFF
--- a/compiler/opam
+++ b/compiler/opam
@@ -24,3 +24,6 @@ depends: [
   "ocamlbuild"
   "ocamlfind"
 ]
+conflicts: [
+  "easy-format" {= "1.3.3" }
+]

--- a/opam
+++ b/opam
@@ -31,3 +31,6 @@ depends: [
   "coq-mathcomp-algebra"
   "coq-mathcomp-word"
 ]
+conflicts: [
+  "easy-format" {= "1.3.3" }
+]


### PR DESCRIPTION
In CI (i.e., when dependencies are managed by nix), installation of
easy-format at version 1.3.3 fails. This OCaml library is a dependency
of `yojson` that is used in Jasmin compiler.

The cause of this failure is not really clear (might be a bug in the
opam description of the easy-format library), but this is a quick
workaround to fix the CI jobs.