### PR TITLE
ci: crytolib job really extends .common

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,12 +181,10 @@ cryptolib:
   dependencies:
   - coq
   - ocaml
-  before_script:
+  script:
   - nix-env -iA nixpkgs.git
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'echo done'
   - git clone --depth 1 --branch master https://github.com/jasmin-lang/cryptolib.git
   - echo $CASE
-  script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -C cryptolib/src/$CASE JASMIN=$PWD/compiler/jasminc.native'
   parallel:
     matrix:


### PR DESCRIPTION
This change ensures that the `before_script` variable defined in the `.common` job is not overridden

Currently, all `cryptolib` jobs (about 36 per pipeline) rebuild apron…