### PR TITLE
Export absolute PREFIX from toplevel Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 # --------------------------------------------------------------------
 SED      ?= sed
 DISTDIR  := jasmin
+PREFIX   ?= /usr/local
+# we compute the absolute path, otherwise it does not make sense when
+# given to the sub-Makefiles
+PREFIX   := $(abspath $(PREFIX))
+export PREFIX
 
 # --------------------------------------------------------------------
 .PHONY: all build check clean install uninstall dist distcheck


### PR DESCRIPTION
In PR https://github.com/jasmin-lang/jasmin/pull/111, I broke the `install` rule when `PREFIX` is a relative path. My fix is simply to ask `make` to compute the absolute path first. I don't think it's a beautiful fix, if you have a better idea (including reverting the PR), please do suggestions.