### PR TITLE
opam: disable sandboxing

### DIFF
--- a/scripts/fix_path_ro.patch
+++ b/scripts/fix_path_ro.patch
@@ -1,8 +1,0 @@
-@@ -87,6 +87,7 @@ add_dune_cache_mount() {
-   add_mount rw "$u_dune_cache" "$dune_cache"
- }
- 
-+OPAM_USER_PATH_RO="$OPAM_USER_PATH_RO:$OPAMROOT"
- # mount unusual path in ro
- if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-    add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')

--- a/scripts/opam-setup.sh
+++ b/scripts/opam-setup.sh
@@ -2,22 +2,7 @@
 
 set -e
 
-opam init --no-setup --compiler=4.12.1
-# If $OPAMROOT is not in a standard location, it may happen that the sandbox
-# hides it during the building of packages, which for some packages results in
-# a build failure. There is a variable OPAM_USER_PATH_RO that is provided to
-# make more directories available inside the sandbox, but the opam nix package
-# overrides its value using "makeWrapper --set". This temporary and hacky fix
-# consists in patching the sandbox script used by opam to add $OPAMROOT to
-# OPAM_USER_PATH_RO after it was overwritten by makeWrapper. In the
-# (hopefully near) future, opam 2.2 will make (nearly) the whole filesystem
-# available in read-only mode, thus eliminating the need for OPAM_USER_PATH_RO
-# and this hack.
-if patch -N -r - "$OPAMROOT/opam-init/hooks/sandbox.sh" scripts/fix_path_ro.patch >/dev/null 2>&1 ; then
-  echo "$OPAMROOT/opam-init/hooks/sandbox.sh patched successfully"
-else
-  echo "no need to patch $OPAMROOT/opam-init/hooks/sandbox.sh"
-fi
+opam init --disable-sandboxing --no-setup --compiler=4.12.1
 if [ $1 ]
 then
   opam repo add coq-released https://coq.inria.fr/opam/released


### PR DESCRIPTION
This script is only meant to be run in contenerized CI jobs, thus there
is no need for an additional layer of sandboxing