### PR TITLE
CI/libjade: test extraction to EasyCrypt

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,7 +182,7 @@ libjade:
   - coq
   - ocaml
   script:
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './scripts/test-libjade.sh'
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './scripts/test-libjade.sh src'
   artifacts:
     paths:
     - results/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,7 +170,7 @@ check:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './compiler/jasminc.native -version'
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C compiler check-ci'
 
-libjade:
+libjade-compile-to-asm:
   stage: test
   variables:
     EXTRA_NIX_ARGUMENTS: --arg testDeps true
@@ -183,6 +183,27 @@ libjade:
   - ocaml
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './scripts/test-libjade.sh src'
+  artifacts:
+    paths:
+    - results/
+
+libjade-extract-to-ec:
+  stage: test
+  variables:
+    EXTRA_NIX_ARGUMENTS: --arg testDeps true --arg ecDeps true
+    WHY3_CONF: $CI_PROJECT_DIR/why3.conf
+    ECARGS: -why3 $WHY3_CONF -I Jasmin:$CI_PROJECT_DIR/eclib
+    ECJOBS: '$(NIX_BUILD_CORES)'
+  extends: .common
+  needs:
+  - coq
+  - ocaml
+  dependencies:
+  - coq
+  - ocaml
+  script:
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt why3config -why3 $WHY3_CONF'
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './scripts/test-libjade.sh proof'
   artifacts:
     paths:
     - results/

--- a/scripts/test-libjade.sh
+++ b/scripts/test-libjade.sh
@@ -3,21 +3,28 @@
 NAME=libjade
 BRANCH=main
 
-FILE=$NAME.tar.gz
-DIR=$NAME-$BRANCH
+FILE="$NAME.tar.gz"
+ROOT="$NAME-$BRANCH"
 
-OUT=results
+OUT="results"
+
+[ 1 -le $# ] || exit 127
+
+DIR="$ROOT/$1"
+
+MAKELINE="-C $DIR CI=1 JASMIN=$PWD/compiler/jasminc.native"
 
 # Exclude primitives that are known not to build
 export EXCLUDE="crypto_kem/kyber/kyber512/amd64/avx2/ crypto_kem/kyber/kyber768/amd64/avx2/"
 
+echo "Info: $MAKELINE (EXCLUDE=$EXCLUDE)"
+
 curl -v -o $FILE https://codeload.github.com/formosa-crypto/$NAME/tar.gz/refs/heads/$BRANCH
 tar xvf $FILE
 
-make -C $DIR/src CI=1 JASMIN=$PWD/compiler/jasminc.native
-res=$?
+make $MAKELINE
 
 mkdir -p $OUT
-(cd $OUT && tar xvf ../$DIR/src/check.tar.gz)
+(cd $OUT && tar xvf ../$DIR/check.tar.gz)
 
-exit $res
+make $MAKELINE err


### PR DESCRIPTION
This makes the `proof/` directory of libjade: extract jasmin programs to EasyCrypt and run EasyCrypt of the generated code.

cc @tfaoliveira 