### PR TITLE
clean spurious Require

### DIFF
--- a/proofs/compiler/arch_params.v
+++ b/proofs/compiler/arch_params.v
@@ -7,14 +7,11 @@ Require Import
   arch_decl
   arch_extra
   arch_sem
-  asm_gen
-  asm_gen_proof.
+  asm_gen.
 Require
   linearization
-  linearization_proof
   lowering
-  stack_alloc
-  stack_alloc_proof.
+  stack_alloc.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/proofs/compiler/lea.v
+++ b/proofs/compiler/lea.v
@@ -1,7 +1,7 @@
 From mathcomp Require Import all_ssreflect all_algebra.
 From CoqWord Require Import ssrZ.
 Require Import Utf8.
-Require Import compiler_util expr low_memory.
+Require Import expr low_memory.
 
 (* -------------------------------------------------------------------- *)
 

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -10,23 +10,19 @@ Require Import
   sem_one_varmap.
 Require Import
   linearization
-  linearization_proof
   lowering
-  stack_alloc
-  stack_alloc_proof.
+  stack_alloc.
 Require
   arch_sem.
 Require Import
   arch_decl
   arch_extra
-  asm_gen
-  asm_gen_proof.
+  asm_gen.
 Require Import
   x86_decl
   x86_extra
   x86_instr_decl
-  x86_lowering
-  x86_lowering_proof.
+  x86_lowering.
 
 Set Implicit Arguments.
 Unset Strict Implicit.


### PR DESCRIPTION
Running `make CIL` no longer compiles any `_proof` file!