### PR TITLE
allows to move mmx reg ptr to reg ptr

### DIFF
--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -80,7 +80,9 @@ let check_safety_p asmOp analyze s (p : (_, 'asm) Prog.prog) source_p =
 (* -------------------------------------------------------------------- *)
 let main () =
 
+  let is_regx tbl x = is_regx (Conv.var_of_cvar tbl x) in
   let lowering_vars tbl = X86_lowering.(
+
     let f ty n = 
       let v = V.mk n (Reg(Normal, Direct)) ty L._dummy [] in
       Conv.cvar_of_var tbl v in
@@ -91,6 +93,7 @@ let main () =
     ; fresh_PF = (b "PF").vname
     ; fresh_ZF = (b "ZF").vname
     ; fresh_multiplicand = (fun sz -> (f (Bty (U sz)) "multiplicand").vname)
+    ; is_regx = is_regx tbl
     }) in
   let lowering_opt =
     X86_lowering.{ use_lea = !Glob_options.lea;
@@ -448,6 +451,7 @@ let main () =
       Compiler.is_reg_ptr  = is_reg_ptr;
       Compiler.is_ptr      = is_ptr;
       Compiler.is_reg_array = is_reg_array;
+      Compiler.is_regx      = is_regx tbl;
     } in
 
     let export_functions, subroutines =

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -117,6 +117,11 @@ let is_ptr k =
   | Stack k | Reg(_, k) -> k <> Direct 
   | _ -> false
 
+let is_regx x = 
+  match x.v_kind with 
+  | Reg (Extra, _) -> true
+  | _ -> false
+
 (* ------------------------------------------------------------------------ *)
 
 type 'len glval =

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -256,6 +256,8 @@ module Sv : Set.S  with type elt = var
 module Mv : Map.S  with type key = var
 module Hv : Hash.S with type key = var
 
+val is_regx : var -> bool
+
 (* -------------------------------------------------------------------- *)
 val kind_i : 'len gvar_i -> v_kind
 val ty_i   : 'len gvar_i -> 'len gty 

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -163,8 +163,9 @@ let memory_analysis pp_err ~debug tbl up =
     Format.eprintf "%a@.@.@." (pp_oracle tbl up) saos
   end;
 
+  let is_regx x = is_regx (Conv.var_of_cvar tbl x) in
   let sp' = 
-    match Stack_alloc.alloc_prog Arch.reg_size Arch.asmOp false Arch.aparams.ap_sap crip crsp gao.gao_data cglobs cget_sao up with
+    match Stack_alloc.alloc_prog Arch.reg_size Arch.asmOp false (Arch.aparams.ap_sap is_regx) crip crsp gao.gao_data cglobs cget_sao up with
     | Utils0.Ok sp -> sp 
     | Utils0.Error e ->
       let e = Conv.error_of_cerror (pp_err tbl) tbl e in

--- a/compiler/tests/success/movx.jazz
+++ b/compiler/tests/success/movx.jazz
@@ -1,13 +1,36 @@
 export fn f(reg u64 x) -> reg u64 {
   #mmx reg u64 e;
+  
   e = #MOVX(x);
   x = #MOVX(e);
 
+  e = x;
+  x = e; 
+  
   #[mmx] reg u32 d;
+
   reg u32 x1;
+
   d = #MOVX_32(x);
   x1 = #MOVX_32(d);
   x  = (64u)x1; 
+
+  d = x;
+  x1 = d;
+  x  = (64u)x1; 
+
+  stack u64[1] s;
+  reg ptr u64[1] r;
+  #mmx reg ptr u64[1] rx;
+
+  s[0] = 0;
+  r = s;
+  r[0] += 1;
+  rx = r;
+  r = rx;
+  r[0] += 1;
+  s = r;
+  x += s[0];
   
   return x;     
 }

--- a/proofs/compiler/arch_params.v
+++ b/proofs/compiler/arch_params.v
@@ -7,14 +7,11 @@ Require Import
   arch_decl
   arch_extra
   arch_sem
-  asm_gen
-  asm_gen_proof.
+  asm_gen.
 Require
   linearization
-  linearization_proof
   lowering
-  stack_alloc
-  stack_alloc_proof.
+  stack_alloc.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -47,7 +44,7 @@ Record architecture_params
   (fresh_vars lowering_options : Type) :=
   {
     (* Stack alloc parameters. See stack_alloc.v. *)
-    ap_sap : stack_alloc.stack_alloc_params;
+    ap_sap : (var -> bool) -> stack_alloc.stack_alloc_params;
 
     (* Linearization parameters. See linearization.v. *)
     ap_lip : linearization.linearization_params;

--- a/proofs/compiler/arch_params_proof.v
+++ b/proofs/compiler/arch_params_proof.v
@@ -61,7 +61,7 @@ Record h_architecture_params
   (aparams : architecture_params fresh_vars lowering_options) :=
   {
     (* Stack alloc hypotheses. See stack_alloc_proof.v. *)
-    hap_hsap : stack_alloc_proof.h_stack_alloc_params (ap_sap aparams);
+    hap_hsap : forall is_regx, stack_alloc_proof.h_stack_alloc_params (ap_sap aparams is_regx);
 
     (* Linearization hypotheses. See linearization_proof.v. *)
     hap_hlip :

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -171,6 +171,7 @@ Record compiler_params
   is_reg_ptr       : var -> bool;
   is_ptr           : var -> bool;
   is_reg_array     : var -> bool;
+  is_regx          : var -> bool;
 }.
 
 Context
@@ -179,7 +180,7 @@ Context
   (aparams : architecture_params fresh_vars lowering_options)
   (cparams : compiler_params fresh_vars lowering_options).
 
-Notation saparams := (ap_sap aparams).
+Notation saparams := (ap_sap aparams cparams.(is_regx)).
 Notation liparams := (ap_lip aparams).
 Notation loparams := (ap_lop aparams).
 Notation agparams := (ap_agp aparams).

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -220,7 +220,7 @@ Qed.
 
 (* TODO: move *)
 Remark sp_globs_stack_alloc rip rsp data ga la (p: uprog) (p': sprog) :
-  alloc_prog (ap_sap aparams) rip rsp data ga la p = ok p' →
+  alloc_prog (ap_sap aparams (is_regx cparams)) rip rsp data ga la p = ok p' →
   sp_globs (p_extra p') = data.
 Proof.
   rewrite /alloc_prog; t_xrbindP => ??.
@@ -307,7 +307,7 @@ Proof.
   have disjoint_va : disjoint_values (sao_params (ao_stack_alloc (stackalloc cparams p1) fn)) va va.
   - rewrite /disjoint_values => i1 pi1 w1 i2 pi2 w2.
     by rewrite (allNone_nth _ params_noptr).
-  have := alloc_progP (hap_hsap haparams) ok_p2 exec_p1 m_mi.
+  have := alloc_progP (hap_hsap haparams (is_regx cparams)) ok_p2 exec_p1 m_mi.
   move => /(_ va ok_va disjoint_va ok_mi).
   case => mi' [] vr2 [] exec_p2 [] m'_mi' [] ok_vr2 ?.
   have [] := compiler_third_partP ok_p3.

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -1122,6 +1122,18 @@ Section PROOF.
     by move => hle; rewrite !zero_extend_wrepr.
   Qed.
 
+  Lemma mov_wsP p1 is_regx s1 e ws tag i x w s2 :
+    (ws <= U64)%CMP -> 
+    (Let i' := sem_pexpr (p_globs p1) s1 e in to_word ws i') = ok i
+    -> write_lval (p_globs p1) x (Vword i) s1 = ok s2
+    -> sem_i p1 w s1 (mov_ws is_regx ws x e tag) s2.
+  Proof.
+    by move=> hws he hx; rewrite /mov_ws; case: ifP => [ /andP [] _ h | _];
+     constructor; rewrite /sem_sopn /= /exec_sopn /=;
+     move: he; t_xrbindP => _ -> /= -> /=;  
+     rewrite /sopn_sem /= /x86_MOVX /x86_MOV /check_size_32_64 /check_size_8_64 hws ?h /= hx.
+  Qed.
+
   Local Lemma Hassgn : sem_Ind_assgn p Pi_r.
   Proof.
     move => s1 s2 l tag ty e v v' Hv hty Hw ii /= Hdisj s1' Hs1'.
@@ -1152,8 +1164,9 @@ Section PROOF.
         by eauto using eq_exc_freshT.
       * exists s2'; split=> //=.
         case: ifP => [/andP [] /andP [] /eqP he ??| _ ];first last.
-        - apply: sem_seq1; apply: EmkI; apply: Eopn.
-          by rewrite /sem_sopn /= /sem_pexprs /= h /= /exec_sopn /sopn_sem /= /truncate_word hsz /x86_MOV /check_size_8_64 hle' /= -hw Hw'.
+        - apply/sem_seq1/EmkI/mov_wsP => //.
+          + by rewrite h /= /truncate_word hsz.
+          by rewrite -hw.
         move: h; rewrite he => /ok_word_inj [?]; subst => /= ?; subst vw.
         rewrite hw zero_extend_u wrepr0 in Hw' => {hw}.
         by case: ifP => hsz64; apply: sem_seq1; apply: EmkI; apply: Eopn;

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -39,8 +39,9 @@ Unset Printing Implicit Defensive.
 Definition lea_ptr x y tag ofs : instr_r :=
   Copn [:: x] tag (Ox86 (LEA Uptr)) [:: add y (cast_const ofs)].
 
-Definition mov_ptr x y tag :=
-  Copn [:: x] tag (Ox86 (MOV Uptr)) [:: y].
+Section IS_REGX.
+
+Context (is_regx : var -> bool).
 
 Variant mov_kind :=
   | MK_LEA
@@ -59,16 +60,17 @@ Definition x86_mov_ofs x tag vpk y ofs :=
       lea_ptr x y tag ofs
     else
       if ofs == 0%Z
-      then mov_ptr x y tag
+      then mov_ws is_regx Uptr x y tag
       else lea_ptr x y tag ofs
   in
   Some addr.
 
-Definition x86_saparams : stack_alloc_params :=
-  {|
-    sap_mov_ofs := x86_mov_ofs;
-  |}.
+End IS_REGX.
 
+Definition x86_saparams is_regx : stack_alloc_params :=
+  {|
+    sap_mov_ofs := x86_mov_ofs is_regx;
+  |}.
 
 (* ------------------------------------------------------------------------ *)
 (* Linearization parameters. *)
@@ -104,7 +106,6 @@ Definition x86_liparams : linearization_params :=
     lip_ensure_rsp_alignment := x86_ensure_rsp_alignment;
     lip_lassign := x86_lassign;
   |}.
-
 
 (* ------------------------------------------------------------------------ *)
 (* Lowering parameters. *)


### PR DESCRIPTION
this allows to write 
#mmx reg ptr u64[8] e;
reg ptr u64[8] x;
x = e;
e = x;

It also allows to write
#mmx reg u64 e;
reg u64 x;
x = e;
e = x;

without using x = MOVX(e)
Examples are provided in tests/success/movx.jazz

