### PR TITLE
compiler/default.nix: add missing dependency on camlidl

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,6 +155,19 @@ tarball:
     paths:
     - compiler/$TARBALL.tgz
 
+build-from-tarball:
+  stage: test
+  variables:
+    TARBALL: jasmin-compiler-$CI_COMMIT_SHORT_SHA
+  needs:
+  - tarball
+  dependencies:
+  - tarball
+  script:
+  - tar xvf compiler/$TARBALL.tgz
+  - nix build -o out -f $TARBALL
+  - ./out/bin/jasminc -version
+
 check:
   stage: test
   variables:

--- a/compiler/default.nix
+++ b/compiler/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "jasmin-0";
   src = ./.;
   buildInputs = [ mpfr ppl ]
-  ++ (with ocamlPackages; [ ocaml findlib ocamlbuild apron batteries menhir menhirLib zarith yojson])
+  ++ (with ocamlPackages; [ ocaml findlib ocamlbuild apron batteries camlidl menhir menhirLib zarith yojson])
   ;
 
   installPhase = ''


### PR DESCRIPTION
When using a recent `nixpkgs` (i.e., strictly posterior to 21.11), building from sources the released version of Jasmin fails with:

> \+ ocamlfind ocamlopt -rectypes -linkpkg -g -package 'batteries, menhirLib, zarith, apron.octMPQ, apron.ppl, apron.boxMPQ, yojson' -I entry jasmin.cmx entry/jasminc.cmx -o entry/jasminc.native
> …/ld: cannot find -lcamlidl: No such file or directory
> collect2: error: ld returned 1 exit status

This PR fixes this issue (well, not for released versions…).