### PR TITLE
Minor cleaning

### DIFF
--- a/compiler/MANIFEST
+++ b/compiler/MANIFEST
@@ -7,6 +7,7 @@ Makefile
 jasmin.mlpack.in
 _tags
 myocamlbuild.ml
+.merlin
 
 find:CIL:*.ml
 find:CIL:*.mli

--- a/compiler/_tags
+++ b/compiler/_tags
@@ -1,7 +1,7 @@
 # --------------------------------------------------------------------
 true : use_menhir, menhir_explain, menhir_table
 true : debug
-true : warn_Z, warn_Y, warn_+28, warn_-23, warn_+33, warn_-58, warn_error(+8)
+true : warn_Z, warn_Y, warn_+28, warn_-23, warn_+32, warn_+33, warn_+34, warn_-58, warn_error(+8)
 true : -traverse
 true : bin_annot
 
@@ -18,11 +18,11 @@ true : bin_annot
 # --------------------------------------------------------------------
 <src/**/*.{ml,mli}>: package(batteries, menhirLib, zarith, apron.octMPQ, apron.ppl, apron.boxMPQ, yojson)
 <src/*.cmx>               : for-pack(Jasmin)
-<src/safety/*.cmx>        : for-pack(Jasmin)
-<src/safety/domains/*.cmx>: for-pack(Jasmin)
+<src/safety{,/domains}/*.ml>: warn_-32
+<src/safety{,/domains}/*.cmx>: for-pack(Jasmin)
 
 <CIL/*.cmx>: for-pack(Jasmin)
-<CIL/*.{ml,mli}>: warn_-20, warn_-33
+<CIL/*.{ml,mli}>: warn_-20, warn_-32, warn_-33, warn_-34
 
 # --------------------------------------------------------------------
 <entry/*>: package(batteries, menhirLib, zarith, apron.octMPQ, apron.ppl, apron.boxMPQ, yojson)

--- a/compiler/src/ct_checker_forward.ml
+++ b/compiler/src/ct_checker_forward.ml
@@ -197,9 +197,6 @@ end = struct
     { env_v  = Mv.empty
     ; env_vl = Svl.empty }
 
-  let is_public_vl env vl = 
-    Svl.mem vl env.env_vl
-
   let norm_lvl_aux env_vl = function
     | Secret -> Secret
     | Public -> Public

--- a/compiler/src/intervalGraphColoring.ml
+++ b/compiler/src/intervalGraphColoring.ml
@@ -6,7 +6,6 @@ type color = var
 type coloring = color Mv.t
 
 type name = var
-type date = int
 
 type event =
   | Start of name

--- a/compiler/src/ppasm.ml
+++ b/compiler/src/ppasm.ml
@@ -229,7 +229,6 @@ let pp_instr_velem_long =
 
 (* -------------------------------------------------------------------- *)
 type 'a tbl = 'a Conv.coq_tbl
-type  gd_t  = Global.glob_decl list
 
 (* -------------------------------------------------------------------- *)
 
@@ -317,8 +316,6 @@ module Intel : BPrinter = struct
 
   (* -------------------------------------------------------------------- *)
   let pp_register = pp_register 
-
-  let pp_xmm_register = pp_xmm_register
 
   (* -------------------------------------------------------------------- *)
   let pp_reg_address (addr : (_, _, _, _, _) Arch_decl.reg_address) =

--- a/compiler/src/printLinear.ml
+++ b/compiler/src/printLinear.ml
@@ -90,8 +90,12 @@ let pp_param tbl fmt x =
   F.fprintf fmt "%a %a %s" Pr.pp_ty y.P.v_ty Pr.pp_kind y.P.v_kind y.P.v_name
 
 let pp_stackframe fmt (sz, ws) =
-  F.fprintf fmt "stack: %a, alignment = %s"
+  F.fprintf fmt "maximal stack usage: %a, alignment = %s"
     Z.pp_print (Conv.z_of_cz sz) (P.string_of_ws ws)
+
+let pp_meta fmt fd =
+  F.fprintf fmt "(* %a *)"
+    pp_stackframe (fd.lfd_total_stack, fd.lfd_align)
 
 let pp_return tbl is_export fmt =
   function
@@ -100,7 +104,8 @@ let pp_return tbl is_export fmt =
 
 let pp_lfun asmOp tbl fmt (fn, fd) =
   let name = Conv.fun_of_cfun tbl fn in
-  F.fprintf fmt "@[<v>fn %s @[(%a)@] -> @[(%a)@] {@   @[<v>%a%a@]@ }@]"
+  F.fprintf fmt "@[<v>%a@ fn %s @[(%a)@] -> @[(%a)@] {@   @[<v>%a%a@]@ }@]"
+    pp_meta fd
     name.P.fn_name
     (pp_list ",@ " (pp_param tbl)) fd.lfd_arg
     (pp_list ",@ " pp_stype) fd.lfd_tyout

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -408,10 +408,6 @@ let pp_func ~debug asmOp fmt fd =
   let pp_var = pp_var ~debug in
   pp_fun pp_opn pp_var fmt fd
 
-let pp_glob fmt (ws, n, z) =
-  Format.fprintf fmt "%a %s = %a;"
-    pp_ty (Bty (U ws)) n Z.pp_print z
-
 let pp_glob pp_var fmt (x, gd) = 
   let pp_size fmt i = F.fprintf fmt "%i" i in
   let pp_vd =  pp_var_decl pp_var pp_size in

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -6,7 +6,6 @@ module L = Location
 
 module Name = struct
   type t = string
-  let equal (n1:t) (n2:t) = n1 = n2
 end
 
 type uid = int

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -733,10 +733,6 @@ let renaming (f: ('info, 'asm) func) : (unit, 'asm) func =
 let remove_phi_nodes (f: ('info, 'asm) func) : (unit, 'asm) func =
   Ssa.remove_phi_nodes f
 
-let is_subroutine = function
-  | Subroutine _ -> true
-  | _            -> false
-
 (** Returns extra information (k, rsp) depending on the calling convention.
 
  - Subroutines:

--- a/compiler/src/safety/domains/safetyDisjunctive.ml
+++ b/compiler/src/safety/domains/safetyDisjunctive.ml
@@ -79,8 +79,6 @@ module Ptree = struct
         pp_cnstr node.constr
         (pp_ptree pp_leaf) node.n_unknwn
 
-  let flip c = flip_constr c |> otolist
-
   let rec same_shape t1 t2 = match t1, t2 with
     | Node n1, Node n2 -> same_shape_n n1 n2
     | Leaf _, Leaf _ -> true

--- a/compiler/src/ssa.ml
+++ b/compiler/src/ssa.ml
@@ -51,10 +51,6 @@ let ir (m: names) (x: var) (y: var) : (unit, 'asm) instr =
   let i_desc = Cassgn (Lvar (v y), AT_phinode, y.v_ty, Pvar (gkvar (v x))) in
   { i_desc ; i_info = () ; i_loc = L.i_dummy ; i_annot = [] }
 
-let is_stack_array x = 
-  let x = L.unloc x in
-  is_ty_arr x.v_ty && x.v_kind = Stack Direct
-
 let split_live_ranges is_move_op (allvars: bool) (f: ('info, 'asm) func) : (unit, 'asm) func =
   let f = Liveness.live_fd is_move_op false f in
   let rec instr_r (li: Sv.t) (lo: Sv.t) (m: names) =

--- a/compiler/src/subst.ml
+++ b/compiler/src/subst.ml
@@ -80,9 +80,9 @@ let subst_func f fc =
 
 (* ---------------------------------------------------------------- *)
 
-type psubst = pexpr Mv.t
+type psubst = pexpr ggvar -> pexpr
 
-let rec psubst_e (f: pexpr ggvar -> pexpr) e = 
+let rec psubst_e (f: psubst) e =
   gsubst_e (psubst_e f) f e
   
 

--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -401,11 +401,6 @@ let pp_ovar env fmt (x:var) =
     else pp_oget true pp_string fmt s
   else pp_string fmt s
 
-let pp_glob env fmt x = 
-  Format.fprintf fmt "%s" (fst (Ms.find x env.glob))
-
-let ty_glob env x = snd (Ms.find x env.glob)
-
 let pp_zeroext fmt (szi, szo) = 
   let io, ii = int_of_ws szo, int_of_ws szi in
   if ii < io then Format.fprintf fmt "zeroextu%a" pp_size szo

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -120,7 +120,7 @@ let check_class f_name f_loc ptr_classes args x s =
 
 type alignment = wsize Hv.t
 
-let classes_alignment (onfun : funname -> param_info option list) gtbl alias c = 
+let classes_alignment (onfun : funname -> param_info option list) (gtbl: alignment) alias c =
   let ltbl = Hv.create 117 in
   let calls = ref Sf.empty in
 

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -24,8 +24,6 @@ module X86 (Lowering_params : X86_input) : Arch_full.Core_arch = struct
   let asm_e = X86_extra.x86_extra
   let aparams = X86_params.x86_params
 
-  let rsp = RSP
-
   include Lowering_params
 
   let pp_asm = Ppasm.pp_prog

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -1,19 +1,11 @@
--arg -w
--arg -notation-overridden
--arg -w
--arg -extraction-reserved-identifier
--arg -w
--arg -extraction-opaque-accessed
--arg -w
--arg -ambiguous-paths
--arg -w
--arg -duplicate-clear
--arg -w
--arg -deprecated-hint-without-locality
--arg -w
--arg -deprecated-hint-rewrite-without-locality
--arg -w
--arg -deprecated-instance-without-locality
+-arg "-w -notation-overridden"
+-arg "-w -extraction-reserved-identifier"
+-arg "-w -extraction-opaque-accessed"
+-arg "-w -ambiguous-paths"
+-arg "-w -duplicate-clear"
+-arg "-w -deprecated-hint-without-locality"
+-arg "-w -deprecated-hint-rewrite-without-locality"
+-arg "-w -deprecated-instance-without-locality"
 
 -R 3rdparty Jasmin
 -R arch Jasmin


### PR DESCRIPTION
This PR gets rid of an ugly workaround in `_CoqProject` and enables OCaml warnings 32 and 34: they warn about unused type & value declarations.

This allow to remove (or use) some dead code.

Side-note: warning 32 fires a lot in the `safety/` directory, so I kept it disabled there (to be fixed later).