### PR TITLE
Reset the default `call_conv` in `main_compiler`

### DIFF
--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -86,11 +86,9 @@ let set_idirs s =
   | [s1; s2] -> idirs := (s1,s2)::!idirs
   | _ -> hierror ~loc:Lnone ~kind:"parsing arguments" "bad format for -I : ident:path expected"
 
-type call_conv = Linux | Windows 
+type call_conv = Linux | Windows
 
-let call_conv = 
-  ref (if Arch.os = Some `Windows then Windows 
-       else Linux)
+let call_conv = ref Linux (* Default value is chosen on start-up in `main_compiler` *)
 
 let set_cc cc = 
   let cc = 

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -10,6 +10,9 @@ let parse () =
   let set_in s =
     if !infile <> "" then error();
     infile := s  in
+  (* Set default option values *)
+  if Arch.os = Some `Windows then set_cc "windows";
+  (* Parse command-line arguments *)
   Arg.parse options set_in usage_msg;
   let c =
     match !color with


### PR DESCRIPTION
This makes the `Glob_options` module independent of `Unix`