### PR TITLE
default flag variable are automatically declared

### DIFF
--- a/compiler/tests/success/cmove8.jazz
+++ b/compiler/tests/success/cmove8.jazz
@@ -56,5 +56,14 @@ fn f(reg u8 b, reg u64 x y) -> reg u64 {
   x = (64u)z;
   r = y if b2;
   r += x;
+
+  ?{ "==" = b0, "<s" = c, "<u" = b1} = #CMP_64(x,y);
+  r = y if b0;
+  r = y if b1;
+  z = #SETcc(b1);
+  x = (64u)z;
+  r += x;
+
+
   return r;
 }


### PR DESCRIPTION
declare default flag variables allow to replace 
?{cf,zf,sf,of, "==" = b0, "<s" = c, "<u" = b1} = #CMP_64(x,y);
by 
?{ "==" = b0, "<s" = c, "<u" = b1} = #CMP_64(x,y);