### PR TITLE
Enable lowering of various memory-to-memory moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 - new option
 	"-call-conv {windows|linux}": select calling convention (default depend on host architecture)
 
+## Improvements
+
+- Lowering of a memory-to-memory copy always introduce an intermediate copy through a register
+
 # Jasmin 22.0
 
 This release is the result of more than two years of active development. It thus

--- a/compiler/tests/success/mem2mem.jazz
+++ b/compiler/tests/success/mem2mem.jazz
@@ -1,0 +1,55 @@
+/* There are different source-level constructions that translate to memory accesses:
+  - user (aka external) memory
+  - global variables (scalars / arrays)
+  - stack variables (scalars / arrays)
+  - reg ptr (arrays)
+*/
+u64 z = 0;
+u64[2] g = { 42, 137 };
+
+export
+fn mem2mem(reg u64 m) -> reg u64 {
+  stack u64[2] s;
+  reg ptr u64[1] p q;
+  reg u64 r;
+  // init
+  r = 0;
+  s[0] = 0;
+  p = g[0:1];
+  // external → external
+  [m] = [m + 8];
+  // global → external
+  [m] = z;
+  [m + 8] = g[0];
+  // stack → external
+  [m + 16] = s[0];
+  // pointer → external
+  [m + 24] = p[0];
+  // external → stack
+  s[0] = [m];
+  r += s[0];
+  // global → stack
+  s[0] = g[0];
+  r += s[0];
+  // stack → stack
+  s[1] = s[0];
+  r += s[1];
+  // pointer → stack
+  s[0] = p[0];
+  r += s[0];
+
+  q = s[1:1];
+  // external → pointer
+  q[0] = [m];
+  r += q[0];
+  // global → pointer
+  q[0] = g[0];
+  r += q[0];
+  // stack → pointer
+  q[0] = s[0];
+  r += q[0];
+  // pointer → pointer
+  q[0] = p[0];
+  r += q[0];
+  return r;
+}

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -254,7 +254,8 @@ Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
   let k16 sz := kb ((U16 ≤ sz) && (sz ≤ U64))%CMP sz in
   let k32 sz := kb ((U32 ≤ sz) && (sz ≤ U64))%CMP sz in
   match e with
-  | Pvar {| gv := ({| v_var := {| vtype := sword sz |} |} as v); gs := Slocal |} =>
+  | Pget _ sz {| gv := v |} _
+  | Pvar {| gv := ({| v_var := {| vtype := sword sz |} |} as v) |} =>
     chk (sz ≤ U64)%CMP (LowerMov (if is_var_in_memory v then is_lval_in_memory x else false))
   | Pload sz _ _ => chk (sz ≤ U64)%CMP (LowerMov (is_lval_in_memory x))
 


### PR DESCRIPTION
This is more uniform and avoids cryptic error messages from asm-gen