### PR TITLE
Followup to #188

### DIFF
--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -152,7 +152,7 @@ Definition and_condt ii e c1 c2 :=
   | _, _ => Error (E.berror ii e "Invalid condition (AND)")
   end.
 
-Definition of_var_e_bool ii (v: var_i) :=
+Definition of_var_e_bool ii (v: var_i) : cexec rflag :=
   match of_var v with
   | Some r => ok r
   | None => Error (asm_gen.E.invalid_flag ii v)
@@ -186,26 +186,26 @@ Fixpoint assemble_cond_r ii (e : pexpr) : cexec condt :=
       and_condt ii e c1 c2
 
   | Papp2 Obeq (Pvar x1) (Pvar x2) =>
-      Let r1 := of_var_e ii (gv x1) in
-      Let r2 := of_var_e ii (gv x2) in
+      Let r1 := of_var_e_bool ii (gv x1) in
+      Let r2 := of_var_e_bool ii (gv x2) in
       if ((r1 == SF) && (r2 == OF)) || ((r1 == OF) && (r2 == SF))
       then ok NL_ct
       else Error (E.berror ii e "Invalid condition (NL)")
 
   (* FIXME: We keep this by compatibility but it will be nice to remove it. *)
   | Pif _ (Pvar v1) (Papp1 Onot (Pvar vn2)) (Pvar v2) =>
-      Let r1 := of_var_e ii (gv v1) in
-      Let rn2 := of_var_e ii (gv vn2) in
-      Let r2 := of_var_e ii (gv v2) in
+      Let r1 := of_var_e_bool ii (gv v1) in
+      Let rn2 := of_var_e_bool ii (gv vn2) in
+      Let r2 := of_var_e_bool ii (gv v2) in
       if [&& r1 == SF, rn2 == OF & r2 == OF]
          || [&& r1 == OF, rn2 == SF & r2 == SF]
       then ok L_ct
       else Error (E.berror ii e "Invalid condition (L)")
 
   | Pif _ (Pvar v1) (Pvar v2) (Papp1 Onot (Pvar vn2)) =>
-      Let r1 := of_var_e ii (gv v1) in
-      Let r2 := of_var_e ii (gv v2) in
-      Let rn2 := of_var_e ii (gv vn2) in
+      Let r1 := of_var_e_bool ii (gv v1) in
+      Let r2 := of_var_e_bool ii (gv v2) in
+      Let rn2 := of_var_e_bool ii (gv vn2) in
       if [&& r1 == SF, rn2 == OF & r2 == OF]
          || [&& r1 == OF, rn2 == SF & r2 == SF]
       then ok NL_ct


### PR DESCRIPTION
We use `of_var_e_bool` everywhere.

I think we could actually get rid of `of_var_e`, since there is only one usecase any more, and only with registers.