### PR TITLE
Linear: linstr need not be an eqType

### DIFF
--- a/proofs/compiler/tunneling.v
+++ b/proofs/compiler/tunneling.v
@@ -28,15 +28,10 @@ Context `{asmop : asmOp}.
 Section LprogSem.
 
   Definition labels_of_body fb :=
-    filter 
-      (fun li => match li with
-               | Llabel _ => true
-               | _ => false
-               end)
-      (map li_i fb).
+    pmap (λ li, if li_i li is Llabel lbl then Some lbl else None) fb.
 
   Definition goto_targets fb :=
-    filter (fun li => if li is Lgoto _ then true else false) (map li_i fb).
+    pmap (λ li, if li_i li is Lgoto lbl then Some lbl else None) fb.
 
   Definition setfb fd fb : lfundef :=
     LFundef
@@ -114,16 +109,13 @@ Section TunnelingWF.
     let lbls := labels_of_body fb in
     uniq lbls &&
     all
-      (fun li => 
-         if li is Lgoto (fn',l) then 
-            (fn != fn') || (Llabel l \in lbls)
-         else false)
+      (fun '(fn', l) => (fn != fn') || (l \in lbls))
       (goto_targets fb).
-  
+
   Definition well_formed_funcs lf :=
     uniq (map fst lf)
     && all (fun func => well_formed_body func.1 func.2.(lfd_body)) lf.
-  
+
   Definition well_formed_lprog p :=
     well_formed_funcs (lp_funcs p).
 

--- a/proofs/compiler/tunneling_proof.v
+++ b/proofs/compiler/tunneling_proof.v
@@ -208,31 +208,6 @@ Section LprogSemProps.
     by apply List.Exists_cons; right; apply IHlf.
   Qed.
 
-  Lemma eq_from_get_fundef (lf lf' : seq (funname * lfundef)) :
-    uniq (map fst lf) ->
-    map fst lf = map fst lf' ->
-    (forall fn, get_fundef lf fn = get_fundef lf' fn) ->
-    lf = lf'.
-  Proof.
-    elim: lf lf' => [|[fn fd] lf IHlf] [|[fn' fd'] lf'] //=.
-    move => /andP [Hnotin Huniq] [? Heqfns] Heqfd; subst fn'.
-    move: (Heqfd fn); rewrite eq_refl => // -[?]; subst fd'; f_equal.
-    apply IHlf => // fn'; move: (Heqfd fn'); case: ifP => //.
-    move => /eqP ?; subst fn' => _; move: (Hnotin); rewrite Heqfns.
-    by move: Hnotin; rewrite -!get_fundef_in; do 2!(case: (get_fundef _ _)).
-  Qed.
-
-  Lemma onth_setfunc lf fn fd i :
-    onth (setfunc lf fn fd) i =
-    match onth lf i with
-    | Some (fn', fd') => if fn == fn' then Some (fn, fd) else Some (fn', fd')
-    | None => None
-    end.
-  Proof.
-    rewrite /setfunc onth_map; case Honth: (onth _ _) => [[fn' fd']|//].
-    by rewrite /fst /snd /=; case: ifP => // /eqP ?; subst fn'.
-  Qed.
-
   Lemma map_foldr (T R : Type) (s1 : seq R) (s2 : seq T) f :
     map (fun x => foldr f x s2) s1 = foldr (fun s => map (f s)) s1 s2.
   Proof.
@@ -340,14 +315,6 @@ Section TunnelingProps.
   Lemma labels_of_body_tunnel_lcmd_pc fn fb pc :
     labels_of_body (tunnel_lcmd_pc fn fb pc) = labels_of_body fb.
   Proof. by rewrite /tunnel_lcmd_pc labels_of_body_tunnel_engine. Qed.
-
-  Lemma labels_of_body_tunnel_lcmd_fn_partial fn fb pc :
-    labels_of_body (tunnel_lcmd_fn_partial fn fb pc) = labels_of_body fb.
-  Proof. by rewrite /tunnel_lcmd_fn_partial labels_of_body_tunnel_engine. Qed.
-
-  Lemma labels_of_body_tunnel_lcmd fn fb :
-    labels_of_body (tunnel_lcmd fn fb) = labels_of_body fb.
-  Proof. by rewrite /tunnel_lcmd labels_of_body_tunnel_engine. Qed.
 
   Lemma funnames_setfunc lf fn fd :
     map fst (setfunc lf fn fd) = map fst lf.

--- a/proofs/lang/linear.v
+++ b/proofs/lang/linear.v
@@ -62,47 +62,4 @@ Record lprog :=
     lp_globs : seq u8;
     lp_funcs : seq (funname * lfundef) }.
 
-Definition eqb_r i1 i2 :=
-  match i1, i2 with
-  | Lopn lv1 o1 e1, Lopn lv2 o2 e2 => (lv1 == lv2) && (o1 == o2) && (e1 == e2)
-  | Lsyscall o1, Lsyscall o2 => o1 == o2
-  | Lalign, Lalign => true
-  | Llabel l1, Llabel l2 => l1 == l2
-  | Lgoto l1, Lgoto l2 => l1 == l2
-  | Ligoto e1, Ligoto e2 => e1 == e2
-  | LstoreLabel x1 lbl1, LstoreLabel x2 lbl2 => (x1 == x2) && (lbl1 == lbl2)
-  | Lcond e1 l1, Lcond e2 l2 => (e1 == e2) && (l1 == l2)
-  | _, _ => false
-  end.
-
-Lemma eqb_r_axiom : Equality.axiom eqb_r.
-Proof.
-  case => [lv1 o1 e1|o1||l1|l1|e1|lv1 l1|e1 l1] [lv2 o2 e2|o2||l2|l2|e2|lv2 l2|e2 l2] //=;try by constructor.
-  + apply (@equivP (((lv1 == lv2) && (o1 == o2)) /\ e1 == e2 ));first by apply andP.
-    by split => [ [] /andP [] /eqP -> /eqP -> /eqP -> //| [] -> -> ->];rewrite !eqxx.
-  1-4: by apply: (equivP eqP); split; congruence.
-  + apply: (equivP andP); split.
-    * by case=> /eqP <- /eqP <-.
-    by case => <- <-; rewrite !eqxx.
-  apply (@equivP ((e1 == e2) /\ (l1 == l2)));first by apply andP.
-  by split => [ [] /eqP -> /eqP -> //| [] -> ->];rewrite !eqxx.
-Qed.
-
-Definition linstr_r_eqMixin := Equality.Mixin eqb_r_axiom.
-Canonical  linstr_r_eqType  := Eval hnf in EqType linstr_r linstr_r_eqMixin.
-
-Definition eqb i1 i2 :=
-  (li_ii i1 == li_ii i2) && (eqb_r (li_i i1) (li_i i2)).
-
-Lemma eqb_axiom : Equality.axiom eqb.
-Proof.
-  case=> [ii1 i1] [ii2 i2];rewrite /eqb /=.
-  apply (@equivP ((ii1 == ii2) /\ eqb_r i1 i2));first by apply andP.
-  split => [[]/eqP -> /eqb_r_axiom -> // | [] -> ->];rewrite eqxx;split => //.
-  by apply /eqb_r_axiom.
-Qed.
-
-Definition linstr_eqMixin := Equality.Mixin eqb_axiom.
-Canonical  linstr_eqType  := Eval hnf in EqType linstr linstr_eqMixin.
-
 End ASM_OP.

--- a/proofs/ssrmisc/seq_extra.v
+++ b/proofs/ssrmisc/seq_extra.v
@@ -1,5 +1,5 @@
 From mathcomp Require Import all_ssreflect.
-Require Import Utf8 oseq.
+Require Import Utf8 oseq utils.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -307,18 +307,13 @@ Section OnthProps.
     by apply IHs1 => i; move: (Heqonth i.+1) => /=.
   Qed.
 
-  Lemma onth_mem (T : eqType) (x : T) (s : seq T) :
-    reflect (exists i, onth s i = Some x) (x \in s).
+  Lemma onth_In {T : Type} (x : T) (s : seq T) i :
+    onth s i = Some x →
+    List.In x s.
   Proof.
-    elim: s => [//=|y s IHs].
-    + by rewrite in_nil; apply ReflectF => -[].
-    rewrite in_cons /=; case Heq: (x == y) => /=.
-    + by apply ReflectT; exists 0; move: Heq => /eqP ->.
-    elim: IHs => [Hexists|Hnexists].
-    + by apply ReflectT; case: Hexists => i Honth; exists (i.+1).
-    apply ReflectF => -[i] Hmatch; apply Hnexists.
-    case: i Hmatch => [[?]|i Honth]; last by exists i.
-    by subst y; rewrite eq_refl in Heq.
+    elim: s i => //= y s IHs [].
+    - by case => <-; left.
+    by move => i /IHs; right.
   Qed.
 
 End OnthProps.
@@ -366,6 +361,18 @@ Section AllProps.
   Proof.
     move => Hcab; elim: s => //= hs ts IHs; case: ifP => //= Hchs /andP [Hahs Hats].
     by apply/andP; split; first rewrite -Hcab; last apply IHs.
+  Qed.
+
+  Lemma allE (T: Type) (p: pred T) m :
+    reflect (List.Forall p m) (all p m).
+  Proof.
+    elim: m; first by left.
+    move => a m ih /=.
+    case h: (p a); last first.
+    - by right => /List_Forall_inv[]; rewrite h.
+    case: ih => ih; constructor.
+    - by constructor.
+    by case/List_Forall_inv.
   Qed.
 
 End AllProps.


### PR DESCRIPTION
Motivation: less code & proofs to maintain.