### PR TITLE
Two trivial fixes

### DIFF
--- a/proofs/compiler/merge_varmaps_proof.v
+++ b/proofs/compiler/merge_varmaps_proof.v
@@ -1,6 +1,7 @@
 (*
 *)
 Require Import sem_one_varmap sem_one_varmap_facts merge_varmaps psem_facts.
+Require Import seq_extra.
 Import Utf8.
 Import all_ssreflect all_algebra.
 Import ssrZ.
@@ -102,7 +103,7 @@ Lemma check_wmapP (wm: Mp.t Sv.t) (fn: funname) (fd: sfundef) :
   get_fundef (p_funcs p) fn = Some fd →
   check_wmap p extra_free_registers var_tmp wm →
   valid_writefun (get_wmap wm) (fn, fd).
-Proof. by move /get_fundef_in' /(@InP [eqType of sfun_decl]) => h /allP /(_ _ h). Qed.
+Proof. by move /get_fundef_in' => h /allE/List.Forall_forall /(_ _ h). Qed.
 
 Let wmap := mk_wmap p extra_free_registers var_tmp.
 Notation wrf := (get_wmap wmap).

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -209,7 +209,7 @@ Notation ok    := (@Ok _).
 Notation "m >>= f" := (rbind f m) (at level 25, left associativity).
 Notation "'Let' x ':=' m 'in' body" := (m >>= (fun x => body)) (x name, at level 25).
 Notation "'Let:' x ':=' m 'in' body" := (m >>= (fun x => body)) (x strict pattern, at level 25).
-Notation "m >> n" := (rbind (λ _, n) m) (at level 25, left associativity).
+Notation "m >> n" := (rbind (λ _, n) m) (at level 30, right associativity, n at next level).
 
 Lemma bindA eT aT bT cT (f : aT -> result eT bT) (g: bT -> result eT cT) m:
   m >>= f >>= g = m >>= (fun a => f a >>= g).


### PR DESCRIPTION
Currently, trying to `Require Import Uint63.` fails with:

> Error: Notation "_ >> _" is already defined at level 25 with arguments constr at level 25, constr at next level
while it is now required to be at level 30 with arguments constr at next level, constr at next level.

The first patch fixes this issue.

The second patch removes the single (real) use of `stk_fun_extra` as an `eqType`.