### PR TITLE
Loop unrolling: change halting condition

### DIFF
--- a/proofs/3rdparty/xseq.v
+++ b/proofs/3rdparty/xseq.v
@@ -131,7 +131,18 @@ End InjAssoc.
 
 (* -------------------------------------------------------------------- *)
 Section AssocMap.
-Context (T: eqType) (U V: Type) (f: U → V) (g: T → U → V).
+Context (T: eqType) (U V: Type) (f: U → V) (g: T → U → V) (h: T * U → T * V).
+
+Lemma assoc_mapE m n :
+  (∀ n u, (h (n, u)).1 = n) →
+  assoc (map h m) n = omap (λ u, (h (n, u)).2) (assoc m n).
+Proof.
+  move => E.
+  elim: m => // - [] t u m /= ->.
+  case htu: h (E t u) => [ ? v ] /= ?; subst.
+  case: eqP => //= ->.
+  by rewrite htu.
+Qed.
 
 Lemma assoc_map m (n: T) :
   assoc [seq (x.1, f x.2) | x <- m] n = omap f (assoc m n).

--- a/proofs/compiler/unrolling.v
+++ b/proofs/compiler/unrolling.v
@@ -12,45 +12,85 @@ Local Open Scope seq_scope.
 (* ** unrolling
  * -------------------------------------------------------------------- *)
 
+(** This pass is to be repeated until a fixed-point is reached.
+  It returns a boolean indicating whether something happened,
+  i.e., if the transformation should be repeated.
+  Beware of wild monads…
+*)
+Section MAP_REPEAT.
+
+Context {U V: Type} (f: U -> V * bool).
+
+Definition map_repeat (m: seq U) : seq V * bool :=
+  List.fold_right
+    (fun u '(vs, a) =>
+       let: (v, b) := f u in
+       (v :: vs, a || b))
+    ([::], false) m.
+
+Lemma map_repeat_1 m :
+  (map_repeat m).1 = [seq (f u).1 | u <- m].
+Proof.
+  elim: m; first by [].
+  move => u m /=.
+  case: map_repeat => _ b /= ->.
+  by case: f.
+Qed.
+
+End MAP_REPEAT.
+
 Section ASM_OP.
 
 Context `{asmop:asmOp}.
 
-Definition unroll_cmd (unroll_i: instr -> cmd) (c:cmd) : cmd :=
-  List.fold_right (fun i c' => unroll_i i ++ c') [::] c.
+Definition unroll_cmd (unroll_i: instr -> cmd * bool) (c:cmd) : cmd * bool :=
+  List.fold_right
+    (fun i '(c', a) =>
+       let: (i', b) := unroll_i i in
+       (i' ++ c', a || b))
+    ([::], false) c.
 
 Definition assgn ii x e := MkI ii (Cassgn (Lvar x) AT_inline x.(v_var).(vtype) e).
 
-Fixpoint unroll_i (i:instr) : cmd :=
+Fixpoint unroll_i (i: instr) : cmd * bool :=
   let (ii, ir) := i in
   match ir with
   | Cassgn _ _ _ _
   | Copn _ _ _ _
   | Csyscall _ _ _
-    => [:: i ]
-  | Cif b c1 c2  => [:: MkI ii (Cif b (unroll_cmd unroll_i c1) (unroll_cmd unroll_i c2)) ]
+  | Ccall _ _ _ _
+    => ([:: i ], false)
+  | Cif b c1 c2  =>
+      let: (c1', b1) := unroll_cmd unroll_i c1 in
+      let: (c2', b2) := unroll_cmd unroll_i c2 in
+      ([:: MkI ii (Cif b c1' c2') ], b1 || b2)
   | Cfor i (dir, low, hi) c =>
-    let c' := unroll_cmd unroll_i c in
+    let: (c', b) := unroll_cmd unroll_i c in
     match is_const low, is_const hi with
     | Some vlo, Some vhi =>
       let l := wrange dir vlo vhi in
       let cs := map (fun n => assgn ii i (Pconst n) :: c') l in
-      flatten cs
-    | _, _       => [:: MkI ii (Cfor i (dir, low, hi) c') ]
+      (flatten cs, true)
+    | _, _       => ([:: MkI ii (Cfor i (dir, low, hi) c') ], b)
     end
-  | Cwhile a c e c'  => [:: MkI ii (Cwhile a (unroll_cmd unroll_i c) e (unroll_cmd unroll_i c')) ]
-  | Ccall _ _ _ _  => [:: i ]
+  | Cwhile a c1 e c2  =>
+      let: (c1', b1) := unroll_cmd unroll_i c1 in
+      let: (c2', b2) := unroll_cmd unroll_i c2 in
+      ([:: MkI ii (Cwhile a c1' e c2') ], b1 || b2)
   end.
 
 Section Section.
 
 Context {T} {pT:progT T}.
 
-Definition unroll_fun (f:fundef) :=
-  let 'MkFun ii si p c so r ev := f in
-  MkFun ii si p (unroll_cmd unroll_i c) so r ev.
+Definition unroll_fun (f: fun_decl) :=
+  let: (fn, MkFun ii si p c so r ev) := f in
+  let: (c', b) := unroll_cmd unroll_i c in
+  ((fn, MkFun ii si p c' so r ev), b).
 
-Definition unroll_prog (p:prog) := map_prog unroll_fun p.
+Definition unroll_prog (p: prog) : prog * bool :=
+  let: (fds, b) := map_repeat unroll_fun (p_funcs p) in
+  ({| p_funcs := fds ; p_globs := p_globs p ; p_extra := p_extra p |}, b).
 
 End Section.
 

--- a/proofs/compiler/unrolling_proof.v
+++ b/proofs/compiler/unrolling_proof.v
@@ -24,21 +24,39 @@ Section PROOF.
   Variable (p : prog) (ev:extra_val_t).
   Notation gd := (p_globs p).
 
-  Let p' := unroll_prog p.
+  Let p' := (unroll_prog p).1.
+
+  Lemma p'_globs : p_globs p' = p_globs p.
+  Proof. by rewrite /p' /unroll_prog; case: map_repeat. Qed.
+
+  Lemma p'_extra : p_extra p' = p_extra p.
+  Proof. by rewrite /p' /unroll_prog; case: map_repeat. Qed.
+
+  Lemma p'_get_fundef fn fd :
+    get_fundef (p_funcs p) fn = Some fd ->
+    get_fundef (p_funcs p') fn = Some (unroll_fun (fn, fd)).1.2.
+  Proof.
+    rewrite /p' /unroll_prog.
+    have := map_repeat_1 unroll_fun (p_funcs p).
+    case: map_repeat => _ b /= ->.
+    rewrite /get_fundef assoc_mapE; last first.
+    - by move => ? [] > /=; case unroll_cmd.
+    by move => ->.
+  Qed.
 
   Let Pi_r s (i:instr_r) s' :=
-    forall ii, sem p' ev s (unroll_i (MkI ii i)) s'.
+    forall ii, sem p' ev s (unroll_i (MkI ii i)).1 s'.
 
   Let Pi s (i:instr) s' :=
-    sem p' ev s (unroll_i i) s'.
+    sem p' ev s (unroll_i i).1 s'.
 
   Let Pc s (c:cmd) s':=
-    sem p' ev s (unroll_cmd unroll_i c) s'.
+    sem p' ev s (unroll_cmd unroll_i c).1 s'.
 
   Let Pfor (i:var_i) vs s c s' :=
-    sem_for p' ev i vs s (unroll_cmd unroll_i c) s'
+    sem_for p' ev i vs s (unroll_cmd unroll_i c).1 s'
     /\ forall ii, sem p' ev s
-      (flatten (map (fun n => assgn ii i (Pconst n) :: (unroll_cmd unroll_i c)) vs)) s'.
+      (flatten (map (fun n => assgn ii i (Pconst n) :: (unroll_cmd unroll_i c).1) vs)) s'.
 
   Let Pfun scs1 m1 fn vargs scs2 m2 vres :=
     sem_call p' ev scs1 m1 fn vargs scs2 m2 vres.
@@ -48,8 +66,11 @@ Section PROOF.
 
   Local Lemma Hcons : sem_Ind_cons p ev Pc Pi.
   Proof.
-    move=> s1 s2 s3 i c Hsi Hi Hsc Hc.
-    exact: (sem_app Hi Hc).
+    move => s1 s2 s3 i c _.
+    rewrite /Pi /Pc /=.
+    case: unroll_i => i' b Hi _.
+    case: unroll_cmd => c' a Hc.
+    exact: sem_app Hi Hc.
   Qed.
 
   Local Lemma HmkI : sem_Ind_mkI p ev Pi_r Pi.
@@ -58,49 +79,63 @@ Section PROOF.
   Local Lemma Hassgn : sem_Ind_assgn p Pi_r.
   Proof.
     move=> s1 s2 x tag ty e v v' hv hv' hw ii.
-    by apply: sem_seq1; apply: EmkI; apply: Eassgn; eauto.
+    by apply: sem_seq1; apply: EmkI; apply: Eassgn; rewrite ?p'_globs; eassumption.
   Qed.
 
   Local Lemma Hopn : sem_Ind_opn p Pi_r.
   Proof.
     move=> s1 s2 t o xs es Hw ii.
-    by apply: sem_seq1; apply: EmkI; apply: Eopn.
+    by apply: sem_seq1; apply: EmkI; apply: Eopn; rewrite ?p'_globs; eassumption.
   Qed.
 
   Local Lemma Hsyscall : sem_Ind_syscall p Pi_r.
   Proof.
     move=> s1 scs m s2 xs o es ves vs hes ho hw ii /=.
-    apply: sem_seq1; apply: EmkI; apply: Esyscall; eauto.
+    apply: sem_seq1; apply: EmkI; apply: Esyscall; rewrite ?p'_globs; eassumption.
   Qed.
 
   Local Lemma Hif_true : sem_Ind_if_true p ev Pc Pi_r.
   Proof.
-    move=> s1 s2 e c1 c2 Hb Hsc Hc ii.
-    by apply: sem_seq1; apply: EmkI; apply: Eif_true.
+    move => s1 s2 e c1 c2 Hb _.
+    rewrite /Pc /Pi_r /=.
+    case: unroll_cmd => c1' b1 /= Hc ii.
+    case: unroll_cmd => c2' b2 /=.
+    by apply: sem_seq1; apply: EmkI; apply: Eif_true; rewrite ?p'_globs.
   Qed.
 
   Local Lemma Hif_false : sem_Ind_if_false p ev Pc Pi_r.
   Proof.
-    move=> s1 s2 e c1 c2 Hb Hsc Hc ii.
-    by apply: sem_seq1; apply: EmkI; apply: Eif_false.
+    move => s1 s2 e c1 c2 Hb _.
+    rewrite /Pc /Pi_r /=.
+    case: unroll_cmd => c2' b2 /= Hc ii.
+    case: unroll_cmd => c1' b1 => /=.
+    by apply: sem_seq1; apply: EmkI; apply: Eif_false; rewrite ?p'_globs.
   Qed.
 
   Local Lemma Hwhile_true : sem_Ind_while_true p ev Pc Pi_r.
   Proof.
-    move=> s1 s2 s3 s4 a c e c' Hsc Hc Hb Hsc' Hc' Hsi Hi ii.
-    apply: sem_seq1; apply: EmkI; apply: Ewhile_true=> //; eauto=> /=.
+    move => s1 s2 s3 s4 a c1 e c2 _.
+    rewrite /Pc /Pi_r /=.
+    case: (unroll_cmd _ c1) => c1' b1 /= Hc1 Hb _.
+    case: (unroll_cmd _ c2) => c2' b2 /= Hc2 _ Hi ii.
+    apply: sem_seq1; apply: EmkI; apply: Ewhile_true; rewrite ?p'_globs; eauto.
     by move: Hi=> /(_ ii) /semE [?] [/sem_IE Hi /semE ->].
   Qed.
 
   Local Lemma Hwhile_false : sem_Ind_while_false p ev Pc Pi_r.
   Proof.
-   move=> s1 s2 a c e c' Hsc Hc Hb ii.
-   by apply: sem_seq1; apply: EmkI; apply: Ewhile_false.
+    move => s1 s2 a c1 e c2 _.
+    rewrite /Pc /Pi_r /=.
+    case: (unroll_cmd _ c1) => c1' b1 /= Hc1 Hb ii.
+    case: (unroll_cmd _ c2) => c2' b2 /=.
+   by apply: sem_seq1; apply: EmkI; apply: Ewhile_false; rewrite ?p'_globs.
   Qed.
 
   Local Lemma Hfor : sem_Ind_for p ev Pi_r Pfor.
   Proof.
-    move=> s1 s2 i d lo hi c vlo vhi Hlo Hhi Hc [Hfor Hfor'] ii /=.
+    move => s1 s2 i d lo hi c vlo vhi Hlo Hhi _ [].
+    rewrite /Pi_r /=.
+    case: unroll_cmd => c' b /= Hfor Hfor' ii.
     case Hlo': (is_const lo)=> [nlo|].
     + case Hhi': (is_const hi)=> [nhi|].
       + have ->: nlo = vlo.
@@ -110,8 +145,7 @@ Section PROOF.
           rewrite /is_const /= in Hhi'.
           by case: hi Hhi Hhi'=> //= z [] -> [] ->.
         exact: Hfor'.
-      apply: sem_seq1; apply: EmkI; apply: Efor; [apply: Hlo|apply: Hhi|apply: Hfor].
-    apply: sem_seq1; apply: EmkI; apply: Efor; [apply: Hlo|apply: Hhi|apply: Hfor].
+    all: apply: sem_seq1; apply: EmkI; apply: Efor; rewrite ?p'_globs; eassumption.
   Qed.
 
   Local Lemma Hfor_nil : sem_Ind_for_nil Pfor.
@@ -137,15 +171,19 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hexpr Hcall Hfun Hw ii'.
-    apply: sem_seq1; apply: EmkI; apply: Ecall; [exact: Hexpr|exact: Hfun|exact: Hw].
+    move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hexpr _ Hfun Hw ii' /=.
+    by apply: sem_seq1; apply: EmkI; apply: Ecall; rewrite ?p'_globs; eassumption.
   Qed.
 
   Local Lemma Hproc : sem_Ind_proc p ev Pc Pfun.
   Proof.
     move => scs1 m1 scs2 m2 fn f vargs vargs' s0 s1 s2 vres vres'.
     case: f=> fi ftyi fparams fc ftyo fres fe /= Hget Htyi Hi Hw _ Hc Hres Htyo Hsys Hfi.
-    apply: EcallRun; first (by rewrite get_map_prog Hget); eauto.
+    move/p'_get_fundef: Hget Hc.
+    rewrite /Pc /=.
+    case: unroll_cmd => c _ /= Hget Hc.
+    apply: EcallRun; first exact: Hget.
+    all: rewrite /= ?p'_extra; eassumption.
   Qed.
 
   Lemma unroll_callP f scs mem scs' mem' va vr:

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -635,22 +635,6 @@ Definition fun_decl := (funname * fundef)%type.
 
 Definition prog := _prog extra_fun_t extra_prog_t.
 
-Definition fundef_beq (fd1 fd2:fundef) :=
-  match fd1, fd2 with
-  | MkFun ii1 tin1 x1 c1 tout1 r1 e1, MkFun ii2 tin2 x2 c2 tout2 r2 e2 =>
-    (ii1 == ii2) && (tin1 == tin2) && (x1 == x2) && (c1 == c2) && (tout1 == tout2) && (r1 == r2) && (e1 == e2)
-  end.
-
-Lemma fundef_eq_axiom : Equality.axiom fundef_beq.
-Proof.
-  move=> [i1 tin1 p1 c1 tout1 r1 e1] [i2 tin2 p2 c2 tout2 r2 e2] /=.
-  by apply (iffP idP) => [/andP[]/andP[]/andP[]/andP[]/andP[]/andP[] | []]
-    /eqP->/eqP->/eqP->/eqP->/eqP->/eqP->/eqP->.
-Qed.
-
-Definition fundef_eqMixin     := Equality.Mixin fundef_eq_axiom.
-Canonical  fundef_eqType      := Eval hnf in EqType fundef fundef_eqMixin.
-
 Definition Build_prog p_funcs p_globs p_extra : prog := Build__prog p_funcs p_globs p_extra.
 
 End PROG.

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -526,69 +526,6 @@ Section ASM_OP.
 
 Context `{asmop:asmOp}.
 
-Fixpoint instr_r_beq (i1 i2:instr_r) :=
-  match i1, i2 with
-  | Cassgn x1 tag1 ty1 e1, Cassgn x2 tag2 ty2 e2 =>
-     (tag1 == tag2) && (ty1 == ty2) && (x1 == x2) && (e1 == e2)
-  | Copn x1 tag1 o1 e1, Copn x2 tag2 o2 e2 =>
-     (x1 == x2) && (tag1 == tag2) && (o1 == o2) && (e1 == e2)
-  | Csyscall xs1 o1 es1, Csyscall xs2 o2 es2 => 
-     (xs1 == xs2) && (o1 == o2) && (es1 == es2)
-  | Cif e1 c11 c12, Cif e2 c21 c22 =>
-    (e1 == e2) && all2 instr_beq c11 c21 && all2 instr_beq c12 c22
-  | Cfor i1 (dir1,lo1,hi1) c1, Cfor i2 (dir2,lo2,hi2) c2 =>
-    (i1 == i2) && (dir1 == dir2) && (lo1 == lo2) && (hi1 == hi2) && all2 instr_beq c1 c2
-  | Cwhile a1 c1 e1 c1' , Cwhile a2 c2 e2 c2' =>
-    (a1 == a2) && all2 instr_beq c1 c2 && (e1 == e2) && all2 instr_beq c1' c2'
-  | Ccall ii1 x1 f1 arg1, Ccall ii2 x2 f2 arg2 =>
-    (ii1 == ii2) && (x1==x2) && (f1 == f2) && (arg1 == arg2)
-  | _, _ => false
-  end
-with instr_beq i1 i2 :=
-  match i1, i2 with
-  | MkI if1 i1, MkI if2 i2 => (if1 == if2) && (instr_r_beq i1 i2)
-  end.
-
-Section EQI.
-  Variable Heq : forall (x y:instr_r), reflect (x=y) (instr_r_beq x y).
-
-  Lemma instr_eq_axiom_ : Equality.axiom instr_beq.
-  Proof.
-    move=> [ii1 ir1] [ii2 ir2] /=.
-    by apply (iffP andP) => -[] /eqP -> /Heq ->.
-  Defined.
-End EQI.
-
-Lemma instr_r_eq_axiom : Equality.axiom instr_r_beq.
-Proof.
-  rewrite /Equality.axiom.
-  fix Hrec 1; move =>
-    [x1 t1 ty1 e1|x1 t1 o1 e1|p1 x1 e1|e1 c11 c12|x1 [[dir1 lo1] hi1] c1|a1 c1 e1 c1'|ii1 x1 f1 arg1 ]
-    [x2 t2 ty2 e2|x2 t2 o2 e2|p2 x2 e2|e2 c21 c22|x2 [[dir2 lo2] hi2] c2|a2 c2 e2 c2'|ii2 x2 f2 arg2 ] /=;
-  try by constructor.
-  + by apply (iffP idP) => [/andP[]/andP[]/andP[] | []] /eqP -> /eqP -> /eqP -> /eqP ->.
-  + by apply (iffP idP) => [/andP[]/andP[]/andP[] | []] /eqP -> /eqP -> /eqP -> /eqP ->.
-  + by apply (iffP idP) => [/andP[]/andP[] | []] /eqP -> /eqP -> /eqP ->.
-  + have Hrec2 := reflect_all2_eqb (instr_eq_axiom_ Hrec).
-    by apply (iffP idP) => [/andP[]/andP[] | []] /eqP -> /Hrec2 -> /Hrec2 ->.
-  + have Hrec2 := reflect_all2_eqb (instr_eq_axiom_ Hrec).
-    by apply (iffP idP) => [/andP[]/andP[]/andP[]/andP[] | []] /eqP -> /eqP -> /eqP -> /eqP -> /Hrec2 ->.
-  + have Hrec2 := reflect_all2_eqb (instr_eq_axiom_ Hrec).
-    by apply (iffP idP) => [/andP[]/andP[]/andP[] | []] /eqP -> /Hrec2 -> /eqP -> /Hrec2 ->.
-  by apply (iffP idP) => [/andP[]/andP[]/andP[] | []] /eqP -> /eqP -> /eqP -> /eqP ->.
-Qed.
-
-Definition instr_r_eqMixin     := Equality.Mixin instr_r_eq_axiom.
-Canonical  instr_r_eqType      := Eval hnf in EqType instr_r instr_r_eqMixin.
-
-Lemma instr_eq_axiom : Equality.axiom instr_beq.
-Proof.
-  apply: instr_eq_axiom_ instr_r_eq_axiom .
-Qed.
-
-Definition instr_eqMixin     := Equality.Mixin instr_eq_axiom.
-Canonical  instr_eqType      := Eval hnf in EqType instr instr_eqMixin.
-
 (* ** Functions
  * -------------------------------------------------------------------- *)
 


### PR DESCRIPTION
This might be more efficient, and this allows to clean away some tedious `eqType` definitions.