### PR TITLE
Extract instr_info & var_info to standard OCaml int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 - Lowering of a memory-to-memory copy always introduce an intermediate copy through a register
 
+- `var_info` and `instr_info` are now plain OCaml `int`
+   ([PR #209](https://github.com/jasmin-lang/jasmin/pull/209)).
+
 # Jasmin 22.0
 
 This release is the result of more than two years of active development. It thus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@
 
 - Lowering of a memory-to-memory copy always introduce an intermediate copy through a register
 
-- `var_info` and `instr_info` are now plain OCaml `int`
+- `instr_info` are now plain OCaml `int` and `var_info` are `Location.t`;
+   this removes costly translations with `positive` and a big conversion table
    ([PR #209](https://github.com/jasmin-lang/jasmin/pull/209)).
 
 # Jasmin 22.0

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -122,13 +122,13 @@ let var_of_cvar tbl cv =
 (* ------------------------------------------------------------------------ *)
 
 let get_loc tbl p =
-  try Hashtbl.find tbl.vari (int_of_pos p)
+  try Hashtbl.find tbl.vari p
   with Not_found -> L._dummy
 
 let set_loc tbl loc =
   let n = new_count tbl in
   Hashtbl.add tbl.vari n loc;
-  pos_of_int n
+  n
 
 let cvari_of_vari tbl v =
   let p = set_loc tbl (L.loc v) in
@@ -230,10 +230,9 @@ let string_of_funname tbl p =
 let set_iinfo tbl loc ii ia =
   let n = new_count tbl in
   Hashtbl.add tbl.iinfo n (loc, ii, ia);
-  pos_of_int n
+  n
 
 let get_iinfo tbl n =
-  let n = int_of_pos n in
   try Hashtbl.find tbl.iinfo n
   with Not_found ->
     Format.eprintf "WARNING: CAN NOT FIND IINFO %i@." n;

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -51,7 +51,7 @@ val fun_of_cfun : 'info coq_tbl -> BinNums.positive -> funname
 
 val string_of_funname : 'info coq_tbl -> BinNums.positive -> string
 
-val get_iinfo   : 'info coq_tbl -> BinNums.positive -> L.i_loc * 'info * Syntax.annotations
+val get_iinfo   : 'info coq_tbl -> Expr.instr_info -> L.i_loc * 'info * Syntax.annotations
 
 val get_finfo   : 'info coq_tbl -> BinNums.positive -> L.t * f_annot * call_conv * Syntax.annotations list
 

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -34,9 +34,8 @@ val z_of_word : wsize -> Obj.t -> Z.t
 (* -------------------------------------------------------------------- *)
 val cty_of_ty : Prog.ty -> Type.stype
 val ty_of_cty : Type.stype -> Prog.ty
-(* -------------------------------------------------------------------- *)
-val get_loc : 'a coq_tbl -> Expr.var_info -> L.t
 
+(* -------------------------------------------------------------------- *)
 val cvar_of_var : 'a coq_tbl -> var -> Var0.Var.var
 val var_of_cvar : 'a coq_tbl -> Var0.Var.var -> var
 val vari_of_cvari : 'a coq_tbl -> Expr.var_i -> var L.located

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -35,7 +35,7 @@ val z_of_word : wsize -> Obj.t -> Z.t
 val cty_of_ty : Prog.ty -> Type.stype
 val ty_of_cty : Type.stype -> Prog.ty
 (* -------------------------------------------------------------------- *)
-val get_loc : 'a coq_tbl -> BinNums.positive -> L.t
+val get_loc : 'a coq_tbl -> Expr.var_info -> L.t
 
 val cvar_of_var : 'a coq_tbl -> var -> Var0.Var.var
 val var_of_cvar : 'a coq_tbl -> Var0.Var.var -> var

--- a/compiler/src/evaluator.ml
+++ b/compiler/src/evaluator.ml
@@ -149,7 +149,7 @@ let init_state scs0 p fn m =
   { s_prog = p;
     s_cmd = f.f_body;
     s_estate = {escs = scs0; emem = m; evm = vmap0 };
-    s_stk = Sempty(Coq_xO Coq_xH, f) }
+    s_stk = Sempty(dummy_instr_info, f) }
 
 
 let exec pd sc_sem asmOp scs0 p fn m =

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -267,7 +267,7 @@ let main () =
               in
               (match m_init with
                  | Utils0.Ok m -> m
-                 | Utils0.Error err -> raise (Evaluator.Eval_error (Coq_xH, err)))
+                 | Utils0.Error err -> raise (Evaluator.Eval_error (Expr.dummy_instr_info, err)))
               |>
               Evaluator.exec
                 Arch.reg_size

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -504,8 +504,7 @@ let pp_err ~debug tbl fmt (pp_e : Compiler_util.pp_error) =
     match pp_e with
     | Compiler_util.PPEstring s -> Format.fprintf fmt "%a" pp_string0 s
     | Compiler_util.PPEvar v -> Format.fprintf fmt "%a" (pp_var tbl) v
-    | Compiler_util.PPEvarinfo vi ->
-      let loc = Conv.get_loc tbl vi in
+    | Compiler_util.PPEvarinfo loc ->
       Format.fprintf fmt "%a" L.pp_loc loc
     | Compiler_util.PPEfunname fn -> Format.fprintf fmt "%s" (Conv.fun_of_cfun tbl fn).fn_name
     | Compiler_util.PPEiinfo ii ->

--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -289,7 +289,7 @@ Definition compile_arg rip ii (ade: (arg_desc * stype) * pexpr) (m: nmap asm_arg
   match ad.1 with
   | ADImplicit i =>
     Let _ :=
-      assert (eq_expr (Plvar (VarI (var_of_implicit i) xH)) e)
+      assert (eq_expr (Plvar (VarI (var_of_implicit i) dummy_var_info)) e)
              (E.internal_error ii "(compile_arg) bad implicit register") in
     ok m
   | ADExplicit k n o =>
@@ -316,7 +316,7 @@ Definition compat_imm ty a' a :=
 
 Definition check_sopn_arg rip ii (loargs : seq asm_arg) (x : pexpr) (adt : arg_desc * stype) :=
   match adt.1 with
-  | ADImplicit i => eq_expr x (Plvar (VarI (var_of_implicit i) xH))
+  | ADImplicit i => eq_expr x (Plvar (VarI (var_of_implicit i) dummy_var_info))
   | ADExplicit k n o =>
     match onth loargs n with
     | Some a =>
@@ -328,7 +328,7 @@ Definition check_sopn_arg rip ii (loargs : seq asm_arg) (x : pexpr) (adt : arg_d
 
 Definition check_sopn_dest rip ii (loargs : seq asm_arg) (x : pexpr) (adt : arg_desc * stype) :=
   match adt.1 with
-  | ADImplicit i => eq_expr x (Plvar (VarI (var_of_implicit i) xH))
+  | ADImplicit i => eq_expr x (Plvar (VarI (var_of_implicit i) dummy_var_info))
   | ADExplicit _ n o =>
     match onth loargs n with
     | Some a =>

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -234,7 +234,7 @@ Qed.
 
 Variant check_sopn_argI rip ii args e : arg_desc -> stype -> Prop :=
 | CSA_Implicit i ty :
-       (eq_expr e (Plvar {| v_var := var_of_implicit i; v_info := 1%positive |}))
+       (eq_expr e (Plvar {| v_var := var_of_implicit i; v_info := dummy_var_info |}))
     -> check_sopn_argI rip ii args e (ADImplicit i) ty
 
 | CSA_Explicit k n o a a' ty :
@@ -1572,7 +1572,7 @@ Proof.
     exists lc; first exact: omap_lc.
     constructor => //=; last by congr _.+1.
     move: ok_r_x.
-    change x with (v_var (VarI x xH)).
+    change x with (v_var (VarI x dummy_var_info)).
     apply: lom_eqv_write_var; first exact: eqm.
     by rewrite /write_var ok_vm.
   - t_xrbindP => cnd lbl cndt ok_c <- b v ok_v ok_b.

--- a/proofs/compiler/array_init.v
+++ b/proofs/compiler/array_init.v
@@ -101,14 +101,11 @@ Section Section.
 
 Context (is_ptr : var -> bool).
 
-(* TODO: move *)
-Definition dummy_info := xH.
-
-Definition add_init_aux ii x c := 
+Definition add_init_aux ii x c :=
   match x.(vtype) with
   | sarr n =>
     if ~~ is_ptr x then
-      let x := VarI x dummy_info in
+      let x := VarI x dummy_var_info in
       MkI ii (Cassgn (Lvar x) AT_none (sarr n) (Parr_init n)) :: c
     else c
   | _ => c

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -484,13 +484,13 @@ Definition linear_body (e: stk_fun_extra) (body: cmd) : lcmd :=
   let: (tail, head, lbl) :=
      match sf_return_address e with
      | RAreg r =>
-       ( [:: MkLI xH (Ligoto (Pvar (Gvar (VarI r dummy_var_info) Slocal))) ]
-       , [:: MkLI xH (Llabel 1) ]
+       ( [:: MkLI dummy_instr_info (Ligoto (Pvar (Gvar (VarI r dummy_var_info) Slocal))) ]
+       , [:: MkLI dummy_instr_info (Llabel 1) ]
        , 2%positive
        )
      | RAstack z =>
-       ( [:: MkLI xH (Ligoto (Pload Uptr rspi (cast_const z))) ]
-       , [:: MkLI xH (Llabel 1) ]
+       ( [:: MkLI dummy_instr_info (Ligoto (Pload Uptr rspi (cast_const z))) ]
+       , [:: MkLI dummy_instr_info (Llabel 1) ]
        , 2%positive
        )
      | RAnone =>
@@ -503,10 +503,10 @@ Definition linear_body (e: stk_fun_extra) (body: cmd) : lcmd :=
           *       Setup stack.
           *)
          let r := VarI x dummy_var_info in
-         ( [:: lmove xH rspi Uptr (Gvar r Slocal) ]
-         , lmove xH r Uptr rspg
-             :: allocate_stack_frame false xH (sf_stk_sz e + sf_stk_extra_sz e)
-             ++ [:: ensure_rsp_alignment xH e.(sf_align) ]
+         ( [:: lmove dummy_instr_info rspi Uptr (Gvar r Slocal) ]
+         , lmove dummy_instr_info r Uptr rspg
+             :: allocate_stack_frame false dummy_instr_info (sf_stk_sz e + sf_stk_extra_sz e)
+             ++ [:: ensure_rsp_alignment dummy_instr_info e.(sf_align) ]
          , 1%positive
          )
        | SavedStackStk ofs =>
@@ -518,13 +518,13 @@ Definition linear_body (e: stk_fun_extra) (body: cmd) : lcmd :=
           *       Push registers to save to the stack.
           *)
          let tmp := VarI var_tmp dummy_var_info in
-         ( pop_to_save xH e.(sf_to_save)
-             ++ [:: lload xH rspi Uptr rspi ofs ]
-         , lmove xH tmp Uptr rspg
-             :: allocate_stack_frame false xH (sf_stk_sz e + sf_stk_extra_sz e)
-             ++ ensure_rsp_alignment xH e.(sf_align)
-             :: lstore xH rspi ofs Uptr (Gvar tmp Slocal)
-             :: push_to_save xH e.(sf_to_save)
+         ( pop_to_save dummy_instr_info e.(sf_to_save)
+             ++ [:: lload dummy_instr_info rspi Uptr rspi ofs ]
+         , lmove dummy_instr_info tmp Uptr rspg
+             :: allocate_stack_frame false dummy_instr_info (sf_stk_sz e + sf_stk_extra_sz e)
+             ++ ensure_rsp_alignment dummy_instr_info e.(sf_align)
+             :: lstore dummy_instr_info rspi ofs Uptr (Gvar tmp Slocal)
+             :: push_to_save dummy_instr_info e.(sf_to_save)
          , 1%positive)
        end
      end

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -346,7 +346,7 @@ Record h_linearization_params :=
       forall (lp : lprog) (s : estate) sp_rsp ii fn pc ts sz,
         let rsp := vid sp_rsp in
         let vm := evm s in
-        let args := lip_allocate_stack_frame liparams (VarI rsp xH) sz in
+        let args := lip_allocate_stack_frame liparams (VarI rsp dummy_var_info) sz in
         let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
         let ts' := pword_of_word (ts + wrepr Uptr sz) in
         let s' := with_vm s (vm.[rsp <- ok ts'])%vmap in
@@ -358,7 +358,7 @@ Record h_linearization_params :=
       forall (lp : lprog) (s : estate) sp_rsp ii fn pc ts sz,
         let rsp := vid sp_rsp in
         let vm := evm s in
-        let args := lip_free_stack_frame liparams (VarI rsp xH) sz in
+        let args := lip_free_stack_frame liparams (VarI rsp dummy_var_info) sz in
         let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
         let ts' := pword_of_word (ts - wrepr Uptr sz) in
         let s' := with_vm s (vm.[rsp <- ok ts'])%vmap in
@@ -369,7 +369,7 @@ Record h_linearization_params :=
     spec_lip_ensure_rsp_alignment :
       forall (lp : lprog) (s : estate) rsp_id ii fn pc ws ts',
         let vrsp := Var (sword Uptr) rsp_id in
-        let vrspi := VarI vrsp xH in
+        let vrspi := VarI vrsp dummy_var_info in
         let rsp' := align_word ws ts' in
         let args := lip_ensure_rsp_alignment liparams vrspi ws in
         let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
@@ -1312,7 +1312,7 @@ Section PROOF.
       mapM (get_var vm2) xs = ok vs2 & List.Forall2 value_uincl vs1 vs2.
   Proof.
     move=> h1 h2;
-    have := get_vars_uincl (xs := map (fun x => {| v_var := x; v_info := xH |}) xs) h1.
+    have := get_vars_uincl (xs := map (fun x => {| v_var := x; v_info := dummy_var_info |}) xs) h1.
     by rewrite !mapM_map => /(_ _ h2).
   Qed.
 
@@ -3303,7 +3303,7 @@ Section PROOF.
             with
               (take 2 P
               ++ [:: ensure_rsp_alignment p liparams xH (sf_align (f_extra fd)),
-                     lstore liparams xH (VarI vrsp xH) stack_saved_rsp Uptr (mk_lvar var_tmp) &
+                     lstore liparams xH (VarI vrsp dummy_var_info) stack_saved_rsp Uptr (mk_lvar var_tmp) &
                      push_to_save p liparams xH (sf_to_save (f_extra fd)) ] ++ lbody ++ Q);
               last by rewrite /P catA.
             move => /find_instr_skip -> /=.
@@ -3315,7 +3315,7 @@ Section PROOF.
             replace (P ++ lbody ++ Q)
             with
               (take 3 P
-              ++ [:: lstore liparams xH (VarI vrsp xH) stack_saved_rsp Uptr (mk_lvar var_tmp) &
+              ++ [:: lstore liparams xH (VarI vrsp dummy_var_info) stack_saved_rsp Uptr (mk_lvar var_tmp) &
                       push_to_save p liparams xH (sf_to_save (f_extra fd)) ] ++ lbody ++ Q);
               last by rewrite /P catA.
             move => /find_instr_skip -> /=.

--- a/proofs/compiler/merge_varmaps_proof.v
+++ b/proofs/compiler/merge_varmaps_proof.v
@@ -963,7 +963,7 @@ Lemma merge_varmaps_export_callP scs m fn args scs' m' res :
   sem_one_varmap.sem_export_call p extra_free_registers var_tmp global_data scs m fn args scs' m' res.
 Proof.
   case => fd ok_fd Export.
-  move => /merge_varmaps_callP /(_ 1%positive fd _ _ ok_fd).
+  move => /merge_varmaps_callP /(_ dummy_instr_info fd _ _ ok_fd).
 
   case: (checkP ok_p ok_fd) => _ok_wrf.
   rewrite /check_fd; t_xrbindP => D.

--- a/proofs/compiler/remove_globals.v
+++ b/proofs/compiler/remove_globals.v
@@ -327,7 +327,7 @@ Section REMOVE.
     Definition remove_glob_fundef (f:ufundef) :=
       let env := Mvar.empty _ in
       let check_var xi :=
-        if is_glob xi.(v_var) then Error (rm_glob_error xH xi) else ok tt in
+        if is_glob xi.(v_var) then Error (rm_glob_error dummy_instr_info xi) else ok tt in
       Let _ := mapM check_var f.(f_params) in
       Let _ := mapM check_var f.(f_res) in
       Let envc := remove_glob remove_glob_i env f.(f_body) in

--- a/proofs/compiler/tunneling.v
+++ b/proofs/compiler/tunneling.v
@@ -58,7 +58,7 @@ End LprogSem.
 
 Section Tunneling.
 
-  Definition Linstr_align := (MkLI xH Lalign).
+  Definition Linstr_align := (MkLI dummy_instr_info Lalign).
 
   Definition tunnel_chart fn uf c c' :=
     match c, c' with

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -590,12 +590,12 @@ Fixpoint lower_i (i:instr) : cmd :=
   | Cassgn l tg ty e => lower_cassgn ii l tg ty e
   | Copn l t o e => map (MkI ii) (lower_copn l t o e)
   | Cif e c1 c2  =>
-     let '(pre, e) := lower_condition xH e in
+     let '(pre, e) := lower_condition dummy_var_info e in
        map (MkI ii) (rcons pre (Cif e (conc_map lower_i c1) (conc_map lower_i c2)))
   | Cfor v (d, lo, hi) c =>
      [:: MkI ii (Cfor v (d, lo, hi) (conc_map lower_i c))]
   | Cwhile a c e c' =>
-     let '(pre, e) := lower_condition xH e in
+     let '(pre, e) := lower_condition dummy_var_info e in
        map (MkI ii) [:: Cwhile a ((conc_map lower_i c) ++ map (MkI xH) pre) e (conc_map lower_i c')]
   | _ =>   map (MkI ii) [:: ir]
   end.

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -596,7 +596,7 @@ Fixpoint lower_i (i:instr) : cmd :=
      [:: MkI ii (Cfor v (d, lo, hi) (conc_map lower_i c))]
   | Cwhile a c e c' =>
      let '(pre, e) := lower_condition dummy_var_info e in
-       map (MkI ii) [:: Cwhile a ((conc_map lower_i c) ++ map (MkI xH) pre) e (conc_map lower_i c')]
+       map (MkI ii) [:: Cwhile a ((conc_map lower_i c) ++ map (MkI dummy_instr_info) pre) e (conc_map lower_i c')]
   | _ =>   map (MkI ii) [:: ir]
   end.
 

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -1757,7 +1757,7 @@ Section PROOF.
     have Hcond: x = lower_condition fv dummy_var_info e by [].
     move: x Hcond=> [i e'] Hcond.
     have [s2' [Hs2'1 Hs2'2]] := Hc Hc1 _ Hs1'.
-    have [s3' [Hs3'1 [Hs3'2 Hs3'3]]] := lower_condition_corr xH Hcond Hs2'2 (sem_pexpr_same Hdisje Hs2'2 Hz).
+    have [s3' [Hs3'1 [Hs3'2 Hs3'3]]] := lower_condition_corr dummy_instr_info Hcond Hs2'2 (sem_pexpr_same Hdisje Hs2'2 Hz).
     have [s4' [Hs4'1 Hs4'2]] := Hc' Hc2 _ Hs3'2.
     have [s5' [Hs5'1 Hs5'2]] := Hwhile ii Hdisj _ Hs4'2.
     exists s5'; split=> //.
@@ -1778,7 +1778,7 @@ Section PROOF.
     have Hcond: x = lower_condition fv dummy_var_info e by [].
     move: x Hcond=> [i e'] Hcond.
     have [s2' [Hs2'1 Hs2'2]] := Hc Hc1 _ Hs1'.
-    have [s3' [Hs3'1 [Hs3'2 Hs3'3]]] := lower_condition_corr xH Hcond Hs2'2 (sem_pexpr_same Hdisje Hs2'2 Hz).
+    have [s3' [Hs3'1 [Hs3'2 Hs3'3]]] := lower_condition_corr dummy_instr_info Hcond Hs2'2 (sem_pexpr_same Hdisje Hs2'2 Hz).
     exists s3'; split=> //.
     apply: sem_seq1; apply: EmkI; apply: Ewhile_false.
     exact: (sem_app Hs2'1 Hs3'1).

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -1718,7 +1718,7 @@ Section PROOF.
     move=> s1 s2 e c1 c2 Hz _ Hc ii /= Hdisj s1' Hs1' /=.
     move: Hdisj; rewrite /disj_fvars /x86_lowering.disj_fvars vars_I_if=> /disj_fvars_union [Hdisje /disj_fvars_union [Hc1 Hc2]].
     set x := lower_condition _ _ _.
-    have Hcond: x = lower_condition fv xH e by [].
+    have Hcond: x = lower_condition fv dummy_var_info e by [].
     move: x Hcond=> [i e'] Hcond.
     have [s2' [Hs2'1 [Hs2'2 Hs2'3]]] := lower_condition_corr ii Hcond Hs1' (sem_pexpr_same Hdisje Hs1' Hz).
     have [s3' [Hs3'1 Hs3'2]] := Hc Hc1 _ Hs2'2.
@@ -1736,7 +1736,7 @@ Section PROOF.
     move=> s1 s2 e c1 c2 Hz _ Hc ii /= Hdisj s1' Hs1' /=.
     move: Hdisj; rewrite /disj_fvars /x86_lowering.disj_fvars vars_I_if=> /disj_fvars_union [Hdisje /disj_fvars_union [Hc1 Hc2]].
     set x := lower_condition _ _ _.
-    have Hcond: x = lower_condition fv xH e by [].
+    have Hcond: x = lower_condition fv dummy_var_info e by [].
     move: x Hcond=> [i e'] Hcond.
     have [s2' [Hs2'1 [Hs2'2 Hs2'3]]] := lower_condition_corr ii Hcond Hs1' (sem_pexpr_same Hdisje Hs1' Hz).
     have [s3' [Hs3'1 Hs3'2]] := Hc Hc2 _ Hs2'2.
@@ -1754,7 +1754,7 @@ Section PROOF.
     move=> s1 s2 s3 s4 a c e c' _ Hc Hz _ Hc' _ Hwhile ii Hdisj s1' Hs1' /=.
     have := Hdisj; rewrite /disj_fvars /x86_lowering.disj_fvars vars_I_while=> /disj_fvars_union [Hdisje /disj_fvars_union [Hc1 Hc2]].
     set x := lower_condition _ _ _.
-    have Hcond: x = lower_condition fv xH e by [].
+    have Hcond: x = lower_condition fv dummy_var_info e by [].
     move: x Hcond=> [i e'] Hcond.
     have [s2' [Hs2'1 Hs2'2]] := Hc Hc1 _ Hs1'.
     have [s3' [Hs3'1 [Hs3'2 Hs3'3]]] := lower_condition_corr xH Hcond Hs2'2 (sem_pexpr_same Hdisje Hs2'2 Hz).
@@ -1775,7 +1775,7 @@ Section PROOF.
     move=> s1 s2 a c e c' _ Hc Hz ii Hdisj s1' Hs1' /=.
     move: Hdisj; rewrite /disj_fvars /x86_lowering.disj_fvars vars_I_while=> /disj_fvars_union [Hdisje /disj_fvars_union [Hc1 Hc2]].
     set x := lower_condition _ _ _.
-    have Hcond: x = lower_condition fv xH e by [].
+    have Hcond: x = lower_condition fv dummy_var_info e by [].
     move: x Hcond=> [i e'] Hcond.
     have [s2' [Hs2'1 Hs2'2]] := Hc Hc1 _ Hs1'.
     have [s3' [Hs3'1 [Hs3'2 Hs3'3]]] := lower_condition_corr xH Hcond Hs2'2 (sem_pexpr_same Hdisje Hs2'2 Hz).

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -80,7 +80,7 @@ Definition x86_free_stack_frame (rspi: var_i) (sz: Z) :=
   ([:: Lvar rspi ], Ox86 (LEA Uptr), [:: p ]).
 
 Definition x86_ensure_rsp_alignment (rspi: var_i) (al: wsize) :=
-  let to_lvar x := Lvar (VarI (to_var x) xH) in
+  let to_lvar x := Lvar (VarI (to_var x) dummy_var_info) in
   let eflags := List.map to_lvar [:: OF ; CF ; SF ; PF ; ZF ] in
   let p0 := Pvar (Gvar rspi Slocal) in
   let p1 := Papp1 (Oword_of_int Uptr) (Pconst (- wsize_size al)) in

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -95,7 +95,7 @@ Context
   (pc : nat).
 
 Let vrsp : var := mk_ptr sp_rsp.
-Let vrspi : var_i := VarI vrsp xH.
+Let vrspi : var_i := VarI vrsp dummy_var_info.
 Let vm := evm s.
 
 Definition x86_spec_lip_allocate_stack_frame ts sz :

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -347,6 +347,7 @@ Definition wrange d (n1 n2 : Z) :=
   end.
 
 Definition instr_info := positive.
+Definition dummy_instr_info : instr_info := 1%positive.
 
 Variant assgn_tag :=
   | AT_none       (* assignment introduced by the developer that can be removed *)

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -238,6 +238,7 @@ Definition type_of_opN (op: opN) : seq stype * stype :=
  * -------------------------------------------------------------------- *)
 (* Used only by the ocaml compiler *)
 Definition var_info := positive.
+Definition dummy_var_info : var_info := 1%positive.
 
 Record var_i := VarI {
   v_var :> var;
@@ -251,7 +252,7 @@ Notation vid ident :=
         vtype := sword Uptr;
         vname := ident%string;
       |};
-    v_info := xH;
+    v_info := dummy_var_info;
   |}.
 
 Record var_attr := VarA {
@@ -863,9 +864,8 @@ Definition eq_lval (x x': lval) : bool :=
   end.
 
 (* ------------------------------------------------------------------- *)
-
 Definition to_lvals (l:seq var) : seq lval := 
-  map (fun x => Lvar {|v_var := x; v_info := xH|}) l.
+  map (fun x => Lvar {|v_var := x; v_info := dummy_var_info |}) l.
 
 (* ------------------------------------------------------------------- *)
 Definition is_false (e: pexpr) : bool :=

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -357,7 +357,10 @@ Definition wrange d (n1 n2 : Z) :=
   | DownTo => [seq (Z.sub n2 (Z.of_nat i)) | i <- iota 0 n]
   end.
 
-Module InstrInfo : TAG := VarInfo.
+Module InstrInfo : TAG.
+  Definition t := positive.
+  Definition witness : t := 1%positive.
+End InstrInfo.
 
 Definition instr_info := InstrInfo.t.
 Definition dummy_instr_info : instr_info := InstrInfo.witness.

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -237,8 +237,19 @@ Definition type_of_opN (op: opN) : seq stype * stype :=
 (* ** Expressions
  * -------------------------------------------------------------------- *)
 (* Used only by the ocaml compiler *)
-Definition var_info := positive.
-Definition dummy_var_info : var_info := 1%positive.
+(** A “tag” is a non-empty type, extracted to plain OCaml [int] *)
+Module Type TAG.
+  Parameter t : Type.
+  Parameter witness : t.
+End TAG.
+
+Module VarInfo : TAG.
+  Definition t := positive.
+  Definition witness : t := 1%positive.
+End VarInfo.
+
+Definition var_info := VarInfo.t.
+Definition dummy_var_info : var_info := VarInfo.witness.
 
 Record var_i := VarI {
   v_var :> var;
@@ -346,8 +357,10 @@ Definition wrange d (n1 n2 : Z) :=
   | DownTo => [seq (Z.sub n2 (Z.of_nat i)) | i <- iota 0 n]
   end.
 
-Definition instr_info := positive.
-Definition dummy_instr_info : instr_info := 1%positive.
+Module InstrInfo : TAG := VarInfo.
+
+Definition instr_info := InstrInfo.t.
+Definition dummy_instr_info : instr_info := InstrInfo.witness.
 
 Variant assgn_tag :=
   | AT_none       (* assignment introduced by the developer that can be removed *)

--- a/proofs/lang/expr_facts.v
+++ b/proofs/lang/expr_facts.v
@@ -271,7 +271,7 @@ Lemma write_I_recE s i : Sv.Equal (write_I_rec s i) (Sv.union s (write_I i)).
 Proof. by apply (write_c_recE s [:: i]). Qed.
 
 Lemma write_i_recE s i : Sv.Equal (write_i_rec s i) (Sv.union s (write_i i)).
-Proof. by apply (write_I_recE s (MkI 1%positive i)). Qed.
+Proof. by apply (write_I_recE s (MkI dummy_instr_info i)). Qed.
 
 Lemma write_c_nil : write_c [::] = Sv.empty.
 Proof. done. Qed.
@@ -390,7 +390,7 @@ Lemma read_IE s i : Sv.Equal (read_I_rec s i) (Sv.union s (read_I i)).
 Proof. by apply (read_cE s [:: i]). Qed.
 
 Lemma read_iE s i : Sv.Equal (read_i_rec s i) (Sv.union s (read_i i)).
-Proof. by apply (read_IE s (MkI 1%positive i)). Qed.
+Proof. by apply (read_IE s (MkI dummy_instr_info i)). Qed.
 
 Lemma read_c_nil : read_c [::] = Sv.empty.
 Proof. done. Qed.

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -19,6 +19,11 @@ Extraction Inline Datatypes.implb.
 Extract Constant strings.ascii_beq => "Char.equal".
 Extract Constant strings.ascii_cmp => "(fun x y -> let c = Char.compare x y in if c = 0 then Datatypes.Eq else if c < 0 then Datatypes.Lt else Datatypes.Gt)".
 
+Extract Constant expr.VarInfo.t => "Stdlib.Int.t".
+Extract Constant expr.VarInfo.witness => "(-1)".
+Extract Constant expr.var_info => "Stdlib.Int.t".
+Extract Constant expr.instr_info => "Stdlib.Int.t".
+
 Cd  "lang/ocaml".
 
 Extraction Blacklist String List Nat Utils Var Array.

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -19,9 +19,11 @@ Extraction Inline Datatypes.implb.
 Extract Constant strings.ascii_beq => "Char.equal".
 Extract Constant strings.ascii_cmp => "(fun x y -> let c = Char.compare x y in if c = 0 then Datatypes.Eq else if c < 0 then Datatypes.Lt else Datatypes.Gt)".
 
-Extract Constant expr.VarInfo.t => "Stdlib.Int.t".
-Extract Constant expr.VarInfo.witness => "(-1)".
-Extract Constant expr.var_info => "Stdlib.Int.t".
+Extract Constant expr.VarInfo.t => "Location.t".
+Extract Constant expr.VarInfo.witness => "Location._dummy".
+Extract Constant expr.var_info => "Location.t".
+Extract Constant expr.InstrInfo.t => "Stdlib.Int.t".
+Extract Constant expr.InstrInfo.witness => "(-1)".
 Extract Constant expr.instr_info => "Stdlib.Int.t".
 
 Cd  "lang/ocaml".

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -1151,7 +1151,7 @@ Qed.
 
 Lemma write_iP i s1 s2 :
    sem_i P ev s1 i s2 -> s1.(evm) = s2.(evm) [\ write_i i].
-Proof. by move=> h; have /write_IP := EmkI 1%positive h. Qed.
+Proof. by move=> h; have /write_IP := EmkI dummy_instr_info h. Qed.
 
 End Write.
 


### PR DESCRIPTION
This seems to be good for performances (of the compiler).

The following table reports compilation times (in seconds) for `.jazz` files in libjade and the corresponding (base-2) speed-up.

Thanks Tiago for the `jtiming` script in libjade!

~~~
path                               before   after    change
────────────────────────────────────────────────────────────
onetimeauth/poly1305/ref             0.08     0.08     0.0
hash/sha3-224/avx2                   0.94     0.93     0.02
hash/sha3-256/avx2                   0.94     0.93     0.02
hash/sha3-384/avx2                   0.94     0.93     0.02
hash/sha3-512/avx2                   0.94     0.93     0.02
stream/chacha/chacha12/avx           5.82     5.65     0.04
stream/chacha/chacha12/avx2          5.74     5.59     0.04
stream/chacha/chacha20-ietf/avx      5.79     5.63     0.04
stream/chacha/chacha20-ietf/avx2     5.72     5.57     0.04
xof/shake128/avx2                    1.11     1.08     0.04
xof/shake256/avx2                    1.11     1.08     0.04
stream/chacha/chacha20/avx           5.83     5.64     0.05
stream/chacha/chacha20/avx2          5.74     5.55     0.05
xof/shake256/ref1                    0.15     0.14     0.1
xof/shake256/spec                    0.3      0.28     0.1
kem/kyber/kyber512/avx2              8.71     7.99     0.12
stream/xsalsa20/avx2                 2.19     2.01     0.12
scalarmult/curve25519/ref4           1.25     1.14     0.13
secretbox/xsalsa20poly1305/avx2      4.04     3.7      0.13
stream/salsa20/salsa20/avx2          1.5      1.37     0.13
stream/xsalsa20/avx                  1.9      1.74     0.13
kem/kyber/kyber768/avx2             11.75    10.63     0.14
secretbox/xsalsa20poly1305/avx       3.77     3.42     0.14
stream/salsa20/salsa2012/avx         1.26     1.14     0.14
stream/salsa20/salsa2012/avx2        1.5      1.36     0.14
hash/sha3-224/ref                    0.6      0.54     0.15
hash/sha3-384/ref                    0.6      0.54     0.15
stream/salsa20/salsa20/avx           1.26     1.13     0.16
xof/shake256/ref                     1.24     1.11     0.16
xof/shake128/ref                     1.25     1.11     0.17
hash/sha3-256/ref                    0.61     0.54     0.18
hash/sha3-512/ref                    0.61     0.54     0.18
stream/salsa20/salsa2012/ref         0.45     0.39     0.21
onetimeauth/poly1305/avx             0.57     0.49     0.22
secretbox/xsalsa20poly1305/ref       1.5      1.29     0.22
scalarmult/curve25519/ref5           1.23     1.05     0.23
stream/chacha/chacha20/ref           0.27     0.23     0.23
stream/salsa20/salsa20/ref           0.46     0.39     0.24
stream/xsalsa20/ref                  0.77     0.65     0.24
onetimeauth/poly1305/avx2            0.51     0.43     0.25
scalarmult/curve25519/mulx           2.09     1.73     0.27
stream/chacha/chacha20-ietf/ref      0.28     0.23     0.28
stream/chacha/chacha12/ref           0.28     0.22     0.35
hash/sha256/ref                      0.68     0.48     0.5
~~~