### PR TITLE
Syscall_t: make independent of extracted code from Coq

### DIFF
--- a/compiler/src/alias.ml
+++ b/compiler/src/alias.ml
@@ -170,7 +170,7 @@ let assign_arr params a x e =
   | None, _ | _, None -> a
   | Some d, Some s -> merge_slices params a d s
 
-let syscall_cc (o : Syscall_t.syscall_t) =
+let syscall_cc (o : 'a Syscall_t.syscall_t) =
   match o with
   | Syscall_t.RandomBytes _ -> [Some 0]
 

--- a/compiler/src/liveness.ml
+++ b/compiler/src/liveness.ml
@@ -98,7 +98,7 @@ let liveness is_move_op weak prog =
   fst prog, fds
 
 let iter_call_sites (cbf: L.i_loc -> funname -> lvals -> Sv.t * Sv.t -> unit)
-                    (cbs: L.i_loc -> Syscall_t.syscall_t -> lvals -> Sv.t * Sv.t -> unit)
+                    (cbs: L.i_loc -> BinNums.positive Syscall_t.syscall_t -> lvals -> Sv.t * Sv.t -> unit)
                     (f: (Sv.t * Sv.t, 'asm) func) : unit =
   let rec iter_instr_r loc ii =
     function

--- a/compiler/src/liveness.mli
+++ b/compiler/src/liveness.mli
@@ -20,7 +20,7 @@ val liveness : ('asm -> bool) -> bool -> ('info, 'asm) prog -> (Sv.t * Sv.t, 'as
 *)
 val iter_call_sites :
   (L.i_loc -> funname -> lvals -> Sv.t * Sv.t -> unit) ->
-  (L.i_loc -> Syscall_t.syscall_t -> lvals -> Sv.t * Sv.t -> unit) ->
+  (L.i_loc -> BinNums.positive Syscall_t.syscall_t -> lvals -> Sv.t * Sv.t -> unit) ->
   (Sv.t * Sv.t, 'asm) func -> unit
 
 val pp_info : Format.formatter -> Sv.t * Sv.t -> unit

--- a/compiler/src/ppasm.ml
+++ b/compiler/src/ppasm.ml
@@ -404,7 +404,7 @@ module Printer (BP:BPrinter) = struct
     Printf.sprintf "%s%s" (Conv.string_of_string0 pp_op.pp_aop_name) (pp_ext pp_op.pp_aop_ext)
 
   (* -------------------------------------------------------------------- *)
-  let pp_syscall (o : Syscall_t.syscall_t) =
+  let pp_syscall (o : 'a Syscall_t.syscall_t) =
     match o with
     | Syscall_t.RandomBytes _ -> "__jasmin_syscall_randombytes__"
 

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -180,7 +180,7 @@ let pp_opn asmOp fmt o =
   pp_string0 fmt (Sopn.string_of_sopn asmOp o)
 
 (* -------------------------------------------------------------------- *)
-let pp_syscall (o:Syscall_t.syscall_t) =
+let pp_syscall (o: 'a Syscall_t.syscall_t) =
   match o with
   | Syscall_t.RandomBytes _ -> "#randombytes"
 

--- a/compiler/src/printer.mli
+++ b/compiler/src/printer.mli
@@ -25,7 +25,7 @@ val string_of_op1 : Expr.sop1 -> string
 val string_of_op2 : Expr.sop2 -> string
 val string_of_combine_flags : Expr.combine_flags -> string
 val pp_opn   : 'asm Sopn.asmOp -> Format.formatter -> 'asm Sopn.sopn -> unit
-val pp_syscall : Syscall_t.syscall_t -> string
+val pp_syscall : BinNums.positive Syscall_t.syscall_t -> string
 
 val pp_ty : Format.formatter -> ty -> unit
 

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -146,7 +146,7 @@ type ('len,'info,'asm) ginstr_r =
   | Cassgn of 'len glval * E.assgn_tag * 'len gty * 'len gexpr
   (* turn 'asm Sopn.sopn into 'sopn? could be useful to ensure that we remove things statically *)
   | Copn   of 'len glvals * E.assgn_tag * 'asm Sopn.sopn * 'len gexprs
-  | Csyscall of 'len glvals * Syscall_t.syscall_t * 'len gexprs
+  | Csyscall of 'len glvals * BinNums.positive Syscall_t.syscall_t * 'len gexprs
   | Cif    of 'len gexpr * ('len,'info,'asm) gstmt * ('len,'info,'asm) gstmt
   | Cfor   of 'len gvar_i * 'len grange * ('len,'info,'asm) gstmt
   | Cwhile of E.align * ('len,'info,'asm) gstmt * 'len gexpr * ('len,'info,'asm) gstmt

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -111,7 +111,7 @@ type 'len grange = E.dir * 'len gexpr * 'len gexpr
 type ('len,'info,'asm) ginstr_r =
   | Cassgn of 'len glval * E.assgn_tag * 'len gty * 'len gexpr
   | Copn   of 'len glvals * E.assgn_tag * 'asm Sopn.sopn * 'len gexprs
-  | Csyscall of 'len glvals * Syscall_t.syscall_t * 'len gexprs
+  | Csyscall of 'len glvals * BinNums.positive Syscall_t.syscall_t * 'len gexprs
   | Cif    of 'len gexpr * ('len,'info,'asm) gstmt * ('len,'info,'asm) gstmt
   | Cfor   of 'len gvar_i * 'len grange * ('len,'info,'asm) gstmt
   | Cwhile of E.align * ('len,'info,'asm) gstmt * 'len gexpr * ('len,'info,'asm) gstmt

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -877,7 +877,7 @@ let global_allocation translate_var (funcs: ('info, 'asm) func list) : (unit, 'a
   (* Live variables at the end of each function, in addition to returned local variables *)
   let get_liveness, slive =
     let live : Sv.t Hf.t = Hf.create 17 in
-    let slive : (Syscall_t.syscall_t, Sv.t) Hashtbl.t = Hashtbl.create 17 in
+    let slive : (BinNums.positive Syscall_t.syscall_t, Sv.t) Hashtbl.t = Hashtbl.create 17 in
     List.iter (fun f ->
         let f_with_liveness = Hf.find liveness_table f.f_name in
         let live_when_calling_f = Hf.find_default live f.f_name Sv.empty in

--- a/compiler/src/syscall_t.ml
+++ b/compiler/src/syscall_t.ml
@@ -1,2 +1,2 @@
-type syscall_t =
-  | RandomBytes of BinNums.positive
+type 'a syscall_t =
+  | RandomBytes of 'a

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -6,7 +6,7 @@ Require ExtrOcamlString.
 
 (* This is a hack to force the extraction to keep the singleton here,
    This need should be removed if we add more constructor to syscall_t *)
-Extract Inductive syscall.syscall_t => "Syscall_t.syscall_t" ["Syscall_t.RandomBytes"].
+Extract Inductive syscall.syscall_t => "BinNums.positive Syscall_t.syscall_t" ["Syscall_t.RandomBytes"].
 
 Extraction Inline ssrbool.is_left.
 Extraction Inline ssrbool.predT ssrbool.pred_of_argType.


### PR DESCRIPTION
Currently, the `Syscall_t` module depends on the `BinNums` module, that is extracted from Coq code.

But the extracted code, residing in the `CIL/` directory, depends on the `Syscall_t` module.

This PR breaks this circular dependency.

This hack should disappear as soon as there are more than one syscall.