### PR TITLE
pretyping: there are no conditional function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   ([PR #212](https://github.com/jasmin-lang/jasmin/pull/212);
   fixes [#197](https://github.com/jasmin-lang/jasmin/issues/197)).
 
+- Conditional function calls now produce a clearer error message
+  ([PR #215](https://github.com/jasmin-lang/jasmin/pull/215);
+  fixes [#199](https://github.com/jasmin-lang/jasmin/issues/199)).
+
 ## New features
 
 - Fill an array with “random” data using `p = #randombytes(p);`

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1772,11 +1772,10 @@ let rec tt_instr pd asmOp (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm En
       if peop2_of_eqop eqop <> None then rs_tyerror ~loc exn;
       let cpi = S.PIAssign (ls, eqop, e, None) in
       let env, i = tt_instr pd asmOp env (annot, L.mk_loc loc cpi) in
-      let i, is =
+      let x, ty, e, is =
         match i with
-        | [] -> assert false
-        | i :: is -> i, is in
-      let x, _, ty, e = P.destruct_move i in
+        | { i_desc = P.Cassgn (x, _, ty, e) ; _ } :: is -> x, ty, e, is
+        | _ -> rs_tyerror ~loc exn in
       let e' = ofdfl (fun _ -> rs_tyerror ~loc exn) (P.expr_of_lval x) in
       let c = tt_expr_bool pd env cp in
       env, mk_i (P.Cassgn (x, AT_none, ty, Pif (ty, c, e, e'))) :: is

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -562,11 +562,6 @@ let expr_of_lval = function
 (* -------------------------------------------------------------------- *)
 (* Functions over instruction                                           *)
 
-let destruct_move i =
-  match i.i_desc with
-  | Cassgn(x, tag, ty, e) -> x, tag, ty, e
-  | _                 -> assert false
-
 let rec has_syscall_i i =
   match i.i_desc with
   | Csyscall _ -> true

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -347,8 +347,6 @@ val expr_of_lval : 'len glval -> 'len gexpr option
 (* -------------------------------------------------------------------- *)
 (* Functions over instruction                                           *)
 
-val destruct_move : ('len, 'info, 'asm) ginstr -> 'len glval * E.assgn_tag * 'len gty * 'len gexpr
-
 val has_syscall : ('len, 'info, 'asm) gstmt -> bool
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
Fixes #199

Currently, the following program makes the Jasmin compiler crash with an assertion failure:

~~~
inline
fn f(reg u64 a) -> reg u64 {
  return a;
}

export
fn g(reg u64 x) -> reg u64 {
  reg u64 y;
  y = 0;
  y = f(x) if x > 1;
  return y;
}
~~~

This change makes it produce a normal error message (with line numbers & colors).