### PR TITLE
Lowering: add a missing case when assigning a not-equal comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   ([PR #215](https://github.com/jasmin-lang/jasmin/pull/215);
   fixes [#199](https://github.com/jasmin-lang/jasmin/issues/199)).
 
+- Fix lowering of not-equal conditions in assignments
+  ([PR #216](https://github.com/jasmin-lang/jasmin/pull/216);
+  fixes [#200](https://github.com/jasmin-lang/jasmin/issues/200)).
+
 ## New features
 
 - Fill an array with “random” data using `p = #randombytes(p);`

--- a/compiler/tests/success/bug_200.jazz
+++ b/compiler/tests/success/bug_200.jazz
@@ -1,0 +1,9 @@
+export
+fn exp(reg u64 e) -> reg u64 {
+  reg u64 m;
+  reg bool c;
+    m = 1;
+    c = e != 0;
+    m = e if c;
+  return m;
+}

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -350,7 +350,7 @@ Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
     | Olsl (Op_w sz) => k8 sz (LowerFopn (Ox86 (SHL sz)) [:: a ; b ] (Some U8))
     | Oasr (Op_w sz) => k8 sz (LowerFopn (Ox86 (SAR sz)) [:: a ; b ] (Some U8))
 
-    | Olt _ | Ole _ | Oeq _ | Oge _ | Ogt _ => LowerCond
+    | Olt _ | Ole _ | Oeq _ | Oneq _ | Oge _ | Ogt _ => LowerCond
 
     | Ovadd ve sz =>
       kb (U128 <= sz)%CMP sz (LowerCopn (Ox86 (VPADD ve sz)) [::a; b])


### PR DESCRIPTION
Fixes #200