### PR TITLE
Generalize flag combinations

### DIFF
--- a/compiler/src/evaluator.ml
+++ b/compiler/src/evaluator.ml
@@ -48,7 +48,7 @@ type ('syscall_state, 'asm) state =
 
 exception Final of Memory.mem * values
 
-let return pd (sc_sem: 'syscall_state Syscall.syscall_sem) s =
+let return spp s =
   assert (s.s_cmd = []);
   match s.s_stk with
   | Sempty(ii, f) ->
@@ -65,7 +65,7 @@ let return pd (sc_sem: 'syscall_state Syscall.syscall_sem) s =
     let vres = 
       exn_exec ii (mapM (fun (x:var_i) -> get_var vm2 x.v_var) f.f_res) in
     let vres' = exn_exec ii (mapM2 ErrType truncate_val f.f_tyout vres) in
-    let s1 = exn_exec ii (write_lvals pd sc_sem gd {escs = scs2; emem = m2; evm = vm1 } xs vres') in
+    let s1 = exn_exec ii (write_lvals spp gd {escs = scs2; emem = m2; evm = vm1 } xs vres') in
     { s with 
       s_cmd = c;
       s_estate = s1;
@@ -75,14 +75,14 @@ let return pd (sc_sem: 'syscall_state Syscall.syscall_sem) s =
     match ws with
     | [] -> { s with s_cmd = c; s_stk = stk }
     | w::ws ->
-      let s1 = exn_exec ii (write_var pd sc_sem i (Vint w) s.s_estate) in
+      let s1 = exn_exec ii (write_var spp i (Vint w) s.s_estate) in
       { s with s_cmd = body;
                s_estate = s1;
                s_stk = Sfor(ii, i, ws, body, c, stk) }
 
-let small_step1 pd (sc_sem: 'syscall_state Syscall.syscall_sem) asmOp s =
+let small_step1 spp s =
   match s.s_cmd with
-  | [] -> return pd sc_sem s
+  | [] -> return spp s
   | i :: c ->
     let MkI(ii,ir) = i in
     let gd = s.s_prog.p_globs in
@@ -90,39 +90,39 @@ let small_step1 pd (sc_sem: 'syscall_state Syscall.syscall_sem) asmOp s =
     match ir with
 
     | Cassgn(x,_,ty,e) ->
-      let v  = exn_exec ii (sem_pexpr pd sc_sem gd s1 e) in
+      let v  = exn_exec ii (sem_pexpr spp gd s1 e) in
       let v' = exn_exec ii (truncate_val ty v) in
-      let s2 = exn_exec ii (write_lval pd sc_sem gd x v' s1) in
+      let s2 = exn_exec ii (write_lval spp gd x v' s1) in
       { s with s_cmd = c; s_estate = s2 }
 
     | Copn(xs,_,op,es) ->
-      let s2 = exn_exec ii (sem_sopn pd sc_sem asmOp gd op s1 xs es) in
+      let s2 = exn_exec ii (sem_sopn spp gd op s1 xs es) in
       { s with s_cmd = c; s_estate = s2 }
 
     | Csyscall(xs,o, es) ->
-        let ves = exn_exec ii (sem_pexprs pd sc_sem gd s1 es) in
-        let ((scs, m), vs) = exn_exec ii (exec_syscall pd sc_sem s1.escs s1.emem o ves) in
-        let s2 = exn_exec ii (write_lvals pd sc_sem gd {escs = scs; emem = m; evm = s1.evm} xs vs) in
+        let ves = exn_exec ii (sem_pexprs spp gd s1 es) in
+        let ((scs, m), vs) = exn_exec ii (exec_syscall spp s1.escs s1.emem o ves) in
+        let s2 = exn_exec ii (write_lvals spp gd {escs = scs; emem = m; evm = s1.evm} xs vs) in
       { s with s_cmd = c; s_estate = s2 }
 
     | Cif(e,c1,c2) ->
-      let b = of_val_b ii (exn_exec ii (sem_pexpr pd sc_sem gd s1 e)) in
+      let b = of_val_b ii (exn_exec ii (sem_pexpr spp gd s1 e)) in
       let c = (if b then c1 else c2) @ c in
       { s with s_cmd = c }
 
     | Cfor (i,((d,lo),hi), body) ->
-      let vlo = of_val_z ii (exn_exec ii (sem_pexpr pd sc_sem gd s1 lo)) in
-      let vhi = of_val_z ii (exn_exec ii (sem_pexpr pd sc_sem gd s1 hi)) in
+      let vlo = of_val_z ii (exn_exec ii (sem_pexpr spp gd s1 lo)) in
+      let vhi = of_val_z ii (exn_exec ii (sem_pexpr spp gd s1 hi)) in
       let rng = wrange d vlo vhi in
       let s =
         {s with s_cmd = []; s_stk = Sfor(ii, i, rng, body, c, s.s_stk) } in
-      return pd sc_sem s
+      return spp s
  
     | Cwhile (_, c1, e, c2) ->
       { s with s_cmd = c1 @ MkI(ii, Cif(e, c2@[i],[])) :: c }
 
     | Ccall(_,xs,fn,es) ->
-      let vargs' = exn_exec ii (sem_pexprs pd sc_sem gd s1 es) in
+      let vargs' = exn_exec ii (sem_pexprs spp gd s1 es) in
       let f = 
         match get_fundef s.s_prog.p_funcs fn with
         | Some f -> f
@@ -131,14 +131,14 @@ let small_step1 pd (sc_sem: 'syscall_state Syscall.syscall_sem) asmOp s =
       let {escs; emem = m1; evm = vm1}  = s1 in
       let stk = Scall(ii,f, xs, vm1, c, s.s_stk) in
       let sf = 
-        exn_exec ii (write_vars pd sc_sem f.f_params vargs {escs; emem = m1; evm = vmap0}) in
+        exn_exec ii (write_vars spp f.f_params vargs {escs; emem = m1; evm = vmap0}) in
       {s with s_cmd = f.f_body;
               s_estate = sf;
               s_stk = stk }
 
 
-let rec small_step pd sc_sem asmOp s =
-  small_step pd sc_sem asmOp (small_step1 pd sc_sem asmOp s)
+let rec small_step spp s =
+  small_step spp (small_step1 spp s)
 
 let init_state scs0 p fn m =
   let f = 
@@ -152,9 +152,9 @@ let init_state scs0 p fn m =
     s_stk = Sempty(dummy_instr_info, f) }
 
 
-let exec pd sc_sem asmOp scs0 p fn m =
+let exec spp scs0 p fn m =
   let s = init_state scs0 p fn m in
-  try small_step pd sc_sem asmOp s
+  try small_step spp s
   with Final(m,vs) -> m, vs 
 
 (* ----------------------------------------------------------- *)

--- a/compiler/src/evaluator.mli
+++ b/compiler/src/evaluator.mli
@@ -1,11 +1,9 @@
 exception Eval_error of Expr.instr_info * Utils0.error
 
 val exec :
-  Wsize.coq_PointerData ->
-  'a Syscall.syscall_sem ->
-  'b Sopn.asmOp ->
-  'a Syscall.syscall_state_t Syscall.syscall_state_t ->
-  'b Expr.prog ->
+  ('a, 'b) Sem.coq_SemPexprParams ->
+  'b ->
+  'a Expr.prog ->
   Utils0.funname ->
   Low_memory.Memory.mem -> Low_memory.Memory.mem * Values.values
 

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -122,6 +122,7 @@ let main () =
     let module Arch = Arch_full.Arch_from_Core_arch (Ocaml_params) in
     let module Regalloc = Regalloc.Regalloc (Arch) in
     let module StackAlloc = StackAlloc.StackAlloc (Arch) in
+    let spp = Arch_extra.spp_of_asm_e Arch.asm_e Syscall_ocaml.sc_sem in
 
     if !safety_makeconfigdoc <> None
     then (
@@ -270,9 +271,7 @@ let main () =
                  | Utils0.Error err -> raise (Evaluator.Eval_error (Expr.dummy_instr_info, err)))
               |>
               Evaluator.exec
-                Arch.reg_size
-                Syscall_ocaml.sc_sem
-                Arch.asmOp
+                spp
                 (Syscall_ocaml.initial_state ())
                 (Expr.to_uprog Arch.asmOp cprog)
                 (Conv.cfun_of_fun tbl f)
@@ -501,6 +500,7 @@ let main () =
     begin match
       Compiler.compile_prog_to_asm
         Arch.asm_e
+        Syscall_ocaml.sc_sem
         Arch.call_conv
         Arch.aparams
         cparams

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -80,6 +80,7 @@ lang/array.v
 lang/expr.v
 lang/expr_facts.v
 lang/extraction.v
+lang/flag_combination.v
 lang/gen_map.v
 lang/global.v
 lang/ident.v

--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -2,6 +2,7 @@
 From mathcomp Require Import all_ssreflect all_algebra.
 From CoqWord Require Import ssrZ.
 Require Import utils oseq strings word memory_model global Utf8 Relation_Operators sem_type syscall label.
+Require Import flag_combination.
 
 Set   Implicit Arguments.
 Unset Strict Implicit.
@@ -42,6 +43,7 @@ Class arch_decl (reg regx xreg rflag cond : Type) :=
   ; reg_size_neq_xreg_size : reg_size != xreg_size
   ; ad_rsp : reg
   ; inj_toS_reg_regx : forall (r:reg) (rx:regx), to_string r <> to_string rx
+  ; ad_fcp : FlagCombinationParams
   }.
 
 Instance arch_pd `{arch_decl} : PointerData := { Uptr := reg_size }.

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -3,6 +3,7 @@ From mathcomp Require Import all_ssreflect all_algebra.
 From CoqWord Require Import ssrZ.
 Require Import xseq strings utils var type values sopn expr arch_decl.
 Require Import compiler_util.
+Require sem.
 
 Set   Implicit Arguments.
 Unset Strict Implicit.
@@ -187,3 +188,21 @@ Global Instance asm_opI : asmOp extended_op :=
     sopn.prim_string := get_prime_op }.
 
 End AsmOpI.
+
+Section SEM_PEXPR_PARAMS.
+
+  Context
+    {reg regx xreg rflag cond asm_op extra_op : Type}
+    {asm_e : asm_extra reg regx xreg rflag cond asm_op extra_op}
+    {syscall_state : Type}
+    {scs : syscall_sem syscall_state}.
+
+  Instance spp_of_asm_e : sem.SemPexprParams extended_op syscall_state :=
+    {
+      _pd := arch_pd;
+      _asmop := asm_opI;
+      _fcp := ad_fcp;
+      _sc_sem := scs;
+    }.
+
+End SEM_PEXPR_PARAMS.

--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -13,11 +13,15 @@ Local Open Scope vmap.
 Local Open Scope seq_scope.
 Local Open Scope Z_scope.
 
-Section Section.
+Section WITH_PARAMS.
 
-Context {pd:PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context `{asmop:asmOp}.
-Context {T:eqType} {pT:progT T} {sCP: semCallParams} (wf_init: wf_init sCP).
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  {T : eqType}
+  {pT : progT T}
+  {sCP : semCallParams}
+  (wf_init : wf_init sCP).
 
 Context (fresh_counter: Ident.ident) (p1 p2: prog) (ev: extra_val_t).
 
@@ -342,10 +346,10 @@ Lemma array_copy_fdP f scs mem scs' mem' va va' vr:
   exists vr', sem_call p2 ev scs mem f va' scs' mem' vr' /\ List.Forall2 value_uincl vr vr'.
 Proof.
   move=> Hall Hsem.
-  have [vres' h1 h2] := @sem_call_Ind _ _ _ _ _ _ _ _ p1 ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
+  have [vres' h1 h2] := @sem_call_Ind _ _ _ _ _ _ p1 ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
                Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc
                scs mem f va scs' mem' vr Hsem _ Hall.
   by exists vres'.
 Qed.
 
-End Section.
+End WITH_PARAMS.

--- a/proofs/compiler/array_expansion_proof.v
+++ b/proofs/compiler/array_expansion_proof.v
@@ -45,13 +45,14 @@ Definition eq_alloc_vm (m : t) (vm1 vm2 : vmap) :=
 Definition eq_alloc {_: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state} (m : t) (s1 s2 : estate) :=
   [/\ eq_alloc_vm m s1.(evm) s2.(evm),
       s1.(escs) = s2.(escs) &  s1.(emem) = s2.(emem)].
-    
-Section Section.
 
-Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context `{asmop:asmOp}.
-Variable (fi : funname -> ufundef -> expand_info).
-Variable p1 p2:uprog.
+Section WITH_PARAMS.
+
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  (fi : funname -> ufundef -> expand_info)
+  (p1 p2 : uprog).
 
 Local Notation gd := (p_globs p1).
 
@@ -536,8 +537,8 @@ Qed.
 Lemma expand_callP f scs mem scs' mem' va vr:
   sem_call p1 ev scs mem f va scs' mem' vr -> sem_call p2 ev scs mem f va scs' mem' vr.
 Proof.
-  apply (@sem_call_Ind _ _ _ _ _ _ _ _ p1 ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
+  apply (@sem_call_Ind _ _ _ _ _ _ p1 ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
           Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc).
 Qed.
 
-End Section.
+End WITH_PARAMS.

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -11,10 +11,11 @@ Unset Printing Implicit Defensive.
 Local Open Scope vmap.
 Local Open Scope seq_scope.
 
-Section ASM_OP.
+Section WITH_PARAMS.
 
-Context {pd:PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context `{asmop:asmOp}.
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}.
 
 Section Section.
 
@@ -244,7 +245,7 @@ Section REMOVE_INIT.
     sem_call p ev scs mem f va scs' mem' vr ->
     exists vr', sem_call p' ev scs mem f va' scs' mem' vr' /\ List.Forall2 value_uincl vr vr'.
   Proof.
-    move=> /(@sem_call_Ind _ _ _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Rnil Rcons RmkI Rasgn Ropn Rsyscall
+    move=> /(@sem_call_Ind _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Rnil Rcons RmkI Rasgn Ropn Rsyscall
              Rif_true Rif_false Rwhile_true Rwhile_false Rfor Rfor_nil Rfor_cons Rcall Rproc) H.
     by move=> /H.
   Qed.
@@ -559,10 +560,10 @@ Section ADD_INIT.
     sem_call p ev scs mem f va scs' mem' vr ->
     sem_call p' ev scs mem f va scs' mem' vr.
   Proof.
-    by apply (@sem_call_Ind _ _ _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun RAnil RAcons RAmkI RAasgn RAopn RAsyscall
+    by apply (@sem_call_Ind _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun RAnil RAcons RAmkI RAasgn RAopn RAsyscall
                RAif_true RAif_false RAwhile_true RAwhile_false RAfor RAfor_nil RAfor_cons RAcall RAproc).
   Qed.
 
 End ADD_INIT.
 
-End ASM_OP.
+End WITH_PARAMS.

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -5,8 +5,9 @@ Require Import Utf8.
 Require Import
   arch_params
   compiler_util
-  expr.
-Require merge_varmaps.
+  expr
+  flag_combination.
+Require sem.
 Require Import
   arch_decl
   arch_extra
@@ -28,6 +29,7 @@ Require Import
   stack_alloc
   tunneling
   unrolling.
+Require merge_varmaps.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -40,6 +42,7 @@ Section IS_MOVE_OP.
 
 Context
   `{asmop : asmOp}
+  {fcp : FlagCombinationParams}
   (is_move_op : asm_op_t -> bool).
 
 Let postprocess (p: uprog) : cexec uprog :=
@@ -145,7 +148,8 @@ Record stack_alloc_oracles : Type :=
   }.
 
 Record compiler_params
-  `{asm_e : asm_extra} 
+  {asm_op : Type}
+  {asmop : asmOp asm_op}
   (fresh_vars lowering_options : Type) := {
   rename_fd        : instr_info -> funname -> _ufundef -> _ufundef;
   expand_fd        : funname -> _ufundef -> expand_info;
@@ -177,8 +181,17 @@ Record compiler_params
   is_regx          : var -> bool;
 }.
 
+
 Context
-  `{asm_e : asm_extra} {call_conv: calling_convention}
+  {reg regx xreg rflag cond asm_op extra_op : Type}
+  {asm_e : asm_extra reg regx xreg rflag cond asm_op extra_op}
+  {syscall_state : Type}
+  {scs : syscall_sem syscall_state}.
+
+Existing Instance arch_extra.spp_of_asm_e.
+
+Context
+  {call_conv: calling_convention}
   {fresh_vars lowering_options : Type}
   (aparams : architecture_params fresh_vars lowering_options)
   (cparams : compiler_params fresh_vars lowering_options).

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -39,12 +39,18 @@ Unset Printing Implicit Defensive.
 Section PROOF.
 
 Context
-  {syscall_state : Type} {sc_sem : syscall.syscall_sem syscall_state}
-  `{asm_e : asm_extra} {call_conv : calling_convention} {asm_scsem : asm_syscall_sem}
+  {syscall_state : Type}
+  {sc_sem : syscall.syscall_sem syscall_state}
+  {reg regx xreg rflag cond asm_op extra_op : Type}
+  {asm_e : asm_extra reg regx xreg rflag cond asm_op extra_op}
+  {call_conv : calling_convention}
+  {asm_scsem : asm_syscall_sem}
   {fresh_vars lowering_options : Type}
   (aparams : architecture_params fresh_vars lowering_options)
   (haparams : h_architecture_params aparams)
   (cparams : compiler_params fresh_vars lowering_options).
+
+Existing Instance spp_of_asm_e.
 
 Hypothesis print_uprogP : forall s p, cparams.(print_uprog) s p = p.
 Hypothesis print_sprogP : forall s p, cparams.(print_sprog) s p = p.
@@ -126,7 +132,10 @@ Proof.
   rewrite print_uprogP => pp ok_pp.
   rewrite print_uprogP => <- {p'} ok_fn exec_p.
   have va_refl := List_Forall2_refl va value_uincl_refl.
-  apply: compose_pass_uincl; first by move=> vr' Hvr'; apply: (pi_callP (sCP := sCP_unit) ok_pp va_refl); exact Hvr'.
+  apply: compose_pass_uincl.
+  - move=> vr' Hvr'.
+    apply: (pi_callP (sCP := sCP_unit) (hpip := hap_hpip haparams) ok_pp va_refl).
+    exact: Hvr'.
   apply: compose_pass.
   - move => vr'.
     by apply:
@@ -136,9 +145,12 @@ Proof.
          (warning cparams)
          (is_var_in_memory cparams)
          ok_fvars).
-  apply: compose_pass; first by move => vr'; apply: (makeReferenceArguments_callP ok_ph).
+  apply: compose_pass;
+    first by move=> vr';
+      apply: (makeReferenceArguments_callP (spp := spp_of_asm_e) ok_ph).
   apply: compose_pass; first by move => vr'; apply: (RGP.remove_globP ok_pg).
-  apply: compose_pass; first by move=> vr'; apply:(expand_callP ok_pf).
+  apply: compose_pass;
+    first by move=> vr'; apply:(expand_callP (spp := spp_of_asm_e) ok_pf).
   apply: compose_pass_uincl; first by move =>vr'; apply: (remove_init_fdPu _ va_refl).
   apply: compose_pass_uincl.
   - move => vr' Hvr'.
@@ -147,7 +159,9 @@ Proof.
   apply: compose_pass_uincl; first by move => vr'; apply: (CheckAllocRegU.alloc_callP ok_pd).
   rewrite surj_prog.
   apply: compose_pass_uincl; first by move=> vr' Hvr'; apply: (unrollP ok_pc _ va_refl); exact: Hvr'.
-  apply: compose_pass; first by move => vr'; exact: (dead_calls_err_seqP (sCP:= sCP_unit) ok_pb).
+  apply: compose_pass;
+    first by move => vr';
+      exact: (dead_calls_err_seqP (spp := spp_of_asm_e) (sCP := sCP_unit) ok_pb).
   apply: compose_pass_uincl; first by move => vr' Hvr'; apply: (inline_call_errP ok_pa va_refl); exact: Hvr'.
   apply: compose_pass; first by move => vr'; apply: (add_init_fdP).
   apply: compose_pass_uincl; first by move=> vr' Hvr'; apply: (array_copy_fdP (sCP := sCP_unit) ok_pa0 va_refl); exact Hvr'.
@@ -165,7 +179,7 @@ Proof.
   by rewrite h.
 Qed.
 
-Lemma compiler_third_partP entries (p: sprog) (p': sprog) :
+Lemma compiler_third_partP entries (p p' : @sprog _pd _ _asmop) :
   compiler_third_part aparams cparams entries p = ok p' →
   [/\
     ∀ fn (gd: pointer) scs m va scs' m' vr,
@@ -196,9 +210,11 @@ Proof.
     rewrite /fn_keep_only (ok_rr _ ok_fn) => vr_vr'.
     by exists vr'.
   rewrite /alloc_ok => fn m alloc_pc fd get_fd.
-  have [fda ok_fda get_fda] := dead_code_prog_tokeep_get_fundef ok_pa get_fd.
+  have [fda ok_fda get_fda] :=
+    dead_code_prog_tokeep_get_fundef (spp := spp_of_asm_e) ok_pa get_fd.
   have [fdb [get_fdb ok_fdb]] := CheckAllocRegS.all_checked ok_pb get_fda.
-  have [fdc ok_fdc get_fdc] := dead_code_prog_tokeep_get_fundef ok_pc get_fdb.
+  have [fdc ok_fdc get_fdc] :=
+    dead_code_prog_tokeep_get_fundef (spp := spp_of_asm_e) ok_pc get_fdb.
   move: (alloc_pc _ get_fdc).
   have [_ _ ->]:= dead_code_fd_meta ok_fdc.
   have /=[_ _ _ <-] := CheckAllocRegS.check_fundef_meta ok_fdb.
@@ -210,8 +226,10 @@ Lemma compiler_third_part_meta entries (p p' : sprog) :
   compiler_third_part aparams cparams entries p = ok p' →
   p_extra p' = p_extra p.
 Proof.
-  rewrite /compiler_third_part; t_xrbindP =>
-    _ pa /dead_code_prog_tokeep_meta [] _ ok_pa _ pb /dead_code_prog_tokeep_meta[].
+  rewrite /compiler_third_part.
+  t_xrbindP => _ pa hpa _ pb hpb.
+  move: hpa => /(dead_code_prog_tokeep_meta (spp := spp_of_asm_e)) [] _ ok_pa.
+  move: hpb => /(dead_code_prog_tokeep_meta (spp := spp_of_asm_e)) [].
   rewrite !print_sprogP /= => _ ok_pb <- {p'}.
   by rewrite ok_pb ok_pa.
 Qed.
@@ -268,7 +286,13 @@ Proof.
   by exists fd.
 Qed.
 
-Lemma compiler_front_endP entries subroutines (p: prog) (p': sprog) (gd: pointer) scs m mi fn va scs' m' vr :
+Lemma compiler_front_endP
+  entries
+  subroutines
+  (p: prog)
+  (p': @sprog _pd _ _asmop)
+  (gd : pointer)
+  scs m mi fn va scs' m' vr :
   compiler_front_end aparams cparams entries subroutines p = ok p' →
   fn \in entries →
   sem.sem_call p scs m fn va scs' m' vr →
@@ -285,7 +309,7 @@ Proof.
   t_xrbindP => p1 ok_p1 /check_no_ptrP checked_entries p2 ok_p2 p3.
   rewrite print_sprogP => ok_p3 <- {p'} ok_fn exec_p.
   rewrite (compiler_third_part_meta ok_p3) => m_mi ok_mi.
-  have {ok_mi} ok_mi : alloc_ok p2 fn mi.
+  have {ok_mi} ok_mi : alloc_ok (spp := spp_of_asm_e) p2 fn mi.
   - exact: compiler_third_part_alloc_ok ok_p3 ok_mi.
   have := compiler_first_partP ok_p1 _ exec_p.
   rewrite mem_cat ok_fn => /(_ erefl).
@@ -293,7 +317,8 @@ Proof.
   have gd2 := sp_globs_stack_alloc ok_p2.
   rewrite -gd2 in ok_p2.
   case/sem_call_length: (exec_p1) => fd [] ok_fd size_params size_tyin size_tyout size_res.
-  case/alloc_prog_get_fundef: (ok_p2) => mglob ok_mglob /(_ _ _ ok_fd)[] fd' /alloc_fd_checked_sao[] ok_sao_p ok_sao_r ok_fd'.
+  have [mglob ok_mglob] := alloc_prog_get_fundef (spp := spp_of_asm_e) ok_p2.
+  move=> /(_ _ _ ok_fd)[] fd' /alloc_fd_checked_sao[] ok_sao_p ok_sao_r ok_fd'.
   move: checked_entries => /(_ _ ok_fn) [] params_noptr return_noptr.
   have ok_va : wf_args (sp_globs (p_extra p2)) gd (ao_stack_alloc (stackalloc cparams p1)) m mi fn va va.
   - move: params_noptr ok_sao_p.
@@ -335,7 +360,7 @@ Lemma compiler_back_end_meta entries (p: sprog) (tp: lprog) :
 Proof.
   rewrite /compiler_back_end; t_xrbindP => _ _ lp ok_lp p2.
   rewrite !print_linearP => ok_tp ?; subst p2.
-  have [ <- [] <- [] <- _ ] := tunnel_program_invariants ok_tp.
+  have [<- [<- [<- _]]] := tunnel_program_invariants (spp := spp_of_asm_e) ok_tp.
   split.
   - exact: lp_ripE ok_lp.
   - exact: lp_rspE ok_lp.
@@ -376,8 +401,8 @@ Proof.
   move: ok_export => /(_ _ ok_fn); rewrite ok_fd => /assertP /eqP export.
   split; last by rewrite export.
   move: ok_fd =>
-    /(get_fundef_p' ok_lp)
-    /(get_fundef_tunnel_program ok_tp)
+    /(get_fundef_p' (spp := spp_of_asm_e) ok_lp)
+    /(get_fundef_tunnel_program (spp := spp_of_asm_e) ok_tp)
     /(ok_get_fundef ok_xp)
     [fd' ok_fd'].
   case/assemble_fdI => _ _ [] ? [] ? [] ? [] _ _ _ ?; subst fd'.
@@ -389,7 +414,18 @@ Qed.
 
 Import sem_one_varmap.
 
-Lemma compiler_back_endP entries (p: sprog) (tp: lprog) (rip: word Uptr) scs (m:mem) scs' (m':mem) (fn: funname) args res :
+Lemma compiler_back_endP
+  entries
+  (p : @sprog _pd _ _asmop)
+  (tp : lprog)
+  (rip : word Uptr)
+  (scs : syscall_state)
+  (m : mem)
+  (scs' : syscall_state)
+  (m' : mem)
+  (fn : funname)
+  args
+  res :
   compiler_back_end aparams cparams entries p = ok tp →
   fn \in entries →
   psem.sem_call p rip scs m fn args scs' m' res →
@@ -440,7 +476,7 @@ Proof.
   - exact: Export.
   move=> lm vm args' H H0 H1 H2 H3 H4 H5.
   have {lp_call} := lp_call lm vm args' H _ H1 H2 H3 _ H5.
-  have [ -> [] -> _ ] := tunnel_program_invariants ok_tp.
+  have [-> [-> _]] := tunnel_program_invariants (spp := spp_of_asm_e) ok_tp.
   move => /(_ H0 H4)[] wt_args' [] vm' [] lm' [] res' [] lp_call M' ok_res' res_res' wt_res'.
   split; first exact: wt_args'.
   exists vm', lm', res'; split; cycle 1.
@@ -453,17 +489,17 @@ Proof.
   exists (tunneling.tunnel_lfundef fn fd).
   - exact: get_fundef_tunnel_program ok_tp ok_fd.
   - exact: Export.
-  case: (lsem_run_tunnel_program ok_tp lp_exec).
+  case: (lsem_run_tunnel_program (spp := spp_of_asm_e) ok_tp lp_exec).
   - by exists fd.
   - move => tp_exec _.
-    rewrite /= size_tunnel_lcmd.
+    rewrite /=. rewrite (size_tunnel_lcmd (spp := arch_extra.spp_of_asm_e)).
     exact: tp_exec.
   exact: ok_callee_saved.
 Qed.
 
 Lemma compiler_back_end_to_asmP
   entries
-  (p : sprog)
+  (p : @sprog _pd _ _asmop)
   (xp : asm_prog)
   (rip : word Uptr)
   scs (m : mem) scs' (m' : mem)
@@ -689,9 +725,10 @@ Proof.
   - rewrite -(asmsem_invariant_rip xm_xm').
     exact: m1.
   - exact: m2.
-  - transitivity mi; last exact: sem_call_stack_stable_sprog sp_call.
+  - transitivity mi;
+      last exact: (sem_call_stack_stable_sprog sp_call).
     transitivity m; last exact: mi3.
-    symmetry; exact: sem_call_stack_stable p_call.
+    symmetry. exact: (sem_call_stack_stable p_call).
   rewrite
     -(ss_limit (sem_call_stack_stable_sprog sp_call))
     -(ss_top_stack (asmsem_invariant_stack_stable xm_xm')).

--- a/proofs/compiler/constant_prop.v
+++ b/proofs/compiler/constant_prop.v
@@ -4,6 +4,7 @@ Require Import expr ZArith sem compiler_util.
 Import all_ssreflect all_algebra.
 Import Utf8.
 Import oseq.
+Require Import flag_combination.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -12,6 +13,11 @@ Unset Printing Implicit Defensive.
 Local Open Scope seq_scope.
 Local Open Scope vmap_scope.
 Local Open Scope Z_scope.
+
+
+Section WITH_PARAMS.
+
+Context {fcp : FlagCombinationParams}.
 
 Definition e2bool (e:pexpr) : exec bool := 
   match e with
@@ -515,3 +521,4 @@ Definition const_prop_prog (p:prog) : prog := map_prog const_prop_fun p.
 End Section.
 
 End ASM_OP.
+End WITH_PARAMS.

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -18,14 +18,14 @@ Local Notation cpm := (Mvar.t const_v).
 (* ** proofs
  * -------------------------------------------------------------------- *)
 
-Section Section.
+Section WITH_PARAMS.
 
 Context
-  {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}
-  `{asmop:asmOp}
-  {T:eqType}
-  {pT:progT T}
-  {sCP: semCallParams}.
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  {T : eqType}
+  {pT : progT T}
+  {sCP : semCallParams}.
 
 Section GLOB_DEFS.
 
@@ -1186,7 +1186,9 @@ Section PROOF.
   Proof.
     move => scs1 m1 sc2 m2 fn f vargs vargs' s0 s1 s2 vres vres'.
     case: f=> fi ftin fparams fc ftout fres fex /= Hget Hargs Hi Hw _ Hc Hres Hfull Hscs Hfi.
-    have := (get_map_prog const_prop_fun p fn);rewrite Hget /=.
+    assert (h := get_map_prog const_prop_fun p fn).
+    move: h.
+    rewrite Hget /=.
     have : valid_cpm (evm s1) empty_cpm by move=> x n;rewrite Mvar.get0.
     move=> /Hc [];case: const_prop => m c' /= hcpm hc' hget vargs1 hargs'.
     have [vargs1' htr hu1]:= mapM2_truncate_val Hargs hargs'.
@@ -1204,11 +1206,11 @@ Section PROOF.
     List.Forall2 value_uincl va va' ->
     exists vr', sem_call p' ev scs mem f va' scs' mem' vr' /\ List.Forall2 value_uincl vr vr'.
   Proof.
-    move=> /(@sem_call_Ind _ _ _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
+    move=> /(@sem_call_Ind _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
              Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc) h.
     apply h.
   Qed.
 
 End PROOF.
 
-End Section.
+End WITH_PARAMS.

--- a/proofs/compiler/dead_calls_proof.v
+++ b/proofs/compiler/dead_calls_proof.v
@@ -8,10 +8,11 @@ Set   Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Section ASM_OP.
+Section WITH_PARAMS.
 
-Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context `{asmop:asmOp}.
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}.
 
 (* -------------------------------------------------------------------- *)
 Fixpoint i_Calls (i : instr) {struct i} : Sp.t :=
@@ -316,7 +317,7 @@ Section PROOF.
     sem_call p' ev scs mem fd va scs' mem' vr.
   Proof.
     move=> Hincl H.
-    apply: (@sem_call_Ind _ _ _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
+    apply: (@sem_call_Ind _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
            Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc)=> //.
     move => ??; SpD.fsetdec.
   Qed.
@@ -380,4 +381,4 @@ Qed.
 
 End Section.
 
-End ASM_OP.
+End WITH_PARAMS.

--- a/proofs/compiler/dead_code_proof.v
+++ b/proofs/compiler/dead_code_proof.v
@@ -11,16 +11,17 @@ Unset Printing Implicit Defensive.
 Local Open Scope vmap.
 Local Open Scope seq_scope.
 
-Section ASM_OP.
+Section WITH_PARAMS.
 
-Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context `{asmop : asmOp}.
-Context (is_move_op : asm_op_t -> bool).
-
-Hypothesis is_move_opP : forall op vx v,
-  is_move_op op ->
-  exec_sopn (Oasm op) [:: vx] = ok v ->
-  List.Forall2 value_uincl v [:: vx].
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  (is_move_op : asm_op_t -> bool)
+  (is_move_opP :
+    forall op vx v,
+      is_move_op op
+      -> exec_sopn (Oasm op) [:: vx ] = ok v
+      -> List.Forall2 value_uincl v [:: vx ]).
 
 Section Section.
 
@@ -599,7 +600,7 @@ Section PROOF.
       sem_call p' ev scs mem fn va' scs' mem' vr' /\  List.Forall2 value_uincl (fn_keep_only onfun fn vr) vr'.
   Proof.
     move=> Hall Hsem.
-    apply (@sem_call_Ind _ _ _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
+    apply (@sem_call_Ind _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
             Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc scs mem fn va scs' mem' vr Hsem _ Hall).
   Qed.
 
@@ -666,4 +667,4 @@ Proof.
   by case: fd => /= ; t_xrbindP => /= ????????? <-.
 Qed.
 
-End ASM_OP.
+End WITH_PARAMS.

--- a/proofs/compiler/inline.v
+++ b/proofs/compiler/inline.v
@@ -4,6 +4,7 @@
 Require Import ZArith.
 From mathcomp Require Import all_ssreflect.
 Require Import expr compiler_util allocation.
+Require sem.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -33,9 +34,10 @@ End E.
 
 Section INLINE.
 
-Context {pd: PointerData}.
-Context `{asmop:asmOp}.
-Context (inline_var: var -> bool).
+Context
+  {asm_op syscall_state : Type}
+  {spp : sem.SemPexprParams asm_op syscall_state}
+  (inline_var : var -> bool).
 
 Definition get_flag (x:lval) flag :=
   match x with

--- a/proofs/compiler/inline_proof.v
+++ b/proofs/compiler/inline_proof.v
@@ -13,10 +13,11 @@ Local Open Scope seq_scope.
 
 Section INLINE.
 
-Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context `{asmop:asmOp}.
-Context (inline_var: var -> bool).
-Variable rename_fd : instr_info -> funname -> ufundef -> ufundef.
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  (inline_var : var -> bool)
+  (rename_fd : instr_info -> funname -> ufundef -> ufundef).
 
 Lemma get_funP p f fd :
   get_fun p f = ok fd -> get_fundef p f = Some fd.
@@ -564,7 +565,7 @@ Section PROOF.
       sem_call p' ev scs mem f va' scs' mem' vr' /\  List.Forall2 value_uincl vr vr'.
   Proof.
     move=> Hall Hsem.
-    apply (@sem_call_Ind _ _ _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
+    apply (@sem_call_Ind _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
                Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc
                scs mem f va scs' mem' vr Hsem _ Hall).
   Qed.

--- a/proofs/compiler/lea_proof.v
+++ b/proofs/compiler/lea_proof.v
@@ -13,8 +13,10 @@ Local Open Scope vmap_scope.
 Local Open Scope seq_scope.
 
 Section PROOF.
-  Context {pd:PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-  Context (gd: glob_decls).
+  Context
+    {asm_op syscall_state : Type}
+    {spp : SemPexprParams asm_op syscall_state}
+    (gd : glob_decls).
 
   (* ---------------------------------------------------------- *)
 

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -21,10 +21,12 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Section ASM_EXTRA.
+Section WITH_PARAMS.
 
 Context
-  {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state} {asm_op} {asmop : asmOp asm_op} {ovm_i : one_varmap_info}.
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  {ovm_i : one_varmap_info}.
 
 Notation spointer := (sword Uptr) (only parsing).
 
@@ -1678,7 +1680,7 @@ Section PROOF.
         exact: sem_stack_stable Ec.
       apply: lsem_trans; last apply: (lsem_trans E1); last apply: (lsem_trans E2).
       - (* align; label *)
-        apply: (@lsem_step_end _ _ _ _ _ _ p' {| lfn := fn; lpc := size (P ++ add_align ii a [::]) |}); last first.
+        apply: (@lsem_step_end _ _ _ _ p' {| lfn := fn; lpc := size (P ++ add_align ii a [::]) |}); last first.
         + move: C.
           rewrite -!catA catA -{1}(addn0 (size _)) /lsem1 /step => /find_instr_skip ->.
           rewrite /eval_instr /= /setpc /= addn0 !size_cat addnA addn1.
@@ -1741,7 +1743,7 @@ Section PROOF.
         exact: sem_validw_stable Ec.
       apply: lsem_trans; last apply: (lsem_trans E1).
       - (* align; label *)
-        apply: (@lsem_step_end _ _ _ _ _ _ p' {| lfn := fn; lpc := size (P ++ add_align ii a [::]) |}); last first.
+        apply: (@lsem_step_end _ _ _ _ p' {| lfn := fn; lpc := size (P ++ add_align ii a [::]) |}); last first.
         + move: C.
           rewrite -!catA catA -{1}(addn0 (size _)) /lsem1 /step => /find_instr_skip ->.
           rewrite /eval_instr /= /setpc /= addn0 !size_cat addnA addn1.
@@ -1907,7 +1909,7 @@ Section PROOF.
       exists m' vm'; [ | | exact: W' | exact: X' | exact: H' | exact: M' ]; last first.
       - apply: vmap_eq_exceptI K; SvD.fsetdec.
       apply: lsem_trans; last apply: (lsem_trans E).
-      - apply: (@lsem_trans _ _ _ _ _ _ _ {| lmem := m ; lvm := vm ; lfn := fn ; lpc := size (P ++ add_align ii a [::]) |}).
+      - apply: (@lsem_trans _ _ _ _ _ {| lmem := m ; lvm := vm ; lfn := fn ; lpc := size (P ++ add_align ii a [::]) |}).
         + subst prefix; case: a C {E} => C; last by rewrite cats0; exact: rt_refl.
           apply: LSem_step.
           move: C.
@@ -3560,7 +3562,7 @@ Section PROOF.
     sem_call p extra_free_registers var_tmp ii k s1 fn s2 →
     Pfun ii k s1 fn s2.
   Proof.
-    exact: (@sem_call_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall Hif_true Hif_false Hwhile_true Hwhile_false Hcall Hproc).
+    exact: (@sem_call_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall Hif_true Hif_false Hwhile_true Hwhile_false Hcall Hproc).
   Qed.
 
   Lemma linear_exportcallP gd scs m fn args scs' m' res :
@@ -3695,4 +3697,4 @@ Section PROOF.
   Qed.
 
 End PROOF.
-End ASM_EXTRA.
+End WITH_PARAMS.

--- a/proofs/compiler/merge_varmaps_proof.v
+++ b/proofs/compiler/merge_varmaps_proof.v
@@ -15,10 +15,11 @@ Unset Printing Implicit Defensive.
 
 Local Open Scope vmap_scope.
 
-Section ASM_OP.
+Section WITH_PARAMS.
 
-Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context `{asmop:asmOp}.
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}.
 
 Lemma vrvs_Lvar xs :
   vrvs [seq Lvar x | x <- xs] = sv_of_list v_var xs.
@@ -82,17 +83,14 @@ Proof. by case: Q; rewrite !(orbT, orbF, andbT). Qed.
 Definition is_export (p: sprog) (fn: funname) : Prop :=
   exists2 fd, get_fundef p.(p_funcs) fn = Some fd & fd.(f_extra).(sf_return_address) = RAnone.
 
-End ASM_OP.
-
 Section PROG.
 
 Context
-  {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}
-  {asm_op} {asmop:asmOp asm_op} {ovm_i : one_varmap_info}
-  (p: sprog)
-  (extra_free_registers: instr_info -> option var)
+  {ovm_i : one_varmap_info}
+  (p : sprog)
+  (extra_free_registers : instr_info -> option var)
   (id_tmp : Ident.ident)
-  (global_data: pointer).
+  (global_data : pointer).
 
 Let var_tmp : var := vid id_tmp.
 
@@ -953,7 +951,7 @@ Section LEMMA.
       _
     :=
       Eval hnf in
-      @sem_call_Ind _ _ _ _ _ _ _ _ p global_data Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hassgn Hopn Hsyscall Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc.
+      @sem_call_Ind _ _ _ _ _ _ p global_data Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hassgn Hopn Hsyscall Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc.
 
 End LEMMA.
 
@@ -1006,3 +1004,5 @@ Proof.
 Qed.
 
 End PROG.
+
+End WITH_PARAMS.

--- a/proofs/compiler/propagate_inline.v
+++ b/proofs/compiler/propagate_inline.v
@@ -1,110 +1,117 @@
-(* ** Imports and settings *)
+From Coq Require Import
+  Utf8
+  ZArith.
+From mathcomp Require Import all_ssreflect.
+
 From CoqWord Require Import ssrZ.
-Require Import compiler_util expr ZArith constant_prop.
-Import all_ssreflect.
-Import Utf8.
+
+Require Import
+  expr
+  flag_combination
+  sem.
+Require Import
+  compiler_util
+  constant_prop.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
+Module Import E.
+
+  Definition pass : string := "propagate inline".
+
+  Definition ii_loop_iterator := ii_loop_iterator pass.
+
+End E.
+
+
 Fixpoint use_mem (e : pexpr) :=
-  match e with 
-  | Pconst _ | Pbool _ | Parr_init _ | Pvar _ => false 
+  match e with
+  | Pconst _ | Pbool _ | Parr_init _ | Pvar _ => false
   | Pload _ _ _ => true
-  | Pget _ _ _ e | Psub _ _ _ _ e | Papp1 _ e => use_mem e 
-  | Papp2 _ e1 e2 => use_mem e1 || use_mem e2 
-  | PappN _ es => has use_mem es 
-  | Pif _ e e1 e2 => use_mem e || use_mem e1 || use_mem e2 
+  | Pget _ _ _ e | Psub _ _ _ _ e | Papp1 _ e => use_mem e
+  | Papp2 _ e1 e2 => use_mem e1 || use_mem e2
+  | PappN _ es => has use_mem es
+  | Pif _ e e1 e2 => use_mem e || use_mem e1 || use_mem e2
   end.
 
 (* -------------------------------------------------------------------------- *)
 (* ** Data structure used for the analisys                                    *)
 (* -------------------------------------------------------------------------- *)
 
-Record pi_cel := { 
+Record pi_cel := {
   pi_def : pexpr; (* associate expression *)
   pi_fv  : Sv.t;  (* read_e pi_def        *)
-  pi_m   : bool;  (* use_mem pi_def       *) 
+  pi_m   : bool;  (* use_mem pi_def       *)
   pi_fv_ok : pi_fv = read_e pi_def;
   pi_m_ok  : pi_m = use_mem pi_def;
 }.
 
-Definition pimap := Mvar.t pi_cel. 
+Definition pimap := Mvar.t pi_cel.
 
 Definition piempty : pimap := Mvar.empty _.
 
-Definition remove (pi:pimap) (x:var) := 
+Definition remove (pi:pimap) (x:var) :=
   Mvar.filter_map (fun y c => if (x == y) || Sv.mem x c.(pi_fv) then None else Some c) pi.
 
-Definition remove_m (pi:pimap) := 
+Definition remove_m (pi:pimap) :=
   Mvar.filter_map (fun y c => if c.(pi_m) then None else Some c) pi.
 
-Definition set (pi:pimap) (x:var) (e:pexpr) := 
+Definition set (pi:pimap) (x:var) (e:pexpr) :=
   let fv := read_e e in
   let use := use_mem e in
   if Sv.mem x fv then pi
-  else 
+  else
     Mvar.set pi x {| pi_def := e; pi_fv_ok := erefl fv; pi_m_ok := erefl use |}.
 
-Definition merge (pi1 pi2:pimap) := 
-  let ondefs (_:var) (o1 o2 : option pi_cel) := 
+Definition merge (pi1 pi2:pimap) :=
+  let ondefs (_:var) (o1 o2 : option pi_cel) :=
     match o1, o2 with
-    | Some c1, Some c2 => 
+    | Some c1, Some c2 =>
       if eq_expr c1.(pi_def) c2.(pi_def) then o1
       else None
     | _, _ => None
     end in
   Mvar.map2 ondefs pi1 pi2.
-  
-Definition incl (pi1 pi2:pimap) := 
+
+Definition incl (pi1 pi2:pimap) :=
   Mvar.incl (fun _ c1 c2 => eq_expr c1.(pi_def) c2.(pi_def)) pi1 pi2.
 
 (* -------------------------------------------------------------------------- *)
 (* ** Transformation                                                          *)
 (* -------------------------------------------------------------------------- *)
 
-Definition sbneq e1 e2 := 
+Section WITH_PARAMS.
+
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}.
+
+Definition sbneq e1 e2 :=
   snot (sbeq e1 e2).
 
-Definition lower_cfc c es := 
-  match es with
-  | [:: Of; Cf; Sf; Zf] =>
-    Some match c with
-    | CFC_O => Of
-    | CFC_B => Cf
-    | CFC_E => Zf
-    | CFC_S => Sf
-    | CFC_L => sbneq Of Sf
-    | CFC_BE => sor Cf Zf
-    | CFC_LE => sor (sbneq Of Sf) Zf
-    end
-  | _ => None
-  end.
+Definition scfc (cf : combine_flags) (es : seq pexpr) : pexpr :=
+  if es is [:: eof; ecf; esf; ezf ]
+  then cf_xsem snot sand sor sbeq eof ecf esf ezf cf
+  else PappN (Ocombine_flags cf) es. (* Never happens. *)
 
-Definition scfc c es := 
-  let (n, cfc) := cf_tbl c in
-  match lower_cfc cfc es with
-  | Some e' => if n then snot e' else e'
-  | None    => (* never happen *) PappN (Ocombine_flags c) es
-  end.
-
-Fixpoint pi_e (pi:pimap) (e:pexpr) := 
+Fixpoint pi_e (pi:pimap) (e:pexpr) :=
   match e with
-  | Pconst _ | Pbool _ | Parr_init _ => e 
-  | Pvar x => 
+  | Pconst _ | Pbool _ | Parr_init _ => e
+  | Pvar x =>
     if is_lvar x then
       match Mvar.get pi x.(gv) with
       | Some c => c.(pi_def)
-      | None => e 
-      end 
+      | None => e
+      end
     else e
   | Pget aa ws x e     => Pget aa ws x (pi_e pi e)
   | Psub aa ws len x e => Psub aa ws len x (pi_e pi e)
   | Pload ws x e       => Pload ws x (pi_e pi e)
   | Papp1 o e          => Papp1 o (pi_e pi e)
   | Papp2 o e1 e2      => Papp2 o (pi_e pi e1) (pi_e pi e2)
-  | PappN o es         => 
+  | PappN o es         =>
     let es := (map (pi_e pi) es) in
     match o with
     | Opack _ _ => PappN o es
@@ -113,26 +120,26 @@ Fixpoint pi_e (pi:pimap) (e:pexpr) :=
   | Pif t e e1 e2      => Pif t (pi_e pi e) (pi_e pi e1) (pi_e pi e2)
   end.
 
-Definition pi_es (pi:pimap) (es:pexprs) := 
+Definition pi_es (pi:pimap) (es:pexprs) :=
   map (pi_e pi) es.
 
 Definition pi_lv (pi:pimap) (lv:lval) :=
   match lv with
-  | Lnone _ _           => (pi, lv) 
+  | Lnone _ _           => (pi, lv)
   | Lvar x              => (remove pi x, lv)
   | Lmem ws x e         => (remove_m pi, Lmem ws x (pi_e pi e))
   | Laset aa ws x e     => (remove pi x, Laset aa ws x (pi_e pi e))
   | Lasub aa ws len x e => (remove pi x, Lasub aa ws len x (pi_e pi e))
-  end. 
-  
+  end.
+
 (* TODO: move this in utils use it in constant_prop.const_prop_rvs ... *)
 Section MF.
   Context (A B C:Type) (f : A -> B -> A * C).
 
-  Fixpoint map_fold (a:A) (lb:list B) : A * list C := 
+  Fixpoint map_fold (a:A) (lb:list B) : A * list C :=
     match lb with
     | [::] => (a, [::])
-    | b::lb => 
+    | b::lb =>
       let (a, c) := f a b in
       let (a, lc) := map_fold a lb in
       (a, c :: lc)
@@ -148,28 +155,16 @@ Definition set_lv (pi:pimap) x tag (e:pexpr) :=
     else pi
   else pi.
 
-Module Import E.
-
-  Definition pass : string := "propagate inline".
-
-  Definition ii_loop_iterator := ii_loop_iterator pass.
-
-End E.
-
-Section ASM_OP.
-
-Context `{asmop:asmOp}.
-
 Section LOOP.
 
-  Context (pi_i : pimap -> instr -> cexec (pimap * instr)). 
+  Context (pi_i : pimap -> instr -> cexec (pimap * instr)).
 
   (* TODO: add map_foldM in utils *)
-  Fixpoint pi_c (pi:pimap) (c:cmd) := 
+  Fixpoint pi_c (pi:pimap) (c:cmd) :=
     match c with
     | [::] => ok (pi, [::])
-    | i::c => 
-      Let pii := pi_i pi i in 
+    | i::c =>
+      Let pii := pi_i pi i in
       Let pic := pi_c pii.1 c in
       ok (pic.1, pii.2 :: pic.2)
     end.
@@ -197,53 +192,52 @@ Section LOOP.
       Let pic1 := pi_c pi c1 in
       Let pic2 := pi_c pic1.1 c2 in
       if incl pi pic2.1 then ok (pic1.1, pic1.2, pi_e pic1.1 e, pic2.2)
-      else loop_while n (merge pi pic2.1) 
+      else loop_while n (merge pi pic2.1)
     end.
 
 End LOOP.
 
-Fixpoint pi_i (pi:pimap) (i:instr) := 
-  let (ii, ir) := i in
+Fixpoint pi_i (pi : pimap) (i : instr) :=
+  let '(MkI ii ir) := i in
   match ir with
   | Cassgn x tag ty e =>
     let e := pi_e pi e in
-    let (pi, x) := pi_lv pi x in 
+    let '(pi, x) := pi_lv pi x in
     let pi := set_lv pi x tag e in
     ok (pi, MkI ii (Cassgn x tag ty e))
 
-  | Copn xs tag o es => 
+  | Copn xs tag o es =>
     let es := pi_es pi es in
-    let (pi, xs) := pi_lvs pi xs in
+    let '(pi, xs) := pi_lvs pi xs in
     ok (pi, MkI ii (Copn xs tag o es))
 
   | Csyscall xs o es =>
     let es := pi_es pi es in
-    (* Remark: for uprog it is not necessary *)
-    let pi := remove_m pi in
-    let (pi, xs) := pi_lvs pi xs in
+    let pi := remove_m pi in (* For uprog this is not necessary. *)
+    let '(pi, xs) := pi_lvs pi xs in
     ok (pi, MkI ii (Csyscall xs o es))
 
-  | Cif e c1 c2 => 
+  | Cif e c1 c2 =>
     let e := pi_e pi e in
     Let pic1 := pi_c pi_i pi c1 in
     Let pic2 := pi_c pi_i pi c2 in
     let pi := merge pic1.1 pic2.1 in
     ok (pi, MkI ii (Cif e pic1.2 pic2.2))
 
-  | Cfor x (d,e1,e2) c => 
+  | Cfor x (d,e1,e2) c =>
     let e1 := pi_e pi e1 in
     let e2 := pi_e pi e2 in
     Let pic := loop_for pi_i ii x c Loop.nb pi in
     ok (pic.1, MkI ii (Cfor x (d,e1,e2) pic.2))
-    
-  | Cwhile a c1 e c2 => 
+
+  | Cwhile a c1 e c2 =>
     Let pic := loop_while pi_i ii c1 e c2 Loop.nb pi in
-    let:(pi, c1, e, c2) := pic in
+    let '(pi, c1, e, c2) := pic in
     ok (pi, MkI ii (Cwhile a c1 e c2))
 
   | Ccall inline xs f es =>
     let es := pi_es pi es in
-    let (pi, xs) := pi_lvs (remove_m pi) xs in
+    let '(pi, xs) := pi_lvs (remove_m pi) xs in
     ok (pi, MkI ii (Ccall inline xs f es))
 
   end.
@@ -254,13 +248,13 @@ Context {T} {pT:progT T}.
 
 Definition pi_fun  (f:fundef) :=
   let 'MkFun ii si p c so r ev := f in
-  Let pic := pi_c pi_i piempty c in 
+  Let pic := pi_c pi_i piempty c in
   ok (MkFun ii si p pic.2 so r ev).
 
-Definition pi_prog (p:prog) := 
+Definition pi_prog (p:prog) :=
   Let funcs := map_cfprog pi_fun (p_funcs p) in
   ok {| p_extra := p_extra p; p_globs := p_globs p; p_funcs := funcs |}.
 
 End Section.
 
-End ASM_OP.
+End WITH_PARAMS.

--- a/proofs/compiler/propagate_inline_proof.v
+++ b/proofs/compiler/propagate_inline_proof.v
@@ -1,6 +1,7 @@
 (* ** Imports and settings *)
 From mathcomp Require Import all_ssreflect all_algebra.
 Require Import psem constant_prop constant_prop_proof.
+Require Import flag_combination.
 Require Export propagate_inline.
 
 Import Utf8 ZArith Morphisms Classes.RelationClasses.
@@ -12,15 +13,29 @@ Unset Printing Implicit Defensive.
 Local Open Scope seq_scope.
 Local Open Scope vmap_scope.
 
-(* ** proofs
- * -------------------------------------------------------------------- *)
 
-Section Section.
+Record h_propagate_inline_params
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state} :=
+  {
+    pip_cf_xsemP :
+      forall gd s e0 e1 e2 e3 cf v,
+        let e := PappN (Ocombine_flags cf) [:: e0; e1; e2; e3 ] in
+        let e' := cf_xsem enot eand eor expr.eeq e0 e1 e2 e3 cf in
+        sem_pexpr gd s e = ok v
+        -> sem_pexpr gd s e' = ok v;
+  }.
+
+Section WITH_PARAMS.
 
 Context
-  {pd:PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}
-  `{asmop:asmOp}
-  {T:eqType} {pT:progT T} {sCP: semCallParams}.
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  {T : eqType}
+  {pT : progT T}
+  {sCP : semCallParams}
+  {hpip : h_propagate_inline_params}.
+
 
 Definition dfl_cel := 
   {| pi_def := Pconst 0; pi_fv := Sv.empty; pi_m := false; pi_fv_ok := erefl _; pi_m_ok := erefl _|}.
@@ -111,10 +126,18 @@ Proof.
   by move=> [v] [->] /value_uinclE ->.
 Qed.
 
-Lemma sbeqE e1 e2 b : 
-  sem_pexpr gd s (Papp2 Obeq e1 e2) = ok (Vbool b) ->
-  sem_pexpr gd s (sbeq e1 e2) = ok (Vbool b).
-Proof. by move=> /sbeqP [v] [-> /value_uinclE ->]. Qed.
+Lemma sbeqE e0 e1 b0 b1 :
+  sem_pexpr gd s e0 = ok (Vbool b0) ->
+  sem_pexpr gd s e1 = ok (Vbool b1) ->
+  sem_pexpr gd s (sbeq e0 e1) = ok (Vbool (b0 == b1)).
+Proof.
+  move=> h0 h1.
+  have : sem_pexpr gd s (Papp2 Obeq e0 e1) = ok (Vbool (b0 == b1)).
+  - by rewrite /= h0 h1.
+  clear h0 h1.
+  move=> /sbeqP [v [-> hincl]].
+  by move: hincl => /value_uinclE ?; subst v.
+Qed.
 
 Lemma sorE e1 e2 b1 b2 : 
   sem_pexpr gd s e1 = ok (Vbool b1) ->
@@ -136,35 +159,83 @@ Proof.
   by move=> /sandP [v] [-> /value_uinclE ->]. 
 Qed.
 
-Lemma scfcP c es vs v: 
-  sem_pexprs gd s es = ok vs → 
-  sem_opN (Ocombine_flags c) vs = ok v → 
-  sem_pexpr gd s (scfc c es) = ok v.
+Lemma fc_esem_ssem e0 e1 e2 e3 fc b :
+  let esem := fc_sem enot eand eor expr.eeq  in
+  let ssem := fc_sem snot sand sor sbeq in
+  sem_pexpr gd s (esem e0 e1 e2 e3 fc) = ok (Vbool b)
+  -> sem_pexpr gd s (ssem e0 e1 e2 e3 fc) = ok (Vbool b).
 Proof.
-  rewrite /scfc /lower_cfc.
-  case heq : cf_tbl => [n cfc] /=.
-  case: es => /= [ [<-] // | oe es].
-  t_xrbindP => ov hov ? h <-.
-  case: es h => /= [ [<-] | ce es]; first by rewrite hov.
-  t_xrbindP => cv hcv ? h <-.
-  case: es h => /= [ [<-] | se es]; first by rewrite hov hcv.
-  t_xrbindP => sv hsv ? h <-.
-  case: es h => /= [ [<-] | ze es]; first by rewrite hov hcv hsv.
-  t_xrbindP => zv hzv ? h <-.
-  case: es h => /= [ [<-] /= | ??]; last first.
-  + by t_xrbindP => ???? <-; rewrite /sem_opN /=; t_xrbindP.
+  rewrite /=.
+  elim: fc b
+    => //= [fc ih | fc0 ih0 fc1 ih1 | fc0 ih0 fc1 ih1 | fc0 ih0 fc1 ih1] b.
+  all: t_xrbindP.
+
+  - move=> v hv hnot.
+    move: hnot => /sem_sop1I /= [nb hnb [?]]; subst b.
+    move: hnb => /to_boolI ?; subst v.
+    apply: snotE.
+    exact: (ih nb hv).
+
+  all: move=> v0 hv0 v1 hv1 h.
+  all: move: h => /sem_sop2I /= [b0 [b1 [b' [hb0 hb1 hb [?]]]]]; subst b'.
+  all: move: hb0 => /to_boolI ?; subst v0.
+  all: move: hb1 => /to_boolI ?; subst v1.
+  all: move: hb => [?]; subst b.
+  all: have h0 := ih0 b0 hv0.
+  all: have h1 := ih1 b1 hv1.
+  all:
+    solve [ exact: (sandE h0 h1) | exact: (sorE h0 h1) | exact: (sbeqE h0 h1) ].
+Qed.
+
+Lemma cf_esem_ssem e0 e1 e2 e3 cf b :
+  let esem := cf_xsem enot eand eor expr.eeq  in
+  let ssem := cf_xsem snot sand sor sbeq in
+  sem_pexpr gd s (esem e0 e1 e2 e3 cf) = ok (Vbool b)
+  -> sem_pexpr gd s (ssem e0 e1 e2 e3 cf) = ok (Vbool b).
+Proof.
+  rewrite /cf_xsem.
+  case: cf_tbl => -[] cfc; last exact: fc_esem_ssem.
+  rewrite /=.
+  t_xrbindP=> v hv hnot.
+  move: hnot => /sem_sop1I /= [nb hnb [?]]; subst b.
+  move: hnb => /to_boolI ?; subst v.
+  apply: snotE.
+  exact: (fc_esem_ssem hv).
+Qed.
+
+Lemma scfcP c es vs v :
+  sem_pexprs gd s es = ok vs
+  -> sem_opN (Ocombine_flags c) vs = ok v
+  -> sem_pexpr gd s (scfc c es) = ok v.
+Proof.
+  rewrite /scfc.
+  case: es => /= [[<-] | eof es]; first done.
+  t_xrbindP=> vof hvof {vs} vs h <-.
+  case: es h => /= [[<-] | ecf es]; first by rewrite hvof.
+  t_xrbindP=> vcf hvcf {vs} vs h <-.
+  case: es h => /= [[<-] | esf es]; first by rewrite hvof hvcf.
+  t_xrbindP=> vsf hvsf {vs} vs h <-.
+  case: es h => /= [[<-] | ezf es]; first by rewrite hvof hvcf hvsf.
+  t_xrbindP=> vzf hvzf {vs} vs h <-.
+
+  case: es h => /= [[<-] | ? ?]; first last.
+  - t_xrbindP=> ???? <-. rewrite /sem_opN /=. by t_xrbindP.
+
+  move=> h.
+  have hv := h.
+  move: h.
   rewrite /sem_opN /=.
-  t_xrbindP => b ob /to_boolI hob cb /to_boolI hcb sb /to_boolI hsb zb /to_boolI hzb hs <-.
-  subst ov cv sv zv.
-  move: hs; rewrite /sem_combine_flags heq /= /sem_cfc /neg_f => -[<-].
-  set E := (X in snot X).
-  set B := (B in ~~ B).
-  have : sem_pexpr gd s E = ok (Vbool B).
-  + rewrite /E /B; case: (cfc) => //.
-    + by apply /snotE /sbeqE; rewrite /= hov hsv.
-    + by apply/sorE.
-    by apply/sorE => //; apply /snotE /sbeqE; rewrite /= hov hsv.
-  by move=> h; case: (n) => //; apply /snotE.
+  t_xrbindP=> b bof hof bcf hcf bsf hsf bzf hzf hb ?; subst v.
+  move: hof => /to_boolI ?; subst vof.
+  move: hcf => /to_boolI ?; subst vcf.
+  move: hsf => /to_boolI ?; subst vsf.
+  move: hzf => /to_boolI ?; subst vzf.
+
+  apply: cf_esem_ssem.
+  apply: (pip_cf_xsemP hpip).
+  rewrite /=.
+  rewrite hvof hvcf hvsf hvzf {hvof hvcf hvsf hvzf} /=.
+  exact: hv.
 Qed.
 
 End SCFC.
@@ -485,7 +556,7 @@ Section PROOF.
     have [vm' ] := pi_lvP_uincl hu hue' hv hwr.
     rewrite heq /= => -[hu' hv' hwr'].
     exists vm' => /=.
-    suff : valid_pi gd s2 (set_lv pi' x' tag (pi_e pi e)).
+    suff : valid_pi gd s2 (set_lv pi' x' tag (pi_e (spp := spp) pi e)).
     + by split => //; constructor; econstructor; eauto; rewrite -eq_globs. 
     case (set_lvE pi' x' tag (pi_e pi e)); last by move=> ->.
     move=> [x0 [?? ->]]; subst x' tag.
@@ -702,11 +773,11 @@ Section PROOF.
     exists vr', sem_call p2 ev scs mem f va' scs' mem' vr' /\ List.Forall2 value_uincl vr vr'.
   Proof.
     by move=>
-      /(@sem_call_Ind _ _ _ _ _ _ _ _ p1 ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
-            Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc) 
+      /(@sem_call_Ind _ _ _ _ _ _ p1 ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
+            Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc)
       h /h [vr' h1 h2]; exists vr'.
   Qed.
 
 End PROOF.
 
-End Section.
+End WITH_PARAMS.

--- a/proofs/compiler/remove_globals_proof.v
+++ b/proofs/compiler/remove_globals_proof.v
@@ -17,8 +17,9 @@ Proof. by move=> h1 h2 g v /h1 /h2. Qed.
 
 Module INCL. Section INCL.
 
-  Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-  Context `{asmop:asmOp}.
+  Context
+    {asm_op syscall_state : Type}
+    {spp : SemPexprParams asm_op syscall_state}.
 
   Section INCL_E.
     Context (gd1 gd2: glob_decls) (s: estate) (hincl: gd_incl gd1 gd2).
@@ -180,7 +181,7 @@ Module INCL. Section INCL.
   Lemma gd_incl_fun scs m (fn : funname) (l : seq value) scs0 m0 vs:
       sem_call P1 ev scs m fn l scs0 m0 vs -> Pfun scs m fn l scs0 m0 vs.
   Proof.
-    apply: (@sem_call_Ind _ _ _ _ _ _ _ _ P1 ev Pc Pi_r Pi Pfor Pfun
+    apply: (@sem_call_Ind _ _ _ _ _ _ P1 ev Pc Pi_r Pi Pfor Pfun
              Hnil Hcons HmkI Hasgn Hopn Hsyscall Hif_true Hif_false Hwhile_true Hwhile_false
              Hfor Hfor_nil Hfor_cons Hcall Hproc).
   Qed.
@@ -295,10 +296,11 @@ End EXTEND. Import EXTEND.
 
 Module RGP. Section PROOFS.
 
-  Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-  Context `{asmop:asmOp}.
-  Context (is_glob : var -> bool).
-  Context (fresh_id : glob_decls -> var -> Ident.ident).
+  Context
+    {asm_op syscall_state : Type}
+    {spp : SemPexprParams asm_op syscall_state}
+    (is_glob : var -> bool)
+    (fresh_id : glob_decls -> var -> Ident.ident).
 
   Notation venv := (Mvar.t var).
 
@@ -770,7 +772,7 @@ Module RGP. Section PROOFS.
      sem_call P ev scs1 m1 f vargs scs2 m2 vres ->
      Pfun scs1 m1 f vargs scs2 m2 vres.
   Proof.
-    apply (@sem_call_Ind _ _ _ _ _ _ _ _ P ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall Hif_true Hif_false
+    apply (@sem_call_Ind _ _ _ _ _ _ P ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall Hif_true Hif_false
               Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc).
   Qed.
 

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -42,14 +42,14 @@ Qed.
 *)
 Notation spointer := (sword Uptr) (only parsing).
 
-Section Section.
+Section WITH_PARAMS.
 
 Context
-  {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}
-  `{asmop:asmOp}
-  (pmap: pos_map)
-  (glob_size: Z)
-  (rsp rip: pointer).
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  (pmap : pos_map)
+  (glob_size : Z)
+  (rsp rip : pointer).
 
 Context
   (Slots : Sv.t)
@@ -4159,4 +4159,4 @@ Proof.
   by apply (valid_state_Incl hincl2).
 Qed.
 
-End Section.
+End WITH_PARAMS.

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -11,6 +11,7 @@ Require Import byteset.
 Require Import Psatz.
 Import Utf8.
 
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -30,19 +31,19 @@ Notation alloc_prog := (alloc_prog true).
 
 Section INIT.
 
-Variable global_data : seq u8.
-Variable global_alloc : seq (var * wsize * Z).
+Context
+  (global_data : seq u8)
+  (global_alloc : seq (var * wsize * Z)).
 
-Let glob_size := Z.of_nat (size global_data).
+Notation glob_size := (Z.of_nat (size global_data)).
 
-Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context `{asmop:asmOp}.
-Variable rip : pointer.
-Hypothesis no_overflow_glob_size : no_overflow rip glob_size.
-
-Variable mglob : Mvar.t (Z * wsize).
-
-Hypothesis hmap : init_map (Z.of_nat (size global_data)) global_alloc = ok mglob.
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  (rip : pointer)
+  (no_overflow_glob_size : no_overflow rip glob_size)
+  (mglob : Mvar.t (Z * wsize))
+  (hmap : init_map (Z.of_nat (size global_data)) global_alloc = ok mglob).
 
 Lemma init_mapP : forall x1 ofs1 ws1,
   Mvar.get mglob x1 = Some (ofs1, ws1) -> [/\
@@ -61,7 +62,7 @@ Proof.
       Mvar.get mglob x2 = Some (ofs2, ws2) -> x1 ≠ x2 ->
       ofs1 + size_slot x1 <= ofs2 ∨ ofs2 + size_slot x2 <= ofs1];
   last first.
-  + by move=> [h1 h2 h3]; split=> //; lia.
+  + move=> [h1 h2 h3]. split=> //. by lia.
   move: hfold x1 ofs1 ws1 hget.
   have: 0 <= (Mvar.empty (Z * wsize), 0).2 /\
     forall x1 ofs1 ws1,
@@ -2718,7 +2719,7 @@ Qed.
 Lemma check_cP scs1 m1 fn vargs scs2 m2 vres : sem_call P ev scs1 m1 fn vargs scs2 m2 vres -> 
    Pfun scs1 m1 fn vargs scs2 m2 vres.
 Proof.
-  apply (@sem_call_Ind _ _ _ _ _ _ _ _ _ _ Pc Pi_r Pi Pfor Pfun
+  apply (@sem_call_Ind _ _ _ _ _ _ _ _ Pc Pi_r Pi Pfor Pfun
                        Hskip
                        Hcons
                        HmkI
@@ -2743,10 +2744,8 @@ End INIT.
 Section HSAPARAMS.
 
 Context
-  {pd : PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}
-  `{asmop : asmOp}.
-
-Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
   (saparams : stack_alloc_params)
   (hsaparams : h_stack_alloc_params saparams)
   (fresh_reg_ : Ident.ident -> stype -> Ident.ident).

--- a/proofs/compiler/tunneling_proof.v
+++ b/proofs/compiler/tunneling_proof.v
@@ -3,6 +3,7 @@ Require Import ZArith.
 Require Import Utf8.
 
 Require Import oseq expr_facts compiler_util label linear linear_sem.
+Require sem.
 Import ssrZ.
 
 Set Implicit Arguments.
@@ -16,10 +17,12 @@ Require Import linear_sem.
 
 
 
-Section ASM_OP.
+Section WITH_PARAMS.
 
-Context {pd:PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context {asm_op} {asmop : asmOp asm_op} {ovm_i : one_varmap.one_varmap_info}.
+Context
+  {asm_op syscall_state : Type}
+  {spp : sem.SemPexprParams asm_op syscall_state}
+  {ovm_i : one_varmap.one_varmap_info}.
 
 Section LprogSemProps.
 
@@ -1368,7 +1371,7 @@ Section TunnelingProof.
     rewrite /Q => {Q} s3 s4 s5 Htlsem34 Htlsem145 Hlsem34.
     apply (lsem_trans Hlsem34); case: (tunnel_lprog_pc_lsem1 Hwf Htlsem145).
     + by move => Hlsem145; apply Relation_Operators.rt_step.
-    by case => s6 [Hlsem146 Hlsem165]; apply (@lsem_trans _ _ _ _ _ _ p s6);
+    by case => s6 [Hlsem146 Hlsem165]; apply (@lsem_trans _ _ _ _ p s6);
     apply Relation_Operators.rt_step.
   Qed.
 
@@ -1576,4 +1579,4 @@ Section TunnelingProof.
 End TunnelingProof.
 
 
-End ASM_OP.
+End WITH_PARAMS.

--- a/proofs/compiler/unrolling_proof.v
+++ b/proofs/compiler/unrolling_proof.v
@@ -15,11 +15,11 @@ Local Open Scope seq_scope.
 Section PROOF.
 
   Context
-    {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}
-    `{asmop:asmOp}
-    {T:eqType}
-    {pT:progT T}
-    {sCP: semCallParams}.
+    {asm_op syscall_state : Type}
+    {spp : SemPexprParams asm_op syscall_state}
+    {T : eqType}
+    {pT : progT T}
+    {sCP : semCallParams}.
 
   Variable (p : prog) (ev:extra_val_t).
   Notation gd := (p_globs p).
@@ -190,7 +190,7 @@ Section PROOF.
     sem_call p  ev scs mem f va scs' mem' vr ->
     sem_call p' ev scs mem f va scs' mem' vr.
   Proof.
-    apply (@sem_call_Ind _ _ _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
+    apply (@sem_call_Ind _ _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hskip Hcons HmkI Hassgn Hopn Hsyscall
              Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc).
   Qed.
 

--- a/proofs/compiler/x86_decl.v
+++ b/proofs/compiler/x86_decl.v
@@ -11,6 +11,7 @@ oseq
 Utf8
 Relation_Operators
 sem_type.
+Require Import flag_combination.
 Require Export arch_decl.
 
 (* Import Memory. *)
@@ -387,6 +388,29 @@ Instance eqC_condt : eqTypeC condt :=
 
 (* -------------------------------------------------------------------- *)
 
+Definition x86_fc_of_cfc (cfc : combine_flags_core) : flag_combination :=
+  let vof := FCVar0 in
+  let vcf := FCVar1 in
+  let vsf := FCVar2 in
+  let vzf := FCVar3 in
+  match cfc with
+  | CFC_O => vof
+  | CFC_B => vcf
+  | CFC_E => vzf
+  | CFC_S => vsf
+  | CFC_L => FCNot (FCEq vof vsf)
+  | CFC_BE => FCOr vcf vzf
+  | CFC_LE => FCOr (FCNot (FCEq vof vsf)) vzf
+  end.
+
+Instance x86_fcp : FlagCombinationParams :=
+  {
+    fc_of_cfc := x86_fc_of_cfc;
+  }.
+
+
+(* -------------------------------------------------------------------- *)
+
 Instance x86_decl : arch_decl register register_ext xmm_register rflag condt :=
   { reg_size := U64
   ; xreg_size := U256
@@ -397,6 +421,7 @@ Instance x86_decl : arch_decl register register_ext xmm_register rflag condt :=
   ; reg_size_neq_xreg_size := refl_equal
   ; ad_rsp := RSP
   ; inj_toS_reg_regx := x86_inj_toS_reg_regx
+  ; ad_fcp := x86_fcp
   }.
 
 Definition x86_linux_call_conv : calling_convention := 
@@ -417,5 +442,5 @@ Definition x86_windows_call_conv : calling_convention :=
    ; call_xreg_args := [:: XMM0; XMM1; XMM2; XMM3 ]
    ; call_reg_ret   := [:: RAX ]
    ; call_xreg_ret  := [:: XMM0 ]
-   ; call_reg_ret_uniq := erefl true;                    
+   ; call_reg_ret_uniq := erefl true;
   |}.

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -76,16 +76,6 @@ Variant sop2 :=
 .
 
 (* N-ary operators *)
-Variant combine_flags_core := 
-| CFC_O       (* overflow:                                OF = 1 *)
-| CFC_B       (* below, not above or equal:               CF = 1 *)
-| CFC_E       (* equal, zero:                             ZF = 1 *)
-| CFC_S       (* sign:                                    SF = 1 *)
-| CFC_L       (* less than, not greater than or equal to: !(OF = SF) *)
-| CFC_BE      (* below or equal, not above:               CF = 1 \/ ZF = 1 *)
-| CFC_LE      (* less than or equal to, not greater than: (!(SF = OF) \/ ZF = 1 *)
-.
-
 Variant combine_flags :=
 | CF_LT    of signedness   (* Alias : signed => L  ; unsigned => B   *) 
 | CF_LE    of signedness   (* Alias : signed => LE ; unsigned => BE  *)
@@ -125,30 +115,6 @@ Qed.
 
 Definition sop2_eqMixin     := Equality.Mixin sop2_eq_axiom.
 Canonical  sop2_eqType      := Eval hnf in EqType sop2 sop2_eqMixin.
-
-Scheme Equality for combine_flags_core.
-
-Lemma combine_flags_core_eq_axiom : Equality.axiom combine_flags_core_beq.
-Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_combine_flags_core_dec_bl.
-  by apply: internal_combine_flags_core_dec_lb.
-Qed.
-
-Definition combine_flags_core_eqMixin     := Equality.Mixin combine_flags_core_eq_axiom.
-Canonical  combine_flags_core_eqType      := Eval hnf in EqType combine_flags_core combine_flags_core_eqMixin.
-
-Scheme Equality for combine_flags.
-
-Lemma combine_flags_eq_axiom : Equality.axiom combine_flags_beq.
-Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_combine_flags_dec_bl.
-  by apply: internal_combine_flags_dec_lb.
-Qed.
-
-Definition combine_flags_eqMixin     := Equality.Mixin combine_flags_eq_axiom.
-Canonical  combine_flags_eqType      := Eval hnf in EqType combine_flags combine_flags_eqMixin.
 
 Scheme Equality for opN.
 
@@ -210,20 +176,6 @@ Definition type_of_op2 (o: sop2) : stype * stype * stype :=
 
 (* Type of n-ary operators: inputs, output *)
 
-Definition cf_tbl (c:combine_flags) := 
-  match c with
-  | CF_LT Signed   => (false, CFC_L)
-  | CF_LT Unsigned => (false, CFC_B)
-  | CF_LE Signed   => (false, CFC_LE)
-  | CF_LE Unsigned => (false, CFC_BE)
-  | CF_EQ          => (false, CFC_E)
-  | CF_NEQ         => (true , CFC_E)
-  | CF_GE Signed   => (true , CFC_L)
-  | CF_GE Unsigned => (true , CFC_B)
-  | CF_GT Signed   => (true , CFC_LE)
-  | CF_GT Unsigned => (true , CFC_BE)
-  end.
-  
 Definition tin_combine_flags := [:: sbool; sbool; sbool; sbool].
 
 Definition type_of_opN (op: opN) : seq stype * stype :=

--- a/proofs/lang/flag_combination.v
+++ b/proofs/lang/flag_combination.v
@@ -1,0 +1,89 @@
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+
+Require Import expr.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+
+(* We distinguish 7 different conditions that can potentially be expressed with
+   flags, these are [combine_flags_core], but provide the user with these and
+   their negations, [combine_flags]. Their correspondence is specified by
+   [cf_tbl].
+   The correspondence between these conditions and flags is
+   architecture-specific. *)
+
+Variant combine_flags_core :=
+| CFC_O      (* Overflow. *)
+| CFC_B      (* Below (not above or equal). *)
+| CFC_E      (* Equal (zero). *)
+| CFC_S      (* Sign (negative). *)
+| CFC_L      (* Less than (not greater than or equal to). *)
+| CFC_BE     (* Below or equal (not above). *)
+| CFC_LE.    (* Less than or equal to (not greater than). *)
+
+Definition cf_tbl (c : combine_flags) : bool * combine_flags_core :=
+  match c with
+  | CF_LT Signed => (false, CFC_L)
+  | CF_LT Unsigned => (false, CFC_B)
+  | CF_LE Signed => (false, CFC_LE)
+  | CF_LE Unsigned => (false, CFC_BE)
+  | CF_EQ => (false, CFC_E)
+  | CF_NEQ => (true, CFC_E)
+  | CF_GE Signed => (true, CFC_L)
+  | CF_GE Unsigned => (true, CFC_B)
+  | CF_GT Signed => (true, CFC_LE)
+  | CF_GT Unsigned => (true, CFC_BE)
+  end.
+
+
+(* -------------------------------------------------------------------- *)
+(* Flag combinations. *)
+
+Inductive flag_combination : Type :=
+| FCVar0 : flag_combination
+| FCVar1 : flag_combination
+| FCVar2 : flag_combination
+| FCVar3 : flag_combination
+| FCNot : flag_combination -> flag_combination
+| FCAnd : flag_combination -> flag_combination -> flag_combination
+| FCOr : flag_combination -> flag_combination -> flag_combination
+| FCEq : flag_combination -> flag_combination -> flag_combination.
+
+Class FlagCombinationParams :=
+  {
+    fc_of_cfc : combine_flags_core -> flag_combination;
+  }.
+
+Section SEM.
+
+  Context
+    {X : Type}
+    {fcp : FlagCombinationParams}
+    (xnot : X -> X)
+    (xand xor xeq : X -> X -> X)
+    (x0 x1 x2 x3 : X).
+
+  Fixpoint fc_sem (fc : flag_combination) : X :=
+    match fc with
+    | FCVar0 => x0
+    | FCVar1 => x1
+    | FCVar2 => x2
+    | FCVar3 => x3
+    | FCNot fc0 => xnot (fc_sem fc0)
+    | FCAnd fc0 fc1 => xand (fc_sem fc0) (fc_sem fc1)
+    | FCOr fc0 fc1 => xor (fc_sem fc0) (fc_sem fc1)
+    | FCEq fc0 fc1 => xeq (fc_sem fc0) (fc_sem fc1)
+    end.
+
+  Definition cfc_xsem (cfc : combine_flags_core) : X :=
+    fc_sem (fc_of_cfc cfc).
+
+  Definition cf_xsem (cf : combine_flags) : X :=
+    let '(n, cfc) := cf_tbl cf in
+    let x := fc_sem (fc_of_cfc cfc) in
+    if n then xnot x else x.
+End SEM.

--- a/proofs/lang/linear_sem.v
+++ b/proofs/lang/linear_sem.v
@@ -18,9 +18,11 @@ Local Open Scope seq_scope.
 
 Section SEM.
 
-Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
-Context {asm_op} {asmop : asmOp asm_op} {ovm_i : one_varmap_info}.
-Variable P: lprog.
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  {ovm_i : one_varmap_info}
+  (P : lprog).
 
 Definition label_in_lcmd (body: lcmd) : seq label :=
   pmap (λ i, if li_i i is Llabel lbl then Some lbl else None) body.
@@ -28,7 +30,6 @@ Definition label_in_lcmd (body: lcmd) : seq label :=
 Definition label_in_lprog : seq remote_label :=
   [seq (f.1, lbl) | f <- lp_funcs P, lbl <- label_in_lcmd (lfd_body f.2) ].
 
-#[local]
 Notation labels := label_in_lprog.
 
 (* --------------------------------------------------------------------------- *)

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -248,20 +248,30 @@ Definition vm_initialized_on (vm: vmap) : seq var → Prop :=
 (* ** Parameter expressions
  * -------------------------------------------------------------------- *)
 
-Section WITH_POINTER_DATA.
-Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
+Record estate
+  {syscall_state : Type}
+  {pd : PointerData}
+  {scs : syscall_sem syscall_state} :=
+  Estate
+    {
+      escs : syscall_state;
+      emem : mem;
+      evm  : vmap
+    }.
 
-Record estate := Estate {
-  escs : syscall_state_t;
-  emem : mem;
-  evm  : vmap
-}.
+Arguments Estate {_ _ _} _ _ _.
 
 Notation "'Let' ( n , t ) ':=' s '.[' v ']' 'in' body" :=
   (@on_arr_var _ (get_var s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, s at level 0).
 
 Notation "'Let' ( n , t ) ':=' gd ',' s '.[' v ']' 'in' body" :=
   (@on_arr_var _ (get_gvar gd s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, gd at level 0, s at level 0).
+
+Section WITH_PARAMS.
+
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}.
 
 Section SEM_PEXPR.
 
@@ -413,7 +423,6 @@ End WITH_SCS.
 
 Section SEM.
 
-Context `{asmop:asmOp}.
 Context {T} {pT:progT T}.
 
 Class semCallParams := SemCallParams {
@@ -833,10 +842,6 @@ Qed.
 
 End SEM.
 
-Section ASM_OP.
-
-Context `{asmop:asmOp}.
-
 Lemma sopn_tinP o vs vs' : exec_sopn o vs = ok vs' ->
   all2 subtype (sopn_tin o) (List.map type_of_val vs).
 Proof.
@@ -846,8 +851,6 @@ Proof.
   elim: tin vs semi hp => /= [ | t tin hrec] [ | v vs] // semi.
   by t_xrbindP => sv /= /of_val_subtype -> /hrec.
 Qed.
-
-End ASM_OP.
 
 Lemma on_arr_varP A (f : forall n, WArray.array n -> exec A) v vm x P:
   (forall n t, vtype x = sarr n -> get_var vm x = ok (@Varr n t) ->
@@ -1104,7 +1107,6 @@ Qed.
 
 Section Write.
 
-Context `{asmop:asmOp}.
 Context {T} {pT:progT T} {sCP : semCallParams}.
 
 Variable P : prog.
@@ -1113,7 +1115,7 @@ Variable ev : extra_val_t.
 Lemma writeP c s1 s2 :
    sem P ev s1 c s2 -> s1.(evm) = s2.(evm) [\ write_c c].
 Proof.
-  apply (@sem_Ind _ _ _ _ sCP P ev (fun s1 c s2 => s1.(evm) = s2.(evm) [\ write_c c])
+  apply (@sem_Ind _ _ sCP P ev (fun s1 c s2 => s1.(evm) = s2.(evm) [\ write_c c])
                   (fun s1 i s2 => s1.(evm) = s2.(evm) [\ write_i i])
                   (fun s1 i s2 => s1.(evm) = s2.(evm) [\ write_I i])
                   (fun x ws s1 c s2 =>
@@ -1739,10 +1741,6 @@ Proof.
   move:Hd;rewrite /disjoint /is_true Sv.is_empty_spec;SvD.fsetdec.
 Qed.
 
-Section ASM_OP.
-
-Context `{asmop:asmOp}.
-
 Lemma vuincl_exec_opn o vs vs' v :
   List.Forall2 value_uincl vs vs' -> exec_sopn o vs = ok v ->
   exists2 v', exec_sopn o vs' = ok v' & List.Forall2  value_uincl v v'.
@@ -1750,8 +1748,6 @@ Proof.
   rewrite /exec_sopn /sopn_sem => vs_vs' ho.
   exact: (get_instr_desc o).(semu) vs_vs' ho.
 Qed.
-
-End ASM_OP.
 
 Lemma set_vm_uincl vm vm' x z z' :
   vm_uincl vm vm' ->
@@ -2236,7 +2232,6 @@ Qed.
 (* ---------------------------------------------------------------- *)
 Section UNDEFINCL.
 
-Context `{asmop:asmOp}.
 Context {T} {pT:progT T} {sCP : semCallParams}.
 Variable p : prog.
 Variable ev : extra_val_t.
@@ -2406,7 +2401,7 @@ Lemma sem_call_uincl vargs scs1 m1 f scs2 m2 vres vargs':
 Proof.
   move=> H1 H2.
   by apply:
-    (@sem_call_Ind _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall
+    (@sem_call_Ind _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall
         Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc) H1.
 Qed.
 
@@ -2419,7 +2414,7 @@ Lemma sem_i_uincl s1 i s2 vm1 :
 Proof.
   move=> H1 H2.
   by apply:
-    (@sem_i_Ind _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall
+    (@sem_i_Ind _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall
         Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc) H1.
 Qed.
 
@@ -2432,7 +2427,7 @@ Lemma sem_I_uincl s1 i s2 vm1 :
 Proof.
   move=> H1 H2.
   by apply:
-    (@sem_I_Ind _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall
+    (@sem_I_Ind _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall
         Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc) H1.
 Qed.
 
@@ -2445,7 +2440,7 @@ Lemma sem_uincl s1 c s2 vm1 :
 Proof.
   move=> H1 H2.
   by apply:
-    (@sem_Ind _ _ _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall
+    (@sem_Ind _ _ _ p ev Pc Pi_r Pi Pfor Pfun Hnil Hcons HmkI Hasgn Hopn Hsyscall
         Hif_true Hif_false Hwhile_true Hwhile_false Hfor Hfor_nil Hfor_cons Hcall Hproc) H1.
 Qed.
 
@@ -2713,10 +2708,6 @@ Section WF.
     apply: rbindP => s1' /(wf_write_lval Hwf);apply Hrec.
   Qed.
 
-  Section ASM_OP.
-
-  Context `{asmop:asmOp}.
-
   Lemma wf_sem p ev s1 c s2 :
     sem p ev s1 c s2 -> wf_vm (evm s1) -> wf_vm (evm s2).
   Proof.
@@ -2766,8 +2757,6 @@ Section WF.
     sem_I p0 ev0 s1 i s2 -> wf_vm (evm s1) -> wf_vm (evm s2).
   Proof. by move=> H;have := sem_seq1 H; apply: wf_sem. Qed.
 
-  End ASM_OP.
-
 End WF.
 
 #[ global ] Arguments wf_init { T pT }.
@@ -2781,15 +2770,9 @@ Proof.
   apply: wf_write_vars h1; apply wf_vmap0.
 Qed.
 
-End WITH_POINTER_DATA.
+End WITH_PARAMS.
 
 (* We redefine the notations outside the section so that we can use them in other files *)
-Notation "'Let' ( n , t ) ':=' s '.[' v ']' 'in' body" :=
-  (@on_arr_var _ (get_var s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, s at level 0).
-
-Notation "'Let' ( n , t ) ':=' gd ',' s '.[' v ']' 'in' body" :=
-  (@on_arr_var _ (get_gvar gd s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, gd at level 0, s at level 0).
-
 Notation "vm1 '=[' s ']' vm2" := (eq_on s vm1 vm2) (at level 70, vm2 at next level,
   format "'[hv ' vm1  =[ s ]  '/'  vm2 ']'").
 
@@ -2803,7 +2786,8 @@ Notation "vm1 '<=[\' s ']' vm2" := (vmap_uincl_ex s vm1 vm2) (at level 70, vm2 a
   format "'[hv ' vm1  <=[\ s ]  '/'  vm2 ']'").
 
 (* Same thing for the hints *)
-#[ export ] Hint Resolve
+#[ export ]
+Hint Resolve
   word_uincl_refl
   value_uincl_refl
   val_uincl_refl

--- a/proofs/lang/psem_of_sem_proof.v
+++ b/proofs/lang/psem_of_sem_proof.v
@@ -9,9 +9,9 @@ Unset Printing Implicit Defensive.
 Section PROOF.
 
 Context
-  {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}
-  `{asmop:asmOp}
-  (p: uprog).
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  (p : uprog).
 
 Notation gd := (p_globs p).
 
@@ -271,7 +271,7 @@ Lemma psem_call scs m fn va scs' m' vr :
   sem.sem_call p scs m fn va scs' m' vr →
   psem.sem_call p tt scs m fn va scs' m' vr.
 Proof.
-apply: (@sem.sem_call_Ind _ _ _ _ _ p Pc Pi_r Pi Pfor Pfun) => {m fn va m' vr}.
+apply: (@sem.sem_call_Ind _ _ _ p Pc Pi_r Pi Pfor Pfun) => {m fn va m' vr}.
 - by move => s s' hss'; exists s'; split; first exact: hss'; constructor.
 - move => s1 s2 s3 [ii i] c [] {ii i s1 s2} ii i s1 s2 _ ihi _ ihc s1' hss'1.
   case: (ihi s1' hss'1) => s2' [hss'2 hi].

--- a/proofs/lang/sem_one_varmap.v
+++ b/proofs/lang/sem_one_varmap.v
@@ -75,11 +75,13 @@ Qed.
 
 Section SEM.
 
-Context {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state} {asm_op} {asmop:asmOp asm_op} {ovm_i : one_varmap_info}
-  (p: sprog)
-  (extra_free_registers: instr_info → option var)
-  (var_tmp: var)
-.
+Context
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  {ovm_i : one_varmap_info}
+  (p : sprog)
+  (extra_free_registers : instr_info → option var)
+  (var_tmp : var).
 
 Local Notation gd := (p_globs p).
 

--- a/proofs/lang/sem_one_varmap_facts.v
+++ b/proofs/lang/sem_one_varmap_facts.v
@@ -13,10 +13,12 @@ Unset Printing Implicit Defensive.
 Section PROG.
 
 Context
-  {pd: PointerData} {syscall_state : Type} {sc_sem : syscall_sem syscall_state} {asm_op} {asmop : asmOp asm_op} {ovm_i : one_varmap_info}
-  (p: sprog)
-  (extra_free_registers: instr_info -> option var)
-  (var_tmp: var).
+  {asm_op syscall_state : Type}
+  {spp : SemPexprParams asm_op syscall_state}
+  {ovm_i : one_varmap_info}
+  (p : sprog)
+  (extra_free_registers : instr_info -> option var)
+  (var_tmp : var).
 
 Lemma wf_kill_var x vm: wf_vm vm -> wf_vm (kill_var x vm).
 Proof.
@@ -96,7 +98,7 @@ Lemma sem_stack_stable k s1 c s2 :
   sem p extra_free_registers var_tmp k s1 c s2 → emem s1 ≡ emem s2.
 Proof.
   exact:
-    (@sem_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               Hnil Hcons HmkI Hassgn Hopn Hsyscall Hif_true Hif_false Hwhile_true Hwhile_false Hcall Hproc k s1 c s2).
 Qed.
 
@@ -104,7 +106,7 @@ Lemma sem_I_stack_stable k s1 i s2 :
   sem_I p extra_free_registers var_tmp k s1 i s2 → emem s1 ≡ emem s2.
 Proof.
   exact:
-    (@sem_I_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_I_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               Hnil Hcons HmkI Hassgn Hopn Hsyscall Hif_true Hif_false Hwhile_true Hwhile_false Hcall Hproc k s1 i s2).
 Qed.
 
@@ -112,7 +114,7 @@ Lemma sem_i_stack_stable ii k s1 i s2 :
   sem_i p extra_free_registers var_tmp ii k s1 i s2 → emem s1 ≡ emem s2.
 Proof.
   exact:
-    (@sem_i_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_i_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               Hnil Hcons HmkI Hassgn Hopn Hsyscall Hif_true Hif_false Hwhile_true Hwhile_false Hcall Hproc ii k s1 i s2).
 Qed.
 
@@ -120,7 +122,7 @@ Lemma sem_call_stack_stable ii k s1 fn s2 :
   sem_call p extra_free_registers var_tmp ii k s1 fn s2 → emem s1 ≡ emem s2.
 Proof.
   exact:
-    (@sem_call_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_call_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               Hnil Hcons HmkI Hassgn Hopn Hsyscall Hif_true Hif_false Hwhile_true Hwhile_false Hcall Hproc ii k s1 fn s2).
 Qed.
 
@@ -235,7 +237,7 @@ Lemma sem_not_written k s1 c s2 :
   s1 = s2 [\k].
 Proof.
   exact:
-    (@sem_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               Hnil_nw Hcons_nw HmkI_nw Hassgn_nw Hopn_nw Hsyscall_nw Hif_true_nw Hif_false_nw Hwhile_true_nw Hwhile_false_nw Hcall_nw Hproc_nw k s1 c s2).
 Qed.
 
@@ -244,7 +246,7 @@ Lemma sem_I_not_written k s1 i s2 :
   s1 = s2 [\k].
 Proof.
   exact:
-    (@sem_I_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_I_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               Hnil_nw Hcons_nw HmkI_nw Hassgn_nw Hopn_nw Hsyscall_nw Hif_true_nw Hif_false_nw Hwhile_true_nw Hwhile_false_nw Hcall_nw Hproc_nw k s1 i s2).
 Qed.
 
@@ -253,7 +255,7 @@ Lemma sem_call_not_written ii k s1 fn s2 :
   s1 = s2 [\k].
 Proof.
   exact:
-    (@sem_call_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_call_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               Hnil_nw Hcons_nw HmkI_nw Hassgn_nw Hopn_nw Hsyscall_nw Hif_true_nw Hif_false_nw Hwhile_true_nw Hwhile_false_nw Hcall_nw Hproc_nw ii k s1 fn s2).
 Qed.
 
@@ -369,7 +371,7 @@ Lemma sem_RSP_GD_not_written k s1 c s2 :
   sem p extra_free_registers var_tmp k s1 c s2 → disjoint k (magic_variables p).
 Proof.
   exact:
-    (@sem_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               Hnil_pm Hcons_pm HmkI_pm Hassgn_pm Hopn_pm Hsyscall_pm Hif_true_pm Hif_false_pm Hwhile_true_pm Hwhile_false_pm Hcall_pm Hproc_pm k s1 c s2).
 Qed.
 
@@ -377,7 +379,7 @@ Lemma sem_I_RSP_GD_not_written k s1 i s2 :
   sem_I p extra_free_registers var_tmp k s1 i s2 → disjoint k (magic_variables p).
 Proof.
   exact:
-    (@sem_I_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_I_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               Hnil_pm Hcons_pm HmkI_pm Hassgn_pm Hopn_pm Hsyscall_pm Hif_true_pm Hif_false_pm Hwhile_true_pm Hwhile_false_pm Hcall_pm Hproc_pm k s1 i s2).
 Qed.
 
@@ -464,7 +466,7 @@ Lemma sem_validw_stable k s1 c s2 :
   sem p extra_free_registers var_tmp k s1 c s2 → emem s1 ≡ emem s2.
 Proof.
   exact:
-    (@sem_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               validw_stable_nil validw_stable_cons validw_stable_mkI validw_stable_assgn validw_stable_opn validw_stable_syscall validw_stable_if_true validw_stable_if_false validw_stable_while_true validw_stable_while_false validw_stable_call validw_stable_proc k s1 c s2).
 Qed.
 
@@ -472,7 +474,7 @@ Lemma sem_I_validw_stable k s1 i s2 :
   sem_I p extra_free_registers var_tmp k s1 i s2 → emem s1 ≡ emem s2.
 Proof.
   exact:
-    (@sem_I_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_I_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               validw_stable_nil validw_stable_cons validw_stable_mkI validw_stable_assgn validw_stable_opn validw_stable_syscall validw_stable_if_true validw_stable_if_false validw_stable_while_true validw_stable_while_false validw_stable_call validw_stable_proc k s1 i s2).
 Qed.
 
@@ -480,7 +482,7 @@ Lemma sem_i_validw_stable ii k s1 i s2 :
   sem_i p extra_free_registers var_tmp ii k s1 i s2 → emem s1 ≡ emem s2.
 Proof.
   exact:
-    (@sem_i_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_i_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               validw_stable_nil validw_stable_cons validw_stable_mkI validw_stable_assgn validw_stable_opn validw_stable_syscall validw_stable_if_true validw_stable_if_false validw_stable_while_true validw_stable_while_false validw_stable_call validw_stable_proc ii k s1 i s2).
 Qed.
 
@@ -488,7 +490,7 @@ Lemma sem_call_validw_stable ii k s1 fn s2 :
   sem_call p extra_free_registers var_tmp ii k s1 fn s2 → emem s1 ≡ emem s2.
 Proof.
   exact:
-    (@sem_call_Ind _ _ _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
+    (@sem_call_Ind _ _ _ _ p extra_free_registers var_tmp Pc Pi Pi_r Pfun
               validw_stable_nil validw_stable_cons validw_stable_mkI validw_stable_assgn validw_stable_opn validw_stable_syscall validw_stable_if_true validw_stable_if_false validw_stable_while_true validw_stable_while_false validw_stable_call validw_stable_proc ii k s1 fn s2).
 Qed.
 


### PR DESCRIPTION
Generalize interpretation of the `?{"==" = b0, "<s" = b1} = #CMP(x, y)` construct.

Add flag combination language and semantics
Add flag combination parameter to architecture declaration
Add `SemPexprParams` as parameters needed to interpret expressions
Add `SemPexprParams` instance for `asm_extra`
Update `sem_pexpr` and `propagate_inline` to use `SemPexprParams`
Update all proofs and ML portion