### PR TITLE
Pretyping: use AT_keep for Copn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 
 ## Improvements
 
+- Intrinsics present at source-level can no longer be removed by dead-code elimination
+  ([PR #221](https://github.com/jasmin-lang/jasmin/pull/221);
+  fixes [#220](https://github.com/jasmin-lang/jasmin/issues/220)).
+
 - Lowering of a memory-to-memory copy always introduce an intermediate copy through a register
 
 - `instr_info` are now plain OCaml `int` and `var_info` are `Location.t`;

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1720,7 +1720,7 @@ let rec tt_instr pd asmOp (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm En
       let tlvs, tes, arguments = prim_sig asmOp p in
       let lvs, einstr = tt_lvalues pd env (L.loc pi) ls (Some arguments) tlvs in
       let es  = tt_exprs_cast pd env (L.loc pi) args tes in
-      env, mk_i (P.Copn(lvs, AT_none, p, es)) :: einstr
+      env, mk_i (P.Copn(lvs, AT_keep, p, es)) :: einstr
 
   | S.PIAssign (ls, `Raw, { pl_desc = PEOp1 (`Cast(`ToWord ct), {pl_desc = PEPrim (f, args) })} , None)
       ->
@@ -1731,7 +1731,7 @@ let rec tt_instr pd asmOp (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm En
       let tlvs, tes, arguments = prim_sig asmOp p in
       let lvs, einstr = tt_lvalues pd env (L.loc pi) ls (Some arguments) tlvs in
       let es  = tt_exprs_cast pd env (L.loc pi) args tes in
-      env, mk_i (P.Copn(lvs, AT_none, p, es)) :: einstr
+      env, mk_i (P.Copn(lvs, AT_keep, p, es)) :: einstr
 
   | PIAssign((None,[lv]), `Raw, pe, None) ->
       let _, flv, vty = tt_lvalue pd env lv in

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -218,9 +218,10 @@ let rec pp_gi pp_info pp_len pp_opn pp_var fmt i =
       | Sopn.Oasm (Arch_extra.BaseOp(Some ws, _)) -> Format.fprintf fmt "(%du)" (int_of_ws ws)
       | _ -> () in
 
-    F.fprintf fmt "@[<hov 2>%a %s=@ %a#%a(%a);@]"
-      (pp_glvs pp_len pp_var) x (pp_tag t) pp_cast o pp_opn o
+    F.fprintf fmt "@[<hov 2>%a =@ %a#%a(%a); /* %s */@]"
+      (pp_glvs pp_len pp_var) x pp_cast o pp_opn o
       (pp_ges pp_len pp_var) e
+      (pp_tag t)
 
   | Csyscall(x, o, e) ->
       F.fprintf fmt "@[<hov 2>%a =@ %s(%a);@]"


### PR DESCRIPTION
This prevents source-level intrinsics to be removed by dead-code
elimination.

Fixes #220
