### PR TITLE
OCaml: move “annotations” to their own module

### DIFF
--- a/compiler/jasmin.mlpack.in
+++ b/compiler/jasmin.mlpack.in
@@ -1,4 +1,5 @@
 src/Alias
+src/Annotations
 src/Arch
 src/Arch_full
 src/Array_expand

--- a/compiler/src/annotations.ml
+++ b/compiler/src/annotations.ml
@@ -1,0 +1,20 @@
+(* -------------------------------------------------------------------- *)
+type symbol = string
+type pident = symbol Location.located
+
+(* -------------------------------------------------------------------- *)
+type wsize = [ `W8 | `W16 | `W32 | `W64 | `W128 | `W256 ]
+
+(* -------------------------------------------------------------------- *)
+type simple_attribute =
+  | Aint    of Z.t
+  | Aid     of symbol
+  | Astring of string
+  | Aws     of wsize
+  | Astruct of annotations
+
+and attribute = simple_attribute Location.located
+
+and annotation = pident * attribute option
+
+and annotations = annotation list

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -71,7 +71,7 @@ type coq_tbl = {
      cvar          : Var.var Hv.t;
      funname       : (funname, BinNums.positive) Hashtbl.t;
      cfunname      : (BinNums.positive, funname) Hashtbl.t;
-     finfo         : (int, L.t * f_annot * call_conv * Syntax.annotations list) Hashtbl.t;
+     finfo         : (int, L.t * f_annot * call_conv * Annotations.annotations list) Hashtbl.t;
   }
 
 let new_count tbl =

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -50,7 +50,7 @@ val fun_of_cfun : coq_tbl -> BinNums.positive -> funname
 
 val string_of_funname : coq_tbl -> BinNums.positive -> string
 
-val get_finfo   : coq_tbl -> BinNums.positive -> L.t * f_annot * call_conv * Syntax.annotations list
+val get_finfo   : coq_tbl -> BinNums.positive -> L.t * f_annot * call_conv * Annotations.annotations list
 
 val cufdef_of_fdef : coq_tbl -> (unit, 'asm) func -> BinNums.positive * 'asm Expr._ufundef
 val fdef_of_cufdef : coq_tbl -> BinNums.positive * 'asm Expr._ufundef -> (unit, 'asm) func

--- a/compiler/src/ct_checker_forward.ml
+++ b/compiler/src/ct_checker_forward.ml
@@ -1,6 +1,7 @@
 open Utils
 open Prog
 
+module A = Annotations
 module S = Syntax
 module Pt = Pretyping
 
@@ -69,7 +70,7 @@ module Lvl : sig
 
   val pp : Format.formatter -> t -> unit
 
-  val parse : single:bool -> kind_allowed:bool -> S.annotations ->
+  val parse : single:bool -> kind_allowed:bool -> A.annotations ->
               lvl_kind option * t option
 
 end = struct
@@ -117,9 +118,9 @@ end = struct
       end
     | Public -> Format.fprintf fmt "#%s" spublic
 
-  let parse ~(single:bool) ~(kind_allowed:bool) (annot: S.annotations) =
+  let parse ~(single:bool) ~(kind_allowed:bool) (annot: A.annotations) =
     let module A = Pt.Annot in
-    let on_struct loc _nid (s:S.annotations) =
+    let on_struct loc _nid s =
       List.iter A.none s;
       let s = List.fold_left (fun s (id, _) -> Svl.add (Vl.mk_poly (L.unloc id)) s) Svl.empty s in
       if single && Svl.cardinal s <> 1 then

--- a/compiler/src/iInfo.ml
+++ b/compiler/src/iInfo.ml
@@ -1,2 +1,2 @@
-type t = Location.i_loc * Syntax.annotations
+type t = Location.i_loc * Annotations.annotations
 let dummy = Location.i_dummy, []

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -1,6 +1,7 @@
 (* * Pretty-print Jasmin program (concrete syntax) as LATEX fragments *)
 
 open Utils
+open Annotations
 open Syntax
 
 module F = Format

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -3,6 +3,7 @@
   module S = Syntax
 
   open Syntax
+  open Annotations
 
   let setsign c s = 
     match c with

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -43,7 +43,7 @@ type 'len gvar = {
   v_kind : v_kind;
   v_ty   : 'len gty;
   v_dloc : L.t;   (* location where declared *)
-  v_annot : Syntax.annotations;
+  v_annot : Annotations.annotations;
 }
 
 type 'len gvar_i = 'len gvar L.located
@@ -156,7 +156,7 @@ and ('len,'info,'asm) ginstr = {
     i_desc : ('len,'info,'asm) ginstr_r;
     i_loc  : L.i_loc;
     i_info : 'info;
-    i_annot : Syntax.annotations;
+    i_annot : Annotations.annotations;
   }
 
 and ('len,'info,'asm) gstmt = ('len,'info,'asm) ginstr list
@@ -198,7 +198,7 @@ type ('len,'info,'asm) gfunc = {
     f_args : 'len gvar list;
     f_body : ('len,'info,'asm) gstmt;
     f_tyout : 'len gty list;
-    f_outannot : Syntax.annotations list; (* annotation attach to return type *)
+    f_outannot : Annotations.annotations list; (* annotation attach to return type *)
     f_ret  : 'len gvar_i list
   }
 

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -43,7 +43,7 @@ type 'len gvar = private {
   v_kind : v_kind;
   v_ty   : 'len gty;
   v_dloc : L.t;   (* location where declared *)
-  v_annot : Syntax.annotations;
+  v_annot : Annotations.annotations;
 }
 
 type 'len gvar_i = 'len gvar L.located
@@ -121,7 +121,7 @@ and ('len,'info,'asm) ginstr = {
   i_desc : ('len,'info,'asm) ginstr_r;
   i_loc  : L.i_loc;
   i_info : 'info;
-  i_annot : Syntax.annotations;
+  i_annot : Annotations.annotations;
 }
 
 and ('len,'info,'asm) gstmt = ('len,'info,'asm) ginstr list
@@ -158,7 +158,7 @@ type ('len,'info,'asm) gfunc = {
     f_args : 'len gvar list;
     f_body : ('len,'info,'asm) gstmt;
     f_tyout : 'len gty list;
-    f_outannot : Syntax.annotations list; (* annotation attach to return type *)
+    f_outannot : Annotations.annotations list; (* annotation attach to return type *)
     f_ret  : 'len gvar_i list
   }
 
@@ -195,7 +195,7 @@ type ('info,'asm) pprog     = (pexpr,'info,'asm) gprog
 module PV : sig
   type t = pvar
 
-  val mk : Name.t -> v_kind -> pty -> L.t -> Syntax.annotations -> pvar
+  val mk : Name.t -> v_kind -> pty -> L.t -> Annotations.annotations -> pvar
 
   val compare : pvar -> pvar -> int
 
@@ -240,7 +240,7 @@ type ('info,'asm) prog     = global_decl list *('info,'asm) func list
 module V : sig
   type t = var
 
-  val mk : Name.t -> v_kind -> ty -> L.t -> Syntax.annotations -> var
+  val mk : Name.t -> v_kind -> ty -> L.t -> Annotations.annotations -> var
 
   val clone : var -> var
 

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -1,3 +1,4 @@
+open Annotations
 (* -------------------------------------------------------------------- *)
 module L = Location
 
@@ -8,13 +9,7 @@ let parse_error ?msg loc =
   raise (ParseError (loc, msg))
 
 (* -------------------------------------------------------------------- *)
-type symbol = string
-type pident = symbol L.located
-
-(* -------------------------------------------------------------------- *)
 type arr_access = Warray_.arr_access 
-
-type wsize = [ `W8 | `W16 | `W32 | `W64 | `W128 | `W256 ]
 
 type sign = [ `Unsigned | `Signed ]
 
@@ -73,20 +68,6 @@ let string_of_svsize (sv,sg,ve) =
   Format.sprintf "%d%s%d" 
     (int_of_vsize sv) (suffix_of_sign sg) (bits_of_vesize ve)
 
-(* -------------------------------------------------------------------- *)
-type simple_attribute = 
-  | Aint    of Z.t
-  | Aid     of symbol
-  | Astring of string
-  | Aws     of wsize 
-  | Astruct of annotations
-
-and attribute = simple_attribute L.located
-
-and annotation = pident * attribute option
-
-and annotations = annotation list
-  
 (* -------------------------------------------------------------------- *)
 type cast = [ `ToWord  of swsize | `ToInt ]
 


### PR DESCRIPTION
This breaks a circular dependency between extracted and hand-written
OCaml code