### PR TITLE
insert-array-copy: do not crash on ill-typed programs

### DIFF
--- a/compiler/src/insert_copy_and_fix_length.ml
+++ b/compiler/src/insert_copy_and_fix_length.ml
@@ -21,7 +21,8 @@ let is_array_copy (x:lval) (e:expr) =
         let y = L.unloc y.gv in
         begin match y.v_ty with
         | Arr(yws, yn) ->
-           assert (arr_size xws xn <= arr_size yws yn);
+           (* Ignore ill-typed copies: they are later rejected by “typing”. *)
+           if arr_size yws yn < arr_size xws xn then None else
            if x.v_kind = Reg(Normal, Direct) then Some (xws, xn)
            else if y.v_kind = Reg(Normal, Direct) then Some (yws, arr_size xws xn / size_of_ws yws)
            else None


### PR DESCRIPTION
Fixes #76