### PR TITLE
stack-alloc: fix stack alignment with syscalls

### DIFF
--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -370,7 +370,10 @@ let alloc_stack_fd pd is_move_op get_info gtbl fd =
   let sao_params, atbl = all_alignment pd ctbl alias sao_return fd.f_args lalloc in
 
   let sao_align, sao_slots, sao_size = alloc_local_stack 0 (Sv.elements slots) atbl in
-    
+
+  (* FIXME: 1- make this U128 arch (call-conv) dependent; 2- make it a semantic requirement. *)
+  let sao_align = if has_syscall fd.f_body && wsize_lt sao_align U128 then U128 else sao_align in
+
   let sao_alloc = List.iter (Hv.remove lalloc) fd.f_args; lalloc in
 
   let sao_modify_rsp = 

--- a/compiler/tests/success/syscall/align.jazz
+++ b/compiler/tests/success/syscall/align.jazz
@@ -1,0 +1,9 @@
+#[stackalign=u128]
+export
+fn randombyte() -> reg u8 {
+    stack u8[1] buf;
+    reg u8 r;
+    buf = #randombytes(buf);
+    r = buf[0];
+    return r;
+}


### PR DESCRIPTION
According to System V AMD64 ABI Draft 0.99.7, stack frames must be aligend to 16 bytes at function call boundaries.

Fixes #240