### PR TITLE
Add `else if` construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@
 - new option
 	"-call-conv {windows|linux}": select calling convention (default depend on host architecture)
 
+- Added syntactic sugar for `else if` blocks
+  ([PR #224](https://github.com/jasmin-lang/jasmin/pull/244)).
+  I.e., you can now use constructions like:
+  ```
+  if x == 0 {
+    // (...)
+  } else if x == 1 {
+    // (...)
+  } else {
+    // (...)
+  }
+  ```
+
 ## Improvements
 
 - Intrinsics present at source-level can no longer be removed by dead-code elimination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 	"-call-conv {windows|linux}": select calling convention (default depend on host architecture)
 
 - Added syntactic sugar for `else if` blocks
-  ([PR #224](https://github.com/jasmin-lang/jasmin/pull/244)).
+  ([PR #244](https://github.com/jasmin-lang/jasmin/pull/244)).
   I.e., you can now use constructions like:
   ```
   if x == 0 {

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -338,11 +338,7 @@ pinstr_r:
     { let { L.pl_loc = loc; L.pl_desc = (f, args) } = fc in
       PIAssign ((None, []), `Raw, L.mk_loc loc (PECall (f, args)), c) }
 
-| IF c=pexpr i1s=pblock
-    { PIIf (c, i1s, None) }
-
-| IF c=pexpr i1s=pblock ELSE i2s=pblock
-    { PIIf (c, i1s, Some i2s) }
+| s=pif { s }
 
 | FOR v=var EQ ce1=pexpr TO ce2=pexpr is=pblock
     { PIFor (v, (`Up, ce1, ce2), is) }
@@ -358,6 +354,19 @@ pinstr_r:
 | vd=postfix(pvardecl(COMMA?), SEMICOLON) 
     { PIdecl vd }
 
+pif:
+| IF c=pexpr i1s=pblock
+    { PIIf (c, i1s, None) }
+
+| IF c=pexpr i1s=pblock ELSE i2s=pelse
+    { PIIf (c, i1s, Some i2s) }
+
+pelseif:
+| s=loc(pif) { [([], s)] }
+
+pelse:
+| s=loc(pelseif) { s }
+| s=pblock { s }
 
 pinstr:
 | a=annotations i=loc(pinstr_r)  { (a,i) }

--- a/compiler/tests/success/ifelse.jazz
+++ b/compiler/tests/success/ifelse.jazz
@@ -1,0 +1,12 @@
+export
+fn test(reg u64 x, reg u64 y) -> reg u64 {
+    reg u64 result;
+    if x != 0 {
+        result = x;
+    } else if y != 0 {
+        result = y;
+    } else {
+        result = 0;
+    }
+    return result;
+}


### PR DESCRIPTION
This patch add syntactic sugar for `else if` constructions. E.g.:

```jazz
if x == 0 {
  // (...)
} else if x == 1 {
  // (...)
} else {
  // (...)
}
```

is parsed as if it were: 

```jazz
if x == 0 {
  // (...)
} else {
  if x == 1 {
    // (...)
  } else {
    // (...)
  }
}
```
