### PR TITLE
[cli] Choose directory for EC extraction of Array support libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@
   }
   ```
 
+- EasyCrypt extraction of array support libraries is controlled
+  through the “-oecarray dir” command line argument
+  ([PR #246](https://github.com/jasmin-lang/jasmin/pull/246)).
+
 ## Improvements
 
 - Intrinsics present at source-level can no longer be removed by dead-code elimination

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -9,6 +9,7 @@ let debug = ref false
 let print_list = ref []
 let ecfile = ref ""
 let ec_list = ref []
+let ec_array_path = ref Filename.current_dir_name
 let check_safety = ref false
 let safety_param = ref None
 let safety_config = ref None
@@ -48,6 +49,9 @@ let set_all_print () =
 
 let set_ec f =
   ec_list := f :: !ec_list
+
+let set_ec_array_path p =
+  ec_array_path := p
 
 let set_constTime () = model := ConstantTime
 let set_safety () = model := Safety
@@ -144,6 +148,7 @@ let options = [
     "-noset0"   , Arg.Clear set0        , ": do not use set0 option";
     "-ec"       , Arg.String  set_ec    , "[f]: extract function [f] and its dependencies to an easycrypt file";
     "-oec"     ,  Arg.Set_string ecfile , "[filename]: use filename as output destination for easycrypt extraction";
+    "-oecarray" , Arg.String set_ec_array_path, "[dir]: output easycrypt array theories to the given path";
     "-CT" , Arg.Unit set_constTime      , ": generates model for constant time verification";
     "-checkCT", Arg.Unit set_ct         , ": checks that the full program is constant time (using a type system)";
     "-checkCTon", Arg.String set_ct_on  , "[f]: checks that the function [f] is constant time (using a type system)";

--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -1295,17 +1295,19 @@ let add_arrsz env f =
   env.warrsz := Sv.fold add_wsz vars !(env.warrsz);
   env
 
-let pp_array_decl i = 
+let pp_array_decl ~prefix i =
   let file = Format.sprintf "Array%i.ec" i in
-  let out = open_out file in
+  let path = Filename.concat prefix file in
+  let out = open_out path in
   let fmt = Format.formatter_of_out_channel out in
   Format.fprintf fmt "@[<v>from Jasmin require import JArray.@ @ ";
   Format.fprintf fmt "clone export PolyArray as Array%i  with op size <- %i.@]@." i i;
   close_out out
 
-let pp_warray_decl i = 
+let pp_warray_decl ~prefix i =
   let file = Format.sprintf "WArray%i.ec" i in
-  let out = open_out file in
+  let path = Filename.concat prefix file in
+  let out = open_out path in
   let fmt = Format.formatter_of_out_channel out in
   Format.fprintf fmt "@[<v>from Jasmin require import JWord_array.@ @ ";
   Format.fprintf fmt "clone export WArray as WArray%i  with op size <- %i.@]@." i i;
@@ -1330,8 +1332,9 @@ let pp_prog pd asmOp fmt model globs funcs arrsz warrsz =
       env globs in
   let env = List.fold_left add_arrsz env funcs in
 
-  Sint.iter pp_array_decl !(env.arrsz);
-  Sint.iter pp_warray_decl !(env.warrsz);
+  let prefix = !Glob_options.ec_array_path in
+  Sint.iter (pp_array_decl ~prefix) !(env.arrsz);
+  Sint.iter (pp_warray_decl ~prefix) !(env.warrsz);
 
   let pp_arrays arr fmt s = 
     let l = Sint.elements s in


### PR DESCRIPTION
Extraction to EasyCrypt may write extra `ArrayN.ec` and `WArrayN.ec` files.

The directory into which these files are written can be changed using the `-oecarray dir` command-line argument.

The default behavior is to write in the current directory (i.e., from which `jasminc` is run).

I would like to turn this off (i.e., do not write extra files unless explicitly asked for), but that would break the LibJade test suite.