### PR TITLE
Increase the lower bound on OCaml version

### DIFF
--- a/compiler/opam
+++ b/compiler/opam
@@ -16,7 +16,7 @@ install: [
   cp "_build/entry/jasminc.native" "%{prefix}%/bin/jasminc"
 ]
 depends: [
-  "ocaml" { >= "4.08" & build }
+  "ocaml" { >= "4.13" & build }
   "batteries" {>= "3.2"}
   "menhir" {>= "20160825" & build }
   "menhirLib"

--- a/opam
+++ b/opam
@@ -15,7 +15,7 @@ install: [
   make "PREFIX=%{prefix}%" "install"
 ]
 depends: [
-  "ocaml" { >= "4.08" & build }
+  "ocaml" { >= "4.13" & build }
   "batteries" {>= "3.2"}
   "menhir" {>= "20160825" & build }
   "menhirLib"


### PR DESCRIPTION
Function `String.for_all` is used in `latex_printer.ml`, and it was introduced only in OCaml 4.13.