### PR TITLE
Remove field id_wsize from instruction descriptors

### DIFF
--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -400,7 +400,6 @@ Record instr_desc_t := {
   id_str_jas    : unit -> string;
   id_check_dest : all2 check_arg_dest id_out id_tout;
   id_safe       : seq safe_cond;
-  id_wsize      : wsize;
   id_pp_asm     : asm_args -> pp_asm_op;
 }.
 
@@ -543,7 +542,6 @@ Definition instr_desc (o:asm_op_msb_t) : instr_desc_t :=
        id_str_jas    := d.(id_str_jas);
        id_check_dest := instr_desc_aux2 ws d.(id_check_dest);
        id_safe       := d.(id_safe);
-       id_wsize      := d.(id_wsize);
        id_pp_asm     := d.(id_pp_asm); |}
     else d (* FIXME do the case for MSB_KEEP *)
   else

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -145,7 +145,6 @@ Definition get_instr_desc (o: extended_op) : instruction_desc :=
     ; tout     := id.(id_tout)
     ; semi     := id.(id_semi)
     ; semu     := @vuincl_app_sopn_v _ _ id.(id_semi) id.(id_tin_narr)
-    ; wsizei   := id.(id_wsize)
     ; i_safe   := id.(id_safe) |}
  | ExtOp o => asm_op_instr o
  end.

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -717,7 +717,7 @@ Proof.
   case: id Hargs Hdest =>
     /= msb_flag id_tin id_in id_tout id_out id_semi id_args_kinds id_nargs
     /andP[] /eqP hsin /eqP hsout
-    _ _ id_str_jas id_check_dest id_safe id_wsize id_pp
+    _ _ id_str_jas id_check_dest id_safe id_pp
     Hargs Hdest vt happ ?;
     subst x.
   elim: id_in id_tin hsin id_semi args vs Hargs happ Hvs; rewrite /sem_prod.

--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -470,7 +470,6 @@ Definition drop_nz (idt : instr_desc_t) : instr_desc_t :=
     id_tout_narr := all_beheadn (id_tout_narr idt);
     id_check_dest := all2_beheadn (id_check_dest idt);
     id_str_jas := id_str_jas idt;
-    id_wsize := id_wsize idt;
     id_safe := id_safe idt;
     id_pp_asm := id_pp_asm idt;
   |}.
@@ -491,7 +490,6 @@ Definition drop_nzc (idt : instr_desc_t) : instr_desc_t :=
     id_tout_narr := all_beheadn (id_tout_narr idt);
     id_check_dest := all2_beheadn (id_check_dest idt);
     id_str_jas := id_str_jas idt;
-    id_wsize := id_wsize idt;
     id_safe := id_safe idt;
     id_pp_asm := id_pp_asm idt;
   |}.
@@ -512,7 +510,6 @@ Definition drop_nzcv (idt : instr_desc_t) : instr_desc_t :=
     id_tout_narr := all_beheadn (id_tout_narr idt);
     id_check_dest := all2_beheadn (id_check_dest idt);
     id_str_jas := id_str_jas idt;
-    id_wsize := id_wsize idt;
     id_safe := id_safe idt;
     id_pp_asm := id_pp_asm idt;
   |}.
@@ -589,7 +586,6 @@ Definition mk_cond (idt : instr_desc_t) : instr_desc_t :=
     id_tout_narr := id_tout_narr idt;
     id_check_dest := id_check_dest idt;
     id_str_jas := id_str_jas idt;
-    id_wsize := id_wsize idt;
     id_safe := id_safe idt;
     id_pp_asm := id_pp_asm idt;
   |}.
@@ -670,7 +666,6 @@ Definition mk_shifted
     id_tout_narr := id_tout_narr idt;
     id_check_dest := id_check_dest idt;
     id_str_jas := id_str_jas idt;
-    id_wsize := id_wsize idt;
     id_safe := id_safe idt;
     id_pp_asm := id_pp_asm idt;
   |}.
@@ -738,7 +733,6 @@ Definition arm_ADD_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -779,7 +773,6 @@ Definition arm_ADC_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -815,7 +808,6 @@ Definition arm_MUL_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -843,7 +835,6 @@ Definition arm_SDIV_instr : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.
@@ -875,7 +866,6 @@ Definition arm_SUB_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -907,7 +897,6 @@ Definition arm_RSB_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -940,7 +929,6 @@ Definition arm_UDIV_instr : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.
@@ -967,7 +955,6 @@ Definition arm_UMULL_instr : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.
@@ -1002,7 +989,6 @@ Definition arm_AND_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1033,7 +1019,6 @@ Definition arm_BIC_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1064,7 +1049,6 @@ Definition arm_EOR_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1103,7 +1087,6 @@ Definition arm_MVN_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1134,7 +1117,6 @@ Definition arm_ORR_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1178,7 +1160,6 @@ Definition arm_ASR_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1213,7 +1194,6 @@ Definition arm_LSL_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1248,7 +1228,6 @@ Definition arm_LSR_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1283,7 +1262,6 @@ Definition arm_ROR_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1312,7 +1290,6 @@ Definition arm_MOV_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1342,7 +1319,6 @@ Definition arm_MOVT_instr : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.
@@ -1372,7 +1348,6 @@ Definition arm_UBFX_instr : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.
@@ -1400,7 +1375,6 @@ Definition arm_UXTB_instr : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.
@@ -1422,7 +1396,6 @@ Definition arm_UXTH_instr : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.
@@ -1446,7 +1419,6 @@ Definition arm_SBFX_instr : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.
@@ -1478,7 +1450,6 @@ Definition arm_CMP_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1512,7 +1483,6 @@ Definition arm_TST_instr : instr_desc_t :=
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
       id_str_jas := pp_s (string_of_arm_mnemonic mn);
-      id_wsize := reg_size;
       id_safe := [::]; (* TODO_ARM: Complete. *)
       id_pp_asm := pp_arm_op mn opts;
     |}
@@ -1546,7 +1516,6 @@ Definition arm_load_instr mn opts : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.
@@ -1573,7 +1542,6 @@ Definition arm_store_instr mn opts : instr_desc_t :=
     id_tout_narr := refl_equal;
     id_check_dest := refl_equal;
     id_str_jas := pp_s (string_of_arm_mnemonic mn);
-    id_wsize := reg_size;
     id_safe := [::]; (* TODO_ARM: Complete. *)
     id_pp_asm := pp_arm_op mn opts;
   |}.

--- a/proofs/compiler/x86_extra.v
+++ b/proofs/compiler/x86_extra.v
@@ -40,26 +40,26 @@ Definition Oset0_instr sz  :=
              (let vf := Some false in
               let vt := Some true in
               ok (::vf, vf, vf, vt, vt & (0%R: word sz)))
-             sz [::]
+             [::]
   else 
     mk_instr_desc (pp_sz "set0" sz)
              [::] [::]  
              (w_ty sz) [::E 0] 
-             (ok (0%R: word sz)) sz [::].
+             (ok (0%R: word sz)) [::].
 
 Definition Oconcat128_instr := 
   mk_instr_desc (pp_s "concat_2u128") 
            [:: sword128; sword128 ] [:: E 1; E 2] 
            [:: sword256] [:: E 0] 
            (λ h l : u128, ok (make_vec U256 [::l;h]))
-           U128 [::].
+           [::].
 
 Definition Ox86MOVZX32_instr := 
   mk_instr_desc (pp_s "MOVZX32") 
            [:: sword32] [:: E 1] 
            [:: sword64] [:: E 0] 
            (λ x : u32, ok (zero_extend U64 x)) 
-           U32 [::].
+           [::].
 
 Definition get_instr_desc o :=
   match o with

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -958,7 +958,7 @@ Definition reg_msb_flag (sz : wsize) :=
   if (sz <= U16)%CMP then MSB_MERGE
   else MSB_CLEAR.
 
-Notation mk_instr str_jas tin tout ain aout msb semi args_kinds nargs wsizei safe_cond pp_asm:=
+Notation mk_instr str_jas tin tout ain aout msb semi args_kinds nargs safe_cond pp_asm:=
  {|
   id_msb_flag   := msb;
   id_tin        := tin;
@@ -973,93 +973,92 @@ Notation mk_instr str_jas tin tout ain aout msb semi args_kinds nargs wsizei saf
   id_tout_narr  := refl_equal;
   id_check_dest := refl_equal;
   id_str_jas    := str_jas;
-  id_wsize      := wsizei;
   id_safe       := safe_cond;
   id_pp_asm     := pp_asm;
 |}.
 
-Notation mk_instr_pp  name tin tout ain aout msb semi check nargs wsizei prc pp_asm :=
-  (mk_instr (pp_s name%string) tin tout ain aout msb semi check nargs wsizei [::] pp_asm,
+Notation mk_instr_pp  name tin tout ain aout msb semi check nargs prc pp_asm :=
+  (mk_instr (pp_s name%string) tin tout ain aout msb semi check nargs [::] pp_asm,
    (name%string, prc)) (only parsing).
 
 Notation mk_instr_w_w name semi ain aout nargs check prc pp_asm :=
  ((fun sz =>
-  mk_instr (pp_sz name sz) (w_ty sz) (w_ty sz) ain aout (reg_msb_flag sz) (semi sz) (check sz) nargs sz [::] (pp_asm sz)), (name%string,prc)) (only parsing).
+  mk_instr (pp_sz name sz) (w_ty sz) (w_ty sz) ain aout (reg_msb_flag sz) (semi sz) (check sz) nargs [::] (pp_asm sz)), (name%string,prc)) (only parsing).
 
 Notation mk_instr_w_w'_10 name sign semi check prc pp_asm :=
  ((fun szo szi =>
-  mk_instr (pp_sz_sz name sign szo szi) (w_ty szi) (w_ty szo) [:: E 1] [:: E 0] (reg_msb_flag szo) (semi szi szo) (check szi szo) 2 szi [::] (pp_asm szi szo)), (name%string,prc)) (only parsing).
+  mk_instr (pp_sz_sz name sign szo szi) (w_ty szi) (w_ty szo) [:: E 1] [:: E 0] (reg_msb_flag szo) (semi szi szo) (check szi szo) 2 [::] (pp_asm szi szo)), (name%string,prc)) (only parsing).
 
 Notation mk_instr_bw2_w_0211 name semi check prc pp_asm :=
  ((fun sz =>
-  mk_instr (pp_sz name sz) (bw2_ty sz) (w_ty sz) [:: E 0; E 2; E 1] [:: E 1] (reg_msb_flag sz) (semi sz) (check sz) 3 sz [::] (pp_asm sz)), (name%string, prc))  (only parsing).
+  mk_instr (pp_sz name sz) (bw2_ty sz) (w_ty sz) [:: E 0; E 2; E 1] [:: E 1] (reg_msb_flag sz) (semi sz) (check sz) 3 [::] (pp_asm sz)), (name%string, prc))  (only parsing).
 
 Notation mk_instr_w_b5w name semi ain aout nargs check prc pp_asm :=
  ((fun sz =>
-  mk_instr (pp_sz name sz) (w_ty sz) (b5w_ty sz) ain (implicit_flags ++ aout) (reg_msb_flag sz) (semi sz) (check sz) nargs sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w_ty sz) (b5w_ty sz) ain (implicit_flags ++ aout) (reg_msb_flag sz) (semi sz) (check sz) nargs [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w_b4w_00 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w_ty sz) (b4w_ty sz) [:: E 0] (implicit_flags_noCF ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 1 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w_ty sz) (b4w_ty sz) [:: E 0] (implicit_flags_noCF ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 1 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2_b name semi ain aout nargs check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2_ty sz sz) (b_ty) ain aout (reg_msb_flag sz) (semi sz) (check sz) nargs sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w2_ty sz sz) (b_ty) ain aout (reg_msb_flag sz) (semi sz) (check sz) nargs [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2_b5 name semi ain nargs check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2_ty sz sz) (b5_ty) ain implicit_flags (reg_msb_flag sz) (semi sz) (check sz) nargs sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w2_ty sz sz) (b5_ty) ain implicit_flags (reg_msb_flag sz) (semi sz) (check sz) nargs [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2_b5w name semi ain aout nargs check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2_ty sz sz) (b5w_ty sz) ain (implicit_flags ++ aout) (reg_msb_flag sz) (semi sz) (check sz) nargs sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w2_ty sz sz) (b5w_ty sz) ain (implicit_flags ++ aout) (reg_msb_flag sz) (semi sz) (check sz) nargs [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2_b5w_010 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2_ty sz sz) (b5w_ty sz) [:: E 0; E 1] (implicit_flags ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 2 sz [::] (pp_asm sz)), (name%string,prc)) (only parsing).
+  mk_instr (pp_sz name sz) (w2_ty sz sz) (b5w_ty sz) [:: E 0; E 1] (implicit_flags ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 2 [::] (pp_asm sz)), (name%string,prc)) (only parsing).
 
 Notation mk_instr_w2b_b5w_010 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2b_ty sz sz) (b5w_ty sz) ([:: E 0; E 1] ++ [::iCF]) (implicit_flags ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 2 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w2b_ty sz sz) (b5w_ty sz) ([:: E 0; E 1] ++ [::iCF]) (implicit_flags ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 2 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2b_bw name semi flag check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2b_ty sz sz) (bw_ty sz) ([:: E 0; E 1] ++ [::F flag]) ([::F flag; E 0]) (reg_msb_flag sz) (semi sz) (check sz) 2 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w2b_ty sz sz) (bw_ty sz) ([:: E 0; E 1] ++ [::F flag]) ([::F flag; E 0]) (reg_msb_flag sz) (semi sz) (check sz) 2 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2_b5w2 name semi ain aout nargs check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2_ty sz sz) (b5w2_ty sz) ain (implicit_flags ++ aout) (reg_msb_flag sz) (semi sz) (check sz) nargs sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w2_ty sz sz) (b5w2_ty sz) ain (implicit_flags ++ aout) (reg_msb_flag sz) (semi sz) (check sz) nargs [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w3_b5w2_da0ad name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w3_ty sz) (b5w2_ty sz) [:: R RDX; R RAX; E 0]  (implicit_flags ++ [:: R RAX; R RDX]) (reg_msb_flag sz) (semi sz) (check sz) 1 sz [::NotZero sz 2] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w3_ty sz) (b5w2_ty sz) [:: R RDX; R RAX; E 0]  (implicit_flags ++ [:: R RAX; R RDX]) (reg_msb_flag sz) (semi sz) (check sz) 1 [::NotZero sz 2] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2_w_120 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (semi sz) (check sz) 3 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (semi sz) (check sz) 3 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_ww8_w_120 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (ww8_ty sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (semi sz) (check sz) 3 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (ww8_ty sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (semi sz) (check sz) 3 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_ww8_b2w_0c0 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (ww8_ty sz) (b2w_ty sz) [:: E 0; Ef 1 RCX] [::F OF; F CF; E 0] (reg_msb_flag sz) (semi sz) (check sz) 2 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (ww8_ty sz) (b2w_ty sz) [:: E 0; Ef 1 RCX] [::F OF; F CF; E 0] (reg_msb_flag sz) (semi sz) (check sz) 2 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_ww8b_b2w_0c0 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (ww8b_ty sz) (b2w_ty sz) [:: E 0; Ef 1 RCX; F CF] [::F OF; F CF; E 0] (reg_msb_flag sz) (semi sz) (check sz) 2 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (ww8b_ty sz) (b2w_ty sz) [:: E 0; Ef 1 RCX; F CF] [::F OF; F CF; E 0] (reg_msb_flag sz) (semi sz) (check sz) 2 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_ww8_b5w_0c0 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (ww8_ty sz) (b5w_ty sz) [:: E 0; Ef 1 RCX] (implicit_flags ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 2 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (ww8_ty sz) (b5w_ty sz) [:: E 0; Ef 1 RCX] (implicit_flags ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 2 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2w8_b5w_01c0 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2w8_ty sz) (b5w_ty sz) [:: E 0; E 1; Ef 2 RCX] (implicit_flags ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 3 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w2w8_ty sz) (b5w_ty sz) [:: E 0; E 1; Ef 2 RCX] (implicit_flags ++ [:: E 0]) (reg_msb_flag sz) (semi sz) (check sz) 3 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2w8_w_1230 name semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w2w8_ty sz) (w_ty sz) [:: E 1 ; E 2 ; E 3] [:: E 0] (reg_msb_flag sz) (semi sz) (check sz) 4 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w2w8_ty sz) (w_ty sz) [:: E 1 ; E 2 ; E 3] [:: E 0] (reg_msb_flag sz) (semi sz) (check sz) 4 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_ve_instr_w2w8_w_1230 name semi check prc pp_asm := ((fun (ve:velem) sz =>
-  mk_instr (pp_ve_sz name ve sz) (w2w8_ty sz) (w_ty sz) [:: E 1 ; E 2 ; E 3] [:: E 0] (reg_msb_flag sz) (semi ve sz) (check sz) 4 sz [::] (pp_asm ve sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_ve_sz name ve sz) (w2w8_ty sz) (w_ty sz) [:: E 1 ; E 2 ; E 3] [:: E 0] (reg_msb_flag sz) (semi ve sz) (check sz) 4 [::] (pp_asm ve sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w_w128_10 name msb semi check prc pp_asm := ((fun sz =>
-  mk_instr (pp_sz name sz) (w_ty sz) (w128_ty) [:: E 1] [:: E 0] msb (semi sz) (check sz) 2 sz [::] (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_sz name sz) (w_ty sz) (w128_ty) [:: E 1] [:: E 0] msb (semi sz) (check sz) 2 [::] (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_ve_instr_w_w_10 name semi check prc pp_asm := ((fun (ve:velem) sz =>
-  mk_instr (pp_ve_sz name ve sz) (w_ty _) (w_ty sz) [:: E 1] [:: E 0] (reg_msb_flag sz) (semi ve sz) (check sz) 2 sz [::] (pp_asm ve sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_ve_sz name ve sz) (w_ty _) (w_ty sz) [:: E 1] [:: E 0] (reg_msb_flag sz) (semi ve sz) (check sz) 2 [::] (pp_asm ve sz)), (name%string,prc))  (only parsing).
 
 Notation mk_ve_instr_w2_w_120 name semi check prc pp_asm := ((fun (ve:velem) sz =>
-  mk_instr (pp_ve_sz name ve sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (semi ve sz) (check sz) 3 sz [::] (pp_asm ve sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_ve_sz name ve sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (semi ve sz) (check sz) 3 [::] (pp_asm ve sz)), (name%string,prc))  (only parsing).
 
 Notation mk_ve_instr_ww8_w_120 name semi check prc pp_asm := ((fun ve sz =>
-  mk_instr (pp_ve_sz name ve sz) (ww8_ty sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (semi ve sz) (check sz) 3 sz [::] (pp_asm ve sz)), (name%string,prc))  (only parsing).
+  mk_instr (pp_ve_sz name ve sz) (ww8_ty sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (semi ve sz) (check sz) 3 [::] (pp_asm ve sz)), (name%string,prc))  (only parsing).
 
 Definition max_32 (sz:wsize) := if (sz <= U32)%CMP then sz else U32.
 Definition primP (op:wsize -> x86_op) := PrimP U64 op.
@@ -1241,7 +1240,7 @@ Definition Ox86_MULX_instr :=
    ((fun (sz:wsize) =>
      mk_instr (pp_sz name sz) (w2_ty sz sz) (w2_ty sz sz)
          [::R RDX; E 2] [:: E 0; E 1] (reg_msb_flag sz)
-         (@x86_MULX sz) check_mulx 3 sz [::] (pp_iname name sz)),
+         (@x86_MULX sz) check_mulx 3 [::] (pp_iname name sz)),
     (name, PrimP U64 MULX)).
 
 Definition check_neg (_:wsize) := [::[::rm false]].
@@ -1259,7 +1258,7 @@ Definition Ox86_LZCNT_instr               :=
 
 Definition check_setcc := [:: [::c; rm false]].
 Definition Ox86_SETcc_instr             :=
-  mk_instr_pp "SETcc" b_ty w8_ty [:: E 0] [:: E 1] (reg_msb_flag U8) x86_SETcc check_setcc 2 U8 (PrimM SETcc) (pp_ct "set" U8).
+  mk_instr_pp "SETcc" b_ty w8_ty [:: E 0] [:: E 1] (reg_msb_flag U8) x86_SETcc check_setcc 2 (PrimM SETcc) (pp_ct "set" U8).
 
 Definition check_bt (_:wsize) := [:: [::rm true; ri U8]].
 Definition Ox86_BT_instr                :=
@@ -1267,10 +1266,10 @@ Definition Ox86_BT_instr                :=
 
 (* -------------------------------------------------------------------- *)
 Definition Ox86_CLC_instr :=
-  mk_instr_pp "CLC" [::] b_ty [::] [:: F CF ] MSB_CLEAR x86_CLC [:: [::]] 0 U8 (PrimM CLC) (pp_name "clc" U8).
+  mk_instr_pp "CLC" [::] b_ty [::] [:: F CF ] MSB_CLEAR x86_CLC [:: [::]] 0 (PrimM CLC) (pp_name "clc" U8).
 
 Definition Ox86_STC_instr :=
-  mk_instr_pp "STC" [::] b_ty [::] [:: F CF ] MSB_CLEAR x86_STC [:: [::]] 0 U8 (PrimM STC) (pp_name "stc" U8).
+  mk_instr_pp "STC" [::] b_ty [::] [:: F CF ] MSB_CLEAR x86_STC [:: [::]] 0 (PrimM STC) (pp_name "stc" U8).
 
 (* -------------------------------------------------------------------- *)
 Definition check_lea (_:wsize) := [:: [::r; m true]].
@@ -1368,7 +1367,7 @@ Definition Ox86_VPMOVSX_instr :=
   let name := "VPMOVSX"%string in
   (λ ve sz ve' sz',
    mk_instr (pp_ve_sz_ve_sz name ve sz ve' sz') [:: sword sz ] [:: sword sz' ] [:: E 1 ] [:: E 0 ]
-            MSB_CLEAR (@x86_VPMOVSX ve sz ve' sz') [:: [:: xmm ; xmmm true]] 2 sz [::] (pp_vpmovx "vpmovsx" ve sz ve' sz'),
+            MSB_CLEAR (@x86_VPMOVSX ve sz ve' sz') [:: [:: xmm ; xmmm true]] 2 [::] (pp_vpmovx "vpmovsx" ve sz ve' sz'),
    (name, PrimVV VPMOVSX)
    ).
 
@@ -1376,7 +1375,7 @@ Definition Ox86_VPMOVZX_instr :=
   let name := "VPMOVZX"%string in
   (λ ve sz ve' sz',
    mk_instr (pp_ve_sz_ve_sz name ve sz ve' sz') [:: sword sz ] [:: sword sz' ] [:: E 1 ] [:: E 0 ]
-            MSB_CLEAR (@x86_VPMOVZX ve sz ve' sz') [:: [:: xmm ; xmmm true]] 2 sz [::] (pp_vpmovx "vpmovzx" ve sz ve' sz'),
+            MSB_CLEAR (@x86_VPMOVZX ve sz ve' sz') [:: [:: xmm ; xmmm true]] 2 [::] (pp_vpmovx "vpmovzx" ve sz ve' sz'),
    (name, PrimVV VPMOVZX)
    ).
 
@@ -1390,8 +1389,8 @@ Definition Ox86_VPADD_instr  := mk_ve_instr_w2_w_120 "VPADD"   x86_VPADD  check_
 Definition Ox86_VPSUB_instr  := mk_ve_instr_w2_w_120 "VPSUB"   x86_VPSUB  check_xmm_xmm_xmmm (PrimV VPSUB) (pp_viname "vpsub").
 
 Definition Ox86_VPMULL_instr := mk_ve_instr_w2_w_120 "VPMULL" x86_VPMULL check_xmm_xmm_xmmm (PrimV VPMULL) (pp_viname "vpmull").
-Definition Ox86_VPMUL_instr  := ((fun sz => mk_instr (pp_sz "VPMUL" sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] MSB_CLEAR (@x86_VPMUL sz) (check_xmm_xmm_xmmm sz) 3 sz [::] (pp_name "vpmuldq" sz)), ("VPMUL"%string, (PrimP U128 VPMUL))).
-Definition Ox86_VPMULU_instr := ((fun sz => mk_instr (pp_sz "VPMULU" sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] MSB_CLEAR (@x86_VPMULU sz) (check_xmm_xmm_xmmm sz) 3 sz [::] (pp_name "vpmuludq" sz)), ("VPMULU"%string, (PrimP U128 VPMULU))).
+Definition Ox86_VPMUL_instr  := ((fun sz => mk_instr (pp_sz "VPMUL" sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] MSB_CLEAR (@x86_VPMUL sz) (check_xmm_xmm_xmmm sz) 3 [::] (pp_name "vpmuldq" sz)), ("VPMUL"%string, (PrimP U128 VPMUL))).
+Definition Ox86_VPMULU_instr := ((fun sz => mk_instr (pp_sz "VPMULU" sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] MSB_CLEAR (@x86_VPMULU sz) (check_xmm_xmm_xmmm sz) 3 [::] (pp_name "vpmuludq" sz)), ("VPMULU"%string, (PrimP U128 VPMULU))).
 
 Definition Ox86_VPMULH_instr := mk_ve_instr_w2_w_120 "VPMULH" x86_VPMULH check_xmm_xmm_xmmm (PrimV VPMULH) (pp_viname "vpmulh").
 Definition Ox86_VPMULHU_instr := mk_ve_instr_w2_w_120 "VPMULHU" x86_VPMULHU check_xmm_xmm_xmmm (PrimV VPMULHU) (pp_viname "vpmulhu").
@@ -1409,7 +1408,7 @@ Definition Ox86_VPEXTR_instr :=
   ((fun sz =>
       let ve := if sz == U32 then  VE32 else VE64 in
       mk_instr (pp_sz "VPEXTR" sz) w128w8_ty (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (@x86_VPEXTR sz)
-                       (check_vpextr sz) 3 U128 [::]
+                       (check_vpextr sz) 3 [::]
                        (pp_viname_t "vpextr" ve [:: sz; U128; U8])),
     ("VPEXTR"%string, (primP VPEXTR))).
 
@@ -1422,7 +1421,7 @@ Definition pp_vpinsr ve args :=
 Definition check_vpinsr (_:wsize) :=  [:: [:: xmm; xmm; rm true; i U8] ].
 Definition Ox86_VPINSR_instr  :=
   ((fun (sz:velem) => mk_instr (pp_ve_sz "VPINSR" sz U128) (w128ww8_ty sz) w128_ty [:: E 1 ; E 2 ; E 3] [:: E 0] MSB_CLEAR (x86_VPINSR sz)
-                               (check_vpinsr sz) 4 U128 [::] (pp_vpinsr sz)),
+                               (check_vpinsr sz) 4 [::] (pp_vpinsr sz)),
    ("VPINSR"%string, PrimV (fun ve _ => VPINSR ve))).
 
 Definition check_xmm_xmm_imm8 (_:wsize) := [:: [:: xmm; xmm; i U8]].
@@ -1474,7 +1473,7 @@ Definition check_xmm_xmm_xmmm_xmm (_:wsize) := [:: [:: xmm; xmm; xmmm true; xmm]
 Definition Ox86_VPBLENDVB_instr :=
   (fun sz => mk_instr
                (pp_sz "VPBLENDVB" sz) (w3_ty sz) (w_ty sz) [:: E 1; E 2; E 3] [:: E 0] MSB_CLEAR
-               (@x86_VPBLENDVB sz) (check_xmm_xmm_xmmm_xmm sz) 4 sz [::]
+               (@x86_VPBLENDVB sz) (check_xmm_xmm_xmmm_xmm sz) 4 [::]
                (pp_name "vpblendvb" sz), ("VPBLENDVB"%string, PrimP U128 VPBLENDVB)).
 
 Definition Ox86_VPACKUS_instr :=
@@ -1508,36 +1507,36 @@ Definition Ox86_VMOVSLDUP_instr :=
 Definition Ox86_VPALIGNR_instr := 
   ((fun sz =>
      mk_instr (pp_sz "VPALIGNR" sz) (w2w8_ty sz) (w_ty sz) [:: E 1 ; E 2 ; E 3] [:: E 0] MSB_CLEAR 
-      (@x86_VPALIGNR sz) (check_xmm_xmm_xmmm_imm8 sz) 4 sz [::] (pp_name "vpalignr" sz)), ("VPALIGNR"%string, PrimP U128 VPALIGNR)).
+      (@x86_VPALIGNR sz) (check_xmm_xmm_xmmm_imm8 sz) 4 [::] (pp_name "vpalignr" sz)), ("VPALIGNR"%string, PrimP U128 VPALIGNR)).
 
 (* 256 *)
 
 Definition Ox86_VBROADCASTI128_instr    :=
   (mk_instr (pp_s "VPBROADCAST_2u128") w128_ty w256_ty [:: E 1] [:: E 0] MSB_CLEAR (x86_VPBROADCAST U256)
-            ([:: [::xmm; m true]]) 2 U256 [::] (pp_name_ty "vbroadcasti128" [::U256; U128]),
+            ([:: [::xmm; m true]]) 2 [::] (pp_name_ty "vbroadcasti128" [::U256; U128]),
    ("VPBROADCAST_2u128"%string, (PrimM VBROADCASTI128))).
 
 Definition check_xmmm_xmm_imm8 (_:wsize) := [:: [:: xmmm false; xmm; i U8]].
 
 Definition Ox86_VEXTRACTI128_instr :=
   mk_instr_pp "VEXTRACTI128" w256w8_ty w128_ty [:: E 1; E 2] [:: E 0] MSB_CLEAR x86_VEXTRACTI128
-              (check_xmmm_xmm_imm8 U256) 3 U256 (PrimM VEXTRACTI128) (pp_name_ty "vextracti128" [::U128; U256; U8]).
+              (check_xmmm_xmm_imm8 U256) 3 (PrimM VEXTRACTI128) (pp_name_ty "vextracti128" [::U128; U256; U8]).
 
 Definition Ox86_VINSERTI128_instr :=
   mk_instr_pp "VINSERTI128" w256w128w8_ty w256_ty [:: E 1; E 2; E 3] [:: E 0] MSB_CLEAR x86_VINSERTI128
-              (check_xmm_xmm_xmmm_imm8 U256) 4 U256 (PrimM VINSERTI128) (pp_name_ty "vinserti128" [::U256;U256; U128; U8]).
+              (check_xmm_xmm_xmmm_imm8 U256) 4 (PrimM VINSERTI128) (pp_name_ty "vinserti128" [::U256;U256; U128; U8]).
 
 Definition Ox86_VPERM2I128_instr :=
   mk_instr_pp "VPERM2I128" w256x2w8_ty w256_ty [:: E 1; E 2; E 3] [:: E 0] MSB_CLEAR x86_VPERM2I128
-              (check_xmm_xmm_xmmm_imm8 U256) 4 U256 (PrimM VPERM2I128) (pp_name_ty "vperm2i128" [::U256;U256;U256;U8]).
+              (check_xmm_xmm_xmmm_imm8 U256) 4 (PrimM VPERM2I128) (pp_name_ty "vperm2i128" [::U256;U256;U256;U8]).
 
 Definition Ox86_VPERMD_instr :=
   mk_instr_pp "VPERMD" (w2_ty U256 U256) w256_ty [:: E 1; E 2] [:: E 0] MSB_CLEAR x86_VPERMD
-       (check_xmm_xmm_xmmm U256) 3 U256 (PrimM VPERMD) (pp_name "vpermd" U256).
+       (check_xmm_xmm_xmmm U256) 3 (PrimM VPERMD) (pp_name "vpermd" U256).
 
 Definition Ox86_VPERMQ_instr :=
   mk_instr_pp "VPERMQ" w256w8_ty w256_ty [:: E 1; E 2] [:: E 0] MSB_CLEAR x86_VPERMQ
-              (check_xmm_xmmm_imm8 U256) 3 U256 (PrimM VPERMQ) (pp_name_ty "vpermq" [::U256;U256;U8]).
+              (check_xmm_xmmm_imm8 U256) 3 (PrimM VPERMQ) (pp_name_ty "vpermq" [::U256;U256;U8]).
 
 Definition Ox86_PMOVMSKB_instr :=
   (fun ssz dsz => mk_instr
@@ -1550,7 +1549,6 @@ Definition Ox86_PMOVMSKB_instr :=
     (@x86_VPMOVMSKB ssz dsz) (* semantics *)
     [:: [:: r ; xmm ] ] (* arg checks *)
     2 (* nargs *)
-    ssz (* size *)
     [::]
     (pp_name_ty "vpmovmskb" [:: dsz; ssz]) (* asm pprinter *)
   , ("VPMOVMSKB"%string, PrimX VPMOVMSKB) (* jasmin concrete syntax *)
@@ -1567,7 +1565,6 @@ Definition Ox86_VPCMPEQ_instr :=
                   (@x86_VPCMPEQ ve sz)
                   (check_xmm_xmm_xmmm sz)
                   3
-                  sz
                   [::]
                   (pp_viname "vpcmpeq" ve sz)
                 ,("VPCMPEQ"%string, PrimV VPCMPEQ)
@@ -1584,7 +1581,6 @@ Definition Ox86_VPCMPGT_instr :=
                   (@x86_VPCMPGT ve sz)
                   (check_xmm_xmm_xmmm sz)
                   3
-                  sz
                   [::]
                   (pp_viname "vpcmpgt" ve sz)
                 ,("VPCMPGT"%string, PrimV VPCMPGT)
@@ -1601,7 +1597,6 @@ Definition Ox86_VPMADDUBSW_instr :=
                 (@x86_VPMADDUBSW sz)
                 (check_xmm_xmm_xmmm sz)
                 3
-                sz
                 [::]
                 (pp_name_ty "vpmaddubsw" [:: sz; sz; sz])
              ,("VPMADDUBSW"%string, PrimP U128 VPMADDUBSW)
@@ -1618,7 +1613,6 @@ Definition Ox86_VPMADDWD_instr :=
                 (@x86_VPMADDWD sz)
                 (check_xmm_xmm_xmmm sz)
                 3
-                sz
                 [::]
                 (pp_name_ty "vpmaddwd" [:: sz; sz; sz])
              ,("VPMADDWD"%string, PrimP U128 VPMADDWD)
@@ -1627,10 +1621,10 @@ Definition Ox86_VPMADDWD_instr :=
 Definition check_movpd := [:: [::m false; xmm]].
 
 Definition Ox86_VMOVLPD_instr :=
-  mk_instr_pp "VMOVLPD" (w_ty U128) (w_ty U64) [:: E 1] [:: E 0] MSB_CLEAR x86_VMOVLPD check_movpd 2 U64 (PrimM VMOVLPD) (pp_name_ty "vmovlpd" [::U64; U128]).
+  mk_instr_pp "VMOVLPD" (w_ty U128) (w_ty U64) [:: E 1] [:: E 0] MSB_CLEAR x86_VMOVLPD check_movpd 2 (PrimM VMOVLPD) (pp_name_ty "vmovlpd" [::U64; U128]).
 
 Definition Ox86_VMOVHPD_instr :=
-  mk_instr_pp "VMOVHPD" (w_ty U128) (w_ty U64) [:: E 1] [:: E 0] MSB_CLEAR x86_VMOVHPD check_movpd 2 U64 (PrimM VMOVHPD) (pp_name_ty "vmovhpd" [::U64;U128]).
+  mk_instr_pp "VMOVHPD" (w_ty U128) (w_ty U64) [:: E 1] [:: E 0] MSB_CLEAR x86_VMOVHPD check_movpd 2 (PrimM VMOVHPD) (pp_name_ty "vmovhpd" [::U64;U128]).
 
 Definition Ox86_VPMINS_instr  := 
   mk_ve_instr_w2_w_120 "VPMINS" x86_VPMINS check_xmm_xmm_xmmm (PrimV VPMINS) (pp_viname "vpmins").
@@ -1648,7 +1642,7 @@ Definition check_vptest (_:wsize) := [:: xmm_xmmm].
 Definition Ox86_VPTEST_instr :=
   (fun sz => mk_instr
                (pp_sz "VPTEST" sz) (w2_ty sz sz) (b5_ty) [:: E 0; E 1] implicit_flags MSB_MERGE
-               (@x86_VPTEST sz) (check_vptest sz) 2 sz [::]
+               (@x86_VPTEST sz) (check_vptest sz) 2 [::]
                (pp_name "vptest" sz), ("VPTEST"%string, PrimP U128 VPTEST)).
 
 (* Monitoring instructions.
@@ -1667,7 +1661,6 @@ Definition Ox86_RDTSC_instr :=
               (Error ErrType) (* No semantics *)
               [:: [::]]
               0 (* nargs *)
-              sz (* size *)
               [::]
               (pp_name_ty "rdtsc" [:: sz; sz]) (* asm pretty-print*)
    ,("RDTSC"%string, PrimP U64 RDTSC) (* jasmin concrete syntax *)
@@ -1684,7 +1677,6 @@ Definition Ox86_RDTSCP_instr :=
               (Error ErrType) (* No semantics *)
               [:: [::]] (* arg checks *)
               0 (* nargs *)
-              sz (* size *)
               [::]
               (pp_name_ty "rdtscp" [:: sz; sz; sz]) (* asm pprinter *)
    ,("RDTSCP"%string, PrimP U64 RDTSCP) (* jasmin concrete syntax *)
@@ -1693,11 +1685,11 @@ Definition Ox86_RDTSCP_instr :=
 (* AES instructions *)
 Definition mk_instr_aes2 jname aname (constr:x86_op) x86_sem msb_flag :=
   mk_instr_pp jname (w2_ty U128 U128) (w_ty U128) [:: E 0; E 1] [:: E 0] msb_flag x86_sem
-         (check_xmm_xmmm U128) 2 U128 (PrimM constr) (pp_name_ty aname [::U128;U128]).
+         (check_xmm_xmmm U128) 2 (PrimM constr) (pp_name_ty aname [::U128;U128]).
 
 Definition mk_instr_aes3 jname aname (constr:x86_op) x86_sem msb_flag :=
   mk_instr_pp jname (w2_ty U128 U128) (w_ty U128) [:: E 1; E 2] [:: E 0] msb_flag x86_sem
-         (check_xmm_xmm_xmmm U128) 3 U128 (PrimM constr) (pp_name_ty aname [::U128;U128;U128]).
+         (check_xmm_xmm_xmmm U128) 3 (PrimM constr) (pp_name_ty aname [::U128;U128;U128]).
 
 Definition Ox86_AESDEC_instr := 
   mk_instr_aes2 "AESDEC" "aesdec" AESDEC x86_AESDEC MSB_MERGE.
@@ -1725,22 +1717,22 @@ Definition Ox86_VAESENCLAST_instr :=
 
 Definition Ox86_AESIMC_instr := 
   mk_instr_pp "AESIMC" (w_ty U128) (w_ty U128) [:: E 1] [:: E 0] MSB_MERGE x86_AESIMC
-         (check_xmm_xmmm U128) 2 U128 (PrimM AESIMC) (pp_name_ty "aesimc" [::U128;U128]).
+         (check_xmm_xmmm U128) 2 (PrimM AESIMC) (pp_name_ty "aesimc" [::U128;U128]).
 
 Definition Ox86_VAESIMC_instr := 
   mk_instr_pp "VAESIMC" (w_ty U128) (w_ty U128) [:: E 1] [:: E 0] MSB_CLEAR x86_AESIMC
-         (check_xmm_xmmm U128) 2 U128 (PrimM VAESIMC) (pp_name_ty "vaesimc" [::U128;U128]).
+         (check_xmm_xmmm U128) 2 (PrimM VAESIMC) (pp_name_ty "vaesimc" [::U128;U128]).
 
 Definition Ox86_AESKEYGENASSIST_instr := 
   mk_instr_pp "AESKEYGENASSIST" (w2_ty U128 U8) (w_ty U128) [:: E 1; E 2] [:: E 0] 
     MSB_MERGE x86_AESKEYGENASSIST
-   (check_xmm_xmmm_imm8 U128) 3 U128 (PrimM AESKEYGENASSIST) 
+   (check_xmm_xmmm_imm8 U128) 3 (PrimM AESKEYGENASSIST)
    (pp_name_ty "aeskeygenassist" [::U128;U128;U8]).
 
 Definition Ox86_VAESKEYGENASSIST_instr := 
   mk_instr_pp "VAESKEYGENASSIST" (w2_ty U128 U8) (w_ty U128) [:: E 1; E 2] [:: E 0] 
     MSB_CLEAR x86_AESKEYGENASSIST
-   (check_xmm_xmmm_imm8 U128) 3 U128 (PrimM VAESKEYGENASSIST) 
+   (check_xmm_xmmm_imm8 U128) 3 (PrimM VAESKEYGENASSIST)
    (pp_name_ty "vaeskeygenassist" [::U128;U128;U8]).
 
 Definition x86_instr_desc o : instr_desc_t :=

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -473,7 +473,7 @@ Section PROOF.
       sem_pexprs gd s a >>= exec_sopn o = ok [:: v' ]
     | LowerInc o a =>
       ∃ b1 b2 b3 b4, sem_pexprs gd s [:: a] >>= exec_sopn o = ok [:: Vbool b1; Vbool b2; Vbool b3; Vbool b4; v']
-    | LowerFopn o e' _ =>
+    | LowerFopn _ o e' _ =>
       let vi := var_info_of_lval l in
       let f  := Lnone vi sbool in
       Sv.Subset (read_es e') (read_e e) ∧
@@ -991,14 +991,14 @@ Section PROOF.
     by eexists.
   Qed.
 
-  Lemma opn_5flags_correct vi ii s a t o cf r xs ys m s' :
+  Lemma opn_5flags_correct vi ii s a t o cf r xs ys m sz s' :
     disj_fvars (read_es a) →
     disj_fvars (vars_lvals [:: cf ; r ]) →
     sem_pexprs gd s a = ok xs →
     exec_sopn o xs = ok ys →
     write_lvals gd s [:: Lnone_b vi ; cf ; Lnone_b vi ; Lnone_b vi ; Lnone_b vi ; r] ys = ok s' →
     ∃ s'',
-    sem p' ev s [seq MkI ii i | i <- opn_5flags fv m vi cf r t o a] s''
+    sem p' ev s [seq MkI ii i | i <- opn_5flags fv m sz vi cf r t o a] s''
     ∧ eq_exc_fresh s'' s'.
   Proof.
     move=> da dr hx hr hs; rewrite/opn_5flags.
@@ -1029,8 +1029,8 @@ Section PROOF.
       move: hr.
       apply opn_no_immP.
       - rewrite /exec_sopn /sopn_sem; case.
-        + by move => ws sz /=; case: eqP => /= ? ->.
-        by move => sz /= ->.
+        + by move => ws ? /=; case: eqP => /= ? ->.
+        by move => _ /= ->.
       by rewrite /exec_sopn => op _ ->.
 
     + exists s'. repeat econstructor. by rewrite /sem_sopn hx /= hr.
@@ -1174,7 +1174,7 @@ Section PROOF.
         rewrite -(zero_extend_wrepr sc hsz2) in Hw'.
         have [] := mulr_ok Hvo Hsc1 hle1 hsz2 _ Hw' Heq; first by rewrite hsz1.
         move=> hsub; t_xrbindP => vo vs hvs hvo hw.
-        case: (opn_5flags_correct ii tag (Some U32) _ _ hvs hvo hw).
+        case: (opn_5flags_correct ii tag (Some U32) sz _ _ hvs hvo hw).
         + apply: disjoint_w Hdisje .
           apply: SvP.MP.subset_trans hrl.
           apply: (SvP.MP.subset_trans hsub).
@@ -1223,8 +1223,8 @@ Section PROOF.
 
     (* LowerFopn *)
     + set vi := var_info_of_lval _.
-      move=> o a m [] LE. t_xrbindP => ys xs hxs hys hs2.
-      case: (opn_5flags_correct ii tag m _ _ hxs hys hs2).
+      move=> sz o a m [] LE. t_xrbindP => ys xs hxs hys hs2.
+      case: (opn_5flags_correct ii tag m sz _ _ hxs hys hs2).
       move: LE Hdisje. apply disjoint_w.
       exact Hdisjl.
       exact: (aux_eq_exc_trans Hs2').
@@ -1503,7 +1503,7 @@ Section PROOF.
       }
       clear C.
       case: D => des' [ xs' [ hxs' [ v' [hv' ho'] ] ] ].
-      case: (opn_5flags_correct ii t (Some U32) des' dxs hxs' hv' ho') => {hv' ho'} so'.
+      case: (opn_5flags_correct ii t (Some U32) sz des' dxs hxs' hv' ho') => {hv' ho'} so'.
       intuition eauto using eeq_excT.
     Qed.
     Opaque lower_addcarry.

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -838,7 +838,7 @@ Lemma sopn_tinP o vs vs' : exec_sopn o vs = ok vs' ->
   all2 subtype (sopn_tin o) (List.map type_of_val vs).
 Proof.
   rewrite /exec_sopn /sopn_tin /sopn_sem.
-  case (get_instr_desc o) => /= _ tin _ tout _ semi _ _ _.
+  case (get_instr_desc o) => /= _ tin _ tout _ semi _ _.
   t_xrbindP => p hp _.
   elim: tin vs semi hp => /= [ | t tin hrec] [ | v vs] // semi.
   by t_xrbindP => sv /= /of_val_subtype -> /hrec.

--- a/proofs/lang/sopn.v
+++ b/proofs/lang/sopn.v
@@ -31,13 +31,12 @@ Record instruction_desc := mkInstruction {
                 List.Forall2 value_uincl vs vs' ->
                 app_sopn_v semi vs = ok v ->
                 exists2 v', app_sopn_v semi vs' = ok v' & List.Forall2 value_uincl v v';
-  wsizei   : wsize;
   i_safe   : seq safe_cond;
 }.
 
 Arguments semu _ [vs vs' v] _ _.
 
-Notation mk_instr_desc str tin i_in tout i_out semi wsizei safe:=
+Notation mk_instr_desc str tin i_in tout i_out semi safe :=
   {| str      := str;
      tin      := tin;
      i_in     := i_in;
@@ -45,7 +44,6 @@ Notation mk_instr_desc str tin i_in tout i_out semi wsizei safe:=
      i_out    := i_out;
      semi     := semi;
      semu     := @vuincl_app_sopn_v tin tout semi refl_equal;
-     wsizei   := wsizei;
      i_safe   := safe;
   |}.
 
@@ -118,7 +116,6 @@ Definition Ocopy_instr ws p :=
      i_out    := [:: E 0];
      semi     := @WArray.copy ws p;
      semu     := @vuincl_copy ws p;
-     wsizei   := U8; (* ??? *)
      i_safe   := [:: AllInit ws p 0];
   |}.
 
@@ -127,7 +124,7 @@ Definition Onop_instr :=
            [::] [::]
            [::] [::]
            (ok tt)
-           U64 [::].
+           [::].
 
 Definition Omulu_instr sz :=
   mk_instr_desc (pp_sz "mulu" sz)
@@ -135,7 +132,7 @@ Definition Omulu_instr sz :=
            [:: E 0; E 1] (* this info is irrelevant *)
            [:: sword sz; sword sz]
            [:: E 2; E 3] (* this info is irrelevant *)
-           (fun x y => ok (@wumul sz x y)) sz [::].
+           (fun x y => ok (@wumul sz x y)) [::].
  
 Definition Oaddcarry_instr sz :=
   mk_instr_desc (pp_sz "adc" sz)
@@ -144,7 +141,7 @@ Definition Oaddcarry_instr sz :=
            [:: sbool; sword sz]
            [:: E 3; E 4]      (* this info is irrelevant *)
            (fun x y c => let p := @waddcarry sz x y c in ok (Some p.1, p.2))
-           sz [::].
+           [::].
 
 Definition Osubcarry_instr sz:= 
   mk_instr_desc (pp_sz "sbb" sz)
@@ -153,7 +150,7 @@ Definition Osubcarry_instr sz:=
            [:: sbool; sword sz]
            [:: E 3; E 4]      (* this info is irrelevant *)
            (fun x y c => let p := @wsubcarry sz x y c in ok (Some p.1, p.2))
-           sz [::].
+           [::].
 
 Definition get_instr_desc o :=
   match o with
@@ -170,7 +167,6 @@ Definition string_of_sopn o : string := str (get_instr_desc o) tt.
 Definition sopn_tin o : list stype := tin (get_instr_desc o).
 Definition sopn_tout o : list stype := tout (get_instr_desc o).
 Definition sopn_sem  o := semi (get_instr_desc o).
-Definition wsize_of_sopn o : wsize := wsizei (get_instr_desc o).
 
 Instance eqC_sopn : eqTypeC sopn :=
   { ceqP := sopn_eq_axiom }.


### PR DESCRIPTION
This field is generally meaningless. It is heuristically used in lowering on x86 to check whether an immediate value fits within the instruction or should go through an intermediate register.

I believe that the current design is bad and that the cleaning done in this commit is a necessary step towards a better design (that is yet to be discovered).