### PR TITLE
Add support for VPMUL instructions

### DIFF
--- a/compiler/tests/success/vector.jazz
+++ b/compiler/tests/success/vector.jazz
@@ -38,6 +38,27 @@ s = #VPADD_2u64(t, r);
 }
 
 export
+fn test_mul(reg u64 p) {
+reg u128 a, b, c;
+reg u256 x, y, z;
+
+a = (u128)[p + 0];
+b = (u128)[p + 16];
+
+c = #VPMUL(a, b);
+
+(u128)[p + 0] = c;
+
+x = (u256)[p + 0];
+y = (u256)[p + 32];
+
+z = #VPMUL_256(x, y);
+
+(u256)[p + 0] = z;
+
+}
+
+export
 fn test_mulu(reg u64 p) {
 reg u128 a, b, c;
 reg u256 x, y, z;

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -417,6 +417,20 @@ op VPMULHRS_16u16 (w1 w2: W256.t): W256.t =
 
 (* ------------------------------------------------------------------- *)
 (*
+| VPMUL    `(wsize)
+*)
+op mul64 (w1 w2 : W64.t) =
+  (W2u32.sigextu64 (W2u32.truncateu32 w1)) *
+  (W2u32.sigextu64 (W2u32.truncateu32 w2)).
+
+op VPMUL_128 (w1 w2: W128.t) =
+  map2 mul64 w1 w2.
+
+op VPMUL_256 (w1 w2: W256.t) =
+  map2 mul64 w1 w2.
+
+(* ------------------------------------------------------------------- *)
+(*
 | VPMULU   `(wsize)
 *)
 op mulu64 (w1 w2 : W64.t) =

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -100,6 +100,7 @@ Variant x86_op : Type :=
 | VPMULH   `(velem) `(wsize)   (* signed multiplication of 16-bits*)
 | VPMULHU  `(velem) `(wsize)
 | VPMULHRS of velem & wsize (* Packed Multiply High with Round and Scale *)
+| VPMUL    `(wsize)
 | VPMULU   `(wsize)
 | VPEXTR   `(wsize)
 | VPINSR   `(velem)
@@ -673,6 +674,8 @@ Definition x86_VPSUB (ve: velem) sz :=
 Definition x86_VPMULL (ve: velem) sz v1 v2 :=
   Let _ := check_size_16_32 ve in
   x86_u128_binop (lift2_vec ve *%R sz) v1 v2.
+
+Definition x86_VPMUL sz := x86_u128_binop (@wpmul sz).
 
 Definition x86_VPMULU sz := x86_u128_binop (@wpmulu sz).
 
@@ -1388,6 +1391,7 @@ Definition Ox86_VPADD_instr  := mk_ve_instr_w2_w_120 "VPADD"   x86_VPADD  check_
 Definition Ox86_VPSUB_instr  := mk_ve_instr_w2_w_120 "VPSUB"   x86_VPSUB  check_xmm_xmm_xmmm (PrimV VPSUB) (pp_viname "vpsub").
 
 Definition Ox86_VPMULL_instr := mk_ve_instr_w2_w_120 "VPMULL" x86_VPMULL check_xmm_xmm_xmmm (PrimV VPMULL) (pp_viname "vpmull").
+Definition Ox86_VPMUL_instr  := ((fun sz => mk_instr (pp_sz "VPMUL" sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] MSB_CLEAR (@x86_VPMUL sz) (check_xmm_xmm_xmmm sz) 3 sz [::] (pp_name "vpmuldq" sz)), ("VPMUL"%string, (PrimP U128 VPMUL))).
 Definition Ox86_VPMULU_instr := ((fun sz => mk_instr (pp_sz "VPMULU" sz) (w2_ty sz sz) (w_ty sz) [:: E 1 ; E 2] [:: E 0] MSB_CLEAR (@x86_VPMULU sz) (check_xmm_xmm_xmmm sz) 3 sz [::] (pp_name "vpmuludq" sz)), ("VPMULU"%string, (PrimP U128 VPMULU))).
 
 Definition Ox86_VPMULH_instr := mk_ve_instr_w2_w_120 "VPMULH" x86_VPMULH check_xmm_xmm_xmmm (PrimV VPMULH) (pp_viname "vpmulh").
@@ -1805,6 +1809,7 @@ Definition x86_instr_desc o : instr_desc_t :=
   | VPADD sz sz'       => Ox86_VPADD_instr.1 sz sz'
   | VPSUB sz sz'       => Ox86_VPSUB_instr.1 sz sz'
   | VPMULL sz sz'      => Ox86_VPMULL_instr.1 sz sz'
+  | VPMUL sz           => Ox86_VPMUL_instr.1 sz
   | VPMULU sz          => Ox86_VPMULU_instr.1 sz
   | VPMULH ve sz       => Ox86_VPMULH_instr.1 ve sz
   | VPMULHU ve sz      => Ox86_VPMULHU_instr.1 ve sz
@@ -1932,6 +1937,7 @@ Definition x86_prim_string :=
    Ox86_VPADD_instr.2;
    Ox86_VPSUB_instr.2;
    Ox86_VPMULL_instr.2;
+   Ox86_VPMUL_instr.2;
    Ox86_VPMULU_instr.2;
    Ox86_VPMULH_instr.2;
    Ox86_VPMULHU_instr.2;

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1096,6 +1096,12 @@ Definition pextr sz (w1 w2: word sz) :=
 Definition halve_list A : seq A → seq A :=
   fix loop m := if m is a :: _ :: m' then a :: loop m' else m.
 
+Definition wpmul sz (x y: word sz) : word sz :=
+  let xs := halve_list (split_vec U32 x) in
+  let ys := halve_list (split_vec U32 y) in
+  let f (a b: u32) : u64 := wrepr U64 (wsigned a * wsigned b) in
+  make_vec sz (map2 f xs ys).
+
 Definition wpmulu sz (x y: word sz) : word sz :=
   let xs := halve_list (split_vec U32 x) in
   let ys := halve_list (split_vec U32 y) in


### PR DESCRIPTION
This commit adds support for the (signed) (V)PMULDQ instruction under the name #VPMUL.

All support was based on the support for the (unsigned) VPMULUDQ instructions, so I conveniently based all the new code on that code.

Reviewing suggestions:
  * check if the semantics in `word.v` are correct;
  * check if I did not forget to add anything

---

Cc @vbgl
Fixes #274