### PR TITLE
Add ADC instruction for ARM-M4

### DIFF
--- a/compiler/examples/arm_m4/adc.jazz
+++ b/compiler/examples/arm_m4/adc.jazz
@@ -1,0 +1,35 @@
+export
+fn adc(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x;
+    reg bool c;
+
+    x = arg1;
+
+    _, x = arg0 + x;
+    c, x = arg0 + x;
+
+    _, x = x + 12;
+    c, x = x + 98;
+
+    c, x = arg0 + x + c;
+    _, x = arg0 + x + c;
+
+    c, x = arg0 + x + false;
+    _, x = arg0 + x + false;
+
+    _, x += arg0;
+    c, x += arg0;
+
+    _, x += 12;
+    c, x += 98;
+
+    c, x += arg0 + c;
+    _, x += arg0 + c;
+
+    c, x += arg0 + false;
+    _, x += arg0 + false;
+
+    reg u32 res;
+    res = x;
+    return res;
+}

--- a/compiler/examples/arm_m4/gimli.jazz
+++ b/compiler/examples/arm_m4/gimli.jazz
@@ -6,7 +6,7 @@ param int ROUND_CONSTANT_LOW = 0x7900;
 
 inline
 fn rotate (reg u32 x, inline int bits) -> reg u32 {
-    x = #ror(x, bits);
+    x = #ROR(x, bits);
     return x;
 }
 
@@ -28,7 +28,7 @@ fn gimli (reg u32 state) {
     reg u32 rc;
 
     rc = ROUND_CONSTANT_LOW;
-    rc = #movt(rc, ROUND_CONSTANT_HIGH);
+    rc = #MOVT(rc, ROUND_CONSTANT_HIGH);
 
     for round = N_ROUND downto 0 {
     for column = 0 to N_COLUMN {

--- a/compiler/examples/arm_m4/intrinsic_adc.jazz
+++ b/compiler/examples/arm_m4/intrinsic_adc.jazz
@@ -1,0 +1,61 @@
+export
+fn adc(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x;
+    reg bool c;
+
+    _, _, c, _, _ = #MOVS(arg0);
+
+    x = #ADC(arg0, arg1, c);
+
+    // Immediates.
+    x = #ADC(x, 1, c);
+    x = #ADC(x, -1, c);
+
+    // Shifts.
+    x = #ADC(x, arg0, c, #LSL(0));
+    x = #ADC(x, arg0, c, #LSL(31));
+    x = #ADC(x, arg0, c, #LSR(1));
+    x = #ADC(x, arg0, c, #LSR(32));
+    x = #ADC(x, arg0, c, #ASR(1));
+    x = #ADC(x, arg0, c, #ASR(32));
+    x = #ADC(x, arg0, c, #ROR(1));
+    x = #ADC(x, arg0, c, #ROR(31));
+    // x = #ADC(x, arg0, #RRX(1));
+
+    // Set flags.
+    reg bool n, z, v;
+    n, z, c, v, x = #ADCS(x, arg0, c);
+    n, z, c, v, x = #ADCS(x, 1, c);
+    n, z, c, v, x = #ADCS(x, arg0, c, #LSL(3));
+
+    // Conditions.
+    x = #ADCcc(x, arg0, c, z, x);            // EQ
+    x = #ADCcc(x, arg0, c, !z, x);           // NE
+    x = #ADCcc(x, arg0, c, c, x);            // CS
+    x = #ADCcc(x, arg0, c, !c, x);           // CC
+    x = #ADCcc(x, arg0, c, n, x);            // MI
+    x = #ADCcc(x, arg0, c, !n, x);           // PL
+    x = #ADCcc(x, arg0, c, v, x);            // VS
+    x = #ADCcc(x, arg0, c, !v, x);           // VC
+    x = #ADCcc(x, arg0, c, c && !z, x);      // HI
+    x = #ADCcc(x, arg0, c, !c || z, x);      // LS
+    x = #ADCcc(x, arg0, c, n == v, x);       // GE
+    x = #ADCcc(x, arg0, c, n != v, x);       // LT
+    x = #ADCcc(x, arg0, c, !z && n == v, x); // GT
+    x = #ADCcc(x, arg0, c, z || n != v, x);  // LE
+
+    x = #ADCcc(x, 1, c, !!!!z, x);
+    n, z, c, v, x = #ADCScc(x, arg0, c, n == v, n, z, c, v, x);
+    n, z, c, v, x = #ADCScc(x, 2, c, !c || z, n, z, c, v, x);
+    x = #ADCcc(x, arg0, c, #LSL(3), z, x);
+    n, z, c, v, x = #ADCScc(x, arg0, c, #LSL(3), z, n, z, c, v, x);
+
+    reg bool zf, cf;
+    ?{CF = c}, x = #ADCS(x, arg0, c);
+    ?{CF = c, ZF = zf}, x = #ADCS(x, arg0, c);
+    ?{cf}, x = #ADCS(x, arg0, c);
+
+    reg u32 res;
+    res = x;
+    return res;
+}

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -128,6 +128,7 @@ let pp_shift (ARM_op (_, opts)) args =
 
 let pp_mnemonic_ext (ARM_op (mn, opts)) args =
   let mn = Conv.string_of_string0 (string_of_arm_mnemonic mn) in
+  let mn = String.lowercase_ascii mn in
   Printf.sprintf "%s%s%s" mn (pp_set_flags opts) (pp_conditional args)
 
 let pp_syscall (o : _ Syscall_t.syscall_t) =

--- a/compiler/src/tt_arm_m4.ml
+++ b/compiler/src/tt_arm_m4.ml
@@ -7,7 +7,7 @@ module S = Syntax
 (* ARM parsing. *)
 
 let get_set_flags s =
-  if String.ends_with s "s" then (true, String.drop_end 1 s) else (false, s)
+  if String.ends_with s "S" then (true, String.drop_end 1 s) else (false, s)
 
 let get_is_conditional s =
   if String.ends_with s "cc" then (true, String.drop_end 2 s) else (false, s)
@@ -32,7 +32,6 @@ let get_has_shift args =
   | Some (i, (sk, sham)) -> (Some sk, List.modify_at i (fun _ -> sham) args)
 
 let get_arm_prim s =
-  let s = String.lowercase_ascii s in
   let is_conditional, s = get_is_conditional s in
   let set_flags, s = get_set_flags s in
   (s, set_flags, is_conditional)
@@ -42,4 +41,6 @@ let tt_prim ps s args =
   let has_shift, args = get_has_shift args in
   match List.assoc_opt name ps with
   | Some (Sopn.PrimARM pr) -> Some (pr set_flags is_conditional has_shift, args)
+  (* The following is for [copy], [mulu], [adc], and [sbb]. *)
+  | Some (Sopn.PrimP (ws, pr)) -> Some ((pr None ws), args)
   | _ -> None

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -1346,27 +1346,6 @@ Section PROOF.
     by eexists _, w1, _, wx'.
   Qed.
 
-  Lemma unsigned_overflow sz (z: Z):
-    (0 <= z)%Z ->
-    (wunsigned (wrepr sz z) != z) = (wbase sz <=? z)%Z.
-  Proof.
-    move => hz.
-    rewrite wunsigned_repr; apply/idP/idP.
-    * apply: contraR => /negbTE /Z.leb_gt lt; apply/eqP.
-        by rewrite Z.mod_small //; lia.
-    * apply: contraL => /eqP <-; apply/negbT/Z.leb_gt.
-      by case: (Z_mod_lt z (wbase sz)).
-  Qed.
-
-  Lemma add_overflow sz (w1 w2: word sz) :
-    (wbase sz <=? wunsigned w1 + wunsigned w2)%Z =
-    (wunsigned (w1 + w2) != (wunsigned w1 + wunsigned w2)%Z).
-  Proof.
-    rewrite unsigned_overflow //; rewrite -!/(wunsigned _).
-    have := wunsigned_range w1; have := wunsigned_range w2.
-    lia.
-  Qed.
-
   Lemma add_carry_overflow sz (w1 w2: word sz) (b: bool) :
     (wbase sz <=? wunsigned w1 + wunsigned w2 + Z.b2z b)%Z =
     (wunsigned (add_carry sz (wunsigned w1) (wunsigned w2) (Z.b2z b)) != (wunsigned w1 + wunsigned w2 + Z.b2z b))%Z.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -101,6 +101,10 @@ Lemma wsize8 : wsize_size U8 = 1%Z. done. Qed.
 Definition wbase (s: wsize) : Z :=
   modulus (wsize_size_minus_1 s).+1.
 
+Lemma wbase_pos ws :
+  (wbase ws > 0)%Z.
+Proof. by case: ws. Qed.
+
 Lemma le0_wsize_size ws : 0 <= wsize_size ws.
 Proof. rewrite /wsize_size; lia. Qed.
 Arguments le0_wsize_size {ws}.
@@ -221,6 +225,10 @@ Proof. by move => e; apply/val_eqP/eqP. Qed.
 
 Lemma wunsigned_inj sz : injective (@wunsigned sz).
 Proof. by move => x y /eqP /val_eqP. Qed.
+
+Lemma wunsigned1 ws :
+  @wunsigned ws 1 = 1%Z.
+Proof. by case: ws. Qed.
 
 Lemma wrepr_unsigned s (w: word s) : wrepr s (wunsigned w) = w.
 Proof. by rewrite /wrepr /wunsigned ureprK. Qed.
@@ -1747,4 +1755,25 @@ Lemma wltsE ws (x y : word ws) :
 Proof.
   case: (x =P y); last by apply wltsE_aux.
   by move=> <-; rewrite /= ltxx GRing.subrr Z.sub_diag wsigned0 msb0.
+Qed.
+
+Lemma unsigned_overflow sz (z: Z):
+  (0 <= z)%Z ->
+  (wunsigned (wrepr sz z) != z) = (wbase sz <=? z)%Z.
+Proof.
+  move => hz.
+  rewrite wunsigned_repr; apply/idP/idP.
+  * apply: contraR => /negbTE /Z.leb_gt lt; apply/eqP.
+      by rewrite Z.mod_small //; lia.
+  * apply: contraL => /eqP <-; apply/negbT/Z.leb_gt.
+    by case: (Z_mod_lt z (wbase sz)).
+Qed.
+
+Lemma add_overflow sz (w1 w2: word sz) :
+  (wbase sz <=? wunsigned w1 + wunsigned w2)%Z =
+  (wunsigned (w1 + w2) != (wunsigned w1 + wunsigned w2)%Z).
+Proof.
+  rewrite unsigned_overflow //; rewrite -!/(wunsigned _).
+  have := wunsigned_range w1; have := wunsigned_range w2.
+  lia.
 Qed.


### PR DESCRIPTION
Now ARM is case sensitive to avoid `adc` and `ADC` clash.