### PR TITLE
arm: immediate arguments are non-negative

### DIFF
--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -26,14 +26,8 @@ let z_of_int32 z  = z_of_cz (Word0.wsigned W.U32 z)
 let z_of_int16 z  = z_of_cz (Word0.wsigned W.U16 z)
 let z_of_int8 z  = z_of_cz (Word0.wsigned W.U8 z)
 
-let z_of_word sz z = 
-  match sz with
-  | W.U8 -> z_of_int8 z 
-  | W.U16 -> z_of_int16 z
-  | W.U32 -> z_of_int32 z
-  | W.U64 -> z_of_int64 z
-  | W.U128 -> z_of_int128 z
-  | W.U256 -> z_of_int256 z
+let z_of_word sz z = z_of_cz (Word0.wsigned sz z)
+let z_unsigned_of_word sz z = z_of_cz (Word0.wunsigned sz z)
 (* ------------------------------------------------------------------------ *)
 
 let string0_of_string s =

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -30,6 +30,7 @@ val z_of_int32 : Obj.t -> Z.t
 val z_of_int16 : Obj.t -> Z.t
 val z_of_int8 : Obj.t -> Z.t
 val z_of_word : wsize -> Obj.t -> Z.t
+val z_unsigned_of_word : wsize -> Obj.t -> Z.t
 
 (* -------------------------------------------------------------------- *)
 val cty_of_ty : Prog.ty -> Type.stype

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -96,7 +96,7 @@ let pp_address addr =
 let pp_asm_arg arg =
   match arg with
   | Condt _ -> None
-  | Imm (ws, w) -> Some (pp_imm (Conv.z_of_word ws w))
+  | Imm (ws, w) -> Some (pp_imm (Conv.z_unsigned_of_word ws w))
   | Reg r -> Some (pp_register r)
   | Regx r -> Some (pp_register_ext r)
   | Addr addr -> Some (pp_address addr)

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -1,3 +1,9 @@
+(* Assembly printer for ARM Cortex M4 (ARMv7-M).
+
+We always use the Unified Assembly Language (UAL).
+Immediate values (denoted <imm>) are always nonnegative integers.
+*)
+
 open Arch_decl
 open Utils
 open Arm_decl
@@ -7,11 +13,12 @@ let arch = arm_decl
 
 let imm_pre = "#"
 
-(* Possible memory accesses in ARMv7-M are:
+(* We support the following ARMv7-M memory accesses.
    Offset addressing:
-     - A base register and an immediate offset (displacement): [<reg>, #<imm>]
-     - A base register and a register offset: [<reg>, <reg>]
-     - A base register and a scaled register offset: [<reg>, <reg>, LSL #<imm>]
+     - A base register and an immediate offset (displacement):
+       [<reg>, #+/-<imm>] (where + can be omitted).
+     - A base register and a register offset: [<reg>, <reg>].
+     - A base register and a scaled register offset: [<reg>, <reg>, LSL #<imm>].
 *)
 let pp_reg_address_aux base disp off scal =
   match (disp, off, scal) with

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -47,11 +47,11 @@ Definition arm_saparams : stack_alloc_params :=
 Definition arm_allocate_stack_frame (rspi : var_i) (sz : Z) :=
   let rspg := Gvar rspi Slocal in
   let esz := Papp1 (Oword_of_int reg_size) (Pconst sz) in
-  ([:: Lvar rspi ], Oarm (ARM_op ADD default_opts), [:: Pvar rspg; esz ]).
+  ([:: Lvar rspi ], Oarm (ARM_op SUB default_opts), [:: Pvar rspg; esz ]).
 
 Definition arm_free_stack_frame (rspi : var_i) (sz : Z) :=
   let rspg := Gvar rspi Slocal in
-  let esz := Papp1 (Oword_of_int reg_size) (Pconst (-sz)) in
+  let esz := Papp1 (Oword_of_int reg_size) (Pconst sz) in
   ([:: Lvar rspi ], Oarm (ARM_op ADD default_opts), [:: Pvar rspg; esz ]).
 
 Definition arm_ensure_rsp_alignment (rspi : var_i) (al : wsize) :=

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -141,24 +141,6 @@ Let vm := evm s.
 Lemma arm_spec_lip_allocate_stack_frame ts sz :
   let args := lip_allocate_stack_frame arm_liparams vrspi sz in
   let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
-  let ts' := pword_of_word (ts + wrepr Uptr sz) in
-  let s' := with_vm s (vm.[vrsp <- ok ts'])%vmap in
-  (vm.[vrsp])%vmap = ok (pword_of_word ts)
-  -> eval_instr lp i (of_estate s fn pc)
-     = ok (of_estate s' fn pc.+1).
-Proof.
-  move=> /= hvm.
-  rewrite /eval_instr /=.
-  rewrite /sem_sopn /=.
-  rewrite /get_gvar /get_var /on_vu /=.
-  rewrite hvm /=.
-  rewrite pword_of_wordE.
-  by rewrite zero_extend_u zero_extend_wrepr.
-Qed.
-
-Lemma arm_spec_lip_free_stack_frame ts sz :
-  let args := lip_free_stack_frame arm_liparams vrspi sz in
-  let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
   let ts' := pword_of_word (ts - wrepr Uptr sz) in
   let s' := with_vm s (vm.[vrsp <- ok ts'])%vmap in
   (vm.[vrsp])%vmap = ok (pword_of_word ts)
@@ -171,7 +153,25 @@ Proof.
   rewrite /get_gvar /get_var /on_vu /=.
   rewrite hvm /=.
   rewrite pword_of_wordE.
-  rewrite wrepr_opp.
+  rewrite wsub_wnot1.
+  by rewrite zero_extend_u zero_extend_wrepr.
+Qed.
+
+Lemma arm_spec_lip_free_stack_frame ts sz :
+  let args := lip_free_stack_frame arm_liparams vrspi sz in
+  let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
+  let ts' := pword_of_word (ts + wrepr Uptr sz) in
+  let s' := with_vm s (vm.[vrsp <- ok ts'])%vmap in
+  (vm.[vrsp])%vmap = ok (pword_of_word ts)
+  -> eval_instr lp i (of_estate s fn pc)
+     = ok (of_estate s' fn pc.+1).
+Proof.
+  move=> /= hvm.
+  rewrite /eval_instr /=.
+  rewrite /sem_sopn /=.
+  rewrite /get_gvar /get_var /on_vu /=.
+  rewrite hvm /=.
+  rewrite pword_of_wordE.
   by rewrite zero_extend_u zero_extend_wrepr.
 Qed.
 

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -65,7 +65,7 @@ Record linearization_params {asm_op : Type} {asmop : asmOp asm_op} :=
        The linear instruction [lip_allocate_stack_frame rspi sz] increases the
        stack pointer [sz] bytes.
        In symbols, it corresponds to:
-               R[rsp] := R[rsp] + sz
+               R[rsp] := R[rsp] − sz
      *)
     lip_allocate_stack_frame :
       var_i    (* Variable with stack pointer register. *)
@@ -391,8 +391,8 @@ Definition allocate_stack_frame (free: bool) (ii: instr_info) (sz: Z) : lcmd :=
   if sz == 0%Z
   then [::]
   else let args := if free
-                   then (lip_allocate_stack_frame liparams) rspi sz
-                   else (lip_free_stack_frame liparams) rspi sz
+                   then (lip_free_stack_frame liparams) rspi sz
+                   else (lip_allocate_stack_frame liparams) rspi sz
        in [:: MkLI ii (Lopn args.1.1 args.1.2 args.2) ].
 
 Definition ensure_rsp_alignment ii (al: wsize) : linstr :=

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -350,7 +350,7 @@ Record h_linearization_params :=
         let vm := evm s in
         let args := lip_allocate_stack_frame liparams (VarI rsp dummy_var_info) sz in
         let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
-        let ts' := pword_of_word (ts + wrepr Uptr sz) in
+        let ts' := pword_of_word (ts - wrepr Uptr sz) in
         let s' := with_vm s (vm.[rsp <- ok ts'])%vmap in
         (vm.[rsp])%vmap = ok (pword_of_word ts)
         -> eval_instr lp i (of_estate s fn pc)
@@ -362,7 +362,7 @@ Record h_linearization_params :=
         let vm := evm s in
         let args := lip_free_stack_frame liparams (VarI rsp dummy_var_info) sz in
         let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
-        let ts' := pword_of_word (ts - wrepr Uptr sz) in
+        let ts' := pword_of_word (ts + wrepr Uptr sz) in
         let s' := with_vm s (vm.[rsp <- ok ts'])%vmap in
         (vm.[rsp])%vmap = ok (pword_of_word ts)
         -> eval_instr lp i (of_estate s fn pc)
@@ -2158,7 +2158,7 @@ Section PROOF.
       + apply: lsem_step; last apply: lsem_step; last apply: lsem_step; last apply: lsem_step_end.
         * rewrite /lsem1 /step -(addn0 (size P)) (find_instr_skip C) addn0 /=.
           apply
-            (spec_lip_free_stack_frame
+            (spec_lip_allocate_stack_frame
                hliparams
                p'
                (s := {| emem := _; evm := _; |})).
@@ -2180,7 +2180,7 @@ Section PROOF.
         rewrite pword_of_wordE in Hvm'.
 
         rewrite
-          (@spec_lip_allocate_stack_frame
+          (@spec_lip_free_stack_frame
              _
              hliparams
              _
@@ -2305,7 +2305,7 @@ Section PROOF.
           ({| escs:= escs s1; emem := m1; evm := vm2; |}.[vrsp])%vmap
           = ok (pword_of_word (@top_stack _ mem _ _ s1)).
         - by rewrite vm2_rsp pword_of_wordE.
-        rewrite (spec_lip_free_stack_frame hliparams _ _ _ _ _ Hvm2).
+        rewrite (spec_lip_allocate_stack_frame hliparams _ _ _ _ _ Hvm2).
         rewrite /of_estate -addn1 -addnA add0n.
         reflexivity.
       + rewrite /lsem1 /step (find_instr_skip C) /=.
@@ -2371,7 +2371,7 @@ Section PROOF.
           subst.
         by rewrite pword_of_wordE.
 
-      rewrite (spec_lip_allocate_stack_frame hliparams _ _ _ _ _ Hvm2) /=.
+      rewrite (spec_lip_free_stack_frame hliparams _ _ _ _ _ Hvm2) /=.
       rewrite /= /of_estate /with_vm /=.
       by rewrite -addn1 -addnA.
     - move => x x_out.
@@ -2832,7 +2832,7 @@ Section PROOF.
               subst.
               by rewrite pword_of_wordE.
 
-            rewrite (@spec_lip_free_stack_frame
+            rewrite (@spec_lip_allocate_stack_frame
                        _
                        hliparams
                        _
@@ -3381,7 +3381,7 @@ Section PROOF.
           * rewrite /lsem1 /step.
             move: ok_body.
             rewrite /P -cat1s -catA -(addn0 1) => /find_instr_skip -> /=.
-            apply: (spec_lip_free_stack_frame hliparams p').
+            apply: (spec_lip_allocate_stack_frame hliparams p').
             rewrite Fv.setP_neq; last by move /negbT: (not_magic_neq_rsp var_tmp_not_magic).
             move: ok_rsp; rewrite /get_var.
             apply: on_vuP => //= -[???] ->.

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -68,12 +68,12 @@ Definition x86_saparams is_regx : stack_alloc_params :=
 
 Definition x86_allocate_stack_frame (rspi: var_i) (sz: Z) :=
   let rspg := Gvar rspi Slocal in
-  let p := Papp2 (Oadd (Op_w Uptr)) (Pvar rspg) (cast_const sz) in
+  let p := Papp2 (Osub (Op_w Uptr)) (Pvar rspg) (cast_const sz) in
   ([:: Lvar rspi ], Ox86 (LEA Uptr), [:: p ]).
 
 Definition x86_free_stack_frame (rspi: var_i) (sz: Z) :=
   let rspg := Gvar rspi Slocal in
-  let p := Papp2 (Osub (Op_w Uptr)) (Pvar rspg) (cast_const sz) in
+  let p := Papp2 (Oadd (Op_w Uptr)) (Pvar rspg) (cast_const sz) in
   ([:: Lvar rspi ], Ox86 (LEA Uptr), [:: p ]).
 
 Definition x86_ensure_rsp_alignment (rspi: var_i) (al: wsize) :=

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -137,7 +137,7 @@ Let vm := evm s.
 Definition x86_spec_lip_allocate_stack_frame ts sz :
   let args := lip_allocate_stack_frame x86_liparams vrspi sz in
   let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
-  let ts' := pword_of_word (ts + wrepr Uptr sz) in
+  let ts' := pword_of_word (ts - wrepr Uptr sz) in
   let s' := with_vm s (vm.[vrsp <- ok ts'])%vmap in
   (vm.[vrsp])%vmap = ok (pword_of_word ts)
   -> eval_instr lp i (of_estate s fn pc)
@@ -154,7 +154,7 @@ Qed.
 Definition x86_spec_lip_free_stack_frame ts sz :
   let args := lip_free_stack_frame x86_liparams vrspi sz in
   let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
-  let ts' := pword_of_word (ts - wrepr Uptr sz) in
+  let ts' := pword_of_word (ts + wrepr Uptr sz) in
   let s' := with_vm s (vm.[vrsp <- ok ts'])%vmap in
   (vm.[vrsp])%vmap = ok (pword_of_word ts)
   -> eval_instr lp i (of_estate s fn pc)


### PR DESCRIPTION
This fixes some examples using `movt`.

This also corrects a terminology confusion between alloc and free…