### PR TITLE
Add ROL and ROR operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   `VPAVG`
   ([PR #285](https://github.com/jasmin-lang/jasmin/pull/285)).
 
+- Add bit rotation operators for expressions: `<<r` and `>>r`
+  ([PR #290](https://github.com/jasmin-lang/jasmin/pull/290)).
+  These get extracted to `|<<|` and `|>>|` in EasyCrypt.
+
 ## Other changes
 
 - Explicit if-then-else in flag combinations is no longer supported

--- a/compiler/examples/arm_m4/intrinsic_ror.jazz
+++ b/compiler/examples/arm_m4/intrinsic_ror.jazz
@@ -5,7 +5,8 @@ fn add(reg u32 arg0, reg u32 arg1) -> reg u32 {
 
     // Immediates.
     x = #ROR(x, 1);
-    x = #ROR(x, 3);
+    x = #ROR(x, 4);
+    x = #ROR(x, 31);
 
     // Set flags.
     reg bool n, z, c, v;

--- a/compiler/examples/arm_m4/ror.jazz
+++ b/compiler/examples/arm_m4/ror.jazz
@@ -1,0 +1,36 @@
+export
+fn ror(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x;
+    x = arg0 >>r arg1;
+
+    // Immediates.
+    x = x >>r 1;
+    x = x >>r 4;
+    x = x >>r 31;
+
+    // Set flags.
+    reg bool n, z, c, v;
+    n, z, c, v, _ = #MOVS(x);
+
+    // Conditions.
+    x = x >>r arg0 if z;            // EQ
+    x = x >>r arg0 if !z;           // NE
+    x = x >>r arg0 if c;            // CS
+    x = x >>r arg0 if !c;           // CC
+    x = x >>r arg0 if n;            // MI
+    x = x >>r arg0 if !n;           // PL
+    x = x >>r arg0 if v;            // VS
+    x = x >>r arg0 if !v;           // VC
+    x = x >>r arg0 if c && !z;      // HI
+    x = x >>r arg0 if !c || z;      // LS
+    x = x >>r arg0 if n == v;       // GE
+    x = x >>r arg0 if n != v;       // LT
+    x = x >>r arg0 if !z && n == v; // GT
+    x = x >>r arg0 if z || n != v;  // LE
+
+    x = x >>r 1 if !!!!z;
+
+    reg u32 res;
+    res = x;
+    return res;
+}

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -55,6 +55,8 @@ let pp_op2 fmt =
   | `BXOr s -> f s "\\textasciicircum{}"
   | `ShR s -> f s ">{}>"
   | `ShL s -> f s "<{}<"
+  | `ROR s -> f s ">{}>r"
+  | `ROL s -> f s "<{}<r"
   | `Eq s -> f s "=="
   | `Neq s -> f s "!="
   | `Lt s -> f s "<"
@@ -95,7 +97,7 @@ let prio_of_op2 =
   | `BAnd _ -> Pbwand
   | `BOr _ -> Pbwor
   | `BXOr _ -> Pbwxor
-  | `ShR _ | `ShL _ -> Pshift
+  | `ShR _  | `ShL _ | `ROR _ | `ROL _ -> Pshift
   | `Eq _ | `Neq _ -> Pcmpeq
   | `Lt _ | `Le _ | `Gt _ | `Ge _
     -> Pcmp

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -152,6 +152,8 @@ rule main = parse
   | "?"     { QUESTIONMARK  }
   | ":"     { COLON  }
 
+  | ">>r"                   { ROR              }
+  | "<<r"                   { ROL              }
   | "<<"                    { LTLT            }
   | "<=" (signletter as s)? { LE   (mk_sign s) }
   | "<"  (signletter as s)? { LT   (mk_sign s) }

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -65,6 +65,8 @@
 %token REG
 %token REQUIRE
 %token RETURN
+%token ROR
+%token ROL
 %token SEMICOLON
 %token <Syntax.swsize>SWSIZE
 %token <Syntax.svsize> SVSIZE
@@ -88,7 +90,7 @@
 %left PIPE
 %left HAT
 %left AMP
-%left LTLT GTGT
+%left LTLT GTGT ROR ROL
 %left PLUS MINUS
 %left STAR SLASH PERCENT
 %nonassoc BANG 
@@ -211,6 +213,8 @@ cast:
 | HAT         c=castop { `BXOr c}
 | LTLT        c=castop { `ShL  c} 
 | s=loc(GTGT) c=castop { `ShR (setsign c s)}
+| ROR         c=castop { `ROR  c}
+| ROL         c=castop { `ROL  c}
 | EQEQ        c=castop { `Eq   c}
 | BANGEQ      c=castop { `Neq  c}
 | s=loc(LT)   c=castop { `Lt  (setsign c s)}
@@ -294,6 +298,8 @@ peqop:
 | STAR  c=castop EQ  { `Mul  c }
 | s=loc(GTGT)  c=castop EQ  { `ShR  (setsign c s) }
 | LTLT  c=castop EQ  { `ShL  c }
+| ROR   c=castop EQ  { `ROR  c }
+| ROL   c=castop EQ  { `ROL  c }
 | AMP   c=castop EQ  { `BAnd c }
 | HAT   c=castop EQ  { `BXOr c }
 | PIPE  c=castop EQ  { `BOr  c }

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -83,6 +83,8 @@ let string_of_op2 = function
   | E.Olsr _ -> ">>"
   | E.Olsl _ -> "<<"
   | E.Oasr _ -> ">>s"
+  | E.Oror _ -> ">>r"
+  | E.Orol _ -> "<<r"
 
   | E.Oeq  k -> "==" ^ string_of_op_kind k
   | E.Oneq k -> "!=" ^ string_of_op_kind k

--- a/compiler/src/safety/safetyAbsExpr.ml
+++ b/compiler/src/safety/safetyAbsExpr.ml
@@ -78,12 +78,19 @@ let op1_to_abs_unop op1 = match op1 with
   | E.Oword_of_int _ | E.Oint_of_word _ | E.Ozeroext _ -> assert false
   | _ -> None
 
+type shift_kind =
+  | Unsigned_left
+  | Unsigned_right
+  | Signed_right
+  | Rotation_right
+  | Rotation_left
+
 type word_op =
   | Wand                        (* supported only for padding with 2^n - 1 *)
   | Wor                         (* currently not-supported *)
   | Wxor                        (* currently not-supported *)
     
-  | Wshift of [`Unsigned_left | `Unsigned_right | `Signed_right ]
+  | Wshift of shift_kind
   (* Remarks: 
      - signed left is a synonymous for unsigned left.
      - currently, shift-right is not supported. *)
@@ -106,9 +113,11 @@ let op2_to_abs_binop op2 = match op2 with
   | E.Odiv (Cmp_w (Signed, _)) -> AB_Unknown
   | E.Odiv _ -> AB_Arith Texpr1.Div
 
-  | E.Olsr _ -> AB_Wop (Wshift `Unsigned_right)
-  | E.Olsl _ -> AB_Wop (Wshift `Unsigned_left)
-  | E.Oasr _ -> AB_Wop (Wshift `Signed_right)
+  | E.Olsr _ -> AB_Wop (Wshift Unsigned_right)
+  | E.Olsl _ -> AB_Wop (Wshift Unsigned_left)
+  | E.Oasr _ -> AB_Wop (Wshift Signed_right)
+  | E.Oror _ -> AB_Wop (Wshift Rotation_right)
+  | E.Orol _ -> AB_Wop (Wshift Rotation_left)
       
   | E.Obeq | E.Oand | E.Oor                   (* boolean connectives *)
   | E.Oeq _ | E.Oneq _ | E.Olt _ | E.Ole _ | E.Ogt _ | E.Oge _ -> AB_Unknown
@@ -526,7 +535,9 @@ module AbsExpr (AbsDom : AbsNumBoolType) = struct
             else wrap_lin_expr Unsigned ws_out lin
           else lin
 
-        | AB_Wop (Wshift `Signed_right)
+        | AB_Wop (Wshift Signed_right)
+        | AB_Wop (Wshift Rotation_left)
+        | AB_Wop (Wshift Rotation_right)
         | AB_Arith Texpr1.Div
         | AB_Arith Texpr1.Pow
         | AB_Unknown ->
@@ -537,8 +548,8 @@ module AbsExpr (AbsDom : AbsNumBoolType) = struct
             match aeval_cst_w_i abs e2 with
             | Some i when i <= int_of_ws ws_e ->
               let absop = match stype with
-                | `Unsigned_right -> Texpr1.Div
-                | `Unsigned_left -> Texpr1.Mul
+                | Unsigned_right -> Texpr1.Div
+                | Unsigned_left -> Texpr1.Mul
                 | _ -> assert false in
               let lin = Mtexpr.(binop absop
                                   (linearize_wexpr abs e1)
@@ -668,6 +679,7 @@ module AbsExpr (AbsDom : AbsNumBoolType) = struct
     match op2 with
     | E.Obeq | E.Oand | E.Oor | E.Oadd _ | E.Omul _ | E.Osub _
     | E.Odiv _ | E.Omod _ | E.Oland _ | E.Olor _
+    | E.Oror _ | E.Orol _
     | E.Olxor _ | E.Olsr _ | E.Olsl _ | E.Oasr _ -> assert false
 
     | E.Oeq k -> (Tcons1.EQ, to_cmp_kind k)
@@ -719,6 +731,7 @@ module AbsExpr (AbsDom : AbsNumBoolType) = struct
     | Papp2 (op2, e1, e2) -> begin match op2 with
         | E.Oadd _ | E.Omul _ | E.Osub _
         | E.Odiv _ | E.Omod _ | E.Oland _ | E.Olor _
+        | E.Oror _ | E.Orol _
         | E.Olxor _ | E.Olsr _ | E.Olsl _ | E.Oasr _ -> assert false
 
         | Ovadd (_, _) | Ovsub (_, _) | Ovmul (_, _)

--- a/compiler/src/safety/safetyInterpreter.ml
+++ b/compiler/src/safety/safetyInterpreter.ml
@@ -234,6 +234,7 @@ let safe_op2 e2 = function
   | E.Obeq | E.Oand | E.Oor | E.Oadd _ | E.Omul _ | E.Osub _
   | E.Oland _ | E.Olor _ | E.Olxor _
   | E.Olsr _ | E.Olsl _ | E.Oasr _
+  | E.Oror _ | E.Orol _
   | E.Oeq _ | E.Oneq _ | E.Olt _ | E.Ole _ | E.Ogt _ | E.Oge _ -> []
 
   | E.Odiv E.Cmp_int -> []

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -89,6 +89,8 @@ type peop2 = [
   | `BOr  of castop
   | `BXOr of castop
   | `ShR  of castop
+  | `ROR  of castop
+  | `ROL  of castop
   | `ShL  of castop
 
   | `Eq   of castop
@@ -137,6 +139,8 @@ let string_of_peop2 : peop2 -> string =
   | `BXOr s -> f s "^"
   | `ShR s -> f s ">>"
   | `ShL s -> f s "<<"
+  | `ROR s -> f s ">>r"
+  | `ROL s -> f s "<<r"
   | `Eq s -> f s "=="
   | `Neq s -> f s "!="
   | `Lt s -> f s "<"
@@ -194,6 +198,8 @@ type peqop = [
   | `Sub  of castop
   | `Mul  of castop
   | `ShR  of castop
+  | `ROR  of castop
+  | `ROL  of castop
   | `ShL  of castop
   | `BAnd of castop
   | `BXOr of castop

--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -463,6 +463,8 @@ let pp_op2 fmt = function
   | E.Olsr  _ -> Format.fprintf fmt "`>>`"
   | E.Olsl  _ -> Format.fprintf fmt "`<<`"
   | E.Oasr  _ -> Format.fprintf fmt "`|>>`"
+  | E.Orol _ -> Format.fprintf fmt "`|<<|`"
+  | E.Oror _ -> Format.fprintf fmt "`|>>|`"
 
   | E.Oeq   _ -> Format.fprintf fmt "="
   | E.Oneq  _ -> Format.fprintf fmt "<>"
@@ -951,6 +953,7 @@ module Leak = struct
     | E.Oadd _  | E.Omul _  | E.Osub _ 
     | E.Oland _ | E.Olor _  | E.Olxor _ 
     | E.Olsr _  | E.Olsl _  | E.Oasr _
+    | E.Orol _ | E.Oror _
     | E.Oeq _   | E.Oneq _  | E.Olt _  | E.Ole _ | E.Ogt _ | E.Oge _ 
     | E.Ovadd _ | E.Ovsub _ | E.Ovmul _
     | E.Ovlsr _ | E.Ovlsl _ | E.Ovasr _ -> safe

--- a/compiler/tests/success/test_rotations.jazz
+++ b/compiler/tests/success/test_rotations.jazz
@@ -1,15 +1,31 @@
+/* Register rotations. */
+
 export
 fn f(reg u64 x) -> reg u64 {
-reg u64 a, b, c;
-reg u8 d;
-reg bool cf, of;
+    reg u64 a, b, c;
+    reg u8 d;
+    reg bool cf, of;
 
-a = x;
-d = 4;
-_, _, a = #ROL(a, d);
-of, cf, b = #ROL(a, 2);
-cf, b += x + cf;
-_, _, c = #ROR(b, d);
-_, _, c = #ROR(c, 3);
-return c;
+    a = x;
+    d = 4;
+
+    // Left rotations (flags are discarded).
+    a = a <<r d;
+    a = a <<r 2;
+
+    // Intrinsic syntax.
+    _, _, a = #ROL(a, d);
+    of, cf, b = #ROL(a, 2);
+
+    cf, b += x + cf;
+
+    // Right rotations (flags are discarded).
+    c = b >>r d;
+    c = b >>r 3;
+
+    // Intrinsic syntax.
+    _, _, c = #ROR(b, d);
+    _, _, c = #ROR(c, 3);
+
+    return c;
 }

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -1059,18 +1059,21 @@ op rol (x : t) (i : int) =
   init (fun j => x.[(j - i) %% size])
 axiomatized by rolE.
 
+abbrev (`|>>>|`) = ror.
+abbrev (`|<<<|`) = rol.
+
 lemma rorwE w k i :
-  (ror w k).[i] = if (0 <= i < size) then w.[(i+k) %% size] else false.
+  (w `|>>>|` k).[i] = if (0 <= i < size) then w.[(i+k) %% size] else false.
 proof. by rewrite rorE initE. qed.
 
 lemma rolwE w k i :
-  (rol w k).[i] = if (0 <= i < size) then w.[(i-k) %% size] else false.
+  (w `|<<<|` k).[i] = if (0 <= i < size) then w.[(i-k) %% size] else false.
 proof. by rewrite rolE initE. qed.
 
 hint simplify (rorwE, rolwE).
 
 lemma rol_xor w i : 0 <= i < size =>
-  rol w i = (w `<<<` i) `^` (w `>>>` (size - i)).
+  w `|<<<|` i = (w `<<<` i) `^` (w `>>>` (size - i)).
 proof.
   move=> hi; apply wordP => k hk /=.
   rewrite hk /=.
@@ -1083,7 +1086,7 @@ qed.
 
 lemma rol_xor_simplify w1 w2 i si:
    w1 = w2 => si = size - i => 0 <= i < size =>
-   (w1 `<<<` i) `^` (w2 `>>>` si) = rol w1 i.
+   (w1 `<<<` i) `^` (w2 `>>>` si) = w1 `|<<<|` i.
 proof. by move=> 2!-> hi;rewrite rol_xor. qed.
 
 (* --------------------------------------------------------------------- *)
@@ -1695,8 +1698,11 @@ theory W8.
     by rewrite modz_small.
   qed.
 
+  op (`|>>|`) (w1 w2 : W8.t) = w1 `|>>>|` (to_uint w2 %% size).
+  op (`|<<|`) (w1 w2 : W8.t) = w1 `|<<<|` (to_uint w2 %% size).
+
   lemma rol_xor_shft w i : 0 < i < size =>
-    rol w i = (w `<<` of_int i) +^ (w `>>` of_int (size - i)).
+    w `|<<<|` i = (w `<<` of_int i) +^ (w `>>` of_int (size - i)).
   proof.
     move=> hi; rewrite /(`<<`) /(`>>`) !of_uintK /=.
     by rewrite !(modz_small _ 256) 1,2:/# !modz_small 1,2:/# rol_xor 1:/#.
@@ -1714,7 +1720,7 @@ theory W8.
     let i = shift_mask i in
     if i = 0 then (undefined_flag, undefined_flag, v) 
     else
-      let r = ror v i in
+      let r = v `|>>>|` i in
       let CF = ALU.SF_of r in
       let OF = if i = 1 then CF <> ALU.SF_of v else undefined_flag in
       (OF , CF,  r)
@@ -1724,7 +1730,7 @@ theory W8.
     let i = shift_mask i in
     if i = 0 then(undefined_flag, undefined_flag, v)
     else
-      let r = rol v i in
+      let r = v `|<<<|` i in
       let CF = ALU.PF_of r in
       let OF = if i = 1 then ALU.SF_of r <> CF else undefined_flag in
       (OF, CF, r)
@@ -1841,6 +1847,8 @@ abstract theory WT.
 
   op bits : t -> int -> int -> bool list.
 
+  abbrev (`|<<<|`) = rol.
+
   axiom initiE (f : int -> bool) (i : int) : 0 <= i < size => (init f).[i] = f i.
 
   axiom andwE (w1 w2 : t) (i : int) : (andw w1 w2).[i] = (w1.[i] /\ w2.[i]).
@@ -1880,7 +1888,7 @@ abstract theory WT.
       andw w (of_int (2^k - 1)) = of_int (to_uint w %% 2^k).
 
   axiom rol_xor_shft w i : 0 < i < size =>
-    rol w i = (w `<<` W8.of_int i) +^ (w `>>` W8.of_int (size - i)).
+    w `|<<<|` i = (w `<<` W8.of_int i) +^ (w `>>` W8.of_int (size - i)).
 
 end WT.
 
@@ -1897,6 +1905,7 @@ abstract theory W_WS.
 
   clone export MonoArray as Pack with
     type elem <- WS.t,
+
     op dfl <- WS.of_int 0,
     op size <- r
     proof ge0_size by smt (gt0_r)
@@ -2310,6 +2319,8 @@ abstract theory BitWordSH.
   op (`>>`) (w1 : t) (w2 : W8.t) = w1 `>>>` (to_uint w2 %% size).
   op (`<<`) (w1 : t) (w2 : W8.t) = w1 `<<<` (to_uint w2 %% size).
   op (`|>>`) (w1 : t) (w2 : W8.t) = sar w1 (to_uint w2 %% size).
+  op (`|>>|`) (w1 : t) (w2 : W8.t) = w1 `|>>>|` (to_uint w2 %% size).
+  op (`|<<|`) (w1 : t) (w2 : W8.t) = w1 `|<<<|` (to_uint w2 %% size).
 
   lemma shr_div w1 w2 : to_uint (w1 `>>` w2) = to_uint w1 %/ 2^ (to_uint w2 %% size).
   proof.
@@ -2328,7 +2339,7 @@ abstract theory BitWordSH.
   qed.
 
   lemma rol_xor_shft w i : 0 < i < size =>
-    rol w i = (w `<<` W8.of_int i) +^ (w `>>` W8.of_int (size - i)).
+    w `|<<<|` i = (w `<<` W8.of_int i) +^ (w `>>` W8.of_int (size - i)).
   proof.
     move=> hi; rewrite /(`<<`) /(`>>`) !W8.of_uintK.
     have h : 0 <= i < `|W8.modulus|.
@@ -2361,7 +2372,7 @@ abstract theory BitWordSH.
     let i = shift_mask i in
     if i = 0 then (undefined_flag, undefined_flag, v) 
     else
-      let r = ror v i in
+      let r = v `|>>>|` i in
       let CF = ALU.SF_of r in
       let OF = if i = 1 then CF <> ALU.SF_of v else undefined_flag in
       (OF , CF,  r)
@@ -2371,7 +2382,7 @@ abstract theory BitWordSH.
     let i = shift_mask i in
     if i = 0 then(undefined_flag, undefined_flag, v)
     else
-      let r = rol v i in
+      let r = v `|<<<|` i in
       let CF = ALU.PF_of r in
       let OF = if i = 1 then ALU.SF_of r <> CF else undefined_flag in
       (OF, CF, r)

--- a/proofs/compiler/arm_decl.v
+++ b/proofs/compiler/arm_decl.v
@@ -502,6 +502,7 @@ Definition shift_of_sop2 (ws : wsize) (op : sop2) : option shift_kind :=
   | U32, Olsl (Op_w U32) => Some SLSL
   | U32, Olsr U32 => Some SLSR
   | U32, Oasr (Op_w U32) => Some SASR
+  | U32, Oror U32 => Some SROR
   | _, _ => None
   end.
 

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -254,6 +254,9 @@ Definition lower_Papp2_op
     | Oasr (Op_w U32) =>
         if is_zero U8 e1 then Some (MOV, e0, [::])
         else Some (ASR, e0, [:: e1 ])
+    | Oror U32 =>
+        if is_zero U8 e1 then Some (MOV, e0, [::])
+        else Some (ROR, e0, [:: e1 ])
     | _ =>
         None
     end

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -58,6 +58,8 @@ Variant sop2 :=
 | Olsr  of wsize 
 | Olsl  of op_kind
 | Oasr  of op_kind
+| Oror  of wsize
+| Orol  of wsize
 
 | Oeq   of op_kind
 | Oneq  of op_kind
@@ -161,7 +163,7 @@ Definition type_of_op2 (o: sop2) : stype * stype * stype :=
   | Odiv (Cmp_w _ s) | Omod (Cmp_w _ s)
   | Oland s | Olor s | Olxor s | Ovadd _ s | Ovsub _ s | Ovmul _ s
     => let t := sword s in (t, t, t)
-  | Olsr s | Olsl (Op_w s) | Oasr (Op_w s)
+  | Olsr s | Olsl (Op_w s) | Oasr (Op_w s) | Oror s | Orol s
   | Ovlsr _ s | Ovlsl _ s | Ovasr _ s
     => let t := sword s in (t, sword8, t)
   | Oeq Op_int | Oneq Op_int

--- a/proofs/lang/sem_op_typed.v
+++ b/proofs/lang/sem_op_typed.v
@@ -39,6 +39,8 @@ Definition sem_shift (shift:forall {s}, word s -> Z -> word s) s (v:word s) (i:u
 Definition sem_shr {s} := @sem_shift (@wshr) s.
 Definition sem_sar {s} := @sem_shift (@wsar) s.
 Definition sem_shl {s} := @sem_shift (@wshl) s.
+Definition sem_ror {s} := @sem_shift (@wror) s.
+Definition sem_rol {s} := @sem_shift (@wrol) s.
 
 Definition sem_vadd (ve:velem) {ws:wsize} := (lift2_vec ve +%R ws).
 Definition sem_vsub (ve:velem) {ws:wsize} := (lift2_vec ve (fun x y => x - y)%R ws).
@@ -93,6 +95,8 @@ Definition sem_sop2_typed (o: sop2) :
   | Olsl (Op_w s) => mk_sem_sop2 sem_shl
   | Oasr Op_int   => mk_sem_sop2 zasr 
   | Oasr (Op_w s) => mk_sem_sop2 sem_sar
+  | Oror s        => mk_sem_sop2 sem_ror
+  | Orol s        => mk_sem_sop2 sem_rol
  
   | Oeq Op_int    => mk_sem_sop2 Z.eqb
   | Oeq (Op_w s)  => mk_sem_sop2 eq_op

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -609,8 +609,33 @@ Proof. by case: sz. Qed.
 Lemma wshr0 sz (w: word sz) : wshr w 0 = w.
 Proof. by rewrite /wshr /lsr Z.shiftr_0_r ureprK. Qed.
 
+Lemma wshr_full sz (w : word sz) : wshr w (wsize_bits sz) = 0%R.
+Proof.
+  apply/eqP/eq_from_wbit_n.
+  move=> i.
+  rewrite w0E.
+  rewrite wshrE.
+  rewrite /wsize_bits /=.
+  rewrite SuccNat2Pos.id_succ.
+  rewrite /wbit_n.
+  rewrite wbit_word_ovf; first done.
+  apply: ltn_addr.
+  exact: ltnSn.
+Qed.
+
 Lemma wshl0 sz (w: word sz) : wshl w 0 = w.
 Proof. by rewrite /wshl /lsl Z.shiftl_0_r ureprK. Qed.
+
+Lemma wshl_full sz (w : word sz) : wshl w (wsize_bits sz) = 0%R.
+Proof.
+  apply/eqP/eq_from_wbit_n.
+  move=> i.
+  rewrite wshlE.
+  rewrite /wsize_bits /=.
+  rewrite SuccNat2Pos.id_succ.
+  case hi: (_ <= _ <= _)%N; last by rewrite w0E.
+  by move: hi => /andP [] /ltn_geF ->.
+Qed.
 
 Lemma wsar0 sz (w: word sz) : wsar w 0 = w.
 Proof. by rewrite /wsar /asr Z.shiftr_0_r sreprK. Qed.
@@ -855,6 +880,24 @@ Proof. by apply/eqP/eq_from_wbit; rewrite /= Z.lxor_nilpotent. Qed.
 
 Lemma wmulE sz (x y: word sz) : (x * y)%R = wrepr sz (wunsigned x * wunsigned y).
 Proof. by rewrite /wunsigned /wrepr; apply: word_ext. Qed.
+
+Lemma wror0 sz (w : word sz) : wror w 0 = w.
+Proof.
+  rewrite /wror.
+  rewrite wshr0.
+  rewrite Zmod_0_l Z.sub_0_r.
+  rewrite wshl_full.
+  by rewrite worC wor0.
+Qed.
+
+Lemma wrol0 sz (w : word sz) : wrol w 0 = w.
+Proof.
+  rewrite /wrol.
+  rewrite wshl0.
+  rewrite Zmod_0_l Z.sub_0_r.
+  rewrite wshr_full.
+  by rewrite worC wor0.
+Qed.
 
 Lemma wadd_zero_extend sz sz' (x y: word sz') :
   (sz ≤ sz')%CMP →


### PR DESCRIPTION
Extend lexing and parsing with `<<r` and `>>r`.
Extend latex and EasyCrypt printing.
Define operators in `eclib/JWord.ec`.
Implement lowering for x86 and ARM-M4.