### PR TITLE
Distinguish internal from external labels

### DIFF
--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -158,7 +158,7 @@ let pp_instr tbl fn (_ : Format.formatter) i =
   | ALIGN ->
       failwith "TODO_ARM: pp_instr align"
 
-  | LABEL lbl ->
+  | LABEL (_, lbl) ->
       [ LLabel (pp_label fn lbl) ]
 
   | STORELABEL (dst, lbl) ->

--- a/compiler/src/ppasm.ml
+++ b/compiler/src/ppasm.ml
@@ -414,7 +414,7 @@ module Printer (BP:BPrinter) = struct
     | ALIGN ->
       `Instr (".p2align", ["5"])
   
-    | LABEL lbl ->
+    | LABEL (_, lbl) ->
       `Label (pp_label name lbl)
   
     | STORELABEL (dst, lbl) ->

--- a/compiler/src/printLinear.ml
+++ b/compiler/src/printLinear.ml
@@ -1,4 +1,5 @@
 open Utils
+open Label
 open Linear
 open PrintCommon
 
@@ -56,6 +57,10 @@ let pp_label fmt lbl =
 let pp_remote_label tbl fmt (fn, lbl) =
   F.fprintf fmt "%s.%a" (Conv.string_of_funname tbl fn) pp_label lbl
 
+let pp_label_kind fmt = function
+  | InternalLabel -> ()
+  | ExternalLabel -> F.fprintf fmt "#returnaddress "
+
 let pp_instr asmOp tbl fmt i =
   match i.li_i with
   | Lopn (lvs, op, es) ->
@@ -72,7 +77,7 @@ let pp_instr asmOp tbl fmt i =
   | Lcall lbl  -> F.fprintf fmt "Call %a" (pp_remote_label tbl) lbl
   | Lret       -> F.fprintf fmt "Return"
   | Lalign     -> F.fprintf fmt "Align"
-  | Llabel lbl -> F.fprintf fmt "Label %a" pp_label lbl
+  | Llabel (k, lbl) -> F.fprintf fmt "Label %a%a" pp_label_kind k pp_label lbl
   | Lgoto lbl -> F.fprintf fmt "Goto %a" (pp_remote_label tbl) lbl
   | Ligoto e -> F.fprintf fmt "IGoto %a" (pp_expr tbl) e
   | LstoreLabel (x, lbl) -> F.fprintf fmt "%a = Label %a" (pp_var tbl) x pp_label lbl

--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -551,7 +551,7 @@ Definition instr_desc (o:asm_op_msb_t) : instr_desc_t :=
 (* Assembly language. *)
 Variant asm_i : Type :=
   | ALIGN
-  | LABEL of label
+  | LABEL of label_kind & label
   | STORELABEL of reg_t & label (* Store the address of a local label *)
   (* Jumps *)
   | JMP    of remote_label (* Direct jump *)

--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -504,8 +504,8 @@ Definition assemble_i (rip : var) (i : linstr) : cexec asm_i :=
   | Lalign =>
       ok ALIGN
 
-  | Llabel lbl =>
-      ok (LABEL lbl)
+  | Llabel k lbl =>
+      ok (LABEL k lbl)
 
   | Lgoto lbl =>
       ok (JMP lbl)

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -1204,7 +1204,7 @@ Lemma assemble_i_is_label (li : linstr) (ai : asm_i) lbl :
   -> linear.is_label lbl li = arch_sem.is_label lbl ai.
 Proof.
   by (rewrite /assemble_i /linear.is_label ; case li =>  ii []; t_xrbindP)
-    => /= [ > _ <- | > <- | > <- | <- | <- | ? <- | ? <- | ? _ ? _ <- | > _ <- | > _ <-].
+    => /= [ > _ <- | > <- | > <- | <- | <- | > <- | ? <- | ? _ ? _ <- | > _ <- | > _ <-].
 Qed.
 
 Lemma assemble_c_find_is_label (lc : lcmd) (ac : asm_code) lbl :
@@ -1481,13 +1481,13 @@ Lemma assemble_get_label_after_pc lc xs ls l:
   → lfn ls = asm_f xs
     → lpc ls = asm_ip xs
       → ssrfun.omap lfd_body (get_fundef (lp_funcs p) (lfn ls)) = Some lc
-        → get_label_after_pc p ls = ok l → onth (asm_c xs) (asm_ip xs).+1 = Some (LABEL l).
+        → get_label_after_pc p ls = ok l → onth (asm_c xs) (asm_ip xs).+1 = Some (LABEL ExternalLabel l).
 Proof.
   move=> eqc eqfn eqpc omap_lc; rewrite /get_label_after_pc /find_instr /= eqpc.
   case: get_fundef omap_lc => // _ [->].
   case onth_eq : onth => [ [ii_ i] | //].
   have [i' [-> /= ]]:= mapM_onth eqc onth_eq.
-  by case: (i) => // ? [<-] [->].
+  by case: (i) => // - [] // ? [<-] [->].
 Qed.
 
 Lemma assemble_iP i j ls ls' lc xs :
@@ -1648,7 +1648,7 @@ Proof.
     eexists; first reflexivity.
     eexists; first eassumption.
     by constructor => //; rewrite /setpc eqpc.
-  - move=> lbl [<-] [?]; subst ls'.
+  - move=> k lbl [<-] [?]; subst ls'.
     eexists; first reflexivity.
     eexists; first eassumption.
     constructor => //.

--- a/proofs/arch/label.v
+++ b/proofs/arch/label.v
@@ -6,6 +6,11 @@ Set   Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
+Variant label_kind :=
+  | InternalLabel
+  | ExternalLabel
+.
+
 (* ==================================================================== *)
 Definition label := positive.
 Bind Scope positive_scope with label.

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -444,6 +444,9 @@ Definition pop_to_save
   in
   map mkli to_save.
 
+Let ReturnTarget := Llabel ExternalLabel.
+Let Llabel := linear.Llabel InternalLabel.
+
 Fixpoint linear_i (i:instr) (lbl:label) (lc:lcmd) :=
   let (ii, ir) := i in
   match ir with
@@ -535,7 +538,7 @@ Fixpoint linear_i (i:instr) (lbl:label) (lc:lcmd) :=
           (lbl, before
                   ++ MkLI ii (LstoreLabel ra lret)
                   :: MkLI ii (Lgoto lcall)
-                  :: MkLI ii (Llabel lret)
+                  :: MkLI ii (ReturnTarget lret)
                   :: after
                   ++ lc
           )
@@ -556,7 +559,7 @@ Fixpoint linear_i (i:instr) (lbl:label) (lc:lcmd) :=
                        ++ MkLI ii (LstoreLabel ra lret)
                        :: of_olinstr_r ii (lstore rspi z Uptr glob_ra)
                        :: MkLI ii (Lgoto lcall)
-                       :: MkLI ii (Llabel lret)
+                       :: MkLI ii (ReturnTarget lret)
                        :: after
                        ++ lc
                )

--- a/proofs/compiler/tunneling.v
+++ b/proofs/compiler/tunneling.v
@@ -2,7 +2,7 @@ From mathcomp Require Import all_ssreflect.
 Require Import ZArith.
 
 Require Import Utf8.
-Require Import expr compiler_util linear.
+Require Import expr compiler_util linear label.
 Require Import seq_extra unionfind.
 
 Set Implicit Arguments.
@@ -28,7 +28,7 @@ Context `{asmop : asmOp}.
 Section LprogSem.
 
   Definition labels_of_body fb :=
-    pmap (λ li, if li_i li is Llabel lbl then Some lbl else None) fb.
+    pmap (λ li, if li_i li is Llabel _ lbl then Some lbl else None) fb.
 
   Definition goto_targets fb :=
     pmap (λ li, if li_i li is Lgoto lbl then Some lbl else None) fb.
@@ -62,9 +62,9 @@ Section Tunneling.
 
   Definition tunnel_chart fn uf c c' :=
     match c, c' with
-    | {| li_i := Llabel l |}, {| li_i := Llabel l' |} =>
+    | {| li_i := Llabel InternalLabel l |}, {| li_i := Llabel InternalLabel l' |} =>
         LUF.union uf l l'
-    | {| li_i := Llabel l |}, {| li_i := Lgoto (fn',l') |} =>
+    | {| li_i := Llabel InternalLabel l |}, {| li_i := Lgoto (fn',l') |} =>
         if fn == fn' then LUF.union uf l l' else uf
     | _, _ => uf
     end.

--- a/proofs/lang/linear.v
+++ b/proofs/lang/linear.v
@@ -20,7 +20,7 @@ Variant linstr_r :=
   | Lcall    : remote_label -> linstr_r
   | Lret     : linstr_r
   | Lalign : linstr_r
-  | Llabel : label -> linstr_r
+  | Llabel : label_kind -> label -> linstr_r
   | Lgoto  : remote_label -> linstr_r
   | Ligoto : pexpr -> linstr_r (* Absolute indirect jump *)
   | LstoreLabel : var -> label -> linstr_r
@@ -31,9 +31,9 @@ Record linstr : Type := MkLI { li_ii : instr_info; li_i : linstr_r }.
 
 Definition lcmd := seq linstr.
 
-Definition is_label (lbl: label) (i:linstr) : bool :=
+Definition is_label (lbl: label) (i: linstr) : bool :=
   match i.(li_i) with
-  | Llabel lbl' => lbl == lbl'
+  | Llabel _ lbl' => lbl == lbl'
   | _ => false
   end.
 

--- a/proofs/lang/linear_sem.v
+++ b/proofs/lang/linear_sem.v
@@ -25,7 +25,7 @@ Context
   (P : lprog).
 
 Definition get_label (i : linstr) : option label :=
-  if li_i i is Llabel lbl then Some lbl else None.
+  if li_i i is Llabel ExternalLabel lbl then Some lbl else None.
 
 Definition label_in_lcmd (body: lcmd) : seq label :=
   pmap get_label body.
@@ -81,7 +81,7 @@ Definition find_instr (s:lstate) :=
 
 Definition get_label_after_pc (s:lstate) :=
   if find_instr (setpc s s.(lpc).+1) is Some i then
-    if li_i i is Llabel l then ok l
+    if li_i i is Llabel ExternalLabel l then ok l
     else type_error
   else type_error.
 
@@ -128,7 +128,7 @@ Definition eval_instr (i : linstr) (s1: lstate) : exec lstate :=
       eval_jump d s1'
     else type_error
   | Lalign   => ok (setpc s1 s1.(lpc).+1)
-  | Llabel _ => ok (setpc s1 s1.(lpc).+1)
+  | Llabel _ _ => ok (setpc s1 s1.(lpc).+1)
   | Lgoto d => eval_jump d s1
   | Ligoto e =>
     Let p := sem_pexpr [::] (to_estate s1) e >>= to_pointer in


### PR DESCRIPTION
External labels correspond to return addresses, or more generally to targets of computed jumps.

External labels may be encoded as a pointer and then stored in registers or in memory.

As the (unspecified) encoding of labels only depends of the set of external labels, adding fresh internal labels is guaranteed to preserve the encoding.