### PR TITLE
Make estate not depend on SemPexprParams

### DIFF
--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -270,7 +270,7 @@ Lemma addr_of_xpexprP rip m s ii x p r vx wx vp wp:
   decode_addr s r = (wx + wp)%R.
 Proof.
   rewrite /addr_of_xpexpr => eqm ha hx hvx hp hvp.
-  have he: sem_pexpr [::] m (Papp2 (Oadd (Op_w Uptr)) (Plvar x) p) = ok (Vword (wx + wp)).
+  have he: sem_pexpr (spp:=mk_spp) [::] m (Papp2 (Oadd (Op_w Uptr)) (Plvar x) p) = ok (Vword (wx + wp)).
   + by rewrite /= /get_gvar /= hx /= hp /= /sem_sop2 /= hvx hvp.
   have := addr_of_pexprP _ eqm he ha.
   by rewrite !zero_extend_u => h;apply h.
@@ -1550,16 +1550,16 @@ Proof.
          {| evm := (vm_after_syscall (lvm ls)) |} h => //= r rs ih s1 /andP [hnin huniq].
       rewrite (sumbool_of_boolET (cmp_le_refl reg_size)) => hw r0 v.
       rewrite (in_cons (T:= @ceqT_eqType _ _)) => /orP []; last by apply: (ih _ huniq hw).
-      move=> /eqP ?; subst r0; rewrite -(get_var_eq_except _ (vrvsP hw));last first.
+      move=> /eqP ?; subst r0; rewrite -(get_var_eq_except _ (vrvsP (spp:=mk_spp) hw));last first.
       + rewrite vrvs_to_lvals => /sv_of_listP /(mapP (T1:= @ceqT_eqType _ _)) [r'] hr' /inj_to_var ?; subst r'.
         by rewrite hr' in hnin.
       rewrite /get_var /= Fv.setP_eq => -[] <-; apply value_uincl_refl.
     have hkill : forall x, Sv.In x syscall_kill -> ~Sv.In x R -> ~~is_sarr (vtype x) ->
       ~is_ok (get_var (evm s) x).
-    + move=> x /Sv_memP hin hnin; rewrite -(get_var_eq_except _ (vrvsP hw)) //=.
+    + move=> x /Sv_memP hin hnin; rewrite -(get_var_eq_except _ (vrvsP (spp:=mk_spp) hw)) //=.
       rewrite /get_var kill_varsE hin /on_vu; case: (vtype x) => //.
     constructor => //=.
-    + by rewrite (write_lvals_escs hw).
+    + by rewrite (write_lvals_escs (spp:=mk_spp) hw).
     + by apply: write_lvals_emem hw; apply: get_lvar_to_lvals.
     + rewrite (get_var_eq_except _ heqx) // /X; first by rewrite hgetrip hrip.
       case: assemble_progP => -[] hripr hriprx hripxr hripf _ _ _.

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -292,7 +292,7 @@ Section PROOF.
         rewrite evm_with_vm => z hz.
         by rewrite !Fv.setP_neq //; apply/eqP => heq; subst z; elim hz;
          auto using of_in_fv, cf_in_fv, sf_in_fv, pf_in_fv.
-      split; rewrite !evm_with_vm /=.
+      split=> /=.
       + rewrite get_gvar_neq; last by move=> _ [] h; have := of_neq_zf; rewrite h eqxx.
         rewrite get_gvar_neq; last by move=> _ [] h; have := of_neq_sf; rewrite h eqxx.
         rewrite get_gvar_neq; last by move=> _ [] h; have := of_neq_cf; rewrite h eqxx.

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -242,8 +242,7 @@ Definition vm_initialized_on (vm: vmap) : seq var → Prop :=
  * -------------------------------------------------------------------- *)
 
 Record estate
-  {asm_op syscall_state : Type}
-  {spp : SemPexprParams asm_op syscall_state} :=
+  {pd: PointerData} {syscall_state : Type} {sc_sem: syscall_sem syscall_state} :=
   Estate
     {
       escs : syscall_state;
@@ -252,6 +251,22 @@ Record estate
     }.
 
 Arguments Estate {_ _ _} _ _ _.
+
+Section UPDATE_FUNCTIONS.
+
+Context
+  {pd: PointerData} {syscall_state : Type} {sc_sem: syscall_sem syscall_state}.
+
+Definition with_vm (s:estate) vm :=
+  {| escs := s.(escs); emem := s.(emem); evm := vm |}.
+
+Definition with_mem (s:estate) m :=
+  {| escs := s.(escs); emem := m; evm := s.(evm) |}.
+
+Definition with_scs (s:estate) scs :=
+  {| escs := scs; emem := s.(emem); evm := s.(evm) |}.
+
+End UPDATE_FUNCTIONS.
 
 Notation "'Let' ( n , t ) ':=' s '.[' v ']' 'in' body" :=
   (@on_arr_var _ (get_var s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, s at level 0).
@@ -308,15 +323,6 @@ Fixpoint sem_pexpr (s:estate) (e : pexpr) : exec value :=
   end.
 
 Definition sem_pexprs s := mapM (sem_pexpr s).
-
-Definition with_vm (s:estate) vm := 
-  {| escs := s.(escs); emem := s.(emem); evm := vm |}.
-
-Definition with_mem (s:estate) m := 
-  {| escs := s.(escs); emem := m; evm := s.(evm) |}.
-
-Definition with_scs (s:estate) scs := 
-  {| escs := scs; emem := s.(emem); evm := s.(evm) |}.
 
 Definition write_var (x:var_i) (v:value) (s:estate) : exec estate :=
   Let vm := set_var s.(evm) x v in


### PR DESCRIPTION
The dependency was artificial. This requires to add some `(spp:=mk_spp)`, but it seems we cannot avoid those.