### PR TITLE
regalloc: fail when some reg bool variables remain unallocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   ([PR #311](https://github.com/jasmin-lang/jasmin/pull/311);
   fixes [#309](https://github.com/jasmin-lang/jasmin/issues/309)).
 
+- Register allocation fails when some `reg bool` variables remain unallocated
+  ([PR #313](https://github.com/jasmin-lang/jasmin/pull/313);
+  fixes [#310](https://github.com/jasmin-lang/jasmin/issues/310)).
+
 ## Other changes
 
 - Explicit if-then-else in flag combinations is no longer supported

--- a/compiler/tests/fail/register_allocation/bug_310.jazz
+++ b/compiler/tests/fail/register_allocation/bug_310.jazz
@@ -1,0 +1,15 @@
+export
+fn test(reg u64 x y) -> reg u64 {
+  reg u64 r;
+  r = y;
+  reg bool valid;
+  if x > 56 {
+    valid = true;
+  } else {
+    valid = false;
+  }
+  if valid {
+    r = x;
+  }
+  return r;
+}


### PR DESCRIPTION
Based on #311 

Fixes #310, #186, #12.