### PR TITLE
CI: use a recent docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 - test
 - deploy
 
-image: nixos/nix:2.3.12
+image: nixos/nix:2.12.0
 
 variables:
   NIX_PATH: nixpkgs=channel:nixpkgs-unstable
@@ -168,7 +168,7 @@ build-from-tarball:
   - tarball
   script:
   - tar xvf compiler/$TARBALL.tgz
-  - nix build -o out -f $TARBALL
+  - nix-build -o out $TARBALL
   - ./out/bin/jasminc -version
 
 check:


### PR DESCRIPTION
Fix breakage due to #318.

CI in progress: https://gitlab.com/jasmin-lang/jasmin/-/pipelines/737915893