### PR TITLE
randombytes syscall : fixing types + ptr copy for returning

### DIFF
--- a/compiler/syscall/jasmin_syscall.c
+++ b/compiler/syscall/jasmin_syscall.c
@@ -7,10 +7,10 @@
 #include <stdint.h>
 #include <sys/random.h>
 
-unsigned char * __jasmin_syscall_randombytes__(unsigned char *x, uint64_t xlen)
+uint8_t* __jasmin_syscall_randombytes__(uint8_t* _x, uint64_t xlen)
 {
-
   int i;
+  uint8_t* x = _x;
 
   while (xlen > 0) {
     if (xlen < 1048576) i = xlen; else i = 1048576;
@@ -23,7 +23,8 @@ unsigned char * __jasmin_syscall_randombytes__(unsigned char *x, uint64_t xlen)
     x += i;
     xlen -= i;
   }
-  return x;
+
+  return _x;
 }
 
 #endif
@@ -36,9 +37,9 @@ unsigned char * __jasmin_syscall_randombytes__(unsigned char *x, uint64_t xlen)
 #error "macOS version not supported (>= 10.12)"
 #endif
 
-unsigned char * __jasmin_syscall_randombytes__(unsigned char *p, uint64_t plen){
-  arc4random_buf(p, plen);
-  return p;
+uint8_t* __jasmin_syscall_randombytes__(uint8_t* x, uint64_t xlen){
+  arc4random_buf(x, xlen);
+  return x;
 }
 
 #endif

--- a/compiler/syscall/jasmin_syscall.h
+++ b/compiler/syscall/jasmin_syscall.h
@@ -2,7 +2,7 @@
 #ifndef JASMIN_SYSCALL
 #define JASMIN_SYSCALL
 /* FIXME this need xlen to be Uptr */
-unsigned char * __jasmin_syscall_randombytes__(unsigned char *x, uint64_t xlen)
+uint8_t* __jasmin_syscall_randombytes__(uint8_t* x, uint64_t xlen)
 asm("__jasmin_syscall_randombytes__");
 
 #endif


### PR DESCRIPTION
I tested with the distribution package of libjade, and it appears to work. 