### PR TITLE
checksafety: better handling of integer shift operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@
   ([PR #290](https://github.com/jasmin-lang/jasmin/pull/290)).
   These get extracted to `|<<|` and `|>>|` in EasyCrypt.
 
-  - x86 intrinsics that accept a size suffix (e.g., `_128`) also accept, with a
-    warning, a vector suffix (e.g., `_4u32`)
-    ([PR #303](https://github.com/jasmin-lang/jasmin/pull/303)).
+- x86 intrinsics that accept a size suffix (e.g., `_128`) also accept, with a
+  warning, a vector suffix (e.g., `_4u32`)
+  ([PR #303](https://github.com/jasmin-lang/jasmin/pull/303)).
 
 - Division and modulo operators can be used in compound assignments
   (e.g., `x /= y`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@
   ([PR #315](https://github.com/jasmin-lang/jasmin/pull/315);
   fixes [#314](https://github.com/jasmin-lang/jasmin/issues/314)).
 
+- Safety checker better handles integer shift operators
+  ([PR #322](https://github.com/jasmin-lang/jasmin/pull/322);
+  fixes [#319](https://github.com/jasmin-lang/jasmin/issues/319)).
+
 ## Other changes
 
 - Explicit if-then-else in flag combinations is no longer supported

--- a/compiler/safety/success/int_shift.jazz
+++ b/compiler/safety/success/int_shift.jazz
@@ -1,0 +1,10 @@
+export
+fn main(reg u64 x) -> reg u64 {
+  inline int i;
+  reg u64 r;
+  r = x;
+  for i = 0 to (1 << 3) - (5 >> 1) {
+    r += x;
+  }
+  return r;
+}


### PR DESCRIPTION
Fixes #319

(The first commit is unrelated, but it does not deserves a PR on its own.)

CI: https://gitlab.com/jasmin-lang/jasmin/-/pipelines/738147944