### PR TITLE
Arm stack alignment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,7 +188,6 @@ check:
 
 check-arm-target:
   extends: check
-  allow_failure: true
   variables:
     EXTRA_NIX_ARGUMENTS: --arg testDeps true --arg armTestDeps true
     EXTRA_MAKE_ARGUMENTS: CHECKCATS=arm

--- a/compiler/examples/arm_m4/set_up_stack.jazz
+++ b/compiler/examples/arm_m4/set_up_stack.jazz
@@ -1,0 +1,92 @@
+param int NREGISTERS = 14;
+param int NREGISTERS_CALLEE_SAVED = 8;
+
+/* Threshold such that all non callee saved registers are used. */
+param int n = NREGISTERS - NREGISTERS_CALLEE_SAVED - 1;
+
+/* Many free registers. */
+export
+fn onregister0(reg u32 x) -> reg u32 {
+    reg u32 result;
+    reg u32[1] tab;
+    inline int i;
+    stack u32 t;
+
+    t = x;
+
+    for i = 0 to 1 {
+        tab[i] = x;
+    }
+
+    result = t;
+    for i = 0 to 1 {
+        result += tab[i];
+    }
+
+    return result;
+}
+
+/* One free register. */
+export
+fn onregister1(reg u32 x) -> reg u32 {
+    reg u32 result;
+    reg u32[n-1] tab;
+    inline int i;
+    stack u32 t;
+
+    t = x;
+
+    for i = 0 to n - 1 {
+        tab[i] = x;
+    }
+
+    result = t;
+    for i = 0 to n - 1 {
+        result += tab[i];
+    }
+
+    return result;
+}
+
+export
+fn onstack0(reg u32 x) -> reg u32 {
+    reg u32 result;
+    reg u32[n] tab;
+    inline int i;
+    stack u32 t;
+
+    t = x;
+
+    for i = 0 to n {
+        tab[i] = x;
+    }
+
+    result = t;
+    for i = 0 to n {
+        result += tab[i];
+    }
+
+    return result;
+}
+
+export
+fn onstack1(reg u32 x) -> reg u32 {
+    reg u32 result;
+    reg u32[NREGISTERS - 1] tab;
+    inline int i;
+    stack u32 t;
+
+    t = x;
+
+    for i = 0 to NREGISTERS - 1 {
+        tab[i] = x;
+    }
+
+    result = t;
+    for i = 0 to NREGISTERS - 1 {
+        result += tab[i];
+    }
+
+    return result;
+}
+

--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -21,6 +21,7 @@ module type Core_arch = sig
 
   val lowering_vars : Conv.coq_tbl -> fresh_vars
   val lowering_opt : lowering_options
+  val not_saved_stack : Name.t list
 
   val pp_asm : Conv.coq_tbl -> Format.formatter -> (reg, regx, xreg, rflag, cond, asm_op) Arch_decl.asm_prog -> unit
   val analyze :
@@ -51,6 +52,7 @@ module type Arch = sig
   val extra_allocatable_vars : var list
   val xmm_allocatable_vars : var list
   val callee_save_vars : var list
+  val not_saved_stack : var list
   val rsp_var : var
   val all_registers : var list
   val syscall_kill : Sv.t
@@ -126,6 +128,9 @@ module Arch_from_Core_arch (A : Core_arch) : Arch = struct
   let callee_save_reg = List.filter_map (Arch_decl.get_ARReg arch_decl) callee_save
   let callee_save_regx = List.filter_map (Arch_decl.get_ARegX arch_decl) callee_save
   let callee_save_xreg = List.filter_map (Arch_decl.get_AXReg arch_decl) callee_save
+
+  let not_saved_stack =
+    List.filter (fun x -> List.mem x.v_name not_saved_stack) reg_vars
 
   let rsp = arch_decl.ad_rsp
 

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -19,6 +19,7 @@ module type Core_arch = sig
 
   val lowering_vars : Conv.coq_tbl -> fresh_vars
   val lowering_opt : lowering_options
+  val not_saved_stack : Name.t list
 
   val pp_asm : Conv.coq_tbl -> Format.formatter -> (reg, regx, xreg, rflag, cond, asm_op) Arch_decl.asm_prog -> unit
   val analyze :
@@ -49,6 +50,7 @@ module type Arch = sig
   val extra_allocatable_vars : var list
   val xmm_allocatable_vars : var list
   val callee_save_vars : var list
+  val not_saved_stack : var list
   val rsp_var : var
   val all_registers : var list
   val syscall_kill : Sv.t

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -40,6 +40,11 @@ module Arm (Lowering_params : Arm_input) : Arch_full.Core_arch = struct
 
   let lowering_opt = ()
 
+  let not_saved_stack =
+    List.map
+      Conv.string_of_string0
+      (Arm_params.arm_liparams.lip_not_saved_stack)
+
   let pp_asm = Pp_arm_m4.print_prog
 
   let analyze _ _ _ = failwith "TODO_ARM: analyze"

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -26,6 +26,11 @@ module X86 (Lowering_params : X86_input) : Arch_full.Core_arch = struct
 
   include Lowering_params
 
+  let not_saved_stack =
+    List.map
+      Conv.string_of_string0
+      (X86_params.x86_liparams.lip_not_saved_stack)
+
   let pp_asm = Ppasm.pp_prog
 
   let analyze source_f_decl f_decl p =

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -20,7 +20,6 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Notation copn_args := (seq lval * sopn * seq pexpr)%type (only parsing).
 Notation lowered_pexpr := (option (arm_op * seq pexpr)) (only parsing).
 
 (* -------------------------------------------------------------------- *)

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -24,16 +24,69 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
+Definition arm_op_mov (x y : var_i) : copn_args :=
+  ([:: Lvar x ], Oarm (ARM_op MOV default_opts), [:: Pvar (mk_lvar y) ]).
+
+Definition arm_op_movi (x : var_i) (imm : Z) : copn_args :=
+  let e := eword_of_int reg_size imm in
+  ([:: Lvar x ], Oarm (ARM_op MOV default_opts), [:: e ]).
+
+Definition arm_op_movt (x : var_i) (imm : Z) : copn_args :=
+  let e := eword_of_int U16 imm in
+  ([:: Lvar x ], Oarm (ARM_op MOVT default_opts), [:: Pvar (mk_lvar x); e ]).
+
+Definition arm_op_sub (x y z : var_i) : copn_args :=
+  let f v := Pvar (mk_lvar v) in
+  ([:: Lvar x ], Oarm (ARM_op SUB default_opts), map f [:: y; z ]).
+
+Definition arm_op_str_off (x y : var_i) (off : Z) : copn_args :=
+  let lv := Lmem reg_size y (cast_const off) in
+  ([:: lv ], Oarm (ARM_op STR default_opts), [:: Pvar (mk_lvar x) ]).
+
+Definition arm_op_arith_imm
+  (op : arm_mnemonic) (x y : var_i) (imm : Z) : copn_args :=
+  let ey := Pvar (mk_lvar y) in
+  let eimm := eword_of_int reg_size imm in
+  ([:: Lvar x ], Oarm (ARM_op op default_opts), [:: ey; eimm ]).
+
+Definition arm_op_addi (x y : var_i) (imm : Z) : copn_args :=
+  arm_op_arith_imm ADD x y imm.
+
+Definition arm_op_subi (x y : var_i) (imm : Z) : copn_args :=
+  arm_op_arith_imm SUB x y imm.
+
+Definition arm_op_align (x y : var_i) (al : wsize) :=
+  arm_op_arith_imm AND x y (- wsize_size al).
+
+(* Precondition: [0 <= imm < wbase reg_size]. *)
+Definition arm_cmd_load_large_imm (x : var_i) (imm : Z) : seq copn_args :=
+  let '(hbs, lbs) := Z.div_eucl imm (wbase U16) in
+  [:: arm_op_movi x lbs; arm_op_movt x hbs ].
+
+(* Return a command that performs an operation with an immediate argument,
+   loading it into a register if needed.
+   In symbols,
+       R[x] := R[y] <+> imm
+ *)
+Definition arm_cmd_large_arith_imm
+  (on_reg : var_i -> var_i -> var_i -> copn_args)
+  (on_imm : var_i -> var_i -> Z -> copn_args)
+  (x y : var_i)
+  (imm : Z) :
+  seq copn_args :=
+  arm_cmd_load_large_imm x imm ++ [:: on_reg x y x ].
+
+Definition arm_cmd_large_subi (x y : var_i) (imm : Z) : seq copn_args :=
+  arm_cmd_large_arith_imm arm_op_sub arm_op_subi x y imm.
+
 (* ------------------------------------------------------------------------ *)
 (* Stack alloc parameters. *)
 
-Definition addi x tag y ofs :=
-  let eofs := Papp1 (Oword_of_int reg_size) (Pconst ofs) in
-  Copn [:: x ] tag (Oarm (ARM_op ADD default_opts)) [:: y; eofs ].
-
 Definition arm_mov_ofs
-  (x : lval) tag (_ : vptr_kind) (y : pexpr) (ofs : Z) : option instr_r :=
-  Some (addi x tag y ofs).
+  (x : lval) (tag : assgn_tag) (_ : vptr_kind) (y : pexpr) (ofs : Z) :
+  option instr_r :=
+  let op := Oarm (ARM_op ADD default_opts) in
+  Some (Copn [:: x ] tag op [:: y; eword_of_int reg_size ofs ]).
 
 Definition arm_saparams : stack_alloc_params :=
   {|
@@ -44,20 +97,17 @@ Definition arm_saparams : stack_alloc_params :=
 (* ------------------------------------------------------------------------ *)
 (* Linearization parameters. *)
 
+Section LINEARIZATION.
+
+Notation vtmpi := {| v_var := to_var R12; v_info := dummy_var_info; |}.
+
+(* TODO_ARM: This assumes 0 <= sz < 4096. *)
 Definition arm_allocate_stack_frame (rspi : var_i) (sz : Z) :=
-  let rspg := Gvar rspi Slocal in
-  let esz := Papp1 (Oword_of_int reg_size) (Pconst sz) in
-  ([:: Lvar rspi ], Oarm (ARM_op SUB default_opts), [:: Pvar rspg; esz ]).
+  arm_op_subi rspi rspi sz.
 
+(* TODO_ARM: This assumes 0 <= sz < 4096. *)
 Definition arm_free_stack_frame (rspi : var_i) (sz : Z) :=
-  let rspg := Gvar rspi Slocal in
-  let esz := Papp1 (Oword_of_int reg_size) (Pconst sz) in
-  ([:: Lvar rspi ], Oarm (ARM_op ADD default_opts), [:: Pvar rspg; esz ]).
-
-Definition arm_ensure_rsp_alignment (rspi : var_i) (al : wsize) :=
-  let p0 := Pvar (Gvar rspi Slocal) in
-  let p1 := Papp1 (Oword_of_int reg_size) (Pconst (- wsize_size al)) in
-  ([:: Lvar rspi ], Oarm (ARM_op AND default_opts), [:: p0; p1 ]).
+  arm_op_addi rspi rspi sz.
 
 (* TODO_ARM: Review. This seems unnecessary. *)
 Definition arm_lassign
@@ -89,14 +139,48 @@ Definition arm_lassign
   then Some ([:: lv ], Oarm (ARM_op mn default_opts), [:: e' ])
   else None.
 
+Definition arm_set_up_sp_register
+  (rspi : var_i)
+  (sf_sz : Z)
+  (al : wsize)
+  (r : var_i) :
+  option (seq copn_args) :=
+  if (0 <=? sf_sz)%Z && (sf_sz <? wbase reg_size)%Z
+  then
+    let i0 := arm_op_mov r rspi in
+    let load_imm := arm_cmd_large_subi vtmpi rspi sf_sz in
+    let i1 := arm_op_align vtmpi vtmpi al in
+    let i2 := arm_op_mov rspi vtmpi in
+    Some (i0 :: load_imm ++ [:: i1; i2 ])
+  else
+    None.
+
+Definition arm_set_up_sp_stack
+  (rspi : var_i) (sf_sz : Z) (al : wsize) (off : Z) : option (seq copn_args) :=
+  if (0 <=? sf_sz)%Z && (sf_sz <? wbase reg_size)%Z
+  then
+    let load_imm := arm_cmd_large_subi vtmpi rspi sf_sz in
+    let i0 := arm_op_align vtmpi vtmpi al in
+    let i1 := arm_op_str_off rspi vtmpi off in
+    let i2 := arm_op_mov rspi vtmpi in
+    Some (load_imm ++ [:: i0; i1; i2 ])
+  else
+    None.
+
+Definition arm_tmp : Ident.ident := vname (v_var vtmpi).
+
 Definition arm_liparams : linearization_params :=
   {|
-    lip_tmp := "r12"%string; (* TODO_ARM: Review. *)
+    lip_tmp := arm_tmp;
+    lip_not_saved_stack := [:: arm_tmp ];
     lip_allocate_stack_frame := arm_allocate_stack_frame;
     lip_free_stack_frame := arm_free_stack_frame;
-    lip_ensure_rsp_alignment := arm_ensure_rsp_alignment;
+    lip_set_up_sp_register := arm_set_up_sp_register;
+    lip_set_up_sp_stack := arm_set_up_sp_stack;
     lip_lassign := arm_lassign;
   |}.
+
+End LINEARIZATION.
 
 
 (* ------------------------------------------------------------------------ *)

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -220,20 +220,7 @@ Lemma wbit_n_add_aux x y z :
   -> (y < x)%Z
   -> (z < x)%Z
   -> (x * y + z < x * x)%Z.
-Proof.
-  rewrite (Zsucc_pred x).
-  move: x (Z.pred x) => _ x.
-  move=> hx hy hz.
-
-  rewrite !Z.mul_succ_l Z.mul_succ_r.
-  apply: (Z.add_le_lt_mono _ _ _ _ _ hz).
-  clear hz.
-
-  move: hy => /Zlt_succ_le hy.
-  apply: (Z.add_le_mono _ _ _ _ _ hy).
-  apply: (Zmult_le_compat_l _ _ _ hy).
-  lia.
-Qed.
+Proof. nia. Qed.
 
 Lemma wbit_n_add ws n lbs hbs (i : nat) :
   let: n2 := (2 ^ n)%Z in
@@ -279,9 +266,6 @@ Proof.
 
     rewrite wbit_nE.
     rewrite wunsigned_repr_small; first done.
-    split; first lia.
-    apply: (Z.lt_le_trans _ (2 ^ n) _); first lia.
-    apply: Z.le_trans; first exact: Zle_n_nn.
     lia.
 
   rewrite -(Zplus_minus n i).
@@ -311,23 +295,7 @@ Lemma mov_movt_aux n x y :
   -> (0 <= y < n)%Z
   -> (0 <= n * x + y < n * n)%Z
   -> (0 <= x < n)%Z.
-Proof.
-  move=> hn [h0y hyn] [hlo hhi].
-  split.
-  - case: (Z.le_gt_cases 0 x) => h0x; first done.
-    exfalso.
-    have h : (n * x < - y)%Z.
-    - apply: (Z.le_lt_trans _ (- n)); last lia.
-      apply Z.opp_le_mono.
-      rewrite Zopp_mult_distr_r.
-      rewrite Z.opp_involutive.
-      rewrite -{1}(Z.mul_1_r n).
-      apply: Z.mul_le_mono_nonneg_l; lia.
-    lia.
-
-  apply: (Zmult_lt_reg_r _ _ _ hn).
-  lia.
-Qed.
+Proof. nia. Qed.
 
 Lemma mov_movt n hbs lbs :
   (0 <= n < wbase reg_size)%Z

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -1,5 +1,9 @@
+From Coq Require Import Relations.
+From Coq Require Import Psatz.
 From mathcomp Require Import all_ssreflect all_algebra.
 From mathcomp.word Require Import ssrZ.
+
+Require Import oseq.
 
 Require Import
   arch_params_proof
@@ -33,6 +37,22 @@ Require Export arm_params.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
+
+
+Lemma vmap_eq_except_wf_vm vm vm' x v :
+  wf_vm vm
+  -> vm' = vm [\ Sv.singleton x ]
+  -> get_var vm' x = ok v
+  -> wf_vm vm'.
+Proof.
+  move=> hwf_vm hvm' hgetx.
+  move=> y.
+  case: (x =P y) => hy.
+  - subst y. move: hgetx. rewrite /get_var. by case: vm'.[x]%vmap => [|[]].
+  rewrite hvm'; first by apply: hwf_vm.
+  exact: (Sv_neq_not_in_singleton hy).
+Qed.
+
 
 Section Section.
 
@@ -83,22 +103,6 @@ Context
   (P' : sprog)
   (P'_globs : p_globs P' = [::]).
 
-Lemma addiP s1 e i x tag ofs w s2 :
-  (Let i' := sem_pexpr [::] s1 e in to_pointer i') = ok i
-  -> write_lval [::] x (Vword (i + wrepr _ ofs)) s1 = ok s2
-  -> psem.sem_i (pT := progStack) P' w s1 (addi x tag e ofs) s2.
-Proof.
-  move=> he hx.
-  constructor.
-  rewrite /sem_sopn /=.
-  rewrite P'_globs.
-  rewrite /exec_sopn /=.
-  move: he.
-  t_xrbindP=> ? -> /= -> /=.
-  rewrite zero_extend_u.
-  by rewrite hx.
-Qed.
-
 End STACK_ALLOC.
 
 Lemma arm_mov_ofsP (P': sprog) s1 e i x tag ofs w vpk s2 ins :
@@ -108,10 +112,15 @@ Lemma arm_mov_ofsP (P': sprog) s1 e i x tag ofs w vpk s2 ins :
   -> write_lval [::] x (Vword (i + wrepr Uptr ofs)) s1 = ok s2
   -> psem.sem_i (pT := progStack) P' w s1 ins s2.
 Proof.
-  move=> P'_globs he.
-  rewrite /arm_mov_ofs.
-  move=> [<-].
-  by apply: addiP.
+  move=> P'_globs he [?] hx; subst ins.
+  constructor.
+  rewrite /sem_sopn /=.
+  rewrite P'_globs.
+  rewrite /exec_sopn /=.
+  move: he.
+  t_xrbindP=> ? -> /= -> /=.
+  rewrite zero_extend_u.
+  by rewrite hx.
 Qed.
 
 Definition arm_hsaparams is_regx :
@@ -126,24 +135,395 @@ Definition arm_hsaparams is_regx :
 
 Section LINEARIZATION.
 
+Section ARM_OP.
+
+(* Linear state after executing a linear instruction [Lopn]. *)
+Notation next_ls ls m vm :=
+  {|
+    lscs := lscs ls;
+    lmem := m;
+    lvm := vm;
+    lfn := lfn ls;
+    lpc := lpc ls + 1;
+  |}
+  (only parsing).
+
+Notation next_vm_ls ls vm := (next_ls ls (lmem ls) vm) (only parsing).
+Notation next_mem_ls ls m := (next_ls ls m (lvm ls)) (only parsing).
+
+Context
+  (xname : Ident.ident)
+  (vi : var_info).
+
+Notation x :=
+  {|
+    v_var := {| vname := xname; vtype := sword reg_size; |};
+    v_info := vi;
+  |}.
+
+(* Try to rewrite and clear all equalities in the context. *)
+Ltac t_rewrite_eqs :=
+  repeat
+    match goal with
+    | [ h : _ = _ |- _ ] => rewrite !h /=; clear h
+    end.
+
+(* Most ARM instructions with default options are executed as follows:
+   1. Unfold instruction execution definitions, e.g. [eval_instr].
+   2. Rewrite argument hypotheses, i.e. [sem_pexpr].
+   3. Unfold casting definitions in result, e.g. [zero_extend] and
+      [pword_of_word].
+   4. Rewrite result hypotheses, i.e. [write_lval].
+ *)
+Ltac t_arm_op :=
+  rewrite /eval_instr /= /sem_sopn /= /get_gvar /=;
+  t_rewrite_eqs;
+  rewrite /of_estate /= /with_vm /=;
+  rewrite ?zero_extend_u ?pword_of_wordE;
+  t_rewrite_eqs.
+
+Lemma arm_op_subi_eval_instr lp ls ii y imm wy :
+  get_var (lvm ls) (v_var y) = ok (Vword wy)
+  -> let: li := li_of_copn_args ii (arm_op_subi x y imm) in
+     let: wx' := (wy - wrepr reg_size imm)%R in
+     let: vm' := (lvm ls).[v_var x <- ok (pword_of_word wx')]%vmap in
+     eval_instr lp li ls = ok (next_vm_ls ls vm').
+Proof. move=> hgety. t_arm_op. by rewrite wsub_wnot1 addn1. Qed.
+
+Lemma arm_op_align_eval_instr lp ls ii y al wy :
+  get_var (lvm ls) (v_var y) = ok (Vword wy)
+  -> let: li := li_of_copn_args ii (arm_op_align x y al) in
+     let: wx' := align_word al wy in
+     let: vm' := (lvm ls).[v_var x <- ok (pword_of_word wx')]%vmap in
+     eval_instr lp li ls = ok (next_vm_ls ls vm').
+Proof. move=> hgety. t_arm_op. by rewrite addn1. Qed.
+
+Lemma arm_op_mov_eval_instr lp ls ii y wy :
+  get_var (lvm ls) (v_var y) = ok (Vword wy)
+  -> let: li := li_of_copn_args ii (arm_op_mov x y) in
+     let: vm' := (lvm ls).[v_var x <- ok (pword_of_word wy)]%vmap in
+     eval_instr lp li ls = ok (next_vm_ls ls vm').
+Proof. move=> hgety. t_arm_op. by rewrite addn1. Qed.
+
+Lemma arm_op_str_off_eval_instr lp ls m' ii y off wx (wy : word reg_size) :
+  get_var (lvm ls) (v_var x) = ok (Vword wx)
+  -> get_var (lvm ls) (v_var y) = ok (Vword wy)
+  -> write (lmem ls) (wx + wrepr Uptr off)%R wy = ok m'
+  -> let: li := li_of_copn_args ii (arm_op_str_off y x off) in
+     eval_instr lp li ls = ok (next_mem_ls ls m').
+Proof. move=> hgety hgetx hwrite. t_arm_op. by rewrite addn1. Qed.
+
+End ARM_OP.
+
+Lemma wbit_n_add_aux x y z :
+  (0 < x)%Z
+  -> (y < x)%Z
+  -> (z < x)%Z
+  -> (x * y + z < x * x)%Z.
+Proof.
+  rewrite (Zsucc_pred x).
+  move: x (Z.pred x) => _ x.
+  move=> hx hy hz.
+
+  rewrite !Z.mul_succ_l Z.mul_succ_r.
+  apply: (Z.add_le_lt_mono _ _ _ _ _ hz).
+  clear hz.
+
+  move: hy => /Zlt_succ_le hy.
+  apply: (Z.add_le_mono _ _ _ _ _ hy).
+  apply: (Zmult_le_compat_l _ _ _ hy).
+  lia.
+Qed.
+
+Lemma wbit_n_add ws n lbs hbs (i : nat) :
+  let: n2 := (2 ^ n)%Z in
+  (n2 * n2 <= wbase ws)%Z
+  -> (0 <= lbs < n2)%Z
+  -> (0 <= hbs < n2)%Z
+  -> let b :=
+       if (i <? n)%Z
+       then wbit_n (wrepr ws lbs) i
+       else wbit_n (wrepr ws hbs) (i - Z.to_nat n)
+     in
+     wbit_n (wrepr ws (2 ^ n * hbs + lbs)) i = b.
+Proof.
+  move=> hn hlbs hhbs.
+
+  have h0i : (0 <= i)%Z.
+  - exact: Zle_0_nat.
+
+  have h0n : (0 <= n)%Z.
+  - case: (Z.le_gt_cases 0 n) => h; first done.
+    rewrite (Z.pow_neg_r _ _  h) in hlbs.
+    lia.
+
+  have hrange : (0 <= 2 ^ n * hbs + lbs < wbase ws)%Z.
+  - split; first lia.
+    apply: (Z.lt_le_trans _ _ _ _ hn).
+    apply: wbit_n_add_aux; lia.
+
+  case: ZltP => hi /=.
+
+  all: rewrite wbit_nE.
+  all: rewrite (wunsigned_repr_small hrange).
+
+  - rewrite -(Zplus_minus i n).
+    rewrite Z.pow_add_r; last lia; last done.
+    rewrite Z.add_comm -Z.mul_assoc Z.mul_comm.
+    rewrite Z_div_plus; first last.
+    + apply/Z.lt_gt. by apply: Z.pow_pos_nonneg.
+
+    rewrite Z.odd_add.
+    rewrite Z_odd_pow_2; last lia.
+    rewrite Bool.xorb_false_r.
+
+    rewrite wbit_nE.
+    rewrite wunsigned_repr_small; first done.
+    split; first lia.
+    apply: (Z.lt_le_trans _ (2 ^ n) _); first lia.
+    apply: Z.le_trans; first exact: Zle_n_nn.
+    lia.
+
+  rewrite -(Zplus_minus n i).
+  rewrite (Z.pow_add_r _ _ _ h0n); last lia.
+  rewrite -Z.div_div; last lia; last lia.
+  rewrite Z.add_comm Z.mul_comm.
+  rewrite Z_div_plus; last lia.
+  rewrite (Zdiv_small _ _ hlbs) /=.
+
+  rewrite wbit_nE.
+  rewrite wunsigned_repr_small; first last.
+  - split; first lia.
+    apply: (Z.lt_le_trans _ _ _ _ hn).
+    rewrite -Z.pow_twice_r.
+    apply: (Z.lt_le_trans _ (2 ^ n)); first lia.
+    apply: Z.pow_le_mono_r; lia.
+
+  rewrite int_of_Z_PoszE.
+  rewrite Nat2Z.n2zB; first by rewrite Z2Nat.id.
+  apply/ZNleP.
+  rewrite (Z2Nat.id _ h0n).
+  by apply/Z.nlt_ge.
+Qed.
+
+Lemma mov_movt_aux n x y :
+  (0 < n)%Z
+  -> (0 <= y < n)%Z
+  -> (0 <= n * x + y < n * n)%Z
+  -> (0 <= x < n)%Z.
+Proof.
+  move=> hn [h0y hyn] [hlo hhi].
+  split.
+  - case: (Z.le_gt_cases 0 x) => h0x; first done.
+    exfalso.
+    have h : (n * x < - y)%Z.
+    - apply: (Z.le_lt_trans _ (- n)); last lia.
+      apply Z.opp_le_mono.
+      rewrite Zopp_mult_distr_r.
+      rewrite Z.opp_involutive.
+      rewrite -{1}(Z.mul_1_r n).
+      apply: Z.mul_le_mono_nonneg_l; lia.
+    lia.
+
+  apply: (Zmult_lt_reg_r _ _ _ hn).
+  lia.
+Qed.
+
+Lemma mov_movt n hbs lbs :
+  (0 <= n < wbase reg_size)%Z
+  -> Z.div_eucl n (wbase U16) = (hbs, lbs)
+  -> let: h := wshl (zero_extend U32 (wrepr U16 hbs)) 16 in
+     let: l := wand (wrepr U32 lbs) (zero_extend U32 (wrepr U16 (-1))) in
+     wor h l = wrepr U32 n.
+Proof.
+  move=> hn.
+
+  have := Z_div_mod n (wbase U16) (wbase_pos U16).
+  case: Z.div_eucl => [h l] [? hlbs] [? ?]; subst n h l.
+
+  rewrite wshl_sem; last done.
+  rewrite (wand_small hlbs).
+  rewrite -wrepr_mul.
+
+  have hhbs : (0 <= hbs < wbase U16)%Z.
+  - exact: (mov_movt_aux _ hlbs hn).
+
+  rewrite (wunsigned_repr_small hhbs).
+  Opaque Z.pow.
+  rewrite wbaseE /=.
+
+  apply/eqP/eq_from_wbit_n.
+  move=> [i hrangei] /=.
+  rewrite worE.
+
+  rewrite wbit_n_add; first last.
+  - by rewrite wbaseE /= in hhbs.
+  - by rewrite wbaseE /= in hlbs.
+  - done.
+
+  case: ZltP => h.
+
+  - rewrite wbit_lower_bits_0 /=; first done.
+    + by have := Zle_0_nat i.
+    rewrite wbaseE /= in hn.
+    lia.
+
+  rewrite (wbit_higher_bits_0 (n := 16) _ hlbs); first last.
+  - split; last by apply/ZNltP. by apply/Z.nlt_ge.
+  - done.
+
+  rewrite orbF.
+  rewrite wbit_pow_2; first done; first done.
+  move: h => /Z.nlt_ge h.
+  apply/andP.
+  split.
+  - apply/ZNleP. by rewrite Z2Nat.id.
+
+  by apply: ltnSE.
+Qed.
+
+Lemma arm_cmd_load_large_imm_lsem lp fn s ii P Q xname imm :
+  let: x := {| vname := xname; vtype := sword reg_size; |} in
+  let: xi := {| v_var := x; v_info := dummy_var_info; |} in
+  let: lcmd := map (li_of_copn_args ii) (arm_cmd_load_large_imm xi imm) in
+  is_linear_of lp fn (P ++ lcmd ++ Q)
+  -> (0 <= imm < wbase reg_size)%Z
+  -> exists vm',
+       let: ls := of_estate s fn (size P) in
+       let: ls' :=
+         {|
+           lscs := lscs ls;
+           lmem := lmem ls;
+           lvm := vm';
+           lfn := fn;
+           lpc := size P + size lcmd;
+         |}
+       in
+       [/\ lsem lp ls ls'
+         , vm' = lvm ls [\ Sv.singleton x ]
+         & get_var vm' x = ok (Vword (wrepr reg_size imm))
+       ].
+Proof.
+  set x := {| v_var := _; |}.
+  rewrite /arm_cmd_load_large_imm /=.
+
+  case hdivmod: Z.div_eucl => [hbs lbs] /=.
+  move=> hbody himm.
+
+  eexists.
+  split.
+  - apply: lsem_step2; rewrite /lsem1 /step /of_estate.
+    + rewrite -(addn0 (size P)).
+      move: (find_instr_skip hbody) => -> /=.
+      rewrite /eval_instr /= /with_vm /= /of_estate /=.
+      rewrite zero_extend_u pword_of_wordE addn0.
+      reflexivity.
+
+    rewrite -addn1.
+    move: (find_instr_skip hbody) => -> /=.
+    rewrite /eval_instr /=.
+    rewrite /sem_sopn /= /get_gvar /=.
+    rewrite get_var_eq /=.
+    rewrite /with_vm /= /of_estate /=.
+    rewrite !zero_extend_u.
+    rewrite (mov_movt himm hdivmod).
+    rewrite pword_of_wordE.
+    rewrite addn1 -addn2.
+    reflexivity.
+
+  - move=> v hv. move: hv => /Sv.singleton_spec ?. by t_vm_get.
+
+  by t_get_var.
+Qed.
+
+Lemma arm_cmd_large_subi_lsem lp fn s ii P Q xname y imm wy :
+  let: x := {| vname := xname; vtype := sword Uptr; |} in
+  let: xi := {| v_var := x; v_info := dummy_var_info; |} in
+  let: lcmd := map (li_of_copn_args ii) (arm_cmd_large_subi xi y imm) in
+  is_linear_of lp fn (P ++ lcmd ++ Q)
+  -> x <> v_var y
+  -> get_var (evm s) (v_var y) = ok (Vword wy)
+  -> (0 <= imm < wbase reg_size)%Z
+  -> exists vm',
+       let: ls := of_estate s fn (size P) in
+       let: ls' :=
+         {|
+           lscs := lscs ls;
+           lmem := lmem ls;
+           lvm := vm';
+           lfn := fn;
+           lpc := size P + size lcmd;
+         |}
+       in
+       [/\ lsem lp ls ls'
+         , vm' = evm s [\ Sv.singleton x ]
+         & get_var vm' x = ok (Vword (wy - wrepr reg_size imm)%R)
+       ].
+Proof.
+  set x := {| v_var := _; |}.
+  move=> hbody hxy hgety himm.
+
+  move: hbody.
+  rewrite /arm_cmd_large_subi /=.
+  rewrite /arm_cmd_large_arith_imm /=.
+  rewrite map_cat.
+  rewrite -(catA _ _ Q).
+  move=> hbody.
+
+  have [vm' [hsem hvm hgetx]] := arm_cmd_load_large_imm_lsem s hbody himm.
+
+  eexists.
+  split.
+  - apply: (lsem_trans hsem).
+    rewrite /of_estate /= -/x.
+    apply: LSem_step.
+    rewrite /lsem1 /step /=.
+
+    rewrite catA in hbody.
+    rewrite -!size_cat.
+    rewrite -(addn0 (size _)).
+    move: (find_instr_skip hbody) => -> /=.
+
+    have {hgety} hgety :
+      get_var vm' y = ok (Vword wy).
+    + rewrite (get_var_eq_except _ hvm) /=; first exact: hgety.
+      exact: (Sv_neq_not_in_singleton hxy).
+
+    rewrite /eval_instr /=.
+    rewrite /sem_sopn /=.
+    rewrite /get_gvar /=.
+    rewrite hgetx hgety {hgetx hgety} /=.
+    rewrite pword_of_wordE !zero_extend_u.
+    rewrite /of_estate /with_vm /=.
+    rewrite wsub_wnot1.
+    rewrite !size_cat addn0 -addn1 addnA /=.
+    reflexivity.
+
+  - move=> z hz.
+    rewrite Fv.setP_neq.
+    + rewrite -(hvm z hz) /=; first done.
+    apply/eqP.
+    SvD.fsetdec.
+
+  by t_get_var.
+Qed.
+
 Context
   (lp : lprog)
-  (s : estate)
   (sp_rsp : Ident.ident)
-  (ii : instr_info)
-  (fn : funname)
-  (pc : nat).
+  (fn : funname).
 
 Let vrsp : var := mk_ptr sp_rsp.
 Let vrspi : var_i := VarI vrsp dummy_var_info.
-Let vm := evm s.
+Let vtmp : var := mk_ptr (lip_tmp arm_liparams).
+Let vtmpi : var_i := VarI vtmp dummy_var_info.
 
-Lemma arm_spec_lip_allocate_stack_frame ts sz :
+Lemma arm_spec_lip_allocate_stack_frame s pc ii ts sz :
   let args := lip_allocate_stack_frame arm_liparams vrspi sz in
   let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
   let ts' := pword_of_word (ts - wrepr Uptr sz) in
-  let s' := with_vm s (vm.[vrsp <- ok ts'])%vmap in
-  (vm.[vrsp])%vmap = ok (pword_of_word ts)
+  let s' := with_vm s (evm s).[vrsp <- ok ts']%vmap in
+  (evm s).[vrsp]%vmap = ok (pword_of_word ts)
   -> eval_instr lp i (of_estate s fn pc)
      = ok (of_estate s' fn pc.+1).
 Proof.
@@ -157,12 +537,12 @@ Proof.
   by rewrite zero_extend_u zero_extend_wrepr.
 Qed.
 
-Lemma arm_spec_lip_free_stack_frame ts sz :
+Lemma arm_spec_lip_free_stack_frame s pc ii ts sz :
   let args := lip_free_stack_frame arm_liparams vrspi sz in
   let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
   let ts' := pword_of_word (ts + wrepr Uptr sz) in
-  let s' := with_vm s (vm.[vrsp <- ok ts'])%vmap in
-  (vm.[vrsp])%vmap = ok (pword_of_word ts)
+  let s' := with_vm s (evm s).[vrsp <- ok ts']%vmap in
+  (evm s).[vrsp]%vmap = ok (pword_of_word ts)
   -> eval_instr lp i (of_estate s fn pc)
      = ok (of_estate s' fn pc.+1).
 Proof.
@@ -175,37 +555,326 @@ Proof.
   by rewrite zero_extend_u zero_extend_wrepr.
 Qed.
 
-Lemma arm_spec_lip_ensure_rsp_alignment ws ts' :
-  let al := align_word ws ts' in
-  let args := lip_ensure_rsp_alignment arm_liparams vrspi ws in
-  let i := MkLI ii (Lopn args.1.1 args.1.2 args.2) in
-  get_var (evm s) vrsp = ok (Vword ts')
+Lemma arm_spec_lip_set_up_sp_register s r ts al sz P Q :
+  let: ts' := align_word al (ts - wrepr Uptr sz) in
+  let: lcmd := set_up_sp_register arm_liparams vrspi sz al r in
+  is_linear_of lp fn (P ++ lcmd ++ Q)
+  -> isSome (lip_set_up_sp_register arm_liparams vrspi sz al r)
+  -> vtype r = sword reg_size
+  -> vtmp <> vrsp
+  -> vname (v_var r) \notin (lip_not_saved_stack arm_liparams)
+  -> v_var r <> vrsp
+  -> get_var (evm s) vrspi = ok (Vword ts)
   -> wf_vm (evm s)
   -> exists vm',
-      [/\ eval_instr lp i (of_estate s fn pc)
-          = ok (of_estate (with_vm s vm') fn pc.+1)
-        , vm' = (evm s).[vrsp <- ok (pword_of_word al)]%vmap
-              [\vflags]
-        , forall x,
-            Sv.In x vflags
-            -> ~ is_ok (vm'.[x]%vmap)
-            -> (evm s).[x]%vmap = vm'.[x]%vmap
-        & wf_vm vm'
-      ].
+       let: ls := of_estate s fn (size P) in
+       let: s' := with_vm s vm' in
+       let: ls' := of_estate s' fn (size P + size lcmd) in
+       let: vars := Sv.add (v_var r) (Sv.add vtmp (Sv.add vrsp vflags)) in
+       [/\ lsem lp ls ls'
+         , wf_vm vm'
+         , vm' = (evm s) [\ vars ]
+         , get_var vm' vrspi = ok (Vword ts')
+         , get_var vm' r = ok (Vword ts)
+         & forall x,
+             Sv.In x vflags
+             -> ~ is_ok (vm'.[x]%vmap)
+             -> (evm s).[x]%vmap = vm'.[x]%vmap
+       ].
 Proof.
-  move=> /= hvrsp hwm1.
-  rewrite /eval_instr /=.
-  rewrite /sem_sopn /=.
-  rewrite /get_gvar /=.
-  rewrite hvrsp /=.
-  rewrite zero_extend_u zero_extend_wrepr; last done.
-  rewrite pword_of_wordE.
-  rewrite /with_vm /=.
-  eexists; split=> //.
-  + move=> x hin. rewrite !(@Fv.setP _ _ vrsp).
-    case: (vrsp =P x) => //.
-    by move=> ?; subst x.
-  by apply wf_vm_set.
+  set ts' := align_word _ _.
+  move: r => [[rtype rname] rinfo] /=.
+  set r := {| v_info := rinfo; |}.
+
+  move=>
+    hbody hset_up ? hneq_tmp_rsp hnot_saved_stack hneq_r_rsp hgetrsp hwf_vm;
+    subst rtype.
+
+  move: hset_up.
+  rewrite /arm_set_up_sp_register.
+  case: ifP => // hset_up _.
+
+  have hneq_r_tmp :
+    v_var r <> vtmp.
+  - move=> [h]. move: hnot_saved_stack. by rewrite mem_seq1 h.
+  clear hnot_saved_stack.
+
+  move: hbody.
+  rewrite /set_up_sp_register /= /arm_set_up_sp_register hset_up /= -/vtmpi.
+  rewrite map_cat.
+  rewrite -catA /=.
+  set cmd_large_subi := _ _ (arm_cmd_large_subi _ _ _).
+  set i_mov_r := _ _ (arm_op_mov _ _).
+  set i_align_tmp := _ _ (arm_op_align _ _ _).
+  set i_mov_rsp := _ _ (arm_op_mov _ _).
+  rewrite -[i_mov_r :: _]/([:: i_mov_r ] ++ _).
+  rewrite catA.
+  move=> hbody.
+
+  (* We need [vm1] before [eexists]. *)
+  set vm0 := (evm s).[v_var r <- ok (pword_of_word ts)]%vmap.
+
+  have hsz : (0 <= sz < wbase reg_size)%Z.
+  - by move: hset_up => /andP [] /ZleP hlo /ZltP hhi.
+  clear hset_up.
+
+  have hgetrsp0 :
+    get_var vm0 vrsp = ok (Vword ts).
+  + rewrite get_var_neq; first exact: hgetrsp.
+    exact: hneq_r_rsp.
+
+  have [vm1 [hsem hvm1 hgettmp1]] :=
+    arm_cmd_large_subi_lsem
+      (s := with_vm s vm0)
+      hbody
+      hneq_tmp_rsp
+      hgetrsp0
+      hsz.
+
+  set vm2 := vm1.[vtmp <- ok (pword_of_word ts')]%vmap.
+  set vm3 := vm2.[vrsp <- ok (pword_of_word ts')]%vmap.
+
+  exists vm3; split.
+
+  - apply: lsem_step.
+
+    (* R[r] := R[rsp]; *)
+    + rewrite /lsem1 /step.
+      rewrite /of_estate.
+      rewrite -catA in hbody.
+      rewrite -{1}(addn0 (size P)).
+      move: (find_instr_skip hbody) => -> /=.
+
+      exact:
+        (arm_op_mov_eval_instr
+           _
+           (ls := {| lvm := evm s; |})
+           _ _ _
+           (y := vrspi)
+           hgetrsp).
+
+    (* R[tmp] := R[rsp] - off; *)
+    rewrite /=.
+
+    have -> :
+      size P + 1 = size (P ++ [:: i_mov_r ]).
+    - by rewrite size_cat.
+
+    rewrite -(add1n (size _)) addnA.
+    apply: (lsem_trans hsem).
+    clear hsem.
+    rewrite /of_estate /=.
+    apply: lsem_step2; rewrite /lsem1 /step.
+
+    (* R[tmp] := R[tmp] & alignment; *)
+    + move: (find_instr_skip hbody) => -> /=.
+      clear hbody.
+      rewrite onth_cat -/cmd_large_subi ltnn subnn /=.
+      exact:
+        (arm_op_align_eval_instr
+           _
+           (ls := {| lvm := vm1; |})
+           _ _ _
+           (y := vtmpi)
+           _
+           hgettmp1).
+
+    (* R[rsp] := R[tmp]; *)
+    + rewrite /= -addnA.
+      move: (find_instr_skip hbody) => -> /=.
+      clear hbody.
+      rewrite onth_cat lt_nm_n sub_nmn /=.
+
+      have hgettmp2 :
+        get_var vm2 vtmp = ok (Vword ts').
+      * by rewrite get_var_eq.
+
+     rewrite !size_cat /=.
+     rewrite
+       -(addn1 1)
+       (addnA _ 1 1)
+       (addn1 (_ + 1))
+       (addnS (_ + _) _)
+       -(addn1 (_ + _ + _)).
+     exact:
+        (arm_op_mov_eval_instr
+           _
+           (ls := {| lvm := vm2; |})
+           _ _ _
+           (y := vtmpi)
+           hgettmp2).
+
+  - repeat apply: wf_vm_set.
+    apply: (vmap_eq_except_wf_vm _ hvm1 hgettmp1).
+    exact: (wf_vm_set _ hwf_vm).
+
+  - move=> x.
+    t_notin_add.
+    t_vm_get.
+    rewrite hvm1; first by t_vm_get.
+    apply: Sv_neq_not_in_singleton.
+    by apply/nesym.
+
+  - by t_get_var.
+
+  - t_get_var.
+    rewrite (get_var_eq_except _ hvm1); first by t_get_var.
+    apply: Sv_neq_not_in_singleton.
+    by apply/nesym.
+
+  rewrite /= -/vm3.
+  move=> x hx _.
+  move: hx => /vflagsP hxtype.
+
+  have ? : v_var r <> x.
+  - apply/eqP. apply: vtype_diff. by rewrite hxtype.
+
+  have ? : vrsp <> x.
+  - apply/eqP. apply: vtype_diff. by rewrite hxtype.
+
+  have ? : vtmp <> x.
+  - apply/eqP. apply: vtype_diff. by rewrite hxtype.
+
+  t_vm_get.
+  rewrite hvm1 /=; first by t_vm_get.
+  by apply: Sv_neq_not_in_singleton.
+Qed.
+
+Lemma arm_spec_lip_set_up_sp_stack s ts m' al sz off P Q :
+  let: ts' := align_word al (ts - wrepr Uptr sz) in
+  let: lcmd := set_up_sp_stack arm_liparams vrspi sz al off in
+  is_linear_of lp fn (P ++ lcmd ++ Q)
+  -> isSome (lip_set_up_sp_stack arm_liparams vrspi sz al off)
+  -> vtmp <> vrsp
+  -> get_var (evm s) vrspi = ok (Vword ts)
+  -> wf_vm (evm s)
+  -> write (emem s) (ts' + wrepr Uptr off)%R ts = ok m'
+  -> exists vm',
+       let: ls := of_estate s fn (size P) in
+       let: s' := {| escs := escs s; evm := vm'; emem := m'; |} in
+       let: ls' := of_estate s' fn (size P + size lcmd) in
+       let: vars := Sv.add vtmpi (Sv.add vrspi vflags) in
+       [/\ lsem (spp := mk_spp) lp ls ls'
+         , wf_vm vm'
+         , vm' = (evm s) [\ vars ]
+         , get_var vm' vrspi = ok (Vword ts')
+         & forall x,
+             Sv.In x vflags
+             -> ~ is_ok (vm'.[x]%vmap)
+             -> (evm s).[x]%vmap = vm'.[x]%vmap
+       ].
+Proof.
+  set ts' := align_word _ _.
+  move=> hbody hset_up hneq_tmp_rsp hgetrsp hwf_vm hwrite.
+
+  move: hset_up.
+  rewrite /= /arm_set_up_sp_stack.
+  case: ifP => // hset_up _.
+
+  move: hbody.
+  rewrite /set_up_sp_stack /= /arm_set_up_sp_stack hset_up /= -/vtmpi.
+  rewrite map_cat /=.
+  set cmd_large_subi := map _ (arm_cmd_large_subi _ _ _).
+  set i_align_tmp := li_of_copn_args _ (arm_op_align _ _ _).
+  set i_str_rsp := li_of_copn_args _ (arm_op_str_off _ _ _).
+  set i_mov_rsp := li_of_copn_args _ (arm_op_mov _ _).
+  rewrite -catA.
+  move=> hbody.
+
+  (* We need [vm0] before [eexists]. *)
+
+  have hsz : (0 <= sz < wbase reg_size)%Z.
+  - by move: hset_up => /andP [] /ZleP hlo /ZltP hhi.
+  clear hset_up.
+
+  have [vm0 [hsem hvm0 hgettmp0]] :=
+    arm_cmd_large_subi_lsem (s := s) hbody hneq_tmp_rsp hgetrsp hsz.
+  set vm1 := vm0.[vtmp <- ok (pword_of_word ts')]%vmap.
+  set vm2 := vm1.[vrsp <- ok (pword_of_word ts')]%vmap.
+
+  have hgetrsp1 :
+    get_var vm1 vrsp = ok (Vword ts).
+  * rewrite get_var_neq; last exact: hneq_tmp_rsp.
+    rewrite (get_var_eq_except _ hvm0); first exact: hgetrsp.
+    exact: (Sv_neq_not_in_singleton hneq_tmp_rsp).
+
+  have hgettmp1 :
+    get_var vm1 vtmp = ok (Vword ts').
+  * by rewrite get_var_eq.
+
+  eexists.
+  split.
+
+  (* R[tmp] := R[rsp] - off; *)
+  - apply: (lsem_trans hsem).
+    apply: lsem_step3; rewrite /lsem1 /step /=.
+
+    (* R[tmp] := R[tmp] & alignment; *)
+    + move: (find_instr_skip hbody) => -> /=.
+      rewrite onth_cat -/cmd_large_subi ltnn subnn /=.
+      exact:
+        (arm_op_align_eval_instr
+           _
+           (ls := {| lvm := vm0; |})
+           _ _ _
+           (y := vtmpi)
+           _
+           hgettmp0).
+
+    (* M[R[rsp]] := R[tmp]; *)
+    + rewrite /= -addnA.
+      move: (find_instr_skip hbody) => -> /=.
+      rewrite onth_cat lt_nm_n sub_nmn /=.
+      exact:
+        (arm_op_str_off_eval_instr
+           _
+           (ls := {| lvm := vm1; |})
+           _
+           (y := vrspi)
+           hgettmp1
+           hgetrsp1
+           hwrite).
+
+    (* R[rsp] := R[tmp]; *)
+    + rewrite /= -!addnA addn1.
+      move: (find_instr_skip hbody) => -> /=.
+      rewrite onth_cat lt_nm_n sub_nmn /=.
+      rewrite /of_estate /=.
+      rewrite !size_cat /=.
+      rewrite -(addn1 2) (addnS _ 2) (addnS (size P) _) -(addn1 (_ + _)).
+      exact:
+        (arm_op_mov_eval_instr
+           _
+           (ls := {| lvm := vm1; |})
+           _ _ _
+           (y := vtmpi)
+           hgettmp1).
+
+  - repeat apply: wf_vm_set.
+    exact: (vmap_eq_except_wf_vm hwf_vm hvm0 hgettmp0).
+
+  - move=> x.
+    t_notin_add.
+    t_vm_get.
+    rewrite hvm0; first done.
+    apply: Sv_neq_not_in_singleton.
+    by apply/nesym.
+
+  - by t_get_var.
+
+  rewrite /= -/vm2.
+  move=> x hx _.
+  move: hx => /vflagsP hxtype.
+
+  have ? : vrsp <> x.
+  - apply/eqP. apply: vtype_diff. by rewrite hxtype.
+
+  have ? : vtmp <> x.
+  - apply/eqP. apply: vtype_diff. by rewrite hxtype.
+
+  t_vm_get.
+  rewrite hvm0 /=; first done.
+  by apply: Sv_neq_not_in_singleton.
 Qed.
 
 Lemma store_mn_of_wsizeP ws ws' mn (w : word ws) (w' : word ws') :
@@ -232,7 +901,7 @@ Proof.
 Qed.
 
 Lemma arm_hlip_lassign
-  (s1 s2 : estate) x e ws li ws' (w : word ws) (w' : word ws') :
+  (s1 s2 : estate) pc ii x e ws li ws' (w : word ws) (w' : word ws') :
   lassign arm_liparams x ws e = Some li
   -> sem_pexpr [::] s1 e = ok (Vword w')
   -> truncate_word ws w' = ok w
@@ -281,7 +950,8 @@ Definition arm_hliparams :
   {|
     spec_lip_allocate_stack_frame := arm_spec_lip_allocate_stack_frame;
     spec_lip_free_stack_frame := arm_spec_lip_free_stack_frame;
-    spec_lip_ensure_rsp_alignment := arm_spec_lip_ensure_rsp_alignment;
+    spec_lip_set_up_sp_register := arm_spec_lip_set_up_sp_register;
+    spec_lip_set_up_sp_stack := arm_spec_lip_set_up_sp_stack;
     hlip_lassign := arm_hlip_lassign;
   |}.
 

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -712,6 +712,9 @@ Definition cast_const z := cast_ptr (Pconst z).
 
 End WITH_POINTER_DATA.
 
+Definition eword_of_int (ws : wsize) (x : Z) : pexpr :=
+  Papp1 (Oword_of_int ws) (Pconst x).
+
 Definition wconst (sz: wsize) (n: word sz) : pexpr :=
   Papp1 (Oword_of_int sz) (Pconst (wunsigned n)).
 
@@ -901,3 +904,5 @@ Definition is_false (e: pexpr) : bool :=
 
 Definition is_zero sz (e: pexpr) : bool :=
   if e is Papp1 (Oword_of_int sz') (Pconst Z0) then sz' == sz else false.
+
+Notation copn_args := (seq lval * sopn * seq pexpr)%type (only parsing).

--- a/proofs/lang/linear_sem.v
+++ b/proofs/lang/linear_sem.v
@@ -176,6 +176,28 @@ Proof.
   by move=> H; apply: rt_trans; apply: rt_step.
 Qed.
 
+Lemma lsem_step2 ls0 ls1 ls2 :
+  lsem1 ls0 ls1
+  -> lsem1 ls1 ls2
+  -> lsem ls0 ls2.
+Proof.
+  move=> h0 h1.
+  apply: (lsem_step h0).
+  apply: (lsem_step h1).
+  exact: rt_refl.
+Qed.
+
+Lemma lsem_step3 ls0 ls1 ls2 ls3 :
+  lsem1 ls0 ls1
+  -> lsem1 ls1 ls2
+  -> lsem1 ls2 ls3
+  -> lsem ls0 ls3.
+Proof.
+  move=> h0 h1 h2.
+  apply: (lsem_step h0).
+  exact: (lsem_step2 h1 h2).
+Qed.
+
 Lemma lsem_step_end s2 s1 s3 :
   lsem s1 s2 →
   lsem1 s2 s3 →

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -229,6 +229,15 @@ Qed.
 Definition vm_initialized_on (vm: vmap) : seq var → Prop :=
   all (λ x, is_ok (get_var vm x >>= of_val (vtype x))).
 
+(* Attempt to simplify goals of the form
+   [get_var vm.[y0 <- z0]...[yn <- zn] x]. *)
+Ltac t_get_var :=
+  repeat (
+    rewrite get_var_eq
+    || (rewrite get_var_neq; last by [|apply/nesym])
+  ).
+
+
 (* ** Parameter expressions
  * -------------------------------------------------------------------- *)
 

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -1458,6 +1458,24 @@ Qed.
 Lemma Z_to_nat_le0 z : z <= 0 -> Z.to_nat z = 0%N.
 Proof. by rewrite /Z.to_nat; case: z => //=; rewrite /Z.le. Qed.
 
+Lemma Z_odd_pow_2 n x :
+  (0 < n)%Z
+  -> Z.odd (2 ^ n * x) = false.
+Proof.
+  move=> hn.
+  rewrite Z.odd_mul.
+  by rewrite (Z.odd_pow _ _ hn).
+Qed.
+
+Lemma Zle_n_nn n :
+  n <= n * n.
+Proof.
+  case: (Z.lt_ge_cases n 0); first Psatz.lia.
+  move: n.
+  apply: natlike_ind; Psatz.lia.
+Qed.
+
+
 (* ** Some Extra tactics
  * -------------------------------------------------------------------- *)
 
@@ -1471,6 +1489,50 @@ Proof. by move=> ?; split. Qed.
 (* -------------------------------------------------------------------- *)
 Definition ZleP : ∀ x y, reflect (x <= y) (x <=? y) := Z.leb_spec0.
 Definition ZltP : ∀ x y, reflect (x < y) (x <? y) := Z.ltb_spec0.
+
+(* -------------------------------------------------------------------- *)
+Section NAT.
+
+Open Scope nat.
+
+Lemma ZNleP x y :
+  reflect (Z.of_nat x <= Z.of_nat y)%Z (x <= y).
+Proof.
+  case h: (x <= y).
+  all: move: h => /leP /Nat2Z.inj_le.
+  all: by constructor.
+Qed.
+
+Lemma ZNltP x y :
+  reflect (Z.of_nat x < Z.of_nat y)%Z (x < y).
+Proof.
+  case h: (x < y).
+  all: move: h => /ZNleP.
+  all: rewrite Nat2Z.inj_succ.
+  all: move=> /Z.le_succ_l.
+  all: by constructor.
+Qed.
+
+Lemma subnn n :
+  n - n = 0.
+Proof. elim: n => //. Qed.
+
+Lemma lt_nm_n n m :
+  n + m < n = false.
+Proof.
+  rewrite -{2}(addn0 n).
+  rewrite ltn_add2l.
+  exact: ltn0.
+Qed.
+
+Lemma sub_nmn n m :
+  n + m - n = m.
+Proof.
+  elim: n => //.
+  by rewrite add0n subn0.
+Qed.
+
+End NAT.
 
 (* ------------------------------------------------------------------------- *)
 
@@ -1660,3 +1722,9 @@ Ltac t_elim_uniq :=
     move=> _
   );
   move=> _.
+
+Inductive and6 (P1 P2 P3 P4 P5 P6 : Prop) : Prop :=
+  And6 of P1 & P2 & P3 & P4 & P5 & P6.
+
+Notation "[ /\ P1 , P2 , P3 , P4 , P5 & P6 ]" :=
+  (and6 P1 P2 P3 P4 P5 P6) : type_scope.

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -1467,15 +1467,6 @@ Proof.
   by rewrite (Z.odd_pow _ _ hn).
 Qed.
 
-Lemma Zle_n_nn n :
-  n <= n * n.
-Proof.
-  case: (Z.lt_ge_cases n 0); first Psatz.lia.
-  move: n.
-  apply: natlike_ind; Psatz.lia.
-Qed.
-
-
 (* ** Some Extra tactics
  * -------------------------------------------------------------------- *)
 
@@ -1512,10 +1503,6 @@ Proof.
   all: move=> /Z.le_succ_l.
   all: by constructor.
 Qed.
-
-Lemma subnn n :
-  n - n = 0.
-Proof. elim: n => //. Qed.
 
 Lemma lt_nm_n n m :
   n + m < n = false.


### PR DESCRIPTION
The architecture parameter that aligns the stack pointer for export functions is now an optional piece of code, instead of an instruction.
Since in some architectures (ARMv7 and RISC-V for instance) we need an extra register whether we store the stack pointer in a register or in the stack, the function that chooses where to store the stack pointer now excludes certain variables (the extra register in these cases).
The solution implemented in ARM is not optimal: if the value is in [0, 4095], it can be done in one instruction, if it fits in 16 bits in two, and otherwise we use what's implemented now. But what is implemented now always works and I'll add this optimization shortly.