### PR TITLE
DIV and MOD can be used in compound assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
     warning, a vector suffix (e.g., `_4u32`)
     ([PR #303](https://github.com/jasmin-lang/jasmin/pull/303)).
 
+- Division and modulo operators can be used in compound assignments
+  (e.g., `x /= y`)
+  ([PR #324](https://github.com/jasmin-lang/jasmin/pull/324)).
+
 ## Bug fixes
 
  - The x86 instructions `VMOVSHDUP` and `VMOVSLDUP` accept a size suffix (`_128`

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -296,6 +296,8 @@ peqop:
 | PLUS  c=castop EQ  { `Add  c }
 | MINUS c=castop EQ  { `Sub  c }
 | STAR  c=castop EQ  { `Mul  c }
+| SLASH c=castop EQ  { `Div  c }
+| PERCENT c=castop EQ  { `Mod  c }
 | s=loc(GTGT)  c=castop EQ  { `ShR  (setsign c s) }
 | LTLT  c=castop EQ  { `ShL  c }
 | ROR   c=castop EQ  { `ROR  c }

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -945,6 +945,8 @@ let peop2_of_eqop (eqop : S.peqop) =
   | `Add  s -> Some (`Add s)
   | `Sub  s -> Some (`Sub s)
   | `Mul  s -> Some (`Mul s)
+  | `Div  s -> Some (`Div s)
+  | `Mod  s -> Some (`Mod s)
   | `ShR  s -> Some (`ShR s)
   | `ROR  s -> Some (`ROR s)
   | `ROL  s -> Some (`ROL s)

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -197,6 +197,8 @@ type peqop = [
   | `Add  of castop 
   | `Sub  of castop
   | `Mul  of castop
+  | `Div  of castop
+  | `Mod  of castop
   | `ShR  of castop
   | `ROR  of castop
   | `ROL  of castop

--- a/compiler/tests/success/divmod.jazz
+++ b/compiler/tests/success/divmod.jazz
@@ -62,3 +62,14 @@ r += e;
 s = r;
 return s;
 }
+
+export
+fn test_compound(reg u64 x y) -> reg u64 {
+  reg u64 a b c;
+  a = x;
+  b = y;
+  a /= b;
+  a %= b;
+  c = a;
+  return c;
+}


### PR DESCRIPTION
There seems to be no justification to the current limitation.