### PR TITLE
Turn a reachable “assert false” into a proper error

### DIFF
--- a/compiler/src/alias.ml
+++ b/compiler/src/alias.ml
@@ -157,7 +157,8 @@ let slice_of_pexpr a =
   | Parr_init _ -> None
   | Pvar x -> Some (normalize_gvar a x)
   | Psub (aa, ws, len, x, i) -> Some (normalize_asub a aa ws len x i)
-  | (Pconst _ | Pbool _ | Pget _ | Pload _ | Papp1 _ | Papp2 _ | PappN _ | Pif _) -> assert false
+  | (Pconst _ | Pbool _ | Pget _ | Pload _ | Papp1 _ | Papp2 _ | PappN _ ) -> assert false
+  | Pif _ -> hierror_no_loc "conditional move of (ptr) arrays is not supported yet"
 
 let slice_of_lval a =
   function

--- a/compiler/tests/pending/cmoveptr.jazz
+++ b/compiler/tests/pending/cmoveptr.jazz
@@ -1,0 +1,31 @@
+export
+fn test(reg u64 a) -> reg u8 {
+  stack u8[2] s;
+  reg ptr u8[1] p q r;
+  reg u8 f;
+  s[0] = 0;
+  s[1] = 1;
+  p = s[0:1];
+  q = s[1:1];
+  r = p;
+  r = q if a <s 0;
+  f = r[0];
+  return f;
+}
+
+inline
+fn zero() -> reg u8 {
+  reg u8 r;
+  #inline r = test(42);
+  return r;
+}
+
+inline
+fn one() -> reg u8 {
+  reg u8 r;
+  #inline r = test(-42);
+  return r;
+}
+
+exec zero()
+exec one()


### PR DESCRIPTION
This is a trivial fix. Proper handling of uncertainty about `ptr` targets seems more daunting.