### PR TITLE
ARM: fix pretty-printing of JAL & CALL asm instructions

### DIFF
--- a/compiler/examples/arm_m4/stack.jazz
+++ b/compiler/examples/arm_m4/stack.jazz
@@ -1,0 +1,25 @@
+fn leaf() -> reg u32 {
+  stack u32 r;
+  reg u32 f;
+  inline int i;
+  f = 0;
+  r = f;
+  for i = 0 to 4 {
+    f = r;
+    f += i;
+    r = f;
+  }
+  f = r;
+  return f;
+}
+
+export
+fn main(reg u32 x) -> reg u32 {
+  stack u32 s;
+  reg u32 k;
+  s = x;
+  k = leaf();
+  x = s;
+  x += k;
+  return x;
+}

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -180,11 +180,11 @@ let pp_instr tbl fn (_ : Format.formatter) i =
       let iname = Printf.sprintf "b%s" (pp_condt ct) in
       [ LInstr (iname, [ pp_label fn lbl ]) ]
 
-  | JAL _ ->
-      failwith "TODO_ARM: pp_instr jal"
-
-  | CALL lbl ->
+  | JAL (LR, lbl) ->
       [ LInstr ("bl", [ pp_remote_label tbl lbl ]) ]
+
+  | CALL _
+  | JAL _ -> assert false
 
   | POPPC ->
       [ LInstr ("pop", [ "{pc}" ]) ]


### PR DESCRIPTION
There is no CALL instruction on ARM…

CI: https://gitlab.com/jasmin-lang/jasmin/-/pipelines/758228456