### PR TITLE
Compiler: perform two rounds of range splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@
   can be expressed using equality and disequality tests
   ([PR #270](https://github.com/jasmin-lang/jasmin/pull/270)).
 
+- The live-range-splitting transformation is run a second time after
+  expansion of register arrays
+  ([PR #341](https://github.com/jasmin-lang/jasmin/pull/341)).
+
 # Jasmin 2022.09.0
 
 ## Bug fixes

--- a/compiler/tests/success/bug_340.jazz
+++ b/compiler/tests/success/bug_340.jazz
@@ -1,0 +1,13 @@
+inline fn xor(reg u256 a b) -> reg u256 {
+  reg u256 c;
+  c = a ^ b;
+  return c;
+}
+
+export
+fn main(reg u256 x) -> reg u256 {
+  reg u256[1] a;
+  a[0] = x;
+  x = xor(a[0], a[0]);
+  return x;
+}

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -225,6 +225,18 @@ Definition check_no_ptr entries (ao: funname -> stk_alloc_oracle_t) : cexec unit
        assert (allNone sao.(sao_return)) (pp_at_fn fn (stack_alloc.E.stk_error_no_var "export functions don’t support “ptr” return values")))
     entries.
 
+Definition live_range_splitting (p: uprog) : cexec uprog :=
+  let pv := split_live_ranges_prog p in
+  let pv := cparams.(print_uprog) Splitting pv in
+  let pv := renaming_prog pv in
+  let pv := cparams.(print_uprog) Renaming pv in
+  let pv := remove_phi_nodes_prog pv in
+  let pv := cparams.(print_uprog) RemovePhiNodes pv in
+  Let _ := check_uprog p.(p_extra) p.(p_funcs) pv.(p_extra) pv.(p_funcs) in
+  Let pv := dead_code_prog (ap_is_move_op aparams) pv false in
+  let p := cparams.(print_uprog) DeadCode_Renaming pv in
+  ok p.
+
 Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
 
   Let p := array_copy_prog cparams.(fresh_counter) p in
@@ -242,21 +254,15 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
   Let p := unroll_loop (ap_is_move_op aparams) p in
   let p := cparams.(print_uprog) Unrolling p in
 
-  let pv := split_live_ranges_prog p in
-  let pv := cparams.(print_uprog) Splitting pv in
-  let pv := renaming_prog pv in
-  let pv := cparams.(print_uprog) Renaming pv in
-  let pv := remove_phi_nodes_prog pv in
-  let pv := cparams.(print_uprog) RemovePhiNodes pv in
-  Let _ := check_uprog p.(p_extra) p.(p_funcs) pv.(p_extra) pv.(p_funcs) in
-  Let pv := dead_code_prog (ap_is_move_op aparams) pv false in
-  let pv := cparams.(print_uprog) DeadCode_Renaming pv in
+  Let pv := live_range_splitting p in
 
   let pr := remove_init_prog cparams.(is_reg_array) pv in
   let pr := cparams.(print_uprog) RemoveArrInit pr in
 
   Let pe := expand_prog cparams.(expand_fd) pr in
   let pe := cparams.(print_uprog) RegArrayExpansion pe in
+
+  Let pe := live_range_splitting pe in
 
   Let pg := remove_glob_prog cparams.(is_glob) cparams.(fresh_id) pe in
   let pg := cparams.(print_uprog) RemoveGlobal pg in


### PR DESCRIPTION
The first round, before expansion of register arrays, does not apply to cells of register arrays. The second round fixes this limitation.

CI: https://gitlab.com/jasmin-lang/jasmin/-/pipelines/765177635