### PR TITLE
Remove DF flag from x86

### DIFF
--- a/proofs/compiler/x86_decl.v
+++ b/proofs/compiler/x86_decl.v
@@ -38,7 +38,7 @@ Variant xmm_register : Type :=
 .
 
 (* -------------------------------------------------------------------- *)
-Variant rflag : Type := CF | PF | ZF | SF | OF | DF.
+Variant rflag : Type := CF | PF | ZF | SF | OF.
 
 (* -------------------------------------------------------------------- *)
 Variant condt : Type :=
@@ -203,7 +203,7 @@ Canonical xreg_finType :=
 
 (* -------------------------------------------------------------------- *)
 #[ local ]
-Definition rflags := [:: CF; PF; ZF; SF; OF; DF].
+Definition rflags := [:: CF; PF; ZF; SF; OF ].
 
 #[ local ]
 Lemma rflags_fin_axiom : Finite.axiom rflags.
@@ -361,7 +361,6 @@ Definition x86_string_of_rflag (rf : rflag) : string :=
  | ZF => "ZF"
  | SF => "SF"
  | OF => "OF"
- | DF => "DF"
  end%string.
 
 Lemma x86_string_of_rflag_inj : injective x86_string_of_rflag.

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -187,7 +187,6 @@ Fixpoint assemble_cond_r ii (e : fexpr) : cexec condt :=
       | ZF => ok E_ct
       | SF => ok S_ct
       | PF => ok P_ct
-      | DF => Error (E.berror ii e "Cannot branch on DF")
       end
 
   | Fapp1 Onot e =>


### PR DESCRIPTION
There was no way to interact with this flag.