### PR TITLE
detect number of cores to make better use of modern machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ PREFIX   ?= /usr/local
 PREFIX   := $(abspath $(PREFIX))
 export PREFIX
 
+# detect the given number of job slots
+MAKE_PID := $(shell echo $$PPID)
+JOB_FLAG := $(shell ps T | sed -n 's/.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs=*\) *\([0-9]*\).*/-j\2/p')
+JOB_NUM  := $(or $(patsubst -j%,%,$(or $(JOB_FLAG),-j1)),$(shell nproc))
 # --------------------------------------------------------------------
 .PHONY: all build check clean install uninstall dist distcheck
 
@@ -16,8 +20,8 @@ all: build
 
 build:
 	$(MAKE) -C proofs all
-	$(MAKE) -C compiler CIL
-	$(MAKE) -C compiler all
+	$(MAKE) -C compiler CIL JOB_NUM=$(JOB_NUM)
+	$(MAKE) -C compiler all JOB_NUM=$(JOB_NUM)
 
 check:
 	$(MAKE) -C eclib check

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -1,7 +1,11 @@
 # -*- Makefile -*-
 
 # --------------------------------------------------------------------
-OCAMLBUILD_JOBS  ?= 2
+MAKE_PID := $(shell echo $$PPID)
+JOB_FLAG := $(shell ps T | sed -n 's/.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs=*\) *\([0-9]*\).*/-j\2/p')
+JOB_NUM  ?= $(or $(patsubst -j%,%,$(or $(JOB_FLAG),-j1)),$(shell nproc))
+
+OCAMLBUILD_JOBS  ?= $(JOB_NUM)
 OCAMLBUILD_BIN   ?= ocamlbuild
 OCAMLBUILD_EXTRA ?=
 OCAMLBUILD_OPTS  := -use-ocamlfind -j $(OCAMLBUILD_JOBS)
@@ -15,7 +19,7 @@ OCAMLBUILD_OPTS += $(OCAMLBUILD_EXTRA)
 OCAMLBUILD := $(OCAMLBUILD_BIN) $(OCAMLBUILD_OPTS)
 
 # --------------------------------------------------------------------
-JSJOBS    ?= 2
+JSJOBS    ?= $(JOB_NUM)
 CHECKPY   ?=
 CHECK     := $(CHECKPY) scripts/runtest --jobs="$(JSJOBS)"
 CHECK     += config/tests.config


### PR DESCRIPTION
This patch unifies the number of OCaml build jobs and the number of Make jobs by default.

Users retain the ability to use a different number of OCaml and JS build jobs, by setting environment variable OCAMLBUILD_JOBS and JSJOBS respectively.

The behavior is as follows:

- If the user does not specify -j at the root dir, then both jasmin/Makefile and jasmin/compiler/Makefile will be invoked with one single job.

- If the user specifies a number, e.g. -j10, at the root dir, then both aforementioned Makefiles will be invoked with 10 jobs.

- If the user passes -j but does not specify a number at the root dir, then both Makefiles will be invoked with as many parallel jobs as the number of detected cores.

- Invoking jasmin/compiler/Makefile in the subdir directly has the same behavior as above, except that the root dir will not be touched.