### PR TITLE
Remove is_regx from lowering-params

### DIFF
--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -97,7 +97,6 @@ let main () =
     ; fresh_PF = (b "PF").vname
     ; fresh_ZF = (b "ZF").vname
     ; fresh_multiplicand = (fun sz -> (f (Bty (U sz)) "multiplicand").vname)
-    ; is_regx = is_regx tbl
     }) in
   try
     parse();

--- a/proofs/compiler/arch_params.v
+++ b/proofs/compiler/arch_params.v
@@ -21,7 +21,8 @@ Record lowering_params
   {
     (* Lower an instruction to architecture-specific instructions. *)
     lop_lower_i :
-      lowering_options      (* Lowering options depend on the architecture. *)
+      (var -> bool) (* Whether the variable is a register from the extra bank. *)
+      -> lowering_options      (* Lowering options depend on the architecture. *)
       -> (instr_info -> warning_msg -> instr_info)
       -> fresh_vars
       -> (var_i -> bool)    (* Whether the variable is in memory. *)

--- a/proofs/compiler/arch_params_proof.v
+++ b/proofs/compiler/arch_params_proof.v
@@ -36,6 +36,7 @@ Record h_lowering_params
         (sCP : semCallParams)
         (p : prog)
         (ev : extra_val_t)
+        (is_regx : var -> bool)
         (options : lowering_options)
         (warning : instr_info -> warning_msg -> instr_info)
         (fv : fresh_vars)
@@ -48,7 +49,7 @@ Record h_lowering_params
         sem_call p ev scs mem f va scs' mem' vr
         -> let lprog :=
              lowering.lower_prog
-               (lop_lower_i loparams)
+               (lop_lower_i loparams is_regx)
                options
                warning
                fv

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -196,7 +196,7 @@ Definition arm_fvars_correct
 
 Definition arm_loparams : lowering_params fresh_vars lowering_options :=
   {|
-    lop_lower_i := fun _ _ => lower_i;
+    lop_lower_i _ _ _ := lower_i;
     lop_fvars_correct := arm_fvars_correct;
   |}.
 

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -942,6 +942,7 @@ Lemma arm_lower_callP
   (sCP : semCallParams)
   (p : prog)
   (ev : extra_val_t)
+  (is_regx : var -> bool)
   (options : lowering_options)
   (warning : instr_info -> warning_msg -> instr_info)
   (fv : fresh_vars)
@@ -953,7 +954,7 @@ Lemma arm_lower_callP
   psem.sem_call p ev scs mem f va scs' mem' vr
   -> let lprog :=
        lowering.lower_prog
-         (lop_lower_i arm_loparams)
+         (lop_lower_i arm_loparams is_regx)
          options
          warning
          fv

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -278,7 +278,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
 
   let pl :=
     lower_prog
-      (lop_lower_i loparams)
+      (lop_lower_i loparams (is_regx cparams))
       (lowering_opt cparams)
       (warning cparams)
       (lowering_vars cparams)

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -167,9 +167,10 @@ Proof.
     exact: Hvr'.
   apply: compose_pass.
   - move => vr'.
-    by apply:
+    exact:
       (hlop_lower_callP
          (hap_hlop haparams)
+         (is_regx cparams)
          (lowering_opt cparams)
          (warning cparams)
          (is_var_in_memory cparams)

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -22,8 +22,6 @@ Definition mov_ws ws x y tag :=
   else
     Copn [:: x] tag (Ox86 (MOV ws)) [:: y].
 
-End IS_REGX.
-
 Section LOWERING.
 
 Record fresh_vars : Type :=
@@ -35,7 +33,6 @@ Record fresh_vars : Type :=
     fresh_ZF : Equality.sort Ident.ident;
 
     fresh_multiplicand : wsize → Equality.sort Ident.ident;
-    is_regx            : var -> bool
   }.
 
 Record lowering_options : Type :=
@@ -468,7 +465,7 @@ Definition lower_cassgn (ii:instr_info) (x: lval) (tg: assgn_tag) (ty: stype) (e
         else
           [:: MkI ii (Copn [:: x] tg (Oasm (ExtOp (Oset0 szty))) [::]) ]
       else 
-        [:: MkI ii (mov_ws fv.(is_regx) szty x e tg)]
+        [:: MkI ii (mov_ws szty x e tg)]
   | LowerCopn o e => copn o e
   | LowerInc o e => inc o e
   | LowerFopn sz o es m => map (MkI ii) (opn_5flags m sz vi f x tg o es)
@@ -616,3 +613,5 @@ Fixpoint lower_i (i:instr) : cmd :=
   end.
 
 End LOWERING.
+
+End IS_REGX.

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -27,15 +27,15 @@ Section PROOF.
   Variable p : prog.
   Variable ev : extra_val_t.
   Notation gd := (p_globs p).
-  Context (options: lowering_options).
+  Context (is_regx: var -> bool) (options: lowering_options).
   Context (warning: instr_info -> warning_msg -> instr_info).
   Variable fv : fresh_vars.
   Context (is_var_in_memory: var_i → bool).
 
   Notation lower_prog :=
-    (lower_prog (asmop := _asmop) lower_i options warning fv is_var_in_memory).
+    (lower_prog (asmop := _asmop) (lower_i is_regx) options warning fv is_var_in_memory).
   Notation lower_cmd :=
-    (lower_cmd (asmop := _asmop) lower_i options warning fv is_var_in_memory).
+    (lower_cmd (asmop := _asmop) (lower_i is_regx) options warning fv is_var_in_memory).
 
   Hypothesis fvars_correct: fvars_correct fv (p_funcs p).
 
@@ -117,7 +117,7 @@ Section PROOF.
   Let Pi s (i:instr) s' :=
     disj_fvars (vars_I i) ->
     forall s1, eq_exc_fresh s1 s ->
-      exists s1', sem p' ev s1 (lower_i options warning fv is_var_in_memory i) s1' /\ eq_exc_fresh s1' s'.
+      exists s1', sem p' ev s1 (lower_i is_regx options warning fv is_var_in_memory i) s1' /\ eq_exc_fresh s1' s'.
 
   Let Pi_r s (i:instr_r) s' :=
     forall ii, Pi s (MkI ii i) s'.
@@ -1103,7 +1103,7 @@ Section PROOF.
     by move => hle; rewrite !zero_extend_wrepr.
   Qed.
 
-  Lemma mov_wsP p1 is_regx s1 e ws tag i x w s2 :
+  Lemma mov_wsP p1 s1 e ws tag i x w s2 :
     (ws <= U64)%CMP -> 
     (Let i' := sem_pexpr (p_globs p1) s1 e in to_word ws i') = ok i
     -> write_lval (p_globs p1) x (Vword i) s1 = ok s2


### PR DESCRIPTION
It is already part of the compiler params, and shared with other passes.

CI: https://gitlab.com/jasmin-lang/jasmin/-/pipelines/783160558