### PR TITLE
Safety checker: on-demand unrolling of while loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   ([PR #372](https://github.com/jasmin-lang/jasmin/pull/372)).
 
 - The safety checker fully unrolls `while` loops annotated as `#bounded`
+  and does not attempt at proving termination of `while` loops annotated
+  with `#no_termination_check`
   ([PR #362](https://github.com/jasmin-lang/jasmin/pull/362)).
 
 ## Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
   `jazz2tex` tool; the `-latex` command line flag is deprecated
   ([PR #372](https://github.com/jasmin-lang/jasmin/pull/372)).
 
+- The safety checker fully unrolls `while` loops annotated as `#bounded`
+  ([PR #362](https://github.com/jasmin-lang/jasmin/pull/362)).
+
 ## Bug fixes
 
 - The x86 instructions `VMOVSHDUP` and `VMOVSLDUP` accept a size suffix (`_128`

--- a/compiler/safety/fail/bounded_while.jazz
+++ b/compiler/safety/fail/bounded_while.jazz
@@ -1,0 +1,23 @@
+param int N = 4;
+
+export
+fn uninit(reg u64 bound) -> reg u64 {
+  reg u64 i max;
+  stack u64[N] t;
+  max = N;
+  max = bound if bound < N;
+  i = 0;
+  #bounded
+  while (i < max) {
+    t[(int) i] = i;
+    i += 1;
+  }
+  max = t[N - 1];
+  return max;
+}
+
+inline
+fn test() {
+  #inline _ = uninit(0);
+}
+exec test()

--- a/compiler/safety/success/bounded_while.jazz
+++ b/compiler/safety/success/bounded_while.jazz
@@ -1,0 +1,15 @@
+param int N = 256;
+
+export
+fn test() -> reg u64 {
+  stack u64[N] t;
+  reg u64 i;
+  i = 0;
+  #bounded
+  while (i < N) {
+    t[(int) i] = i;
+    i += 1;
+  }
+  i = t[N/2];
+  return i;
+}

--- a/compiler/safety/success/trusted-termination.jazz
+++ b/compiler/safety/success/trusted-termination.jazz
@@ -1,0 +1,14 @@
+export
+fn eventually_terminates() -> reg u64 {
+  reg u64 r c;
+  stack u8[1] b;
+  ?{}, c = #set0();
+  #no_termination_check
+  while {
+    b = #randombytes(b);
+  } (b[0] != 0) {
+    c += 1;
+  }
+  r = c;
+  return r;
+}

--- a/compiler/src/safety/safetyPreanalysis.ml
+++ b/compiler/src/safety/safetyPreanalysis.ml
@@ -71,11 +71,11 @@ end = struct
 
   and mk_lvals fn lvs = List.map (mk_lval fn) lvs
 
-  and mk_instr fn st = { i_desc = mk_instr_r fn st.i_desc;
-                         i_loc = st.i_loc;
-                         i_info = { i_instr_number = uniq_i_nb ();};
-                         i_annot = [];
-                       }
+  and mk_instr fn st = {
+      st with
+      i_desc = mk_instr_r fn st.i_desc;
+      i_info = { i_instr_number = uniq_i_nb ();};
+    }
 
   and mk_instr_r fn st = match st with
     | Cassgn (lv, tag, ty, e) ->

--- a/compiler/tests/success/stack_array.jazz
+++ b/compiler/tests/success/stack_array.jazz
@@ -7,6 +7,7 @@ fn fill(reg u64 in, reg u64 out, reg u64 len) -> reg u64 {
    max = len if len < max;
 
    i = 0;
+   #bounded
    while (i < max) {
      // t[(int)i] = [in + 8 * i];  // works but not in the spirit
      aux = [in + 8 * i];


### PR DESCRIPTION
While loops with a `#bounded` annotation are optimistically unrolled during safety analysis until the loop condition can be refuted.

CI: https://gitlab.com/jasmin-lang/jasmin/-/pipelines/790348734