### PR TITLE
Register allocation: register banks depend on arch

### DIFF
--- a/compiler/tests/fail/arm-m4/bug_201.jazz
+++ b/compiler/tests/fail/arm-m4/bug_201.jazz
@@ -1,0 +1,3 @@
+export
+fn main (reg u64 state)  {
+}


### PR DESCRIPTION
The classification of registers between general-purpose “word”-sized registers and “vector” registers depends on the architecture.

Fixes #201