### PR TITLE
checksafety: heuristic for bounded loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@
 - The safety checker fully unrolls `while` loops annotated as `#bounded`
   and does not attempt at proving termination of `while` loops annotated
   with `#no_termination_check`
-  ([PR #362](https://github.com/jasmin-lang/jasmin/pull/362)).
+  ([PR #362](https://github.com/jasmin-lang/jasmin/pull/362)),
+  ([PR #384](https://github.com/jasmin-lang/jasmin/pull/384)).
 
 ## Bug fixes
 

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -553,6 +553,9 @@ let rec has_call_or_syscall_i i =
 
 and has_call_or_syscall c = List.exists has_call_or_syscall_i c
 
+let has_annot a { i_annot ; _ } =
+  List.exists (fun (k, _) -> String.equal (L.unloc k) a) i_annot
+
 (* -------------------------------------------------------------------- *)
 let clamp (sz : wsize) (z : Z.t) =
   Z.erem z (Z.shift_left Z.one (int_of_ws sz))

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -329,6 +329,8 @@ val expr_of_lval : 'len glval -> 'len gexpr option
 
 val has_syscall : ('len, 'info, 'asm) gstmt -> bool
 val has_call_or_syscall : ('len, 'info, 'asm) gstmt -> bool
+val has_annot : Annotations.symbol -> ('len, 'info, 'asm) ginstr -> bool
+
 (* -------------------------------------------------------------------- *)
 val clamp : wsize -> Z.t -> Z.t
 val clamp_pe : pelem -> Z.t -> Z.t

--- a/compiler/src/safety/safetyInterpreter.ml
+++ b/compiler/src/safety/safetyInterpreter.ml
@@ -1555,9 +1555,6 @@ end = struct
       fname
       L.pp_iloc ginstr.i_loc
 
-  let has_annot a { i_annot ; _ } =
-    List.exists (fun (k, _) -> String.equal (L.unloc k) a) i_annot
-
   let cells_of_array x ofs n =
     let x = L.unloc x in
     List.init (Conv.int_of_pos n) (fun i -> SafetyVar.AarraySlice (x, U8, ofs + i))

--- a/compiler/src/safety/safetyPreanalysis.ml
+++ b/compiler/src/safety/safetyPreanalysis.ml
@@ -366,6 +366,12 @@ end = struct
       (* We ignore the loop index, since we do not use widening for loops. *)
       pa_stmt fn prog st c
 
+    | Cwhile (_, c1, _, c2) when has_annot "bounded" instr ->
+      (* Ignore the loop condition, as this loop will be fully unrolled at analysis time. *)
+      let st = pa_stmt fn prog st c1 in
+      let st = pa_stmt fn prog st c2 in
+      st
+
     | Cwhile (_, c1, b, c2) ->
       let vs,st = expr_vars st b in
 


### PR DESCRIPTION
Variables that are involved in the guards of bounded loops need not be put in the relational domain.