### PR TITLE
CI: split the Coq job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,17 +45,29 @@ cache dependencies:
     | xargs nix-store --query --requisites
     | cachix push jasmin'
 
-coq:
+coq-program:
   stage: prove
   variables:
     EXTRA_NIX_ARGUMENTS: --arg coqDeps true
   extends: .common
   script:
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs'
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs Makefile.coq'
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs -f Makefile.coq compiler/jasmin_compiler.vo'
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C compiler CIL'
   artifacts:
     paths:
+    - proofs/
     - compiler/CIL/
+
+coq-proof:
+  stage: prove
+  variables:
+    EXTRA_NIX_ARGUMENTS: --arg coqDeps true
+  extends: .common
+  needs:
+  - coq-program
+  script:
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs'
 
 ocaml:
   stage: build
@@ -63,9 +75,7 @@ ocaml:
     EXTRA_NIX_ARGUMENTS: --arg ocamlDeps true
   extends: .common
   needs:
-  - coq
-  dependencies:
-  - coq
+  - coq-program
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C compiler'
   artifacts:
@@ -121,9 +131,7 @@ opam-compiler:
     EXTRA_NIX_ARGUMENTS: --arg opamDeps true
   extends: .common
   needs:
-  - coq
-  dependencies:
-  - coq
+  - coq-program
   cache:
     key:
       files:
@@ -149,9 +157,7 @@ tarball:
     TARBALL: jasmin-compiler-$CI_COMMIT_SHORT_SHA
   extends: .common
   needs:
-  - coq
-  dependencies:
-  - coq
+  - coq-program
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -C compiler dist DISTDIR=$TARBALL'
   artifacts:
@@ -164,8 +170,6 @@ build-from-tarball:
     TARBALL: jasmin-compiler-$CI_COMMIT_SHORT_SHA
   needs:
   - tarball
-  dependencies:
-  - tarball
   script:
   - tar xvf compiler/$TARBALL.tgz
   - nix-build -o out $TARBALL
@@ -177,10 +181,7 @@ check:
     EXTRA_NIX_ARGUMENTS: --arg testDeps true
   extends: .common
   needs:
-  - coq
-  - ocaml
-  dependencies:
-  - coq
+  - coq-program
   - ocaml
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './compiler/jasminc.native -version'
@@ -192,10 +193,7 @@ libjade-compile-to-asm:
     EXTRA_NIX_ARGUMENTS: --arg testDeps true
   extends: .common
   needs:
-  - coq
-  - ocaml
-  dependencies:
-  - coq
+  - coq-program
   - ocaml
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './scripts/test-libjade.sh src'
@@ -213,10 +211,7 @@ libjade-extract-to-ec:
     ECJOBS: '$(NIX_BUILD_CORES)'
   extends: .common
   needs:
-  - coq
-  - ocaml
-  dependencies:
-  - coq
+  - coq-program
   - ocaml
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt why3config -why3 $WHY3_CONF'
@@ -238,10 +233,7 @@ test-extract-to-ec:
     JSJOBS: $(NIX_BUILD_CORES)
   extends: .common
   needs:
-  - coq
-  - ocaml
-  dependencies:
-  - coq
+  - coq-program
   - ocaml
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt why3config -why3 $WHY3_CONF'
@@ -261,8 +253,6 @@ push-compiler-code:
     GIT_STRATEGY: none
     TARBALL: jasmin-compiler-$CI_COMMIT_SHORT_SHA
   needs:
-  - tarball
-  dependencies:
   - tarball
   before_script:
   - nix-env -iA nixpkgs.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,8 +51,6 @@ coq-program:
     EXTRA_NIX_ARGUMENTS: --arg coqDeps true
   extends: .common
   script:
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs Makefile.coq'
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs -f Makefile.coq compiler/jasmin_compiler.vo'
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C compiler CIL'
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ ocaml:
     paths:
     - compiler/_build/
     - compiler/jasminc.native
-    - compiler/jasminpp.native
+    - compiler/jazz2tex.native
 
 eclib:
   stage: prove

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,6 @@ variables:
 
 .common:
   before_script:
-  - nix-shell -p nix-info --run 'nix-info -m'
   - >-
     nix-shell
     --extra-substituters "$EXTRA_SUBSTITUTERS"

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -56,6 +56,7 @@ compiler/dead_code.v
 compiler/dead_code_proof.v
 compiler/inline.v
 compiler/inline_proof.v
+compiler/jasmin_compiler.v
 compiler/lea.v
 compiler/lea_proof.v
 compiler/linearization.v

--- a/proofs/compiler/jasmin_compiler.v
+++ b/proofs/compiler/jasmin_compiler.v
@@ -1,0 +1,6 @@
+(** This module is meant as the minimal dependency of extracted code. *)
+Require compiler.
+Require sem.
+Require arm_params.
+Require x86_params.
+Require sem_params_of_arch_extra.

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -1,12 +1,9 @@
-Require Import var compiler.
-Require sem.
-Require arm_params.
-Require x86_params.
-Require sem_params_of_arch_extra.
-Require waes.
+Require jasmin_compiler.
+(* Do not “Require” other modules from Jasmin here:
+   expand the jasmin_compiler module instead. *)
 
-Require ExtrOcamlBasic.
-Require ExtrOcamlString.
+From Coq Require ExtrOcamlBasic.
+From Coq Require ExtrOcamlString.
 
 (* This is a hack to force the extraction to keep the singleton here,
    This need should be removed if we add more constructor to syscall_t *)

--- a/scripts/nixpkgs.nix
+++ b/scripts/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/6a0d2701705c3cf6f42c15aa92b7885f1f8a477f.tar.gz";
-  sha256 = "sha256:0dk8wx7rn6311rf1hanwda6xrgb0rbk4a1wf1zavjfcyxk2687lg";
+  url = "https://github.com/NixOS/nixpkgs/archive/67f26c1cfc5d5783628231e776a81c1ade623e0b.tar.gz";
+  sha256 = "sha256:1spvf68a2yjxd13x7q1n3nppnmp5vf0m1gl9lp3n58bcs3frcnb3";
 })


### PR DESCRIPTION
Fixes #377.

With this change, no CI job (apart from itself) depend on the `coq-proof` one, which checks all Coq proofs. Therefore, even when proofs are (transiently) broken, other jobs (testing libjade, building the tarball, etc) can go on.