### PR TITLE
Fix borderline smt calls in JModel

### DIFF
--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -186,7 +186,10 @@ qed.
 op dword = duniform all_words.
 
 lemma dword_ll : is_lossless dword.
-proof. apply duniform_ll; smt(List.in_nil all_wordsP). qed.
+proof.
+apply: duniform_ll; apply/negP=> eq0.
+by have := all_wordsP witness; rewrite eq0.
+qed.
 
 lemma dword_uni : is_uniform dword.
 proof. by apply duniform_uni. qed.


### PR DESCRIPTION
JModel has a borderline (in term of timeout) `smt` call that do not pass anymore when moving to Why3 1.6.

This PR simplifies this `smt` call.