### PR TITLE
Move the safety analyzer out of the Arch modules

### DIFF
--- a/compiler/entry/jazz2tex.ml
+++ b/compiler/entry/jazz2tex.ml
@@ -7,9 +7,11 @@ let parse_and_print arch call_conv =
     J.Arch_full.Arch_from_Core_arch
       ((val match arch with
             | Amd64 ->
-                J.CoreArchFactory.core_arch_x86 ~use_lea:false ~use_set0:false
-                  call_conv
-            | CortexM -> (module J.CoreArchFactory.Core_arch_ARM))) in
+                (module (val J.CoreArchFactory.core_arch_x86 ~use_lea:false
+                               ~use_set0:false call_conv)
+                : J.Arch_full.Core_arch)
+            | CortexM ->
+                (module J.CoreArchFactory.Core_arch_ARM : J.Arch_full.Core_arch))) in
   fun output file ->
     let _, _, ast = J.Compile.parse_file A.reg_size A.asmOp_sopn file in
     let out, close =

--- a/compiler/jasmin.mlpack.in
+++ b/compiler/jasmin.mlpack.in
@@ -65,4 +65,5 @@ src/Typing
 src/Utils
 src/Varalloc
 src/X86_arch_full
+src/X86_safety
 src/Arm_arch_full

--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -29,11 +29,6 @@ module type Core_arch = sig
   val not_saved_stack : Name.t list
 
   val pp_asm : Conv.coq_tbl -> Format.formatter -> (reg, regx, xreg, rflag, cond, asm_op) Arch_decl.asm_prog -> unit
-  val analyze :
-    (unit, (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op) Prog.func ->
-    (unit, (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op) Prog.func ->
-    (unit, (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op) Prog.prog ->
-    unit
 
   val callstyle : reg callstyle
 

--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -68,7 +68,15 @@ module type Arch = sig
   val callstyle : var callstyle
 end
 
-module Arch_from_Core_arch (A : Core_arch) : Arch = struct
+module Arch_from_Core_arch (A : Core_arch) :
+  Arch
+    with type reg = A.reg
+     and type regx = A.regx
+     and type xreg = A.xreg
+     and type rflag = A.rflag
+     and type cond = A.cond
+     and type asm_op = A.asm_op
+     and type extra_op = A.extra_op = struct
   include A
 
   let arch_decl = A.asm_e._asm._arch_decl 

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -72,3 +72,10 @@ module type Arch = sig
 end
 
 module Arch_from_Core_arch (A : Core_arch) : Arch
+       with type reg = A.reg
+        and type regx =  A.regx
+        and type xreg = A.xreg
+        and type rflag = A.rflag
+        and type cond = A.cond
+        and type asm_op = A.asm_op
+        and type extra_op = A.extra_op

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -31,12 +31,7 @@ module type Core_arch = sig
   val not_saved_stack : Name.t list
 
   val pp_asm : Conv.coq_tbl -> Format.formatter -> (reg, regx, xreg, rflag, cond, asm_op) Arch_decl.asm_prog -> unit
-  val analyze :
-    (unit, (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op) Prog.func ->
-    (unit, (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op) Prog.func ->
-    (unit, (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op) Prog.prog ->
-    unit
-  
+
   val callstyle : reg callstyle
 
 end

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -47,7 +47,5 @@ module Arm (Lowering_params : Arm_input) : Arch_full.Core_arch = struct
 
   let pp_asm = Pp_arm_m4.print_prog
 
-  let analyze _ _ _ = failwith "TODO_ARM: analyze"
-
   let callstyle = Arch_full.ByReg (Some LR)
 end

--- a/compiler/src/coreArchFactory.ml
+++ b/compiler/src/coreArchFactory.ml
@@ -1,16 +1,25 @@
 open Glob_options
 open Prog
+open X86_decl
 
 module Core_arch_ARM : Arch_full.Core_arch = Arm_arch_full.Arm (struct
   let call_conv = Arm_decl.arm_linux_call_conv
 end)
 
-let core_arch_x86 ~use_lea ~use_set0 call_conv : (module Arch_full.Core_arch) =
+let core_arch_x86 ~use_lea ~use_set0 call_conv :
+    (module Arch_full.Core_arch
+       with type reg = register
+        and type regx = register_ext
+        and type xreg = xmm_register
+        and type rflag = rflag
+        and type cond = condt
+        and type asm_op = X86_instr_decl.x86_op
+        and type extra_op = X86_extra.x86_extra_op) =
   let module Lowering_params = struct
     let call_conv =
       match call_conv with
-      | Linux -> X86_decl.x86_linux_call_conv
-      | Windows -> X86_decl.x86_windows_call_conv
+      | Linux -> x86_linux_call_conv
+      | Windows -> x86_windows_call_conv
 
     open X86_lowering
 

--- a/compiler/src/coreArchFactory.mli
+++ b/compiler/src/coreArchFactory.mli
@@ -1,7 +1,15 @@
 module Core_arch_ARM : Arch_full.Core_arch
+open X86_decl
 
 val core_arch_x86 :
   use_lea:bool ->
   use_set0:bool ->
   Glob_options.call_conv ->
-  (module Arch_full.Core_arch)
+  (module Arch_full.Core_arch
+     with type reg = register
+      and type regx = register_ext
+      and type xreg = xmm_register
+      and type rflag = rflag
+      and type cond = condt
+      and type asm_op = X86_instr_decl.x86_op
+      and type extra_op = X86_extra.x86_extra_op)

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -65,7 +65,7 @@ let main () =
 
     let (module Ocaml_params : Arch_full.Core_arch) =
       match !target_arch with
-      | X86_64 -> CoreArchFactory.core_arch_x86 ~use_lea:!lea ~use_set0:!set0 !call_conv
+      | X86_64 -> (module (val CoreArchFactory.core_arch_x86 ~use_lea:!lea ~use_set0:!set0 !call_conv) : Arch_full.Core_arch)
       | ARM_M4 -> (module CoreArchFactory.Core_arch_ARM)
     in
     let module Arch = Arch_full.Arch_from_Core_arch (Ocaml_params) in

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -10,7 +10,15 @@ module type X86_input = sig
 end 
 
 
-module X86 (Lowering_params : X86_input) : Arch_full.Core_arch = struct
+module X86 (Lowering_params : X86_input) :
+  Arch_full.Core_arch
+    with type reg = register
+     and type regx = register_ext
+     and type xreg = xmm_register
+     and type rflag = rflag
+     and type cond = condt
+     and type asm_op = X86_instr_decl.x86_op
+     and type extra_op = X86_extra.x86_extra_op = struct
   type reg = register
   type regx = register_ext
   type xreg = xmm_register

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -40,16 +40,5 @@ module X86 (Lowering_params : X86_input) :
       (X86_params.x86_liparams.lip_not_saved_stack)
 
   let pp_asm = Ppasm.pp_prog
-
-  let analyze source_f_decl f_decl p =
-    let module AbsInt = SafetyInterpreter.AbsAnalyzer(struct
-        let main_source = source_f_decl
-        let main = f_decl
-        let prog = p
-      end) in
-  (* FIXME: code duplication! already in arch_full.ml *)
-  let asmOp = Arch_extra.asm_opI asm_e in
-  AbsInt.analyze asmOp ()
-
   let callstyle = Arch_full.StackDirect
 end

--- a/compiler/src/x86_safety.ml
+++ b/compiler/src/x86_safety.ml
@@ -1,0 +1,7 @@
+let analyze asmOp source_f_decl f_decl p =
+  let module AbsInt = SafetyInterpreter.AbsAnalyzer (struct
+    let main_source = source_f_decl
+    let main = f_decl
+    let prog = p
+  end) in
+  AbsInt.analyze asmOp ()

--- a/compiler/src/x86_safety.mli
+++ b/compiler/src/x86_safety.mli
@@ -1,0 +1,8 @@
+open X86_extra
+
+val analyze :
+  x86_extended_op Sopn.asmOp ->
+  (unit, x86_extended_op) Prog.func ->
+  (unit, x86_extended_op) Prog.func ->
+  (unit, x86_extended_op) Prog.prog ->
+  unit


### PR DESCRIPTION
IIRC, this function has been put there only for convenience, without a good reason.