### PR TITLE
fix a bug on the handling of #VPEXTR_8 and #VPEXTR_16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@
   fixes [#385](https://github.com/jasmin-lang/jasmin/issues/385)),
   [#386](https://github.com/jasmin-lang/jasmin/issues/386)).
 
+- Fix compilation and semantics of the `VPEXTR` and `VPINSR` instructions
+  ([PR #394](https://github.com/jasmin-lang/jasmin/pull/394);
+  fixes [#395](https://github.com/jasmin-lang/jasmin/issues/395)).
+
 ## Other changes
 
 - Explicit if-then-else in flag combinations is no longer supported

--- a/compiler/tests/success/x86-64/vector.jazz
+++ b/compiler/tests/success/x86-64/vector.jazz
@@ -213,21 +213,28 @@ z = #VPSLLV_4u64(x, y);
 }
 
 export
-fn test_vpextr(reg u64 p) -> reg u32 {
-reg u32 r, x;
-reg u64 y;
+fn test_vpextr(reg u64 p) -> reg u64 {
+reg u32 r32, x;
+reg u64 r64, y;
 reg u128 a;
 
-r = 0;
+r32 = 0;
 
 a = (u128)[p + 0];
 
+x = (32u) #VPEXTR_8(a, 5);
+r32 += x;
 x = #VPEXTR_32(a, 0);
-y = #VPEXTR_64(a, 1);
-r += x;
-r += y;
+r32 += x;
 
-return r;
+r64 = (64u) r32;
+
+y = (64u) #VPEXTR_16(a, 3);
+r64 += y;
+y = #VPEXTR_64(a, 1);
+r64 += y;
+
+return r64;
 }
 
 export

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -1427,11 +1427,11 @@ Definition pp_viname_t name ve (ts:seq wsize) args :=
 
 Definition Ox86_VPEXTR_instr :=
   ((fun sz =>
-      let ve := if sz == U32 then  VE32 else VE64 in
-      mk_instr (pp_sz "VPEXTR" sz) w128w8_ty (w_ty sz) [:: E 1 ; E 2] [:: E 0] (reg_msb_flag sz) (@x86_VPEXTR sz)
-                       (check_vpextr sz) 3 [::]
-                       (pp_viname_t "vpextr" ve [:: sz; U128; U8])),
-    ("VPEXTR"%string, (primP VPEXTR))).
+      let ve := match sz with U8 => VE8 | U16 => VE16 | U32 => VE32 | _ => VE64 end in
+      mk_instr (pp_sz "VPEXTR" sz) w128w8_ty (w_ty sz) [:: E 1 ; E 2] [:: E 0]
+               MSB_CLEAR (@x86_VPEXTR sz) (check_vpextr sz) 3 [::]
+               (pp_viname_t "vpextr" ve [:: if sz==U32 then U32 else U64; U128; U8])),
+   ("VPEXTR"%string, (primP VPEXTR))).
 
 Definition pp_vpinsr ve args :=
   let rs := match ve with VE8 | VE16 | VE32 => U32 | VE64 => U64 end in

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -716,10 +716,12 @@ Definition x86_VPMULHRS ve sz v1 v2 :=
 (* ---------------------------------------------------------------- *)
 Definition x86_VPEXTR (ve: wsize) (v: u128) (i: u8) : ex_tpl (w_ty ve) :=
   Let _ := check_size_8_64 ve in
+  let i := wand i (x86_nelem_mask ve U128) in
   ok (nth (0%R: word ve) (split_vec ve v) (Z.to_nat (wunsigned i))).
 
 (* ---------------------------------------------------------------- *)
 Definition x86_VPINSR (ve: velem) (v1: u128) (v2: word ve) (i: u8) : ex_tpl (w_ty U128) :=
+  let i := wand i (x86_nelem_mask ve U128) in
   ok (wpinsr v1 v2 i).
 
 Arguments x86_VPINSR : clear implicits.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -428,6 +428,9 @@ Definition x86_shift_mask (s:wsize) : u8 :=
   | U256 => wrepr U8 255
   end%Z.
 
+Definition x86_nelem_mask (sze szc:wsize) : u8 :=
+  wrepr U8 (2 ^ (wsize_log2 szc - wsize_log2 sze) - 1).
+
 Definition wbit_n sz (w:word sz) (n:nat) : bool :=
    wbit (wunsigned w) n.
 


### PR DESCRIPTION
Attempt to fix a bug in the handling of #VPEXTR_8 and #VPEXTR_16, which are currently miscompiled into "vpextrq".