### PR TITLE
add support for PCLMULQDQ instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   ([PR #328](https://github.com/jasmin-lang/jasmin/pull/328)),
   `VMOVDQA`
   ([PR #279](https://github.com/jasmin-lang/jasmin/pull/279)).
+  `PCLMULQDQ`, `VPCLMULQDQ`
+  ([PR #396](https://github.com/jasmin-lang/jasmin/pull/396)).
 
 - Add bit rotation operators for expressions: `<<r` and `>>r`
   ([PR #290](https://github.com/jasmin-lang/jasmin/pull/290)).

--- a/compiler/tests/success/x86-64/vpclmulqdq.jazz
+++ b/compiler/tests/success/x86-64/vpclmulqdq.jazz
@@ -1,0 +1,22 @@
+export fn test (reg u64 in) { 
+  reg u128 x y z;
+  reg u256 xx yy zz;
+  x = (u128)[in];
+  y = x;
+  z = #PCLMULQDQ(x,y,0x10);
+  (u128)[in] = z;
+
+  x = (u128)[in];
+  y = x;
+  z = #VPCLMULQDQ(x,y,0x11);
+  (u128)[in] = x;
+  (u128)[in] = y;
+  (u128)[in] = z;
+
+  xx = (u256)[in];
+  yy = xx;
+  zz = #VPCLMULQDQ_256(xx,yy,0x01);
+  (u256)[in] = xx;
+  (u256)[in] = yy;
+  (u256)[in] = zz;
+}

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -977,8 +977,8 @@ op clmulq (x y: W64.t): W128.t =
        (iota_ 0 64).
 
 op PCLMULQDQ (v1 v2: W128.t) (k: W8.t): W128.t =
- let x0 = v1 \bits64 (W8.to_uint k %% 2) in
- let x1 = v2 \bits64 (W8.to_uint k %/ 16 %% 2) in
+ let x0 = v1 \bits64 (b2i k.[0]) in
+ let x1 = v2 \bits64 (b2i k.[4]) in
  clmulq x0 x1.
 
 abbrev [-printing] VPCLMULQDQ_128 = PCLMULQDQ.

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -964,6 +964,30 @@ abbrev [-printing] VAESENCLAST      = AESENCLAST.
 abbrev [-printing] VAESIMC          = AESIMC.
 abbrev [-printing] VAESKEYGENASSIST = AESKEYGENASSIST.
 
+(* ------------------------------------------------------------------- *)
+(* PCLMULQDQ instructions *)
+(*
+| PCLMULQDQ
+| VPCLMULQDQ  of wsize
+*)
+op clmulq (x y: W64.t): W128.t =
+ let x128 =  W128.of_int (to_uint x) in
+ foldr (fun i r => (if y.[i] then x128 `<<<` i else W128.zero) `^` r)
+       W128.zero
+       (iota_ 0 64).
+
+op PCLMULQDQ (v1 v2: W128.t) (k: int): W128.t =
+ let x1 = v1 \bits64 (k %% 2) in
+ let x2 = v2 \bits64 (k %% 16 %% 2) in
+ clmulq x1 x2.
+
+abbrev [-printing] VPCLMULQDQ_128 = PCLMULQDQ.
+
+op VPCLMULQDQ_256 (v1 v2: W256.t) (k: int): W256.t =
+ let x1 = v1 \bits64 (k %% 2) in
+ let x2 = v2 \bits64 (k %% 16 %% 2) in
+ pack2 [ W128.zero; clmulq x1 x2].
+
 
 (* -------------------------------------------------------------------- *)
 

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -976,18 +976,16 @@ op clmulq (x y: W64.t): W128.t =
        W128.zero
        (iota_ 0 64).
 
-op PCLMULQDQ (v1 v2: W128.t) (k: int): W128.t =
- let x1 = v1 \bits64 (k %% 2) in
- let x2 = v2 \bits64 (k %% 16 %% 2) in
- clmulq x1 x2.
+op PCLMULQDQ (v1 v2: W128.t) (k: W8.t): W128.t =
+ let x0 = v1 \bits64 (W8.to_uint k %% 2) in
+ let x1 = v2 \bits64 (W8.to_uint k %/ 16 %% 2) in
+ clmulq x0 x1.
 
 abbrev [-printing] VPCLMULQDQ_128 = PCLMULQDQ.
 
-op VPCLMULQDQ_256 (v1 v2: W256.t) (k: int): W256.t =
- let x1 = v1 \bits64 (k %% 2) in
- let x2 = v2 \bits64 (k %% 16 %% 2) in
- pack2 [ W128.zero; clmulq x1 x2].
-
+op VPCLMULQDQ_256 (v1 v2: W256.t) (k: W8.t): W256.t =
+ pack2 [ PCLMULQDQ (v1 \bits128 0) (v2 \bits128 0) k
+       ; PCLMULQDQ (v1 \bits128 1) (v2 \bits128 1) k ].
 
 (* -------------------------------------------------------------------- *)
 

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -172,6 +172,10 @@ Variant x86_op : Type :=
 | VAESIMC
 | AESKEYGENASSIST
 | VAESKEYGENASSIST 
+
+(* PCLMULQDQ instructions *)
+| PCLMULQDQ
+| VPCLMULQDQ of wsize
 .
 
 Scheme Equality for x86_op.
@@ -956,6 +960,39 @@ Definition x86_AESENC          (v1 v2 : u128)           : ex_tpl (w_ty U128) := 
 Definition x86_AESENCLAST      (v1 v2 : u128)           : ex_tpl (w_ty U128) := ok (wAESENCLAST      v1 v2).
 Definition x86_AESIMC          (v1    : u128)           : ex_tpl (w_ty U128) := ok (wAESIMC          v1).
 Definition x86_AESKEYGENASSIST (v1    : u128) (v2 : u8) : ex_tpl (w_ty U128) := ok (wAESKEYGENASSIST v1 v2).
+
+(* --------------------------------------------------------------------------------------
+Instruction:		PCLMULQDQ xmm1, xmm2/m128, imm8
+CPUID feature flag:	PCLMULQDQ
+Description:		Carry-less multiplication of one quadword of xmm1 by one quadword
+			of xmm2/m128, stores the 128-bit result in xmm1. The immediate is
+			used to determine which quadwords of xmm1 and xmm2/m128 should be
+			used.
+Instruction:		VPCLMULQDQ xmm1, xmm2, xmm3/m128, imm8
+CPUID feature flag:	PCLMULQDQ AVX
+Description:		Carry-less multiplication of one quadword of xmm2 by one quadword
+			of xmm3/m128, stores the 128-bit result in xmm1. The immediate is
+			used to determine which quadwords of xmm2 and xmm3/m128 should be
+			used.
+Instruction:		VPCLMULQDQ ymm1, ymm2, ymm3/m256, imm8
+CPUID feature flag:	VPCLMULQDQ
+Description:		Carry-less multiplication of one quadword of ymm2 by one quadword
+			of ymm3/m256, stores the 128-bit result in ymm1. The immediate is
+			used to determine which quadwords of ymm2 and ymm3/m256 should be
+			used.                                                            *)
+
+Definition wclmulq (x1 x2: word U64): word U128 :=
+ let x := zero_extend U128 x1 in
+ foldr (fun k r => wxor (if wbit_n x2 k then wshl x (Z.of_nat k) else 0%R) r) 0%R (iota 0 64).
+
+Definition wPCLMULDQD sz (w1 w2: word sz): word sz :=
+ let x1 := @nth (word U64) 0%R (split_vec U64 w1) (wbit_n w2 0) in
+ let x2 := @nth (word U64) 0%R (split_vec U64 w2) (wbit_n w2 4) in
+ zero_extend sz (wclmulq x1 x2).
+
+Definition x86_VPCLMULQDQ sz (v1 v2: word sz) (k: u8): ex_tpl (w_ty sz) :=
+ let _ := check_size_128_256 sz in
+ ok (wPCLMULDQD v1 v2).
 
 (* ----------------------------------------------------------------------------- *)
 
@@ -1767,6 +1804,23 @@ Definition Ox86_VAESKEYGENASSIST_instr :=
    (check_xmm_xmmm_imm8 U128) 3 (PrimM VAESKEYGENASSIST)
    (pp_name_ty "vaeskeygenassist" [::U128;U128;U8]).
 
+(* PCLMULDQD instructions *)
+
+Definition Ox86_PCLMULQDQ_instr := 
+  mk_instr_pp "PCLMULQDQ" [:: sword U128; sword U128; sword U8] (w_ty U128)
+    [:: E 0; E 1; E 2] [:: E 0] MSB_CLEAR (@x86_VPCLMULQDQ U128)
+    (check_xmm_xmmm_imm8 U128) 3 (PrimM PCLMULQDQ)
+   (pp_name_ty "pclmulqdq" [::U128;U128;U8]).
+
+Definition Ox86_VPCLMULQDQ_instr := 
+ (fun sz =>
+   mk_instr (pp_sz "VPCLMULQDQ"%string sz) [:: sword sz; sword sz; sword U8] (w_ty sz)
+       [:: E 1; E 2; E 3] [:: E 0] MSB_CLEAR (@x86_VPCLMULQDQ sz)
+       (check_xmm_xmm_xmmm_imm8 sz) 4 [::] (pp_name "vpclmulqdq" sz)
+ , ("VPCLMULQDQ"%string, PrimP U128 VPCLMULQDQ)).
+  
+
+
 Definition x86_instr_desc o : instr_desc_t :=
   match o with
   | MOV sz             => Ox86_MOV_instr.1 sz
@@ -1898,6 +1952,8 @@ Definition x86_instr_desc o : instr_desc_t :=
   | VAESIMC            => Ox86_VAESIMC_instr.1         
   | AESKEYGENASSIST    => Ox86_AESKEYGENASSIST_instr.1 
   | VAESKEYGENASSIST   => Ox86_VAESKEYGENASSIST_instr.1 
+  | PCLMULQDQ          => Ox86_PCLMULQDQ_instr.1
+  | VPCLMULQDQ sz      => Ox86_VPCLMULQDQ_instr.1 sz
   end.
 
 (* -------------------------------------------------------------------- *)
@@ -2033,6 +2089,8 @@ Definition x86_prim_string :=
    Ox86_VAESIMC_instr.2;         
    Ox86_AESKEYGENASSIST_instr.2; 
    Ox86_VAESKEYGENASSIST_instr.2;
+   Ox86_PCLMULQDQ_instr.2;
+   Ox86_VPCLMULQDQ_instr.2;
    ("VPMAX"%string, 
      PrimSV (fun signedness ve sz => 
               if signedness is Signed then VPMAXS ve sz else VPMAXU ve sz));


### PR DESCRIPTION
This PR adds support for the carry-less multiplication instructions (PCLMULQDQ and VPCLMULQDQ). 