### PR TITLE
[CI] EasyCrypt: use why3 1.6.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,6 +20,13 @@ let mathcomp-word = callPackage scripts/mathcomp-word.nix { inherit coqPackages;
 
 let easycrypt = callPackage scripts/easycrypt.nix {
   inherit ecRef;
+  why3 = pkgs.why3.overrideAttrs (o: rec {
+      version = "1.6.0";
+      src = pkgs.fetchurl {
+        url = "https://why3.gitlabpages.inria.fr/releases/${o.pname}-${version}.tar.gz";
+        hash = "sha256-hFvM6kHScaCtcHCc6Vezl9CR7BFbiKPoTEh7kj0ZJxw=";
+      };
+    });
 }; in
 
 let inherit (coqPackages.coq) ocamlPackages; in

--- a/scripts/easycrypt.nix
+++ b/scripts/easycrypt.nix
@@ -28,12 +28,14 @@ with {
       sha256 = "sha256:09rdwcj70lkamkhd895p284rfpz4bcnsf55mcimhiqncd2a21ml7";
     };
 
-    # Fix build with Why3 1.5
-    patches = fetchpatch {
-      url = "https://github.com/EasyCrypt/easycrypt/commit/d226387432deb7f22738e1d5579346a2cbc9be7a.patch";
-      sha256 = "sha256:1zvxij35fnr3h9b5wdl8ml17aqfx3a39rd4mgwmdvkapbg3pa4lm";
-    };
-
+    patches = lib.lists.map fetchpatch [
+      # Fix build with Why3 1.5
+      { url = "https://github.com/EasyCrypt/easycrypt/commit/d226387432deb7f22738e1d5579346a2cbc9be7a.patch";
+        hash = "sha256:1zvxij35fnr3h9b5wdl8ml17aqfx3a39rd4mgwmdvkapbg3pa4lm"; }
+      # Fix build with Why3 1.6
+      { url = "https://github.com/EasyCrypt/easycrypt/commit/876f2ed50a0434afdf2fb20e7c50b8a3e26bb06e.patch";
+        hash = "sha256-UycfLZWYHNsppb7qHSRaAF4Y0UnwoFueEG0wUcBUPYE="; }
+    ];
   };
 
 }."${ecRef}";


### PR DESCRIPTION
Fix after https://github.com/EasyCrypt/easycrypt/pull/352