### PR TITLE
Safety: add -nocheckalignment command-line flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@
   ([PR #362](https://github.com/jasmin-lang/jasmin/pull/362)),
   ([PR #384](https://github.com/jasmin-lang/jasmin/pull/384)).
 
+- The safety checker warns about possible alignment issues rather than failing,
+  when the `-nocheckalignment` command-line flag is given
+  ([PR #401](https://github.com/jasmin-lang/jasmin/pull/401)).
+
 ## Bug fixes
 
 - The x86 instructions `VMOVSHDUP` and `VMOVSLDUP` accept a size suffix (`_128`

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -14,6 +14,7 @@ let safety_param = ref None
 let safety_config = ref None
 let stop_after = ref None
 let safety_makeconfigdoc = ref None   
+let trust_aligned = ref false
 
 let help_version = ref false
 let help_intrinsics = ref false
@@ -176,6 +177,7 @@ let options = [
      len_1,...,len_k: input lengths of f_i";
      "-safetyconfig", Arg.String set_safetyconfig, "[filename]: use filename (JSON) as configuration file for the safety checker";
     "-safetymakeconfigdoc", Arg.String set_safety_makeconfigdoc, "[dir]: make the safety checker configuration docs in [dir]";
+    "-nocheckalignment", Arg.Set trust_aligned, "do not report alignment issue as safety violations";
     "-wlea", Arg.Unit (add_warning UseLea), ": print warning when lea is used";
     "-w_"  , Arg.Unit (add_warning IntroduceNone), ": print warning when extra _ is introduced";
     "-wea", Arg.Unit (add_warning ExtraAssignment), ": print warning when extra assignment is introduced";


### PR DESCRIPTION
When the `-nocheckalignment` flag is given on the command-line, alignement issues no longer count as safety violations.

For expert users only, use at your own risk.

cc @cryptojedi