### PR TITLE
Add ocaml-lsp to dev tools

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
          cmdliner
          (batteries.overrideAttrs (o: { doCheck = false; }))
          menhir (oP.menhirLib or null) zarith camlidl apron yojson ]))
-    ++ optionals devTools (with oP; [ merlin ])
+    ++ optionals devTools (with oP; [ merlin ocaml-lsp ])
     ++ optionals ecDeps [ easycrypt easycrypt.runtest alt-ergo z3.out ]
     ++ optionals opamDeps [ rsync git pkg-config perl ppl mpfr opam ]
     ;


### PR DESCRIPTION
This is useful for devs working on the Jasmin OCaml code using an LSP-based IDE.