### PR TITLE
x86 lowering: handle shifts with explicit masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,10 @@
   previous timestamp is also displayed
   ([PR #403](https://github.com/jasmin-lang/jasmin/pull/403)).
 
+- Instruction selection for `x86_64` recognizes shifts (rotations, etc.) by
+  an amount that is explicitly truncated (e.g., `x >>= y & 63`)
+  ([PR #412](https://github.com/jasmin-lang/jasmin/pull/412)).
+
 # Jasmin 2022.09.0
 
 ## Bug fixes

--- a/compiler/examples/x86-64/hw.jazz
+++ b/compiler/examples/x86-64/hw.jazz
@@ -29,7 +29,7 @@ xc[i] = [xp + 8 * i];
 yc[i] = [yp + 8 * i];
 }
 
-swap >>= sb;
+swap >>= sb & 63;
 
 xc, yc = cswap(xc, yc, swap);
 

--- a/compiler/tests/success/x86-64/opsizes.jazz
+++ b/compiler/tests/success/x86-64/opsizes.jazz
@@ -6,9 +6,9 @@ u = v;
 x = x + s;
 x = x + 64;
 x = x + 64s s;
-x = x >> u;
-x = x >>s 64;
-x = x >>64s u;
+x >>= u & 63;
+x = x >>s 24;
+x >>64s= u & 63;
 return x;
 }
 

--- a/compiler/tests/success/x86-64/test_rotations.jazz
+++ b/compiler/tests/success/x86-64/test_rotations.jazz
@@ -10,7 +10,7 @@ fn f(reg u64 x) -> reg u64 {
     d = 4;
 
     // Left rotations (flags are discarded).
-    a = a <<r d;
+    a <<r= d & 63;
     a = a <<r 2;
 
     // Intrinsic syntax.
@@ -20,7 +20,7 @@ fn f(reg u64 x) -> reg u64 {
     cf, b += x + cf;
 
     // Right rotations (flags are discarded).
-    c = b >>r d;
+    c = b >>r (d & 63);
     c = b >>r 3;
 
     // Intrinsic syntax.

--- a/compiler/tests/success/x86-64/test_shift.jazz
+++ b/compiler/tests/success/x86-64/test_shift.jazz
@@ -7,3 +7,23 @@ export fn reduce(reg u64 a) -> reg u64
   return u;
 }
 
+export
+fn constant_folding(reg u64 x) -> reg u64 {
+  inline int i;
+  stack u64[128] t;
+  reg u64 r;
+  for i = 0 to 128 {
+    t[i] = x;
+  }
+  for i = 0 to 128 {
+    r = t[i];
+    r >>s= i & 63;
+    t[i] = r;
+  }
+  r = 0;
+  for i = 0 to 128 {
+    x = t[i];
+    r |= x;
+  }
+  return r;
+}

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -243,6 +243,15 @@ Definition mulr sz a b :=
     end
  end.
 
+  Definition check_shift_amount sz e :=
+    match match e with
+    | Papp2 (Oland _) a b =>
+        if is_wconst U8 b is Some n
+        then if n == x86_shift_mask sz then Some a else None
+        else None
+    | _ => None end
+    with None => Some e | x => x end.
+
 (* x =(ty) e *)
 Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
   let chk (b: bool) r := if b then r else LowerAssgn in
@@ -359,11 +368,11 @@ Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
       if (sz ≤ U64)%CMP
       then k8 sz (LowerFopn sz (Ox86 (XOR sz)) [:: a ; b ] (Some U32))
       else kb true sz (LowerCopn (Ox86 (VPXOR sz)) [:: a ; b ])
-    | Olsr sz => k8 sz (LowerFopn sz (Ox86 (SHR sz)) [:: a ; b ] (Some U8))
-    | Olsl (Op_w sz) => k8 sz (LowerFopn sz (Ox86 (SHL sz)) [:: a ; b ] (Some U8))
-    | Oasr (Op_w sz) => k8 sz (LowerFopn sz (Ox86 (SAR sz)) [:: a ; b ] (Some U8))
-    | Oror sz => k8 sz (LowerDiscardFlags 2 (Ox86 (ROR sz)) [:: a ; b ])
-    | Orol sz => k8 sz (LowerDiscardFlags 2 (Ox86 (ROL sz)) [:: a ; b ])
+    | Olsr sz => if check_shift_amount sz b is Some b then k8 sz (LowerFopn sz (Ox86 (SHR sz)) [:: a ; b ] (Some U8)) else LowerAssgn
+    | Olsl (Op_w sz) => if check_shift_amount sz b is Some b then k8 sz (LowerFopn sz (Ox86 (SHL sz)) [:: a ; b ] (Some U8)) else LowerAssgn
+    | Oasr (Op_w sz) => if check_shift_amount sz b is Some b then k8 sz (LowerFopn sz (Ox86 (SAR sz)) [:: a ; b ] (Some U8)) else LowerAssgn
+    | Oror sz => if check_shift_amount sz b is Some b then k8 sz (LowerDiscardFlags 2 (Ox86 (ROR sz)) [:: a ; b ]) else LowerAssgn
+    | Orol sz => if check_shift_amount sz b is Some b then k8 sz (LowerDiscardFlags 2 (Ox86 (ROL sz)) [:: a ; b ]) else LowerAssgn
 
     | Olt _ | Ole _ | Oeq _ | Oneq _ | Oge _ | Ogt _ => LowerCond
 

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -465,6 +465,44 @@ Section PROOF.
     by rewrite /x86_IMULt /check_size_16_64 hsz64 /= Hw.
   Qed.
 
+  Lemma to_word_m sz sz' a w :
+    to_word sz a = ok w →
+    (sz' ≤ sz)%CMP →
+    to_word sz' a = ok (zero_extend sz' w).
+  Proof.
+    clear.
+    case/to_wordI' => n [] m [] sz_le_n ->{a} ->{w} /= sz'_le_sz.
+    by rewrite /truncate_word zero_extend_idem // (cmp_le_trans sz'_le_sz sz_le_n).
+  Qed.
+
+  Lemma check_shift_amountP sz e sa s z w :
+    check_shift_amount sz e = Some sa →
+    sem_pexpr gd s e = ok z →
+    to_word U8 z = ok w →
+    Sv.Subset (read_e sa) (read_e e) ∧
+    exists2 n, sem_pexpr gd s sa >>= to_word U8 = ok n & ∀ f (a: word sz), sem_shift f a w = sem_shift f a n.
+  Proof.
+   Ltac eop := move => > /Some_inj -> -> /= ->; split; [ reflexivity | eexists ].
+    rewrite /check_shift_amount.
+    case: e; try by eop.
+    case; try by eop.
+    move => sz' a b.
+    case en: is_wconst => [ n | ]; last by eop.
+    case: eqP => n_range; last by eop.
+    move => /Some_inj ? /=; subst a n.
+    rewrite /sem_sop2 /=; t_xrbindP => a ok_a c ok_c wa ok_wa wb ok_wb <-{z} /truncate_wordP[] _ ->{w}.
+    have! := (is_wconstP gd s en).
+    rewrite {en} ok_a ok_c /= => hc.
+    split.
+    - clear; rewrite {2}/read_e /= !read_eE; SvD.fsetdec.
+    eexists; first by rewrite (to_word_m ok_wa (wsize_le_U8 _)).
+    move => f x; rewrite /sem_shift; do 2 f_equal.
+    have := to_word_m ok_wb (wsize_le_U8 _).
+    rewrite {ok_wb} hc => /ok_inj ->.
+    rewrite !wand_zero_extend; only 2-3: exact: wsize_le_U8.
+    by rewrite -wandA wand_xx.
+  Qed.
+
   Lemma lower_cassgn_classifyP e l s s' v ty v' (Hs: sem_pexpr gd s e = ok v)
       (Hv': truncate_val ty v = ok v')
       (Hw: write_lval gd l v' s = ok s'):
@@ -851,71 +889,92 @@ Section PROOF.
         rewrite /x86_VPXOR /x86_u128_binop /=.
         by rewrite (wsize_nle_u64_check_128_256 hty).
       (* Olsr *)
-      + case: andP => // - [hsz64] /eqP ?; subst ty.
-         rewrite /sem_pexprs /=; t_xrbindP => v1 -> v2 ->.
-         rewrite /sem_sop2 /exec_sopn /sopn_sem /=.
-         t_xrbindP => w1 -> w2 -> /= ?; subst v.
-         move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
-         split. by rewrite read_es_swap.
-         move: Hw; rewrite /sem_shr /sem_shift /x86_SHR /check_size_8_64 hsz64 /=.
-         case: eqP.
-         * by move => ->; rewrite /= wshr0 => ->.
-         move => _ /=.
-         by case: ifP => /= _ ->.
+      + case good_shift: check_shift_amount => [ sa | ]; last by [].
+        case: andP => // - [hsz64] /eqP ?; subst ty.
+        rewrite /sem_pexprs /=; t_xrbindP => v1 -> v2 ok_v2.
+        move/check_shift_amountP: good_shift => /(_ _ _ _ ok_v2) good_shift.
+        rewrite /sem_sop2 /exec_sopn /sopn_sem /=.
+        t_xrbindP => w1 ok_w1 w2 ok_w2 /= ?; subst.
+        move: good_shift => /(_ _ ok_w2) []read_subset[]; t_xrbindP => ?? -> /= -> /= {} ok_w2.
+        rewrite {} ok_w1.
+        move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
+        split.
+        * rewrite /read_es /read_e /= !read_eE; move: read_subset; clear; SvD.fsetdec.
+        move: Hw; rewrite /sem_shr ok_w2 /sem_shift /x86_SHR /check_size_8_64 hsz64 /=.
+        case: eqP.
+        * by move => ->; rewrite /= wshr0 => ->.
+        move => _ /=.
+        by case: ifP => /= _ ->.
       (* Olsl *)
       + case: sz => // sz.
+        case good_shift: check_shift_amount => [ sa | ]; last by [].
         case: andP => // - [hsz64] /eqP ?; subst ty.
-        rewrite /sem_pexprs /=; t_xrbindP => v1 -> v2 ->.
-         rewrite /sem_sop2 /exec_sopn /sopn_sem /=; t_xrbindP => w1 -> w2 -> /= ?; subst v.
-         move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
-         split. by rewrite read_es_swap.
-         move: Hw; rewrite /sem_shl /sem_shift /x86_SHL /check_size_8_64 hsz64 /=.
-         case: eqP.
-         * by move => ->; rewrite /= wshl0 => ->.
-         move => _ /=.
-         by case: ifP => /= _ ->.
+        rewrite /sem_pexprs /=; t_xrbindP => v1 -> v2 ok_v2.
+        move/check_shift_amountP: good_shift => /(_ _ _ _ ok_v2) good_shift.
+        rewrite /sem_sop2 /exec_sopn /sopn_sem /=.
+        t_xrbindP => w1 ok_w1 w2 ok_w2 /= ?; subst.
+        move: good_shift => /(_ _ ok_w2) []read_subset[]; t_xrbindP => ?? -> /= -> /= {} ok_w2.
+        rewrite {} ok_w1.
+        move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
+        split.
+        * rewrite /read_es /read_e /= !read_eE; move: read_subset; clear; SvD.fsetdec.
+        move: Hw; rewrite /sem_shl ok_w2 /sem_shift /x86_SHL /check_size_8_64 hsz64 /=.
+        case: eqP.
+        * by move => ->; rewrite /= wshl0 => ->.
+        move => _ /=.
+        by case: ifP => /= _ ->.
       (* Oasr *)
       + case: sz => // sz.
+        case good_shift: check_shift_amount => [ sa | ]; last by [].
         case: andP => // - [hsz64] /eqP ?; subst ty.
-        rewrite /sem_pexprs /=; t_xrbindP => v1 -> v2 ->.
-         rewrite /sem_sop2 /exec_sopn /sopn_sem /=; t_xrbindP => w1 -> w2 -> /= ?; subst v.
-         move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
-         split. by rewrite read_es_swap.
-         move: Hw; rewrite /sem_sar /sem_shift /x86_SAR /check_size_8_64 hsz64 /=.
-         case: eqP.
-         * by move => ->; rewrite /= wsar0 => ->.
-         move => _ /=.
-         by case: ifP => /= _ ->.
+        rewrite /sem_pexprs /=; t_xrbindP => v1 -> v2 ok_v2.
+        move/check_shift_amountP: good_shift => /(_ _ _ _ ok_v2) good_shift.
+        rewrite /sem_sop2 /exec_sopn /sopn_sem /=.
+        t_xrbindP => w1 ok_w1 w2 ok_w2 /= ?; subst.
+        move: good_shift => /(_ _ ok_w2) []read_subset[]; t_xrbindP => ?? -> /= -> /= {} ok_w2.
+        rewrite {} ok_w1.
+        move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
+        split.
+        * rewrite /read_es /read_e /= !read_eE; move: read_subset; clear; SvD.fsetdec.
+        move: Hw; rewrite /sem_sar ok_w2 /sem_shift /x86_SAR /check_size_8_64 hsz64 /=.
+        case: eqP.
+        * by move => ->; rewrite /= wsar0 => ->.
+        move => _ /=.
+        by case: ifP => /= _ ->.
       (* Oror *)
-      + case: andP => // - [hsz64] /eqP ?; subst ty.
-         rewrite /=; t_xrbindP => v1 -> v2 ->.
-         rewrite /sem_sop2 /exec_sopn /sopn_sem /=.
-         t_xrbindP => w1 -> w2 -> /= ?; subst v.
-         move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
-         split. by rewrite read_es_swap.
-         move: Hw; rewrite /sem_shr /sem_shift /x86_ROR /check_size_8_64 hsz64 /=.
-         case: eqP.
-         * rewrite /sem_ror /sem_shift.
-           move=> -> /=.
-           rewrite wunsigned0 wror0.
-           by move=> ->.
-         move=> _ /=.
-         by case: ifP => /= _ ->.
+      + case good_shift: check_shift_amount => [ sa | ]; last by [].
+        case: andP => // - [hsz64] /eqP ?; subst ty.
+        rewrite /=; t_xrbindP => v1 -> v2 ok_v2.
+        move/check_shift_amountP: good_shift => /(_ _ _ _ ok_v2) good_shift.
+        rewrite /sem_sop2 /exec_sopn /sopn_sem /=.
+        t_xrbindP => w1 ok_w1 w2 ok_w2 /= ?; subst.
+        move: good_shift => /(_ _ ok_w2) []read_subset[]; t_xrbindP => ?? -> /= -> /= {} ok_w2.
+        rewrite {} ok_w1.
+        move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
+        split.
+        * rewrite /read_es /read_e /= !read_eE; move: read_subset; clear; SvD.fsetdec.
+        move: Hw; rewrite /sem_ror ok_w2 /sem_shift /x86_ROR /check_size_8_64 hsz64 /=.
+        case: eqP.
+        * by move=> -> /=; rewrite wunsigned0 wror0 => ->.
+        move=> _ /=.
+        by case: ifP => /= _ ->.
       (* Orol *)
-      + case: andP => // - [hsz64] /eqP ?; subst ty.
-         rewrite /=; t_xrbindP => v1 -> v2 ->.
-         rewrite /sem_sop2 /exec_sopn /sopn_sem /=.
-         t_xrbindP => w1 -> w2 -> /= ?; subst v.
-         move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
-         split. by rewrite read_es_swap.
-         move: Hw; rewrite /sem_shr /sem_shift /x86_ROL /check_size_8_64 hsz64 /=.
-         case: eqP.
-         * rewrite /sem_rol /sem_shift.
-           move=> -> /=.
-           rewrite wunsigned0 wrol0.
-           by move=> ->.
-         move=> _ /=.
-         by case: ifP => /= _ ->.
+      + case good_shift: check_shift_amount => [ sa | ]; last by [].
+        case: andP => // - [hsz64] /eqP ?; subst ty.
+        rewrite /=; t_xrbindP => v1 -> v2 ok_v2.
+        move/check_shift_amountP: good_shift => /(_ _ _ _ ok_v2) good_shift.
+        rewrite /sem_sop2 /exec_sopn /sopn_sem /=.
+        t_xrbindP => w1 ok_w1 w2 ok_w2 /= ?; subst.
+        move: good_shift => /(_ _ ok_w2) []read_subset[]; t_xrbindP => ?? -> /= -> /= {} ok_w2.
+        rewrite {} ok_w1.
+        move: Hv'; rewrite /truncate_val /= /truncate_word cmp_le_refl zero_extend_u => /ok_inj ?; subst v'.
+        split.
+        * rewrite /read_es /read_e /= !read_eE; move: read_subset; clear; SvD.fsetdec.
+        move: Hw; rewrite /sem_rol ok_w2 /sem_shift /x86_ROL /check_size_8_64 hsz64 /=.
+        case: eqP.
+        * by move=> -> /=; rewrite wunsigned0 wrol0 => ->.
+        move=> _ /=.
+        by case: ifP => /= _ ->.
 
       (* Ovadd ve sz *)
       + case: ifP => // /andP [hle /eqP ?]; subst ty.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -937,6 +937,9 @@ Qed.
 Lemma wand0 sz (x: word sz) : wand 0 x = 0%R.
 Proof. by apply/eqP. Qed.
 
+Lemma wand_xx sz (x: word sz) : wand x x = x.
+Proof. by apply/eqP/eq_from_wbit; rewrite /= Z.land_diag. Qed.
+
 Lemma wandN1 sz (x: word sz) : wand (-1) x = x.
 Proof.
   apply/eqP/eq_from_wbit_n => i.

--- a/scripts/test-libjade.sh
+++ b/scripts/test-libjade.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+REPO=formosa-crypto
 NAME=libjade
 BRANCH=main
 
@@ -19,7 +20,7 @@ export EXCLUDE=""
 
 echo "Info: $MAKELINE (EXCLUDE=$EXCLUDE)"
 
-curl -v -o $FILE https://codeload.github.com/formosa-crypto/$NAME/tar.gz/refs/heads/$BRANCH
+curl -v -o $FILE https://codeload.github.com/$REPO/$NAME/tar.gz/refs/heads/$BRANCH
 tar xvf $FILE
 
 make $MAKELINE


### PR DESCRIPTION
This is meant as a first step before the semantics of shifts changes.

With this change, the compiler is able to correctly compile current and future jasmin programs. This will allow to update existing jasmin programs before breaking changes are introduced to the compiler.