### PR TITLE
ARM: intrinsics with shifts

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -5,7 +5,7 @@ JSJOBS    ?= 2
 CHECKPY   ?=
 CHECK     := $(CHECKPY) scripts/runtest --jobs="$(JSJOBS)"
 CHECK     += config/tests.config
-CHECKCATS ?= safety CCT x86-64-ATT x86-64-Intel x86-64-print x86-64-nolea arm-m4
+CHECKCATS ?= safety CCT x86-64-ATT x86-64-Intel x86-64-print x86-64-nolea arm-m4 arm-m4-print
 
 # --------------------------------------------------------------------
 DESTDIR  ?=

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -42,3 +42,8 @@ exclude = !tests/success/noextract
 bin = ./scripts/check-arm-m4
 okdirs = examples/**/arm-m4 tests/success/**/arm-m4
 kodirs = tests/fail/**/arm-m4
+
+[test-arm-m4-print]
+bin = ./scripts/parse-print-parse
+args = arm
+okdirs = tests/success/**/arm-m4

--- a/compiler/scripts/parse-print-parse
+++ b/compiler/scripts/parse-print-parse
@@ -7,11 +7,19 @@ OUT=${DIR}/jasmin.jazz
 
 trap "rm -r ${DIR}" EXIT
 
+if [[ $1 == "arm" ]]
+then
+    shift
+    ARCH="-arch arm-m4"
+else
+    ARCH="-arch x86-64"
+fi
+
 set -x
 
 # Check that no printer crashes
-$(dirname $0)/../jasminc -pall "$@" >/dev/null
+$(dirname $0)/../jasminc ${ARCH} -pall "$@" >/dev/null
 # Pretty-print the program before compilation
-$(dirname $0)/../jasminc -ptyping "$@" > ${OUT}
+$(dirname $0)/../jasminc ${ARCH} -ptyping "$@" > ${OUT}
 # Try to parse it and type-check it again
-$(dirname $0)/../jasminc -until_typing ${OUT}
+$(dirname $0)/../jasminc ${ARCH} -until_typing ${OUT}

--- a/compiler/src/tt_arm_m4.ml
+++ b/compiler/src/tt_arm_m4.ml
@@ -16,21 +16,6 @@ let shift_kind_assoc =
   let s_of_sk sk = Conv.string_of_string0 (Arm_decl.string_of_shift_kind sk) in
   List.map (fun sk -> (s_of_sk sk, sk)) Arm_decl.shift_kinds
 
-let get_has_shift args =
-  let get_shift _ a =
-    match a.L.pl_desc with
-    | S.PEPrim (id, [ ({ L.pl_desc = S.PEInt _ } as sham) ]) -> begin
-        let s = String.lowercase_ascii id.pl_desc in
-        match List.assoc_opt s shift_kind_assoc with
-        | Some sk -> Some (sk, sham)
-        | None -> None
-        end
-    | _ -> None
-  in
-  match List.opicki get_shift args with
-  | None -> (None, args)
-  | Some (i, (sk, sham)) -> (Some sk, List.modify_at i (fun _ -> sham) args)
-
 let get_arm_prim s =
   let is_conditional, s = get_is_conditional s in
   let set_flags, s = get_set_flags s in
@@ -38,11 +23,10 @@ let get_arm_prim s =
 
 let tt_prim ps s sa args =
   let name, set_flags, is_conditional = get_arm_prim s in
-  let has_shift, args = get_has_shift args in
   match List.assoc_opt name ps with
   | Some (Sopn.PrimARM pr) ->
     if sa == S.SA
-    then Some (pr set_flags is_conditional has_shift, args)
+    then Some (pr set_flags is_conditional None, args)
     else None
   (* The following is for [copy], [mulu], [adc], and [sbb]. *)
   | Some (Sopn.PrimP (ws, pr)) ->

--- a/compiler/tests/success/arm-m4/intrinsic_adc.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_adc.jazz
@@ -12,21 +12,21 @@ fn adc(reg u32 arg0, reg u32 arg1) -> reg u32 {
     x = #ADC(x, -1, c);
 
     // Shifts.
-    x = #ADC(x, arg0, c, #LSL(0));
-    x = #ADC(x, arg0, c, #LSL(31));
-    x = #ADC(x, arg0, c, #LSR(1));
-    x = #ADC(x, arg0, c, #LSR(32));
-    x = #ADC(x, arg0, c, #ASR(1));
-    x = #ADC(x, arg0, c, #ASR(32));
-    x = #ADC(x, arg0, c, #ROR(1));
-    x = #ADC(x, arg0, c, #ROR(31));
+    x = #ADC(x, arg0 << 0, c);
+    x = #ADC(x, arg0 << 31, c);
+    x = #ADC(x, arg0 >> 1, c);
+    x = #ADC(x, arg0 >> 32, c);
+    x = #ADC(x, arg0 >>s 1, c);
+    x = #ADC(x, arg0 >>s 32, c);
+    x = #ADC(x, arg0 >>r 1, c);
+    x = #ADC(x, arg0 >>r 31, c);
     // x = #ADC(x, arg0, #RRX(1));
 
     // Set flags.
     reg bool n, z, v;
     n, z, c, v, x = #ADCS(x, arg0, c);
     n, z, c, v, x = #ADCS(x, 1, c);
-    n, z, c, v, x = #ADCS(x, arg0, c, #LSL(3));
+    n, z, c, v, x = #ADCS(x, arg0 << 3, c);
 
     // Conditions.
     x = #ADCcc(x, arg0, c, z, x);            // EQ
@@ -47,8 +47,8 @@ fn adc(reg u32 arg0, reg u32 arg1) -> reg u32 {
     x = #ADCcc(x, 1, c, !!!!z, x);
     n, z, c, v, x = #ADCScc(x, arg0, c, n == v, n, z, c, v, x);
     n, z, c, v, x = #ADCScc(x, 2, c, !c || z, n, z, c, v, x);
-    x = #ADCcc(x, arg0, c, #LSL(3), z, x);
-    n, z, c, v, x = #ADCScc(x, arg0, c, #LSL(3), z, n, z, c, v, x);
+    x = #ADCcc(x, arg0 << 3, c, z, x);
+    n, z, c, v, x = #ADCScc(x, arg0 << 3, c, z, n, z, c, v, x);
 
     reg bool zf, cf;
     ?{CF = c}, x = #ADCS(x, arg0, c);

--- a/compiler/tests/success/arm-m4/intrinsic_add.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_add.jazz
@@ -14,23 +14,23 @@ fn add(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
 
     // Shifts.
-    x = #ADD(arg0, arg1, #LSL(0));
+    x = #ADD(arg0, arg1 << 0);
     [x] = x;
-    x = #ADD(arg0, arg1, #LSL(1));
+    x = #ADD(arg0, arg1 << 1);
     [x] = x;
-    x = #ADD(arg0, arg1, #LSL(31));
+    x = #ADD(arg0, arg1 << 31);
     [x] = x;
-    x = #ADD(arg0, arg1, #LSR(1));
+    x = #ADD(arg0, arg1 >> 1);
     [x] = x;
-    x = #ADD(arg0, arg1, #LSR(31));
+    x = #ADD(arg0, arg1 >> 31);
     [x] = x;
-    x = #ADD(arg0, arg1, #ASR(1));
+    x = #ADD(arg0, arg1 >>s 1);
     [x] = x;
-    x = #ADD(arg0, arg1, #ASR(31));
+    x = #ADD(arg0, arg1 >>s 31);
     [x] = x;
-    x = #ADD(arg0, arg1, #ROR(1));
+    x = #ADD(arg0, arg1 >>r 1);
     [x] = x;
-    x = #ADD(arg0, arg1, #ROR(31));
+    x = #ADD(arg0, arg1 >>r 31);
     [x] = x;
 
     // Set flags.
@@ -71,24 +71,24 @@ fn add(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, vf, x = #ADDScc(x, arg0, nf == vf, nf, zf, cf, vf, x);
     nf, zf, cf, vf, x = #ADDS(x, 2);
-    nf, zf, cf, vf, x = #ADDS(x, arg0, #LSL(3));
-    nf, zf, cf, vf, x = #ADDS(x, arg0, #LSR(3));
-    nf, zf, cf, vf, x = #ADDS(x, arg0, #ASR(3));
-    nf, zf, cf, vf, x = #ADDS(x, arg0, #ROR(3));
+    nf, zf, cf, vf, x = #ADDS(x, arg0 << 3);
+    nf, zf, cf, vf, x = #ADDS(x, arg0 >> 3);
+    nf, zf, cf, vf, x = #ADDS(x, arg0 >>s 3);
+    nf, zf, cf, vf, x = #ADDS(x, arg0 >>r 3);
     nf, zf, cf, vf, x = #ADDScc(x, 2, nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #ADDScc(x, arg0, #LSL(3), nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #ADDScc(x, arg0, #LSL(3), !!(nf == vf), nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #ADDScc(x, arg0, #LSR(3), nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #ADDScc(x, arg0, #ASR(3), nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #ADDScc(x, arg0, #ROR(3), nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #ADDScc(x, arg0 << 3, nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #ADDScc(x, arg0 << 3, !!(nf == vf), nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #ADDScc(x, arg0 >> 3, nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #ADDScc(x, arg0 >>s 3, nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #ADDScc(x, arg0 >>r 3, nf == vf, nf, zf, cf, vf, x);
     x = #ADDcc(x, arg0, !!!!zf, x);
     x = #ADDcc(x, 2, zf, x);
     x = #ADDcc(x, 2, !!zf, x);
-    x = #ADDcc(x, arg0, #LSL(3), zf, x);
-    x = #ADDcc(x, arg0, #LSL(3), !!zf, x);
-    x = #ADDcc(x, arg0, #LSR(3), zf, x);
-    x = #ADDcc(x, arg0, #ASR(3), zf, x);
-    x = #ADDcc(x, arg0, #ROR(3), zf, x);
+    x = #ADDcc(x, arg0 << 3, zf, x);
+    x = #ADDcc(x, arg0 << 3, !!zf, x);
+    x = #ADDcc(x, arg0 >> 3, zf, x);
+    x = #ADDcc(x, arg0 >>s 3, zf, x);
+    x = #ADDcc(x, arg0 >>r 3, zf, x);
 
     reg u32 res;
     res = x;

--- a/compiler/tests/success/arm-m4/intrinsic_and.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_and.jazz
@@ -14,23 +14,23 @@ fn and(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
 
     // Shifts.
-    x = #AND(arg0, arg1, #LSL(0));
+    x = #AND(arg0, arg1 << 0);
     [x] = x;
-    x = #AND(arg0, arg1, #LSL(1));
+    x = #AND(arg0, arg1 << 1);
     [x] = x;
-    x = #AND(arg0, arg1, #LSL(31));
+    x = #AND(arg0, arg1 << 31);
     [x] = x;
-    x = #AND(arg0, arg1, #LSR(1));
+    x = #AND(arg0, arg1 >> 1);
     [x] = x;
-    x = #AND(arg0, arg1, #LSR(31));
+    x = #AND(arg0, arg1 >> 31);
     [x] = x;
-    x = #AND(arg0, arg1, #ASR(1));
+    x = #AND(arg0, arg1 >>s 1);
     [x] = x;
-    x = #AND(arg0, arg1, #ASR(31));
+    x = #AND(arg0, arg1 >>s 31);
     [x] = x;
-    x = #AND(arg0, arg1, #ROR(1));
+    x = #AND(arg0, arg1 >>r 1);
     [x] = x;
-    x = #AND(arg0, arg1, #ROR(31));
+    x = #AND(arg0, arg1 >>r 31);
     [x] = x;
 
     // Set flags.
@@ -71,24 +71,24 @@ fn and(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #ANDScc(x, arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #ANDS(x, 2);
-    nf, zf, cf, x = #ANDS(x, arg0, #LSL(3));
-    nf, zf, cf, x = #ANDS(x, arg0, #LSR(3));
-    nf, zf, cf, x = #ANDS(x, arg0, #ASR(3));
-    nf, zf, cf, x = #ANDS(x, arg0, #ROR(3));
+    nf, zf, cf, x = #ANDS(x, arg0 << 3);
+    nf, zf, cf, x = #ANDS(x, arg0 >> 3);
+    nf, zf, cf, x = #ANDS(x, arg0 >>s 3);
+    nf, zf, cf, x = #ANDS(x, arg0 >>r 3);
     nf, zf, cf, x = #ANDScc(x, 2, nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #ANDScc(x, arg0, #LSL(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #ANDScc(x, arg0, #LSL(3), !!(nf == vf), nf, zf, cf, x);
-    nf, zf, cf, x = #ANDScc(x, arg0, #LSR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #ANDScc(x, arg0, #ASR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #ANDScc(x, arg0, #ROR(3), nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #ANDScc(x, arg0 << 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #ANDScc(x, arg0 << 3, !!(nf == vf), nf, zf, cf, x);
+    nf, zf, cf, x = #ANDScc(x, arg0 >> 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #ANDScc(x, arg0 >>s 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #ANDScc(x, arg0 >>r 3, nf == vf, nf, zf, cf, x);
     x = #ANDcc(x, arg0, !!!!zf, x);
     x = #ANDcc(x, 2, zf, x);
     x = #ANDcc(x, 2, !!zf, x);
-    x = #ANDcc(x, arg0, #LSL(3), zf, x);
-    x = #ANDcc(x, arg0, #LSL(3), !!zf, x);
-    x = #ANDcc(x, arg0, #LSR(3), zf, x);
-    x = #ANDcc(x, arg0, #ASR(3), zf, x);
-    x = #ANDcc(x, arg0, #ROR(3), zf, x);
+    x = #ANDcc(x, arg0 << 3, zf, x);
+    x = #ANDcc(x, arg0 << 3, !!zf, x);
+    x = #ANDcc(x, arg0 >> 3, zf, x);
+    x = #ANDcc(x, arg0 >>s 3, zf, x);
+    x = #ANDcc(x, arg0 >>r 3, zf, x);
 
     reg u32 res;
     res = x;

--- a/compiler/tests/success/arm-m4/intrinsic_bic.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_bic.jazz
@@ -14,23 +14,23 @@ fn bic(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
 
     // Shifts.
-    x = #BIC(arg0, arg1, #LSL(0));
+    x = #BIC(arg0, arg1 << 0);
     [x] = x;
-    x = #BIC(arg0, arg1, #LSL(1));
+    x = #BIC(arg0, arg1 << 1);
     [x] = x;
-    x = #BIC(arg0, arg1, #LSL(31));
+    x = #BIC(arg0, arg1 << 31);
     [x] = x;
-    x = #BIC(arg0, arg1, #LSR(1));
+    x = #BIC(arg0, arg1 >> 1);
     [x] = x;
-    x = #BIC(arg0, arg1, #LSR(31));
+    x = #BIC(arg0, arg1 >> 31);
     [x] = x;
-    x = #BIC(arg0, arg1, #ASR(1));
+    x = #BIC(arg0, arg1 >>s 1);
     [x] = x;
-    x = #BIC(arg0, arg1, #ASR(31));
+    x = #BIC(arg0, arg1 >>s 31);
     [x] = x;
-    x = #BIC(arg0, arg1, #ROR(1));
+    x = #BIC(arg0, arg1 >>r 1);
     [x] = x;
-    x = #BIC(arg0, arg1, #ROR(31));
+    x = #BIC(arg0, arg1 >>r 31);
     [x] = x;
 
     // Set flags.
@@ -71,24 +71,24 @@ fn bic(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #BICScc(x, arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #BICS(x, 2);
-    nf, zf, cf, x = #BICS(x, arg0, #LSL(3));
-    nf, zf, cf, x = #BICS(x, arg0, #LSR(3));
-    nf, zf, cf, x = #BICS(x, arg0, #ASR(3));
-    nf, zf, cf, x = #BICS(x, arg0, #ROR(3));
+    nf, zf, cf, x = #BICS(x, arg0 << 3);
+    nf, zf, cf, x = #BICS(x, arg0 >> 3);
+    nf, zf, cf, x = #BICS(x, arg0 >>s 3);
+    nf, zf, cf, x = #BICS(x, arg0 >>r 3);
     nf, zf, cf, x = #BICScc(x, 2, nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #BICScc(x, arg0, #LSL(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #BICScc(x, arg0, #LSL(3), !!(nf == vf), nf, zf, cf, x);
-    nf, zf, cf, x = #BICScc(x, arg0, #LSR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #BICScc(x, arg0, #ASR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #BICScc(x, arg0, #ROR(3), nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #BICScc(x, arg0 << 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #BICScc(x, arg0 << 3, !!(nf == vf), nf, zf, cf, x);
+    nf, zf, cf, x = #BICScc(x, arg0 >> 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #BICScc(x, arg0 >>s 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #BICScc(x, arg0 >>r 3, nf == vf, nf, zf, cf, x);
     x = #BICcc(x, arg0, !!!!zf, x);
     x = #BICcc(x, 2, zf, x);
     x = #BICcc(x, 2, !!zf, x);
-    x = #BICcc(x, arg0, #LSL(3), zf, x);
-    x = #BICcc(x, arg0, #LSL(3), !!zf, x);
-    x = #BICcc(x, arg0, #LSR(3), zf, x);
-    x = #BICcc(x, arg0, #ASR(3), zf, x);
-    x = #BICcc(x, arg0, #ROR(3), zf, x);
+    x = #BICcc(x, arg0 << 3, zf, x);
+    x = #BICcc(x, arg0 << 3, !!zf, x);
+    x = #BICcc(x, arg0 >> 3, zf, x);
+    x = #BICcc(x, arg0 >>s 3, zf, x);
+    x = #BICcc(x, arg0 >>r 3, zf, x);
 
     reg u32 res;
     res = x;

--- a/compiler/tests/success/arm-m4/intrinsic_eor.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_eor.jazz
@@ -14,23 +14,23 @@ fn eor(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
 
     // Shifts.
-    x = #EOR(arg0, arg1, #LSL(0));
+    x = #EOR(arg0, arg1 << 0);
     [x] = x;
-    x = #EOR(arg0, arg1, #LSL(1));
+    x = #EOR(arg0, arg1 << 1);
     [x] = x;
-    x = #EOR(arg0, arg1, #LSL(31));
+    x = #EOR(arg0, arg1 << 31);
     [x] = x;
-    x = #EOR(arg0, arg1, #LSR(1));
+    x = #EOR(arg0, arg1 >> 1);
     [x] = x;
-    x = #EOR(arg0, arg1, #LSR(31));
+    x = #EOR(arg0, arg1 >> 31);
     [x] = x;
-    x = #EOR(arg0, arg1, #ASR(1));
+    x = #EOR(arg0, arg1 >>s 1);
     [x] = x;
-    x = #EOR(arg0, arg1, #ASR(31));
+    x = #EOR(arg0, arg1 >>s 31);
     [x] = x;
-    x = #EOR(arg0, arg1, #ROR(1));
+    x = #EOR(arg0, arg1 >>r 1);
     [x] = x;
-    x = #EOR(arg0, arg1, #ROR(31));
+    x = #EOR(arg0, arg1 >>r 31);
     [x] = x;
 
     // Set flags.
@@ -71,24 +71,24 @@ fn eor(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #EORScc(x, arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #EORS(x, 2);
-    nf, zf, cf, x = #EORS(x, arg0, #LSL(3));
-    nf, zf, cf, x = #EORS(x, arg0, #LSR(3));
-    nf, zf, cf, x = #EORS(x, arg0, #ASR(3));
-    nf, zf, cf, x = #EORS(x, arg0, #ROR(3));
+    nf, zf, cf, x = #EORS(x, arg0 << 3);
+    nf, zf, cf, x = #EORS(x, arg0 >> 3);
+    nf, zf, cf, x = #EORS(x, arg0 >>s 3);
+    nf, zf, cf, x = #EORS(x, arg0 >>r 3);
     nf, zf, cf, x = #EORScc(x, 2, nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #EORScc(x, arg0, #LSL(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #EORScc(x, arg0, #LSL(3), !!(nf == vf), nf, zf, cf, x);
-    nf, zf, cf, x = #EORScc(x, arg0, #LSR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #EORScc(x, arg0, #ASR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #EORScc(x, arg0, #ROR(3), nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #EORScc(x, arg0 << 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #EORScc(x, arg0 << 3, !!(nf == vf), nf, zf, cf, x);
+    nf, zf, cf, x = #EORScc(x, arg0 >> 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #EORScc(x, arg0 >>s 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #EORScc(x, arg0 >>r 3, nf == vf, nf, zf, cf, x);
     x = #EORcc(x, arg0, !!!!zf, x);
     x = #EORcc(x, 2, zf, x);
     x = #EORcc(x, 2, !!zf, x);
-    x = #EORcc(x, arg0, #LSL(3), zf, x);
-    x = #EORcc(x, arg0, #LSL(3), !!zf, x);
-    x = #EORcc(x, arg0, #LSR(3), zf, x);
-    x = #EORcc(x, arg0, #ASR(3), zf, x);
-    x = #EORcc(x, arg0, #ROR(3), zf, x);
+    x = #EORcc(x, arg0 << 3, zf, x);
+    x = #EORcc(x, arg0 << 3, !!zf, x);
+    x = #EORcc(x, arg0 >> 3, zf, x);
+    x = #EORcc(x, arg0 >>s 3, zf, x);
+    x = #EORcc(x, arg0 >>r 3, zf, x);
 
     reg u32 res;
     res = x;

--- a/compiler/tests/success/arm-m4/intrinsic_mvn.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_mvn.jazz
@@ -14,23 +14,23 @@ fn mvn(reg u32 arg0) -> reg u32 {
     [x] = x;
 
     // Shifts.
-    x = #MVN(arg0, #LSL(0));
+    x = #MVN(arg0 << 0);
     [x] = x;
-    x = #MVN(arg0, #LSL(1));
+    x = #MVN(arg0 << 1);
     [x] = x;
-    x = #MVN(arg0, #LSL(31));
+    x = #MVN(arg0 << 31);
     [x] = x;
-    x = #MVN(arg0, #LSR(1));
+    x = #MVN(arg0 >> 1);
     [x] = x;
-    x = #MVN(arg0, #LSR(31));
+    x = #MVN(arg0 >> 31);
     [x] = x;
-    x = #MVN(arg0, #ASR(1));
+    x = #MVN(arg0 >>s 1);
     [x] = x;
-    x = #MVN(arg0, #ASR(31));
+    x = #MVN(arg0 >>s 31);
     [x] = x;
-    x = #MVN(arg0, #ROR(1));
+    x = #MVN(arg0 >>r 1);
     [x] = x;
-    x = #MVN(arg0, #ROR(31));
+    x = #MVN(arg0 >>r 31);
     [x] = x;
 
     // Set flags.
@@ -71,24 +71,24 @@ fn mvn(reg u32 arg0) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #MVNScc(arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #MVNS(2);
-    nf, zf, cf, x = #MVNS(arg0, #LSL(3));
-    nf, zf, cf, x = #MVNS(arg0, #LSR(3));
-    nf, zf, cf, x = #MVNS(arg0, #ASR(3));
-    nf, zf, cf, x = #MVNS(arg0, #ROR(3));
+    nf, zf, cf, x = #MVNS(arg0 << 3);
+    nf, zf, cf, x = #MVNS(arg0 >> 3);
+    nf, zf, cf, x = #MVNS(arg0 >>s 3);
+    nf, zf, cf, x = #MVNS(arg0 >>r 3);
     nf, zf, cf, x = #MVNScc(2, nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #MVNScc(arg0, #LSL(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #MVNScc(arg0, #LSL(3), !!(nf == vf), nf, zf, cf, x);
-    nf, zf, cf, x = #MVNScc(arg0, #LSR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #MVNScc(arg0, #ASR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #MVNScc(arg0, #ROR(3), nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #MVNScc(arg0 << 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #MVNScc(arg0 << 3, !!(nf == vf), nf, zf, cf, x);
+    nf, zf, cf, x = #MVNScc(arg0 >> 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #MVNScc(arg0 >>s 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #MVNScc(arg0 >>r 3, nf == vf, nf, zf, cf, x);
     x = #MVNcc(arg0, !!!!zf, x);
     x = #MVNcc(2, zf, x);
     x = #MVNcc(2, !!zf, x);
-    x = #MVNcc(arg0, #LSL(3), zf, x);
-    x = #MVNcc(arg0, #LSL(3), !!zf, x);
-    x = #MVNcc(arg0, #LSR(3), zf, x);
-    x = #MVNcc(arg0, #ASR(3), zf, x);
-    x = #MVNcc(arg0, #ROR(3), zf, x);
+    x = #MVNcc(arg0 << 3, zf, x);
+    x = #MVNcc(arg0 << 3, !!zf, x);
+    x = #MVNcc(arg0 >> 3, zf, x);
+    x = #MVNcc(arg0 >>s 3, zf, x);
+    x = #MVNcc(arg0 >>r 3, zf, x);
 
     reg u32 res;
     res = x;

--- a/compiler/tests/success/arm-m4/intrinsic_orr.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_orr.jazz
@@ -14,23 +14,23 @@ fn orr(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
 
     // Shifts.
-    x = #ORR(arg0, arg1, #LSL(0));
+    x = #ORR(arg0, arg1 << 0);
     [x] = x;
-    x = #ORR(arg0, arg1, #LSL(1));
+    x = #ORR(arg0, arg1 << 1);
     [x] = x;
-    x = #ORR(arg0, arg1, #LSL(31));
+    x = #ORR(arg0, arg1 << 31);
     [x] = x;
-    x = #ORR(arg0, arg1, #LSR(1));
+    x = #ORR(arg0, arg1 >> 1);
     [x] = x;
-    x = #ORR(arg0, arg1, #LSR(31));
+    x = #ORR(arg0, arg1 >> 31);
     [x] = x;
-    x = #ORR(arg0, arg1, #ASR(1));
+    x = #ORR(arg0, arg1 >>s 1);
     [x] = x;
-    x = #ORR(arg0, arg1, #ASR(31));
+    x = #ORR(arg0, arg1 >>s 31);
     [x] = x;
-    x = #ORR(arg0, arg1, #ROR(1));
+    x = #ORR(arg0, arg1 >>r 1);
     [x] = x;
-    x = #ORR(arg0, arg1, #ROR(31));
+    x = #ORR(arg0, arg1 >>r 31);
     [x] = x;
 
     // Set flags.
@@ -71,24 +71,24 @@ fn orr(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #ORRScc(x, arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #ORRS(x, 2);
-    nf, zf, cf, x = #ORRS(x, arg0, #LSL(3));
-    nf, zf, cf, x = #ORRS(x, arg0, #LSR(3));
-    nf, zf, cf, x = #ORRS(x, arg0, #ASR(3));
-    nf, zf, cf, x = #ORRS(x, arg0, #ROR(3));
+    nf, zf, cf, x = #ORRS(x, arg0 << 3);
+    nf, zf, cf, x = #ORRS(x, arg0 >> 3);
+    nf, zf, cf, x = #ORRS(x, arg0 >>s 3);
+    nf, zf, cf, x = #ORRS(x, arg0 >>r 3);
     nf, zf, cf, x = #ORRScc(x, 2, nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #ORRScc(x, arg0, #LSL(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #ORRScc(x, arg0, #LSL(3), !!(nf == vf), nf, zf, cf, x);
-    nf, zf, cf, x = #ORRScc(x, arg0, #LSR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #ORRScc(x, arg0, #ASR(3), nf == vf, nf, zf, cf, x);
-    nf, zf, cf, x = #ORRScc(x, arg0, #ROR(3), nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #ORRScc(x, arg0 << 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #ORRScc(x, arg0 << 3, !!(nf == vf), nf, zf, cf, x);
+    nf, zf, cf, x = #ORRScc(x, arg0 >> 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #ORRScc(x, arg0 >>s 3, nf == vf, nf, zf, cf, x);
+    nf, zf, cf, x = #ORRScc(x, arg0 >>r 3, nf == vf, nf, zf, cf, x);
     x = #ORRcc(x, arg0, !!!!zf, x);
     x = #ORRcc(x, 2, zf, x);
     x = #ORRcc(x, 2, !!zf, x);
-    x = #ORRcc(x, arg0, #LSL(3), zf, x);
-    x = #ORRcc(x, arg0, #LSL(3), !!zf, x);
-    x = #ORRcc(x, arg0, #LSR(3), zf, x);
-    x = #ORRcc(x, arg0, #ASR(3), zf, x);
-    x = #ORRcc(x, arg0, #ROR(3), zf, x);
+    x = #ORRcc(x, arg0 << 3, zf, x);
+    x = #ORRcc(x, arg0 << 3, !!zf, x);
+    x = #ORRcc(x, arg0 >> 3, zf, x);
+    x = #ORRcc(x, arg0 >>s 3, zf, x);
+    x = #ORRcc(x, arg0 >>r 3, zf, x);
 
     reg u32 res;
     res = x;

--- a/compiler/tests/success/arm-m4/intrinsic_rsb.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_rsb.jazz
@@ -14,23 +14,23 @@ fn rsb(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
 
     // Shifts.
-    x = #RSB(arg0, arg1, #LSL(0));
+    x = #RSB(arg0, arg1 << 0);
     [x] = x;
-    x = #RSB(arg0, arg1, #LSL(1));
+    x = #RSB(arg0, arg1 << 1);
     [x] = x;
-    x = #RSB(arg0, arg1, #LSL(31));
+    x = #RSB(arg0, arg1 << 31);
     [x] = x;
-    x = #RSB(arg0, arg1, #LSR(1));
+    x = #RSB(arg0, arg1 >> 1);
     [x] = x;
-    x = #RSB(arg0, arg1, #LSR(31));
+    x = #RSB(arg0, arg1 >> 31);
     [x] = x;
-    x = #RSB(arg0, arg1, #ASR(1));
+    x = #RSB(arg0, arg1 >>s 1);
     [x] = x;
-    x = #RSB(arg0, arg1, #ASR(31));
+    x = #RSB(arg0, arg1 >>s 31);
     [x] = x;
-    x = #RSB(arg0, arg1, #ROR(1));
+    x = #RSB(arg0, arg1 >>r 1);
     [x] = x;
-    x = #RSB(arg0, arg1, #ROR(31));
+    x = #RSB(arg0, arg1 >>r 31);
     [x] = x;
 
     // Set flags.
@@ -71,24 +71,24 @@ fn rsb(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, vf, x = #RSBScc(x, arg0, nf == vf, nf, zf, cf, vf, x);
     nf, zf, cf, vf, x = #RSBS(x, 2);
-    nf, zf, cf, vf, x = #RSBS(x, arg0, #LSL(3));
-    nf, zf, cf, vf, x = #RSBS(x, arg0, #LSR(3));
-    nf, zf, cf, vf, x = #RSBS(x, arg0, #ASR(3));
-    nf, zf, cf, vf, x = #RSBS(x, arg0, #ROR(3));
+    nf, zf, cf, vf, x = #RSBS(x, arg0 << 3);
+    nf, zf, cf, vf, x = #RSBS(x, arg0 >> 3);
+    nf, zf, cf, vf, x = #RSBS(x, arg0 >>s 3);
+    nf, zf, cf, vf, x = #RSBS(x, arg0 >>r 3);
     nf, zf, cf, vf, x = #RSBScc(x, 2, nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #RSBScc(x, arg0, #LSL(3), nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #RSBScc(x, arg0, #LSL(3), !!(nf == vf), nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #RSBScc(x, arg0, #LSR(3), nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #RSBScc(x, arg0, #ASR(3), nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #RSBScc(x, arg0, #ROR(3), nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #RSBScc(x, arg0 << 3, nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #RSBScc(x, arg0 << 3, !!(nf == vf), nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #RSBScc(x, arg0 >> 3, nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #RSBScc(x, arg0 >>s 3, nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #RSBScc(x, arg0 >>r 3, nf == vf, nf, zf, cf, vf, x);
     x = #RSBcc(x, arg0, !!!!zf, x);
     x = #RSBcc(x, 2, zf, x);
     x = #RSBcc(x, 2, !!zf, x);
-    x = #RSBcc(x, arg0, #LSL(3), zf, x);
-    x = #RSBcc(x, arg0, #LSL(3), !!zf, x);
-    x = #RSBcc(x, arg0, #LSR(3), zf, x);
-    x = #RSBcc(x, arg0, #ASR(3), zf, x);
-    x = #RSBcc(x, arg0, #ROR(3), zf, x);
+    x = #RSBcc(x, arg0 << 3, zf, x);
+    x = #RSBcc(x, arg0 << 3, !!zf, x);
+    x = #RSBcc(x, arg0 >> 3, zf, x);
+    x = #RSBcc(x, arg0 >>s 3, zf, x);
+    x = #RSBcc(x, arg0 >>r 3, zf, x);
 
     reg u32 res;
     res = x;

--- a/compiler/tests/success/arm-m4/intrinsic_sub.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_sub.jazz
@@ -14,23 +14,23 @@ fn sub(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
 
     // Shifts.
-    x = #SUB(arg0, arg1, #LSL(0));
+    x = #SUB(arg0, arg1 << 0);
     [x] = x;
-    x = #SUB(arg0, arg1, #LSL(1));
+    x = #SUB(arg0, arg1 << 1);
     [x] = x;
-    x = #SUB(arg0, arg1, #LSL(31));
+    x = #SUB(arg0, arg1 << 31);
     [x] = x;
-    x = #SUB(arg0, arg1, #LSR(1));
+    x = #SUB(arg0, arg1 >> 1);
     [x] = x;
-    x = #SUB(arg0, arg1, #LSR(31));
+    x = #SUB(arg0, arg1 >> 31);
     [x] = x;
-    x = #SUB(arg0, arg1, #ASR(1));
+    x = #SUB(arg0, arg1 >>s 1);
     [x] = x;
-    x = #SUB(arg0, arg1, #ASR(31));
+    x = #SUB(arg0, arg1 >>s 31);
     [x] = x;
-    x = #SUB(arg0, arg1, #ROR(1));
+    x = #SUB(arg0, arg1 >>r 1);
     [x] = x;
-    x = #SUB(arg0, arg1, #ROR(31));
+    x = #SUB(arg0, arg1 >>r 31);
     [x] = x;
 
     // Set flags.
@@ -71,24 +71,24 @@ fn sub(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, vf, x = #SUBScc(x, arg0, nf == vf, nf, zf, cf, vf, x);
     nf, zf, cf, vf, x = #SUBS(x, 2);
-    nf, zf, cf, vf, x = #SUBS(x, arg0, #LSL(3));
-    nf, zf, cf, vf, x = #SUBS(x, arg0, #LSR(3));
-    nf, zf, cf, vf, x = #SUBS(x, arg0, #ASR(3));
-    nf, zf, cf, vf, x = #SUBS(x, arg0, #ROR(3));
+    nf, zf, cf, vf, x = #SUBS(x, arg0 << 3);
+    nf, zf, cf, vf, x = #SUBS(x, arg0 >> 3);
+    nf, zf, cf, vf, x = #SUBS(x, arg0 >>s 3);
+    nf, zf, cf, vf, x = #SUBS(x, arg0 >>r 3);
     nf, zf, cf, vf, x = #SUBScc(x, 2, nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #SUBScc(x, arg0, #LSL(3), nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #SUBScc(x, arg0, #LSL(3), !!(nf == vf), nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #SUBScc(x, arg0, #LSR(3), nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #SUBScc(x, arg0, #ASR(3), nf == vf, nf, zf, cf, vf, x);
-    nf, zf, cf, vf, x = #SUBScc(x, arg0, #ROR(3), nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #SUBScc(x, arg0 << 3, nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #SUBScc(x, arg0 << 3, !!(nf == vf), nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #SUBScc(x, arg0 >> 3, nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #SUBScc(x, arg0 >>s 3, nf == vf, nf, zf, cf, vf, x);
+    nf, zf, cf, vf, x = #SUBScc(x, arg0 >>r 3, nf == vf, nf, zf, cf, vf, x);
     x = #SUBcc(x, arg0, !!!!zf, x);
     x = #SUBcc(x, 2, zf, x);
     x = #SUBcc(x, 2, !!zf, x);
-    x = #SUBcc(x, arg0, #LSL(3), zf, x);
-    x = #SUBcc(x, arg0, #LSL(3), !!zf, x);
-    x = #SUBcc(x, arg0, #LSR(3), zf, x);
-    x = #SUBcc(x, arg0, #ASR(3), zf, x);
-    x = #SUBcc(x, arg0, #ROR(3), zf, x);
+    x = #SUBcc(x, arg0 << 3, zf, x);
+    x = #SUBcc(x, arg0 << 3, !!zf, x);
+    x = #SUBcc(x, arg0 >> 3, zf, x);
+    x = #SUBcc(x, arg0 >>s 3, zf, x);
+    x = #SUBcc(x, arg0 >>r 3, zf, x);
 
     reg u32 res;
     res = x;


### PR DESCRIPTION
This PR implements a few things; I can split it if required:

 - support for intrisics with shifted arguments using operator syntax, e.g., `#ADD(x, y >> 2)`
 - use this syntax in the tests and drop support for the old syntax `#ADD(x, y, #LSR(2))`
 - test the pretty-printer for ARM in the test-suite and on CI

Dropping support for the old syntax enables me to implement extraction to EasyCrypt in a simple way.