### PR TITLE
x86: fixes for instruction BT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,9 @@
   argument (the shift amount) is no longer truncated
   ([PR #413](https://github.com/jasmin-lang/jasmin/pull/413)).
 
+- Fixes for x86 instruction `BT`
+  ([PR #420](https://github.com/jasmin-lang/jasmin/pull/420)).
+
 ## Other changes
 
 - Explicit if-then-else in flag combinations is no longer supported

--- a/compiler/tests/success/x86-64/bt.jazz
+++ b/compiler/tests/success/x86-64/bt.jazz
@@ -1,0 +1,19 @@
+export
+fn test_bt(reg u64 x y) -> reg u64 {
+  reg u64 r;
+  reg bool c;
+  r = x;
+  c = #BT_16(x, y);
+  r = y if c;
+  c = #BT_32(x, y);
+  r = y if c;
+  c = #BT_64(x, y);
+  r = y if c;
+  c = #BT_16(x, 5);
+  r = y if c;
+  c = #BT_32(x, 15);
+  r = y if c;
+  c = #BT_64(x, 15);
+  r = y if c;
+  return r;
+}

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -460,7 +460,7 @@ Definition x86_LZCNT sz (w: word sz) : ex_tpl (b5w_ty sz) :=
 Definition x86_SETcc (b:bool) : ex_tpl (w_ty U8) := ok (wrepr U8 (Z.b2z b)).
 
 Definition x86_BT sz (x y: word sz) : ex_tpl (b_ty) :=
-  Let _  := check_size_8_64 sz in
+  Let _  := check_size_16_64 sz in
   ok (Some (wbit x y)).
 
 (* -------------------------------------------------------------------- *)
@@ -1325,7 +1325,7 @@ Definition Ox86_SETcc_instr             :=
 
 Definition check_bt (_:wsize) := [:: [::rm true; ri U8]].
 Definition Ox86_BT_instr                :=
-  mk_instr_w2_b "BT" x86_BT [:: E 0; E 1] [:: F CF] 2 check_bt (primP BT) (pp_iname_w_8 "bt").
+  mk_instr_w2_b "BT" x86_BT [:: E 0; E 1] [:: F CF] 2 check_bt (primP BT) (pp_iname "bt").
 
 (* -------------------------------------------------------------------- *)
 Definition Ox86_CLC_instr :=


### PR DESCRIPTION
  - There is no 8-bit variant for this instruction
  - The generated assembly is now well-formed