### PR TITLE
Change sopn.implicit_arg to var

### DIFF
--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1521,10 +1521,10 @@ let tt_lvalues pd env loc (pimp, pls) implicit tys =
       let arguments = 
         (* FIXME this is not generic *)
         let open Sopn in
-        List.map 
-          (function ADExplicit _           -> None 
-                  | ADImplicit (IArflag f) -> Some (Conv.string_of_string0 (Var0.Var.vname f))
-                  | ADImplicit (IAreg r)   -> Some (Conv.string_of_string0 (Var0.Var.vname r)))
+        List.map
+          (function
+           | ADExplicit _ -> None
+           | ADImplicit v -> Some (Conv.string_of_string0 (Var0.Var.vname v)))
           implicit in
 
       let iargs = List.pmap (Option.map String.uppercase_ascii) arguments in

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -560,24 +560,18 @@ module Regalloc (Arch : Arch_full.Arch)
       match x with Pvar x when is_gkvar x -> allocate_one x.gv y a | _ -> ()
     in
     let id = get_instr_desc Arch.asmOp op in
-    (* TODO: move !! *)
-    let var_of_implicit v =
-      match v with
-      | IArflag v -> v
-      | IAreg v -> v
-    in
     List.iter2 (fun ad lv ->
         match ad with
         | ADImplicit v ->
            begin match lv with
-           | Lvar w -> allocate_one w (translate_var (var_of_implicit v)) a
+           | Lvar w -> allocate_one w (translate_var v) a
            | _ -> assert false
            end
         | ADExplicit _ -> ()) id.i_out lvs;
     List.iter2 (fun ad e ->
         match ad with
         | ADImplicit v ->
-           mallocate_one e (translate_var (var_of_implicit v)) a
+           mallocate_one e (translate_var v) a
         | ADExplicit (_, Some v) ->
            mallocate_one e (translate_var v) a
         | ADExplicit (_, None) -> ()) id.i_in es

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -86,8 +86,8 @@ Proof. move=> [] hsize _; apply/eqP/reg_size_neq_xreg_size:hsize. Qed.
 
 Definition sopn_implicit_arg (i: implicit_arg) :=
   match i with
-  | IArflag r => sopn.IArflag (to_var r)
-  | IAreg   r => sopn.IArflag (to_var r)
+  | IArflag r => to_var r
+  | IAreg r => to_var r
   end.
 
 Definition sopn_arg_desc (ad:arg_desc) :=

--- a/proofs/lang/sopn.v
+++ b/proofs/lang/sopn.v
@@ -11,13 +11,8 @@ Local Unset Elimination Schemes.
 
 (* ----------------------------------------------------------------------------- *)
 
-Variant implicit_arg : Type :=
-  | IArflag of var
-  | IAreg   of var
-  .
-
 Variant arg_desc :=
-| ADImplicit  of implicit_arg
+| ADImplicit  of var
 | ADExplicit  of nat & option var.
 
 Record instruction_desc := mkInstruction {


### PR DESCRIPTION
From outside Coq we don't need to distinguish `reg` and `flag` implicit arguments.