### PR TITLE
Prune unused local functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,10 @@
   an amount that is explicitly truncated (e.g., `x >>= y & 63`)
   ([PR #412](https://github.com/jasmin-lang/jasmin/pull/412)).
 
+- Local functions that are never called are removed from the program during the
+  “remove unused function” pass
+  ([PR #427](https://github.com/jasmin-lang/jasmin/pull/427)).
+
 # Jasmin 2022.09.0
 
 ## Bug fixes

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -267,17 +267,16 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     }
   in
 
-  let export_functions, subroutines =
+  let export_functions =
     let conv fd = Conv.cfun_of_fun tbl fd.f_name in
     List.fold_right
-      (fun fd ((e, i) as acc) ->
+      (fun fd acc ->
         match fd.f_cc with
-        | Export -> (conv fd :: e, i)
-        | Internal -> acc
-        | Subroutine _ -> (e, conv fd :: i))
-      (snd prog) ([], [])
+        | Export -> conv fd :: acc
+        | Internal | Subroutine _ -> acc)
+      (snd prog) []
   in
 
   Compiler.compile_prog_to_asm Arch.asm_e Arch.call_conv Arch.aparams cparams
-    export_functions subroutines
+    export_functions
     (Expr.to_uprog Arch.asmOp cprog)

--- a/compiler/tests/fail/stack_allocation/x86-64/bad_alignment.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/bad_alignment.jazz
@@ -7,3 +7,10 @@ fn f (reg ptr u64[2] r) -> reg u32 {
   res = b[1];
   return res;
 }
+
+export fn main() -> reg 32 {
+  stack u64[2] s;
+  reg u32 r;
+  r = f(s);
+  return r;
+}

--- a/compiler/tests/fail/stack_allocation/x86-64/merge_global_param.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/merge_global_param.jazz
@@ -1,10 +1,17 @@
 u64[2] g = {0,1};
 
-fn f (reg ptr u64[1] r1, reg ptr u64[1] r2) -> reg u64 {
+fn f (reg ptr u64[1] r1) -> reg u64 {
   reg u64 res;
   reg ptr u64[2] rg;
   rg = g;
   rg[0:1] = r1[0:1];
   res = rg[0];
   return res;
+}
+
+export fn dummy() -> reg u64 {
+  stack u64[1] s;
+  reg u64 r;
+  r = f(s);
+  return r;
 }

--- a/compiler/tests/fail/stack_allocation/x86-64/merge_globals.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/merge_globals.jazz
@@ -1,11 +1,18 @@
 u64[2] g1 = {0,1};
 u64[2] g2 = {0,1};
 
-fn f (reg ptr u64[1] r1, reg ptr u64[1] r2) -> reg u64 {
+fn f (reg ptr u64[1] r1) -> reg u64 {
   reg u64 res;
   reg ptr u64[2] rg;
   rg = g1;
   rg[0:1] = g2[0:1];
   res = rg[0];
   return res;
+}
+
+export fn dummy() -> reg u64 {
+  stack u64[1] s;
+  reg u64 r;
+  r = f(s);
+  return r;
 }

--- a/compiler/tests/fail/stack_allocation/x86-64/non_constant_index.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/non_constant_index.jazz
@@ -1,3 +1,4 @@
+export
 fn f (reg u64 i) -> reg u64 {
   reg u64 res;
   stack u64[2] a;

--- a/compiler/tests/fail/stack_allocation/x86-64/pointer_to_stack2.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/pointer_to_stack2.jazz
@@ -7,3 +7,10 @@ r = s[0];
 
 return r;
 }
+
+export fn dummy() -> reg u64 {
+  stack u64[1] s;
+  reg u64 r;
+  r = bad(s);
+  return r;
+}

--- a/compiler/tests/fail/stack_allocation/x86-64/range_overflow.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/range_overflow.jazz
@@ -1,3 +1,4 @@
+export
 fn f () -> reg u64 {
   stack u64[2] a, b;
   reg u64 res;

--- a/compiler/tests/fail/stack_allocation/x86-64/slice_same.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/slice_same.jazz
@@ -1,3 +1,4 @@
+export
 fn f () -> reg u64 {
   stack u64[2] a;
   reg u64 res;

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -308,9 +308,9 @@ Definition compiler_third_part (entries: seq funname) (ps: sprog) : cexec sprog 
 
   ok pd.
 
-Definition compiler_front_end (entries subroutines : seq funname) (p: prog) : cexec sprog :=
+Definition compiler_front_end (entries: seq funname) (p: prog) : cexec sprog :=
 
-  Let pl := compiler_first_part (entries ++ subroutines) p in
+  Let pl := compiler_first_part entries p in
 
   (* stack + register allocation *)
 
@@ -360,7 +360,7 @@ Definition compiler_back_end_to_asm (entries: seq funname) (p: sprog) :=
   Let lp := compiler_back_end entries p in
   assemble_prog agparams lp.
 
-Definition compile_prog_to_asm entries subroutines (p: prog): cexec asm_prog :=
-  compiler_front_end entries subroutines p >>= compiler_back_end_to_asm entries.
+Definition compile_prog_to_asm entries (p: prog): cexec asm_prog :=
+  compiler_front_end entries p >>= compiler_back_end_to_asm entries.
 
 End COMPILER.

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -329,12 +329,11 @@ Qed.
 
 Lemma compiler_front_endP
   entries
-  subroutines
   (p: prog)
   (p': @sprog _pd _ _asmop)
   (gd : pointer)
   scs m mi fn va scs' m' vr :
-  compiler_front_end aparams cparams entries subroutines p = ok p' →
+  compiler_front_end aparams cparams entries p = ok p' →
   fn \in entries →
   sem.sem_call p scs m fn va scs' m' vr →
   extend_mem m mi gd (sp_globs (p_extra p')) →
@@ -352,8 +351,7 @@ Proof.
   rewrite (compiler_third_part_meta ok_p3) => m_mi ok_mi.
   assert (ok_mi' : alloc_ok (sip := sip_of_asm_e) p2 fn mi).
   - exact: compiler_third_part_alloc_ok ok_p3 ok_mi.
-  have := compiler_first_partP ok_p1 _ exec_p.
-  rewrite mem_cat ok_fn => /(_ erefl).
+  have := compiler_first_partP ok_p1 ok_fn exec_p.
   case => {p ok_p1 exec_p} vr1 vr_vr1 exec_p1.
   have gd2 := sp_globs_stack_alloc ok_p2.
   rewrite -gd2 in ok_p2.
@@ -714,7 +712,6 @@ Definition mem_agreement (m m': mem) (gd: pointer) (data: seq u8) : Prop :=
 
 Lemma compile_prog_to_asmP
   entries
-  subroutine
   (p : prog)
   (xp : asm_prog)
   scs (m : mem) scs' (m' : mem)
@@ -722,7 +719,7 @@ Lemma compile_prog_to_asmP
   va
   vr
   xm :
-  compile_prog_to_asm aparams cparams entries subroutine p = ok xp
+  compile_prog_to_asm aparams cparams entries p = ok xp
   -> fn \in entries
   -> sem.sem_call p scs m fn va scs' m' vr
   -> mem_agreement m (asm_mem xm) (asm_rip xm) (asm_globs xp)


### PR DESCRIPTION
Local functions that are not reachable from any “export” functions are
removed from the program after inlining.

The compiler notoriously exhibits weird behaviors when local functions
are never called.