### PR TITLE
Handle assignments before linearization

### DIFF
--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -94,9 +94,13 @@ Definition arm_mov_ofs
     end in
   Some (Copn [:: x ] tag (Oarm (ARM_op op default_opts)) args).
 
+Definition arm_immediate (x: var_i) z :=
+  Copn [:: Lvar x ] AT_none (Oarm (ARM_op MOV default_opts)) [:: cast_const z ].
+
 Definition arm_saparams : stack_alloc_params :=
   {|
     sap_mov_ofs := arm_mov_ofs;
+    sap_immediate := arm_immediate;
   |}.
 
 

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -122,10 +122,20 @@ Proof.
   all: by rewrite /sem_sopn /= P'_globs /exec_sopn /sem_sop2 /= ok_z /= ok_i /= !zero_extend_u /= hx.
 Qed.
 
+Lemma arm_immediateP (P': sprog) w s (x: var_i) z :
+  vtype x = sword Uptr
+  -> psem.sem_i (pT := progStack) P' w s (arm_immediate x z) (with_vm s (evm s).[x <- pof_val x.(vtype) (Vword (wrepr Uptr z))])%vmap.
+Proof.
+  case: x => - [] [] // [] // x xi _ /=.
+  constructor.
+  by rewrite /sem_sopn /= zero_extend_u.
+Qed.
+
 Definition arm_hsaparams is_regx :
   h_stack_alloc_params (ap_sap arm_params is_regx) :=
   {|
     mov_ofsP := arm_mov_ofsP;
+    sap_immediateP := arm_immediateP;
   |}.
 
 

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -322,13 +322,7 @@ Definition stack_frame_allocation_size (e: stk_fun_extra) : Z :=
   Fixpoint check_i (i:instr) : cexec unit :=
     let (ii,ir) := i in
     match ir with
-    | Cassgn x tag ty e =>
-      if ty is sword ws
-      then
-        if isSome (lassign' x ws e)
-        then ok tt
-        else Error (E.ii_error ii "assign failed")
-      else Error (E.ii_error ii "assign not a word")
+    | Cassgn x tag ty e => Error (E.ii_error ii "assign remains")
     | Copn xs tag o es =>
       allM (check_rexpr ii) es >> allM (check_lexpr ii) xs
     | Csyscall xs o es =>
@@ -572,11 +566,7 @@ Let Llabel := linear.Llabel InternalLabel.
 Fixpoint linear_i (i:instr) (lbl:label) (lc:lcmd) :=
   let (ii, ir) := i in
   match ir with
-  | Cassgn x _ ty e =>
-    let lc' := if ty is sword sz
-               then of_olinstr_r ii (lassign' x sz e) :: lc
-               else lc
-    in (lbl, lc')
+  | Cassgn _ _ _ _ => (lbl, lc) (* absurd case *)
   | Copn xs _ o es =>
       match oseq.omap lexpr_of_lval xs, oseq.omap rexpr_of_pexpr es with
       | Some xs, Some es => (lbl, MkLI ii (Lopn xs o es) :: lc)

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -586,12 +586,7 @@ Section VALIDITY.
   Qed.
 
   Let Hassign (x : lval) (tg : assgn_tag) (ty : stype) (e : pexpr) : Pr (Cassgn x tg ty e).
-  Proof.
-    move => ii fn lbl /=.
-    case: ty;
-      (split => //; first exact: Pos.le_refl).
-    exact: valid_lassign.
-  Qed.
+  Proof. move => ???; exact: default. Qed.
 
   Let Hopn (xs : lvals) (t : assgn_tag) (o : sopn) (es : pexprs) : Pr (Copn xs t o es).
   Proof.
@@ -755,12 +750,7 @@ Section NUMBER_OF_LABELS.
   Qed.
 
   Let Hassign (x : lval) (tg : assgn_tag) (ty : stype) (e : pexpr) : Pr (Cassgn x tg ty e).
-  Proof.
-    move => ii fn lbl /=.
-    case: ty => /=; try lia.
-    move=> ws.
-    by rewrite get_label_lassign' /=; apply Z.le_refl.
-  Qed.
+  Proof. move => ???; exact: Z.le_refl. Qed.
 
   Let Hopn (xs : lvals) (t : assgn_tag) (o : sopn) (es : pexprs) : Pr (Copn xs t o es).
   Proof.
@@ -960,7 +950,7 @@ Section PROOF.
   Hypothesis linear_ok : linear_prog liparams p = ok p'.
 
   Notation is_linear_of := (is_linear_of p').
-  Notation check_i := (check_i liparams p).
+  Notation check_i := (check_i p).
   Notation check_fd := (check_fd liparams p).
   Notation linear_i := (linear_i liparams p).
   Notation linear_c fn := (linear_c (linear_i fn)).
@@ -1694,34 +1684,7 @@ Section PROOF.
   Qed.
 
   Local Lemma Hasgn : sem_Ind_assgn p Pi_r.
-  Proof.
-    move => ii s1 s2 x tg ty e v v'; rewrite p_globs_nil => ok_v ok_v' ok_s2.
-    move => fn lbl /checked_iE[] fd ok_fd.
-    case: ty ok_v' ok_s2 => // sz.
-    move=> /truncate_val_typeE [w0 [sz' [w' [htw ??]]]]; subst v v' => ok_s2.
-
-    rewrite /check_i.
-    case: ifP => // /isSome_obind[] d ok_d /isSome_obind[] r ok_r hchk _.
-
-    move => fr_undef m1 vm1 P Q W1 M1 X1 D1 C1.
-    have [ v' ok_v' ] := sem_pexpr_uincl X1 ok_v.
-    case/value_uinclE => [sz''] [w] [?]; subst v' => /andP[] hle' /eqP ?; subst w'.
-    have [ vm2 /(match_mem_write_lval M1) [ m2 ok_s2' M2 ] ok_vm2 ] := write_uincl X1 (value_uincl_refl _) ok_s2.
-    exists m2 vm2; [ | | | exact: ok_vm2 | | exact: M2]; last first.
-    + exact: write_lval_preserves_metadata ok_s2 ok_s2' _ X1 M1.
-    + exact: wf_write_lval ok_s2'.
-    + apply: vmap_eq_except_union. by have := vrvP ok_s2'.
-    apply: LSem_step.
-    rewrite -(addn0 (size P)) /lsem1 /step /= (find_instr_skip C1) /=.
-    rewrite /lassign' ok_d ok_r /=.
-    rewrite /of_estate size_cat addn1 addn0.
-    have {} ok_v' := match_mem_sem_pexpr M1 ok_v'.
-    have {} ok_v' := rexpr_of_pexprP ok_r ok_v'.
-    have {} ok_s2' := lexpr_of_lvalP ok_d ok_s2'.
-    apply: (spec_lassign hliparams _ _ _ _ hchk ok_v' _ ok_s2').
-    move: htw => /truncate_wordP [hle ->].
-    by rewrite (zero_extend_idem _ hle) /truncate_word (ifT _ _ (cmp_le_trans hle hle')).
-  Qed.
+  Proof. by move => ii s1 s2 x tg ty e v v' ok_v ok_v' ok_s2 fn lbl /checked_iE[]. Qed.
 
   Lemma check_rexprsP ii es u :
     allM (check_rexpr ii) es = ok u →

--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -461,6 +461,8 @@ Record stack_alloc_params :=
       -> pexpr        (* Variable with base address. *)
       -> Z            (* Offset. *)
       -> option instr_r;
+    (* Build an instruction that assigns an immediate value *)
+    sap_immediate : var_i -> Z -> instr_r;
   }.
 
 Variant mov_kind :=
@@ -1119,7 +1121,7 @@ Definition alloc_syscall ii rmap rs o es :=
       Let sr := get_sub_region rmap xe in
       Let rmap := set_sub_region rmap x sr (Some 0%Z) (Zpos len) in
       ok (rmap,
-          [:: MkI ii (Cassgn (Lvar xlen) AT_none (sword Uptr) (cast_const (Zpos len)));
+          [:: MkI ii (sap_immediate saparams xlen (Zpos len));
               MkI ii (Csyscall [::Lvar xp] o [:: Plvar p; Plvar xlen])])
     | _, _ =>
       Error (stk_ierror_no_var "randombytes: invalid args or result")

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -2000,7 +2000,7 @@ Proof.
   move=> s1 scs m s2 o xs es ves vxs hves hvxs hs2.
   move=> pmap rsp Slots Addr Writable Align rmap1 rmap2 ii1 c2 hpmap hwf sao /=.
   move=> hsyscall m0 s1' hvs hext hsao.
-  by apply (alloc_syscallP hwf.(wfsl_no_overflow) hwf.(wfsl_disjoint) hpmap P' hsyscall hvs hves hvxs hs2).
+  by apply (alloc_syscallP hwf.(wfsl_no_overflow) hwf.(wfsl_disjoint) hpmap P' hsaparams hsyscall hvs hves hvxs hs2).
 Qed.
 
 Local Lemma Hif_true : sem_Ind_if_true P ev Pc Pi_r.

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -54,11 +54,15 @@ Definition x86_mov_ofs x tag vpk y ofs :=
   in
   Some addr.
 
+Definition x86_immediate x z :=
+  mov_ws is_regx Uptr (Lvar x) (cast_const z) AT_none.
+
 End IS_REGX.
 
 Definition x86_saparams is_regx : stack_alloc_params :=
   {|
     sap_mov_ofs := x86_mov_ofs is_regx;
+    sap_immediate := x86_immediate is_regx;
   |}.
 
 (* ------------------------------------------------------------------------ *)


### PR DESCRIPTION
Ensure (and enforce) that there are no assignment left when reaching the linearization pass.

  - Lowering must handle all existing assignments
  - Passes that come after should not introduce new assignments.

Does this need a changelog entry?