### PR TITLE
Cleanup and move architecture utils

### DIFF
--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -186,9 +186,7 @@ Scheme Equality for msb_flag.
 
 Lemma msb_flag_eq_axiom : Equality.axiom msb_flag_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_msb_flag_dec_bl.
-  by apply: internal_msb_flag_dec_lb.
+  exact: (eq_axiom_of_scheme internal_msb_flag_dec_bl internal_msb_flag_dec_lb).
 Qed.
 
 Definition msb_flag_eqMixin := Equality.Mixin msb_flag_eq_axiom.
@@ -232,9 +230,8 @@ Scheme Equality for addr_kind.
 
 Lemma addr_kind_eq_axiom : Equality.axiom addr_kind_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_addr_kind_dec_bl.
-  by apply: internal_addr_kind_dec_lb.
+  exact:
+    (eq_axiom_of_scheme internal_addr_kind_dec_bl internal_addr_kind_dec_lb).
 Qed.
 
 Definition addr_kind_eqMixin := Equality.Mixin addr_kind_eq_axiom.
@@ -299,9 +296,7 @@ Scheme Equality for arg_kind.
 
 Lemma arg_kind_eq_axiom : Equality.axiom arg_kind_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_arg_kind_dec_bl.
-  by apply: internal_arg_kind_dec_lb.
+  exact: (eq_axiom_of_scheme internal_arg_kind_dec_bl internal_arg_kind_dec_lb).
 Qed.
 
 Definition arg_kind_eqMixin := Equality.Mixin arg_kind_eq_axiom.
@@ -676,9 +671,7 @@ Scheme Equality for rflagv.
 
 Lemma rflagv_eq_axiom : Equality.axiom rflagv_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_rflagv_dec_bl.
-  by apply: internal_rflagv_dec_lb.
+  exact: (eq_axiom_of_scheme internal_rflagv_dec_bl internal_rflagv_dec_lb).
 Qed.
 
 Definition rflagv_eqMixin := Equality.Mixin rflagv_eq_axiom.

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -84,7 +84,7 @@ Lemma to_var_regx_neq_xreg (r : regx_t) (x : xreg_t) :
   to_var r <> to_var x.
 Proof. move=> [] hsize _; apply/eqP/reg_size_neq_xreg_size:hsize. Qed.
 
-Definition sopn_implicit_arg (i: implicit_arg) :=
+Definition var_of_implicit_arg (i : implicit_arg) : var :=
   match i with
   | IArflag r => to_var r
   | IAreg r => to_var r
@@ -92,7 +92,7 @@ Definition sopn_implicit_arg (i: implicit_arg) :=
 
 Definition sopn_arg_desc (ad:arg_desc) :=
   match ad with
-  | ADImplicit ia => sopn.ADImplicit (sopn_implicit_arg ia)
+  | ADImplicit ia => sopn.ADImplicit (var_of_implicit_arg ia)
   | ADExplicit _ n ox => sopn.ADExplicit n (omap to_var ox)
   end.
 

--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -270,14 +270,8 @@ Definition nset (T:Type) (m:nmap T) (n:nat) (t:T) :=
   fun x => if x == n then Some t else nget m x.
 Definition nempty (T:Type) := fun n:nat => @None T.
 
-Definition var_of_implicit (i:implicit_arg) :=
-  match i with
-  | IArflag f => to_var f
-  | IAreg r   => to_var r
-  end.
-
 Definition is_implicit (i: implicit_arg) (e: rexpr) : bool :=
-  if e is Rexpr (Fvar x) then x.(v_var) == var_of_implicit i else false.
+  if e is Rexpr (Fvar x) then x.(v_var) == var_of_implicit_arg i else false.
 
 Definition compile_arg rip ii (ade: (arg_desc * stype) * rexpr) (m: nmap asm_arg) : cexec (nmap asm_arg) :=
   let ad := ade.1 in

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -311,7 +311,7 @@ Qed.
 
 Lemma is_implicitP i e :
   is_implicit i e →
-  ∃ vi, e = Rexpr (Fvar {| v_var := var_of_implicit i ; v_info := vi |}).
+  ∃ vi, e = Rexpr (Fvar {| v_var := var_of_implicit_arg i ; v_info := vi |}).
 Proof. by case: e => //- [] // [] x vi //= /eqP ->; exists vi. Qed.
 
 Section EVAL_ASSEMBLE_COND.

--- a/proofs/compiler/arm_decl.v
+++ b/proofs/compiler/arm_decl.v
@@ -34,15 +34,12 @@ Variant register : Type :=
 | LR                            (* Subroutine link register. *)
 | SP.                           (* Stack pointer. *)
 
-Definition register_dec_eq (r0 r1: register) : {r0 = r1} + {r0 <> r1}.
-  by repeat decide equality.
-Defined.
-
-Definition register_beq (r0 r1: register) : bool :=
-  is_left (register_dec_eq r0 r1).
+Scheme Equality for register.
 
 Lemma register_eq_axiom : Equality.axiom register_beq.
-Proof. by t_eq_axiom register_beq register_dec_eq. Qed.
+Proof.
+  exact: (eq_axiom_of_scheme internal_register_dec_bl internal_register_dec_lb).
+Qed.
 
 #[ export ]
 Instance eqTC_register : eqTypeC register :=
@@ -104,15 +101,12 @@ Variant rflag : Type :=
 | CF    (* Carry condition flag. *)
 | VF.   (* Overflow condition flag. *)
 
-Definition rflag_dec_eq (f0 f1: rflag) : {f0 = f1} + {f0 <> f1}.
-  by repeat decide equality.
-Defined.
-
-Definition rflag_beq (f0 f1: rflag) : bool :=
-  is_left (rflag_dec_eq f0 f1).
+Scheme Equality for rflag.
 
 Lemma rflag_eq_axiom : Equality.axiom rflag_beq.
-Proof. by t_eq_axiom rflag_beq rflag_dec_eq. Qed.
+Proof.
+  exact: (eq_axiom_of_scheme internal_rflag_dec_bl internal_rflag_dec_lb).
+Qed.
 
 #[ export ]
 Instance eqTC_rflag : eqTypeC rflag :=
@@ -171,15 +165,12 @@ Variant condt : Type :=
 | GT_ct    (* Signed greater than. *)
 | LE_ct.   (* Signed less than or equal. *)
 
-Definition condt_dec_eq (c0 c1: condt) : {c0 = c1} + {c0 <> c1}.
-  by repeat decide equality.
-Defined.
-
-Definition condt_beq (c0 c1: condt) : bool :=
-  is_left (condt_dec_eq c0 c1).
+Scheme Equality for condt.
 
 Lemma condt_eq_axiom : Equality.axiom condt_beq.
-Proof. by t_eq_axiom condt_beq condt_dec_eq. Qed.
+Proof.
+  exact: (eq_axiom_of_scheme internal_condt_dec_bl internal_condt_dec_lb).
+Qed.
 
 #[ export ]
 Instance eqTC_condt : eqTypeC condt :=
@@ -228,16 +219,13 @@ Definition string_of_condt (c : condt) : string :=
  * Some instructions can shift a register before performing an operation.
  *)
 
-Definition shift_kind_dec_eq (sk0 sk1 : shift_kind) :
-  {sk0 = sk1} + {sk0 <> sk1}.
-  by repeat decide equality.
-Defined.
-
-Definition shift_kind_beq (sk0 sk1 : shift_kind) : bool :=
-  is_left (shift_kind_dec_eq sk0 sk1).
+Scheme Equality for shift_kind.
 
 Lemma shift_kind_eq_axiom : Equality.axiom shift_kind_beq.
-Proof. by t_eq_axiom shift_kind_beq shift_kind_dec_eq. Qed.
+Proof.
+  exact:
+    (eq_axiom_of_scheme internal_shift_kind_dec_bl internal_shift_kind_dec_lb).
+Qed.
 
 #[ export ]
 Instance eqTC_shift_kind : eqTypeC shift_kind :=
@@ -281,7 +269,6 @@ Definition shift_of_sop2 (ws : wsize) (op : sop2) : option shift_kind :=
   | U32, Oror U32 => Some SROR
   | _, _ => None
   end.
-
 
 (* -------------------------------------------------------------------- *)
 (* Flag combinations.
@@ -339,7 +326,8 @@ Instance arm_decl : arch_decl register register_ext xregister rflag condt :=
   }.
 
 Definition arm_linux_call_conv : calling_convention :=
-  {| callee_saved   := map ARReg [:: R04; R05; R06; R07; R08; R09; R10; R11; SP ]
+  {| callee_saved :=
+      map ARReg [:: R04; R05; R06; R07; R08; R09; R10; R11; SP ]
    ; callee_saved_not_bool := erefl true
    ; call_reg_args  := [:: R00; R01; R02; R03 ]
    ; call_xreg_args := [::]

--- a/proofs/compiler/arm_extra.v
+++ b/proofs/compiler/arm_extra.v
@@ -26,9 +26,10 @@ Scheme Equality for arm_extra_op.
 
 Lemma arm_extra_op_eq_axiom : Equality.axiom arm_extra_op_beq.
 Proof.
-  move=> x y; apply:(iffP idP).
-  + by apply: internal_arm_extra_op_dec_bl.
-  by apply: internal_arm_extra_op_dec_lb.
+  exact:
+    (eq_axiom_of_scheme
+       internal_arm_extra_op_dec_bl
+       internal_arm_extra_op_dec_lb).
 Qed.
 
 Definition arm_extra_op_eqMixin :=

--- a/proofs/compiler/arm_instr_decl_lemmas.v
+++ b/proofs/compiler/arm_instr_decl_lemmas.v
@@ -6,7 +6,9 @@ From mathcomp Require Import word_ssrZ.
 Require Import
   psem
   shift_kind.
-Require Import sem_params_of_arch_extra.
+Require Import
+  arch_utils
+  sem_params_of_arch_extra.
 Require Import
   arm_decl
   arm_extra
@@ -96,8 +98,6 @@ Proof.
     ).
 
   all: move: hsemop.
-  all: rewrite /sopn_sem /=.
-  all: rewrite /drop_semi_nzcv /=.
   all: move=> [?]; subst v.
   all: by case: b.
 Qed.

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -1279,8 +1279,6 @@ Proof.
   rewrite /exec_sopn /=.
   t_xrbindP=> w w'' hvx.
   have [ws' [w' [-> /truncate_wordP [hws' ->]]]] := to_wordI hvx.
-  rewrite /sopn_sem /=.
-  rewrite /drop_semi_nzcv /=.
   move=> [<-] <-.
   apply: List.Forall2_cons; last done.
   exact: (word_uincl_zero_ext w' hws').

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -129,9 +129,10 @@ Definition compiler_step_list := [::
 Scheme Equality for compiler_step.
 Lemma compiler_step_eq_axiom : Equality.axiom compiler_step_beq.
 Proof.
-  move=> x y; apply:(iffP idP).
-  + by apply: internal_compiler_step_dec_bl.
-  by apply: internal_compiler_step_dec_lb.
+  exact:
+    (eq_axiom_of_scheme
+       internal_compiler_step_dec_bl
+       internal_compiler_step_dec_lb).
 Qed.
 Definition compiler_step_eqMixin := Equality.Mixin compiler_step_eq_axiom.
 Canonical  compiler_step_eqType  := Eval hnf in EqType compiler_step compiler_step_eqMixin.

--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -118,9 +118,7 @@ Scheme Equality for zone.
 
 Lemma zone_eq_axiom : Equality.axiom zone_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_zone_dec_bl.
-  by apply: internal_zone_dec_lb.
+  exact: (eq_axiom_of_scheme internal_zone_dec_bl internal_zone_dec_lb).
 Qed.
 
 Definition zone_eqMixin := Equality.Mixin zone_eq_axiom.

--- a/proofs/compiler/x86_decl.v
+++ b/proofs/compiler/x86_decl.v
@@ -68,9 +68,7 @@ Scheme Equality for register.
 
 Lemma reg_eq_axiom : Equality.axiom register_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_register_dec_bl.
-  by apply: internal_register_dec_lb.
+  exact: (eq_axiom_of_scheme internal_register_dec_bl internal_register_dec_lb).
 Qed.
 
 Definition reg_eqMixin := Equality.Mixin reg_eq_axiom.
@@ -83,9 +81,10 @@ Scheme Equality for register_ext.
 
 Lemma regx_eq_axiom : Equality.axiom register_ext_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_register_ext_dec_bl.
-  by apply: internal_register_ext_dec_lb.
+  exact:
+    (eq_axiom_of_scheme
+       internal_register_ext_dec_bl
+       internal_register_ext_dec_lb).
 Qed.
 
 Definition regx_eqMixin := Equality.Mixin regx_eq_axiom.
@@ -97,9 +96,10 @@ Scheme Equality for xmm_register.
 
 Lemma xreg_eq_axiom : Equality.axiom xmm_register_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_xmm_register_dec_bl.
-  by apply: internal_xmm_register_dec_lb.
+  exact:
+    (eq_axiom_of_scheme
+       internal_xmm_register_dec_bl
+       internal_xmm_register_dec_lb).
 Qed.
 
 Definition xreg_eqMixin := Equality.Mixin xreg_eq_axiom.
@@ -111,9 +111,7 @@ Scheme Equality for rflag.
 
 Lemma rflag_eq_axiom : Equality.axiom rflag_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_rflag_dec_bl.
-  by apply: internal_rflag_dec_lb.
+  exact: (eq_axiom_of_scheme internal_rflag_dec_bl internal_rflag_dec_lb).
 Qed.
 
 Definition rflag_eqMixin := Equality.Mixin rflag_eq_axiom.
@@ -125,9 +123,7 @@ Scheme Equality for condt.
 
 Lemma condt_eq_axiom : Equality.axiom condt_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_condt_dec_bl.
-  by apply: internal_condt_dec_lb.
+  exact: (eq_axiom_of_scheme internal_condt_dec_bl internal_condt_dec_lb).
 Qed.
 
 Definition condt_eqMixin := Equality.Mixin condt_eq_axiom.

--- a/proofs/compiler/x86_extra.v
+++ b/proofs/compiler/x86_extra.v
@@ -22,9 +22,10 @@ Scheme Equality for x86_extra_op.
 
 Lemma x86_extra_op_eq_axiom : Equality.axiom x86_extra_op_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_x86_extra_op_dec_bl.
-  by apply: internal_x86_extra_op_dec_lb.
+  exact:
+    (eq_axiom_of_scheme
+       internal_x86_extra_op_dec_bl
+       internal_x86_extra_op_dec_lb).
 Qed.
 
 Definition x86_extra_op_eqMixin     := Equality.Mixin x86_extra_op_eq_axiom.

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -182,9 +182,7 @@ Scheme Equality for x86_op.
 
 Lemma x86_op_eq_axiom : Equality.axiom x86_op_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_x86_op_dec_bl.
-  by apply: internal_x86_op_dec_lb.
+  exact: (eq_axiom_of_scheme internal_x86_op_dec_bl internal_x86_op_dec_lb).
 Qed.
 
 Definition x86_op_eqMixin := Equality.Mixin x86_op_eq_axiom.

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -97,9 +97,7 @@ Scheme Equality for sop1.
 
 Lemma sop1_eq_axiom : Equality.axiom sop1_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_sop1_dec_bl.
-  by apply: internal_sop1_dec_lb.
+  exact: (eq_axiom_of_scheme internal_sop1_dec_bl internal_sop1_dec_lb).
 Qed.
 
 Definition sop1_eqMixin     := Equality.Mixin sop1_eq_axiom.
@@ -110,9 +108,7 @@ Scheme Equality for sop2.
 
 Lemma sop2_eq_axiom : Equality.axiom sop2_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_sop2_dec_bl.
-  by apply: internal_sop2_dec_lb.
+  exact: (eq_axiom_of_scheme internal_sop2_dec_bl internal_sop2_dec_lb).
 Qed.
 
 Definition sop2_eqMixin     := Equality.Mixin sop2_eq_axiom.
@@ -122,9 +118,7 @@ Scheme Equality for opN.
 
 Lemma opN_eq_axiom : Equality.axiom opN_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_opN_dec_bl.
-  by apply: internal_opN_dec_lb.
+  exact: (eq_axiom_of_scheme internal_opN_dec_bl internal_opN_dec_lb).
 Qed.
 
 Definition opN_eqMixin     := Equality.Mixin opN_eq_axiom.
@@ -228,9 +222,7 @@ Scheme Equality for v_scope.
 
 Lemma v_scope_eq_axiom : Equality.axiom v_scope_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_v_scope_dec_bl.
-  by apply: internal_v_scope_dec_lb.
+  exact: (eq_axiom_of_scheme internal_v_scope_dec_bl internal_v_scope_dec_lb).
 Qed.
 
 Definition v_scope_eqMixin     := Equality.Mixin v_scope_eq_axiom.
@@ -296,9 +288,7 @@ Scheme Equality for dir.
 
 Lemma dir_eq_axiom : Equality.axiom dir_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_dir_dec_bl.
-  by apply: internal_dir_dec_lb.
+  exact: (eq_axiom_of_scheme internal_dir_dec_bl internal_dir_dec_lb).
 Qed.
 
 Definition dir_eqMixin     := Equality.Mixin dir_eq_axiom.
@@ -335,9 +325,8 @@ Scheme Equality for assgn_tag.
 
 Lemma assgn_tag_eq_axiom : Equality.axiom assgn_tag_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_assgn_tag_dec_bl.
-  by apply: internal_assgn_tag_dec_lb.
+  exact:
+    (eq_axiom_of_scheme internal_assgn_tag_dec_bl internal_assgn_tag_dec_lb).
 Qed.
 
 Definition assgn_tag_eqMixin     := Equality.Mixin assgn_tag_eq_axiom.
@@ -353,9 +342,10 @@ Scheme Equality for inline_info.
 
 Lemma inline_info_eq_axiom : Equality.axiom inline_info_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_inline_info_dec_bl.
-  by apply: internal_inline_info_dec_lb.
+  exact:
+    (eq_axiom_of_scheme
+       internal_inline_info_dec_bl
+       internal_inline_info_dec_lb).
 Qed.
 
 Definition inline_info_eqMixin     := Equality.Mixin inline_info_eq_axiom.
@@ -371,9 +361,7 @@ Scheme Equality for align.
 
 Lemma align_eq_axiom : Equality.axiom align_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_align_dec_bl.
-  by apply: internal_align_dec_lb.
+  exact: (eq_axiom_of_scheme internal_align_dec_bl internal_align_dec_lb).
 Qed.
 
 Definition align_eqMixin     := Equality.Mixin align_eq_axiom.

--- a/proofs/lang/strings.v
+++ b/proofs/lang/strings.v
@@ -14,9 +14,7 @@ Scheme Equality for Ascii.ascii.
 
 Lemma ascii_eqP : Equality.axiom ascii_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_ascii_dec_bl.
-  by apply: internal_ascii_dec_lb.
+  exact: (eq_axiom_of_scheme internal_ascii_dec_bl internal_ascii_dec_lb).
 Qed.
 
 Definition ascii_eqMixin := EqMixin ascii_eqP.
@@ -59,9 +57,7 @@ Scheme Equality for String.string.
 
 Lemma string_eqP : Equality.axiom string_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_string_dec_bl.
-  by apply: internal_string_dec_lb.
+  exact: (eq_axiom_of_scheme internal_string_dec_bl internal_string_dec_lb).
 Qed.
 
 Definition string_eqMixin := EqMixin string_eqP.

--- a/proofs/lang/syscall.v
+++ b/proofs/lang/syscall.v
@@ -1,6 +1,9 @@
 From mathcomp Require Import all_ssreflect all_algebra.
 From Coq Require Import PArith ZArith.
-Require Import word type.
+Require Import
+  word
+  type
+  utils.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -15,9 +18,8 @@ Scheme Equality for syscall_t.
 
 Lemma syscall_t_eq_axiom : Equality.axiom syscall_t_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_syscall_t_dec_bl.
-  by apply: internal_syscall_t_dec_lb.
+  exact:
+    (eq_axiom_of_scheme internal_syscall_t_dec_bl internal_syscall_t_dec_lb).
 Qed.
 
 Definition syscall_t_eqMixin     := Equality.Mixin syscall_t_eq_axiom.

--- a/proofs/lang/type.v
+++ b/proofs/lang/type.v
@@ -41,9 +41,7 @@ Scheme Equality for stype.
 
 Lemma stype_axiom : Equality.axiom stype_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_stype_dec_bl.
-  by apply: internal_stype_dec_lb.
+  exact: (eq_axiom_of_scheme internal_stype_dec_bl internal_stype_dec_lb).
 Qed.
 
 Definition stype_eqMixin     := Equality.Mixin stype_axiom.

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -13,6 +13,12 @@ Unset Printing Implicit Defensive.
 
 Local Open Scope Z_scope.
 
+Lemma eq_axiom_of_scheme X (beq : X -> X -> bool) :
+  (forall x y : X, beq x y -> x = y) ->
+  (forall x y : X, x = y -> beq x y) ->
+  Equality.axiom beq.
+Proof. move=> hbl hlb x y. apply: (iffP idP); first exact: hbl. exact: hlb. Qed.
+
 (* -------------------------------------------------------------------- *)
 Module FinIsCount.
 Section FinIsCount.
@@ -248,9 +254,7 @@ Scheme Equality for error.
 
 Lemma error_beqP : Equality.axiom error_beq.
 Proof.
-  move=> e1 e2;case Heq: error_beq;constructor.
-  + by apply: internal_error_dec_bl.
-  by move=> /internal_error_dec_lb;rewrite Heq.
+  exact: (eq_axiom_of_scheme internal_error_dec_bl internal_error_dec_lb).
 Qed.
 
 Canonical error_eqMixin := EqMixin error_beqP.
@@ -1193,9 +1197,8 @@ Scheme Equality for comparison.
 
 Lemma comparison_beqP : Equality.axiom comparison_beq.
 Proof.
-  move=> e1 e2;case Heq: comparison_beq;constructor.
-  + by apply: internal_comparison_dec_bl.
-  by move=> /internal_comparison_dec_lb;rewrite Heq.
+  exact:
+    (eq_axiom_of_scheme internal_comparison_dec_bl internal_comparison_dec_lb).
 Qed.
 
 Canonical comparison_eqMixin := EqMixin comparison_beqP.
@@ -1731,3 +1734,9 @@ Tactic Notation "have!" ":= " constr(x) :=
 Tactic Notation "have!" simple_intropattern(ip) ":= " constr(x) :=
   let h := fresh "h" in
   (assert (h := x); move: h => ip).
+
+(* Attempt to prove [injective f] on [eqType]s by case analysis on the
+   arguments. *)
+Ltac t_inj_cases :=
+  move=> [] [] /eqP h;
+  apply/eqP.

--- a/proofs/lang/warray_.v
+++ b/proofs/lang/warray_.v
@@ -20,9 +20,8 @@ Scheme Equality for arr_access.
 
 Lemma arr_access_eq_axiom : Equality.axiom arr_access_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_arr_access_dec_bl.
-  by apply: internal_arr_access_dec_lb.
+  exact:
+    (eq_axiom_of_scheme internal_arr_access_dec_bl internal_arr_access_dec_lb).
 Qed.
 
 Definition arr_access_eqMixin     := Equality.Mixin arr_access_eq_axiom.

--- a/proofs/lang/wsize.v
+++ b/proofs/lang/wsize.v
@@ -44,9 +44,7 @@ Scheme Equality for wsize.
 
 Lemma wsize_axiom : Equality.axiom wsize_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_wsize_dec_bl.
-  by apply: internal_wsize_dec_lb.
+  exact: (eq_axiom_of_scheme internal_wsize_dec_bl internal_wsize_dec_lb).
 Qed.
 
 Definition wsize_eqMixin     := Equality.Mixin wsize_axiom.
@@ -78,9 +76,7 @@ Scheme Equality for velem.
 
 Lemma velem_axiom : Equality.axiom velem_beq.
 Proof.
-  move=> x y;apply:(iffP idP).
-  + by apply: internal_velem_dec_bl.
-  by apply: internal_velem_dec_lb.
+  exact: (eq_axiom_of_scheme internal_velem_dec_bl internal_velem_dec_lb).
 Qed.
 
 Definition velem_eqMixin     := Equality.Mixin velem_axiom.


### PR DESCRIPTION
General cleanup (prefer `Scheme Equality`) and move some more definitions to `arch_utils` for when I come back to OTBN. Should I use `t_eq_axiom` in other files? (or remove it?)