### PR TITLE
Fix typos, remove dead code in runtest

### DIFF
--- a/compiler/scripts/runtest
+++ b/compiler/scripts/runtest
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 # --------------------------------------------------------------------
-import sys, os, errno, re, glob, shutil, itertools, logging
+import sys, os, re, glob, itertools, logging
 import subprocess as sp, time, datetime, socket, yaml
 import collections as cl, configparser as cp
 
@@ -104,7 +104,7 @@ def _options():
             parser.error('timeout must be positive')
 
     if cmdopt.jobs <= 0:
-        parse.error('jobs must be positive')
+        parser.error('jobs must be positive')
 
     options = Object(scenarios = dict())
     options.timeout  = cmdopt.timeout
@@ -134,12 +134,6 @@ def _options():
         options.args.extend(itertools.chain.from_iterable( \
           x.split() for x in cmdopt.bin_args))
 
-    def _parse_timeout(x):
-        m = re.search(r'^(.*):(\d+)$', x)
-        if m is None:
-            parse.parseerror('invalid timeout: %s' % (x,))
-        return (m.group(1), int(m.group(2)))
-
     for test in [x for x in config.sections() if x.startswith('test-')]:
         scenario = Object()
         scenario.bin     = config.get(test, 'bin')
@@ -165,7 +159,6 @@ def _dump_report(config, results, out):
         grouped.setdefault(result.config.group, []).append(result)
 
     for gname, group in grouped.items():
-        ok   = [x for x in group if     x.success]
         ko   = [x for x in group if not x.success]
         node = cl.OrderedDict()
 
@@ -216,16 +209,17 @@ def _run_test(config, options):
         process = sp.Popen(command, stdout = sp.PIPE, stderr = sp.PIPE)
 
         try:
-            out, err = process.communicate()
+            _, err = process.communicate()
             status   = process.poll()
         finally:
-            try   : sp.kill()
+            try   : process.kill()
             except: pass
     except OSError as e:
         logging.error("cannot run `%s': %s" % (binary, e))
         exit (1)
     timestamp = time.time() - timestamp
     success   = (bool(status) != bool(config.isvalid))
+
 
     logging.info("result for `%s': success: %s" % \
                      (config.filename, rcolor(success, success)))
@@ -250,7 +244,7 @@ def _main():
         format = logfmt)
 
     # ------------------------------------------------------------------
-    def gather(obj, scenario):
+    def gather(obj):
         logging.debug("gathering scripts in `%s'" % (obj.src,))
         try:
             scripts = os.listdir(obj.src)
@@ -293,12 +287,12 @@ def _main():
         dirs.extend([Object(src = x, valid = False, **data) \
                          for x in expand(scenario.kodirs)])
         dirs = [x for x in dirs if x.src not in expand(scenario.exclude)]
-        dirs = map(lambda x : gather(x, scenario), dirs)
+        dirs = map(gather, dirs)
         return list(itertools.chain.from_iterable(dirs))
 
     def gatherall():
         dirs = [options.scenarios[x] for x in options.targets]
-        dirs = map(lambda x : gather_for_scenario(x), dirs)
+        dirs = map(gather_for_scenario, dirs)
         return list(itertools.chain.from_iterable(dirs))
 
     allscripts = gatherall()


### PR DESCRIPTION
1. Remove unused imports.
2. `parse.error` does not exist.
3. `_parse_timeout` is never used.
4. `ok   = [x for x in group if     x.success]` is never used.
5. `sp.kill()` does not exist.
6. `def gather(obj, scenario):` never uses `scenario`.