### PR TITLE
subtype and value_uincl require equal size for array

### DIFF
--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -144,10 +144,8 @@ Proof.
   rewrite /sopn_sem /= => hcopy ?; subst vs; t_xrbindP => s hw ?; subst s.
   have [|v1 hv1 /value_uinclE uv1] := sem_pexpr_uincl_on (vm2:= vm1) (e:= Pvar y) _ hy.
   + by apply: vmap_uincl_onI hvm1;SvD.fsetdec.
-  have [ny [? [? ]]]:= to_arrI hty; subst vy.
-  rewrite -/len => /WArray.cast_uincl utyty'.
-  case: uv1 => n2 [ty1 [? ut]]; subst v1.
-  have {ut utyty' hty} ut:= WArray.uincl_trans utyty' ut.
+  have ? := to_arrI hty; subst vy.
+  case: uv1 => [ty1 ? ut]; subst v1.
   set ipre := if _ then _ else _; set c := [:: MkI _ (Cassgn _ _ _ _) ].
   have [vm1' [hvm1' [tx0 htx0]] hipre] : exists2 vm1', 
     vm1 <=[Sv.union (read_e y) (Sv.remove x X)]  vm1' /\ exists tx, vm1'.[x] = ok tx & 
@@ -165,7 +163,8 @@ Proof.
       by move: hxy; rewrite read_e_var /eq_gvar /= /read_gvar; case: (y) => /= vy [/= /eqP | /=]; SvD.fsetdec.
     constructor; apply: Eassgn => //=; first by rewrite /truncate_val /= WArray.castK.
     by rewrite /write_var /set_var /= /on_vu WArray.castK.
-  move: hcopy; rewrite /WArray.copy -/len => /(WArray.fcopy_uincl (WArray.uincl_empty tx0 (Z.le_refl _))) => -[tx'] hcopy hutx.
+  move: hcopy; rewrite /WArray.copy -/len => /(WArray.fcopy_uincl (WArray.uincl_empty tx0 erefl)) 
+    => -[tx'] hcopy hutx.
   have :
     forall (j:Z), 0 <= j -> j <= n ->
       forall vm1'  (tx0:WArray.array len),
@@ -188,7 +187,8 @@ Proof.
         have [hxy hyl]: v_var (gv y) = v_var x /\ is_lvar y.
         + by move: hz; rewrite /read_gvar; case: ifP => ?; first split => //; SvD.fsetdec.
         move: hv1; rewrite /= /get_gvar hyl /get_gvar hxy /get_var; apply on_vuP => //=.
-        move=> _t heq /Varr_inj [?]; subst n2 => /= ?; subst _t.
+        move=> _t heq /Varr_inj [en]; rewrite (Eqdep_dec.UIP_dec Pos.eq_dec en erefl) /= => ?.
+        subst.
         rewrite heq /= /pval_uincl /value_uincl /=.
         split; first by Psatz.lia.
         move: hvm1'; rewrite read_e_var => /(_ _ hz) /=; rewrite hx heq /= /pval_uincl /= => hu k w8.
@@ -209,9 +209,9 @@ Proof.
       + by move=> _ heqy; move: hv1 => /= /type_of_get_gvar; rewrite -heqy.
       case: (sem_pexpr_uincl_on (vm2 := vm1') _ hv1).
       + by apply: vmap_uincl_onI hvm1'; SvD.fsetdec.
-      move=> _v hv /value_uinclE [n' [ty' [? hty]]]; subst _v.
+      move=> _v hv /value_uinclE [? ? hty']; subst _v.
       rewrite -eq_globs; move: hv => /= => -> /=.
-      by rewrite (@get_gvar_eq _ (mk_lvar i)) //= (WArray.uincl_get (WArray.uincl_trans ut hty) hget).
+      by rewrite (@get_gvar_eq _ (mk_lvar i)) //= (WArray.uincl_get (WArray.uincl_trans ut hty') hget).
     + by rewrite /truncate_val /= truncate_word_u. 
     rewrite /= get_var_neq //= /get_var hx /= (@get_gvar_eq _ (mk_lvar i)) //= truncate_word_u /=.
     by rewrite hset /= /write_var /set_var /= WArray.castK. 

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -116,7 +116,7 @@ Section REMOVE_INIT.
         case: ({| vtype := sarr p0; vname := xn |} =P z) => [<- _ | /eqP neq].
         + rewrite Fv.setP_eq; have := Wf1 {| vtype := sarr p0; vname := xn |}.
           case: (vm1.[_]) => //= [ | [] //].
-          move=> a _;split;first by apply Z.le_refl.
+          move=> a _;split => //.
           move=> ??; rewrite (WArray.get_empty); case: ifP => //.
         by rewrite Fv.setP_neq.
       by rewrite /of_val;case:xt => //= ? ?; case: wsize_eq_dec => // ?; case: CEDecStype.pos_dec.
@@ -135,7 +135,7 @@ Section REMOVE_INIT.
     case: vm1.[x] => [a2 | //] [ _ hu] heq _.
     have ?:= Varr_inj1 (ok_inj heq); subst a1 => {heq}.
     rewrite WArray.castK.
-    split; first by apply Z.le_refl.
+    split => //.
     move=> k w; rewrite (WArray.set_sub_get8 ht1) /=; case: ifP => ?.
     + by rewrite WArray.get_empty; case: ifP.
     by apply hu.

--- a/proofs/compiler/makeReferenceArguments_proof.v
+++ b/proofs/compiler/makeReferenceArguments_proof.v
@@ -171,8 +171,7 @@ Context
   rewrite /truncate_val; case: t v => [||q|w].
   + by move=> x; t_xrbindP=> b bE <-.
   + by move=> x; t_xrbindP=> i iE <-.
-  + move=> x; t_xrbindP=> a aE <- /=.
-    by rewrite /WArray.cast Z.leb_refl /=; case: (a).
+  + by move=> x; t_xrbindP=> a aE <- /=; rewrite WArray.castK.
   + move=> x; t_xrbindP=> w' w'E <- /=.
     by rewrite truncate_word_u.
   Qed.
@@ -714,9 +713,7 @@ Context
     exists2 x, pof_val (type_of_val v) v = ok x & pto_val x = v.
   Proof.
   case: v => //=; eauto.
-  + move=> n a _;rewrite /WArray.cast.
-    exists a => //; case: ifP => /ZleP; last by Psatz.lia.
-    by move=> _; f_equal;case: a.
+  + by move=> n a _; rewrite WArray.castK /=; exists a.
   move => sz w _; rewrite (sumbool_of_boolET (cmp_le_refl sz)).
   eexists; split; eauto.
   Qed.

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -30,7 +30,7 @@ Proof. by apply size_of_gt0. Qed.
 Lemma size_of_le ty ty' : subtype ty ty' -> size_of ty <= size_of ty'.
 Proof.
   case: ty => [||p|ws]; case:ty' => [||p'|ws'] //.
-  + by move=> /ZleP.
+  + by move=> /eqP ->; lia.
   move=> /wsize_size_le.
   by apply Z.divide_pos_le.
 Qed.
@@ -1951,7 +1951,7 @@ Lemma type_of_get_gvar_array gd vm x n (a : WArray.array n) :
 Proof.
   move=> hget.
   have hnword: ~ is_sword x.(gv).(vtype).
-  + by have [? [-> _]] := subtypeEl (type_of_get_gvar hget).
+  + by rewrite (subtypeEl (type_of_get_gvar hget)).
   by have := type_of_get_gvar_not_word hnword hget.
 Qed.
 
@@ -2438,7 +2438,7 @@ Lemma alloc_array_moveP m0 s1 s2 s1' rmap1 rmap2 r tag e v v' n i2 :
   ∃ s2' : estate, sem_i P' rip s2 i2 s2' ∧ valid_state rmap2 m0 s1' s2'.
 Proof.
   move=> hvs he; rewrite /truncate_val /=.
-  t_xrbindP=> a' /to_arrI [m [a [? ha']]] ? hw; subst v v'.
+  t_xrbindP=> a' /to_arrI ?? hw; subst v v'.
   rewrite /alloc_array_move.
   t_xrbindP=> -[x ofsx] hgetr [y ofsy] hgete.
   case hkindy: (get_var_kind pmap y) => [vk|] //.
@@ -2462,12 +2462,11 @@ Proof.
   + have /wfr_gptr := hgvalidy.
     by rewrite hkindy => -[_ [[]] <-].
   move=> [e1 ofs2] /(mk_addr_pexprP _ hwfpky hpky) [w [he1 haddr]] ? <- <- ?; subst sry' ofs2'.
-  have [? [ay [hgety hay]]] := get_Pvar_subP he hgete hofsy; subst m.
-
+  have [? [ay [hgety hay]]] := get_Pvar_subP he hgete hofsy.
   have hread: forall bytes,
     eq_sub_region_val_read (emem s2) (sub_region_at_ofs sry (Some ofs) len) bytes (Varr a').
-  + move=> bytes off hmem w' /(cast_get8 ha') /dup[].
-    rewrite -{1}get_read8 => /WArray.get_valid8 /WArray.in_boundP; rewrite Z2Pos.id // => hoff.
+  + move=> bytes off hmem w' /= /dup[]; subst n.
+    rewrite -{1}get_read8 => /WArray.get_valid8 /WArray.in_boundP hoff.
     move=> /hay.
     rewrite -sub_region_addr_offset -GRing.addrA -wrepr_add.
     assert (hval := wfr_val hgvalidy hgety).
@@ -2475,7 +2474,7 @@ Proof.
     apply hread.
     rewrite memi_mem_U8; apply: mem_incl_r hmemy; rewrite subset_interval_of_zone.
     rewrite -(sub_zone_at_ofs_compose _ _ _ len).
-    apply zbetween_zone_byte => //.
+    apply zbetween_zone_byte; last by rewrite /=; lia.
     by apply zbetween_zone_refl.
 
   case: r hgetr hw => //.
@@ -2496,8 +2495,7 @@ Proof.
 
     have hwf: wf_sub_region (sub_region_at_ofs sry (Some ofs) len) x.(vtype).
     + apply: (wf_sub_region_subtype _ hwfy').
-      apply /ZleP.
-      by apply: Z.le_trans (WArray.cast_len hax) (WArray.cast_len ha').
+      by apply /eqP; rewrite (WArray.cast_len hax). 
 
     rewrite -(WArray.castK ax).
 
@@ -3747,7 +3745,7 @@ Proof.
   have /is_sarrP [nx hty] := hlocal.(wfr_type).
   apply: set_varP; last by rewrite {1}hty.
   case: x hty hset hlx hlocal => -[_ xn] xii /= -> /= hset hlx hlocal.
-  move=> ax /to_arrI [nr [ar [? hcast]]] <- <-; subst vres1.
+  move=> ax /to_arrI ? <- <-; subst vres1.
   have :=
     Forall3_nth haddr None (Vbool true) (Vbool true) (nth_not_default hnth ltac:(discriminate)) _ _ hnth.
   rewrite hresp.(wrp_args) => -[[?] hwf]; subst w.
@@ -3757,15 +3755,13 @@ Proof.
   split.
   + rewrite /set_var /vp.
     by case: (p) hlocal.(wfr_rtype) => -[_ pn] pii /= ->.
-  rewrite -(WArray.castK ax).
-  apply: (valid_state_set_sub_region_regptr hvs _ (subtype_refl _) _ hlx hset (x:={|v_var:=_;v_info:=xii|}) (v:=Varr ax)) => /=.
+  have := (valid_state_set_sub_region_regptr hvs _ (subtype_refl _) _ hlx hset (x:={|v_var:=_;v_info:=xii|}) (v:=Varr ax)) => /=; rewrite WArray.castK; apply.
   + apply: wf_sub_region_subtype hwf.
     apply: subtype_trans hresp.(wrp_subtype).
-    apply /ZleP.
-    by apply (WArray.cast_len hcast).
+    by apply /eqP.
   + by move=> _ [<-] /=; lia.
   split=> //.
-  move=> off hmem w /= /(cast_get8 hcast).
+  move=> off hmem w /=.
   by apply hresp.(wrp_read).
 Qed.
 
@@ -4032,7 +4028,7 @@ Proof.
   case: es => // -[] // g [] //.
   t_xrbindP=> pg /get_regptrP hlg px /get_regptrP hlx srg /get_sub_regionP hgetg {rmap2}rmap2 hrmap2 <- <-{c}.
   rewrite /= /exec_getrandom /=.
-  t_xrbindP=> vg hgvarg <-{ves} [_ _] ag' /to_arrI [ng [a [? hcast]]]
+  t_xrbindP=> vg hgvarg <-{ves} [_ _] ag' /to_arrI ?
     a2 hfill [<- <-] <-{scs} <-{m} <-{vs} /=; subst vg.
   t_xrbindP=> {s1'}s1' hw <-.
   have /wf_locals /= hlocal := hlx.
@@ -4062,13 +4058,11 @@ Proof.
     by apply (check_gvalid_wf wfr_wf hgvalidg).
   have hofs: forall zofs, Some 0 = Some zofs -> 0 <= zofs /\ zofs + size_of (sarr len) <= size_slot g.(gv).
   + move=> _ [<-].
-    have -> /= := type_of_get_gvar_array hgvarg.
-    by move: hcast => /WArray.cast_len; lia.
+    have -> /= := type_of_get_gvar_array hgvarg; lia.
   have /= hwfg' := sub_region_at_ofs_wf hwfg hofs.
   have hsub: subtype x.(vtype) g.(gv).(vtype).
   + have -> /= := type_of_get_gvar_array hgvarg.
-    apply /ZleP.
-    move: hcast => /WArray.cast_len.
+    apply /eqP.
     move: hcastx => /WArray.cast_len.
     by lia.
 

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -2437,8 +2437,7 @@ Lemma alloc_array_moveP m0 s1 s2 s1' rmap1 rmap2 r tag e v v' n i2 :
   alloc_array_move saparams pmap rmap1 r tag e = ok (rmap2, i2) →
   ∃ s2' : estate, sem_i P' rip s2 i2 s2' ∧ valid_state rmap2 m0 s1' s2'.
 Proof.
-  move=> hvs he; rewrite /truncate_val /=.
-  t_xrbindP=> a' /to_arrI ?? hw; subst v v'.
+  move=> hvs he /truncate_val_typeE[] a' ?? hw; subst v v'.
   rewrite /alloc_array_move.
   t_xrbindP=> -[x ofsx] hgetr [y ofsy] hgete.
   case hkindy: (get_var_kind pmap y) => [vk|] //.
@@ -2463,9 +2462,10 @@ Proof.
     by rewrite hkindy => -[_ [[]] <-].
   move=> [e1 ofs2] /(mk_addr_pexprP _ hwfpky hpky) [w [he1 haddr]] ? <- <- ?; subst sry' ofs2'.
   have [? [ay [hgety hay]]] := get_Pvar_subP he hgete hofsy.
+  subst n.
   have hread: forall bytes,
     eq_sub_region_val_read (emem s2) (sub_region_at_ofs sry (Some ofs) len) bytes (Varr a').
-  + move=> bytes off hmem w' /= /dup[]; subst n.
+  + move=> bytes off hmem w' /= /dup[].
     rewrite -{1}get_read8 => /WArray.get_valid8 /WArray.in_boundP hoff.
     move=> /hay.
     rewrite -sub_region_addr_offset -GRing.addrA -wrepr_add.
@@ -2495,7 +2495,7 @@ Proof.
 
     have hwf: wf_sub_region (sub_region_at_ofs sry (Some ofs) len) x.(vtype).
     + apply: (wf_sub_region_subtype _ hwfy').
-      by apply /eqP; rewrite (WArray.cast_len hax). 
+      by apply /eqP; rewrite -(WArray.cast_len hax).
 
     rewrite -(WArray.castK ax).
 
@@ -4063,8 +4063,7 @@ Proof.
   have hsub: subtype x.(vtype) g.(gv).(vtype).
   + have -> /= := type_of_get_gvar_array hgvarg.
     apply /eqP.
-    move: hcastx => /WArray.cast_len.
-    by lia.
+    by move/WArray.cast_len: hcastx => ->.
 
   (* clear the argument *)
   have [rmap1 [rmap2' [hrmap1 hrmap2' hincl2]]] := set_sub_region_clear hrmap2.

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -1461,7 +1461,7 @@ Proof.
   apply: set_varP hvm1; last by rewrite {1}hty2.
   case: param hty2 hnnew heq1 heq3 heq4 hpi hpmap2 => -[_ paramn] paramii /= -> /=.
   set param := {| vname := paramn |} => hnnew heq1 heq3 heq4 hpi hpmap2.
-  move=> a1 /to_arrI [n2 [a2 [? hcast]]] <-; subst varg1.
+  move=> a1 /to_arrI ? <-; subst varg1.
   set sr := sub_region_full _ _.
   have hin: Sv.In sr.(sr_region).(r_slot) Slots_params.
   + by apply in_Slots_params => /=; congruence.
@@ -1481,8 +1481,7 @@ Proof.
   + split=> //.
     move=> off _ w' hget.
     rewrite -haddr.
-    apply hargp.(wap_read).
-    by apply (cast_get8 hcast).
+    by apply hargp.(wap_read).
   + by rewrite /get_local /= Mvar.setP_eq.
   case:(hvs) => hscs hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr heqmem hglobv htop.
   split=> //.
@@ -2291,8 +2290,9 @@ Lemma value_uincl_get_val_byte v1 v2 :
     get_val_byte v1 off = ok w ->
     get_val_byte v2 off = ok w.
 Proof.
-  move=> /value_uinclE; case: v1 => //= > [? [? [-> H]]] >.
-  + by case: H => _; apply.
+  move=> /value_uinclE; case: v1 => //= >.
+  + by move=> [? -> H] > /=; case: H => _; apply.
+  move=> [? [? [-> H]]] >.
   case: ifP => //=; rewrite !zify; move: H => /andP[hle /eqP ->] hoff.
   have hle' := Z.divide_pos_le _ _ (wsize_size_pos _) (wsize_size_le hle).
   move=> <-; rewrite ifT; last by rewrite !zify; lia.
@@ -2474,7 +2474,7 @@ Proof.
   t_xrbindP=> vm1 hvm1 _.
   apply: set_varP hvm1; last by rewrite {1}hty.
   move=> t h _; move: t h; rewrite hty /=.
-  by move=> _ /to_arrI [n' [_ [-> /WArray.cast_len /ZleP]]] /=.
+  by move=> _ /to_arrI -> /=.
 Qed.
 
 Lemma alloc_stack_spec_wf_args m1 m2 fn vargs1 vargs2 ws sz ioff sz' m3 :

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -1871,7 +1871,7 @@ Lemma subtype_eval_uincl_pundef t1 t2 :
   eval_uincl (pundef_addr t1) (pundef_addr t2).
 Proof.
   case: t1 => /= [/eqP?|/eqP?|n| s];subst => //=; case: t2 => //=.
-  by move=> ? /eqP ? /=; split => // ??; rewrite WArray.get_empty; case: ifP.
+  by move => ? /eqP [] <-.
 Qed.
 
 Lemma compat_type_word w t : compat_type (sword w) t -> exists w', t = sword w'.
@@ -2666,8 +2666,8 @@ Definition apply_undef t (v : exec (psem_t t)) :=
 Lemma eval_uincl_undef t1 t2 (v:psem_t t2) :
   subtype t1 t2 ->
   eval_uincl (pundef_addr t1) (ok v).
-Proof. 
-  case: t1 => //= p; case: t2 v => //= p2 a /eqP; split => // ??. 
+Proof.
+  case: t1 => //= p; case: t2 v => //= p2 a /eqP[] ->; split => // ??.
   by rewrite WArray.get_empty; case: ifP.
 Qed.
 

--- a/proofs/lang/type.v
+++ b/proofs/lang/type.v
@@ -209,7 +209,6 @@ Proof. by case: ty => //= w [->]. Qed.
 Definition vundef_type (t:stype) :=
   match t with
   | sword _ => sword8
-  | sarr _  => sarr 1
   | _       => t
   end.
 
@@ -219,14 +218,14 @@ Definition compat_type t1 t2 :=
   | sint    => t2 == sint
   | sbool   => t2 == sbool
   | sword _ => is_sword t2
-  | sarr _  => is_sarr t2
+  | sarr _  => t2 == t1
   end.
 
 Lemma compat_typeC t1 t2 : compat_type t1 t2 = compat_type t2 t1.
-Proof. by case: t1 t2 => [||n1|wz1] [||n2|wz2]. Qed.
+Proof. by case: t1 t2 => [||n1|wz1] [||n2|wz2] /=. Qed.
 
 Lemma compat_type_refl t : compat_type t t.
-Proof. by case: t => [||n|wz]. Qed.
+Proof. by case: t => [||n|wz] /=. Qed.
 #[global]
 Hint Resolve compat_type_refl : core.
 
@@ -235,7 +234,7 @@ Proof.
   case: t1 => /=.
   + by move => /eqP -> /eqP ->.
   + by move => /eqP -> /eqP ->.
-  + by case: t2.
+  + by move=> n /eqP -> /=.
   by case: t2.
 Qed.
 
@@ -246,7 +245,7 @@ Proof. by case t. Qed.
 Definition subtype (t t': stype) :=
   match t with
   | sword w => if t' is sword w' then (w ≤ w')%CMP else false
-  | sarr n => if t' is sarr n' then (n <=? n')%Z else false
+  | sarr n => if t' is sarr n' then n == n' else false
   | _ => t == t'
   end.
 
@@ -254,12 +253,12 @@ Lemma subtypeE ty ty' :
   subtype ty ty' →
   match ty' with
   | sword sz' => ∃ sz, ty = sword sz ∧ (sz ≤ sz')%CMP
-  | sarr n'   => ∃ n, ty = sarr n ∧ (n <= n')%Z
+  | sarr n'   => ty = sarr n' 
   | _         => ty = ty'
 end.
 Proof.
   destruct ty; try by move/eqP => <-.
-  + by case: ty'=> //= p' /ZleP ?; eauto.
+  + by case: ty'=> //= p' /eqP ->.
   by case: ty' => //; eauto.
 Qed.
 
@@ -267,37 +266,35 @@ Lemma subtypeEl ty ty' :
   subtype ty ty' →
   match ty with
   | sword sz => ∃ sz', ty' = sword sz' ∧ (sz ≤ sz')%CMP
-  | sarr n   => ∃ n', ty' = sarr n' ∧ (n <= n')%Z
+  | sarr n   => ty' = sarr n 
   | _        => ty' = ty
   end.
 Proof.
   destruct ty; try by move/eqP => <-.
-  + by case: ty'=> //= p' /ZleP ?; eauto.
+  + by case: ty'=> //= p' /eqP ->.
   by case: ty' => //; eauto.
 Qed.
 
 Lemma subtype_refl x : subtype x x.
-Proof. case: x => //= ?;apply Z.leb_refl. Qed.
+Proof. case: x => //=. Qed.
 #[global]
 Hint Resolve subtype_refl : core.
 
 Lemma subtype_trans y x z : subtype x y -> subtype y z -> subtype x z.
 Proof.
   case: x => //= [/eqP<-|/eqP<-|n1|sx] //.
-  + case: y => //= n2 /ZleP h1;case: z => //= n3 /ZleP h2.
-    by apply /ZleP;apply: Z.le_trans h1 h2.
+  + by case: y => //= n2 /eqP ->.
   case: y => //= sy hle;case: z => //= sz;apply: cmp_le_trans hle.
 Qed.
 
 Lemma subtype_compat t1 t2 : subtype t1 t2 -> compat_type t1 t2.
 Proof.
-  by case: t1 => [/eqP ->| /eqP -> | p | w] // ; case: t2.
+  by case: t1 => [/eqP ->| /eqP -> | p | w] // ; case: t2 => //= > /eqP ->.
 Qed.
-
 
 Lemma compat_subtype_undef t1 t2 : compat_type t1 t2 → subtype (vundef_type t1) t2.
 Proof.
-  case: t1 => [/eqP ->|/eqP ->|?|?] //=; case: t2 => // *.
-  + by apply /ZleP; Lia.lia.
-  by apply wsize_le_U8.
+  case: t1 => [/eqP ->|/eqP ->|?|?] //=; case: t2 => // >.
+  + by move=> /eqP [->].
+  by move=> ?; apply wsize_le_U8.
 Qed.

--- a/proofs/lang/type.v
+++ b/proofs/lang/type.v
@@ -245,7 +245,6 @@ Proof. by case t. Qed.
 Definition subtype (t t': stype) :=
   match t with
   | sword w => if t' is sword w' then (w ≤ w')%CMP else false
-  | sarr n => if t' is sarr n' then n == n' else false
   | _ => t == t'
   end.
 
@@ -253,12 +252,10 @@ Lemma subtypeE ty ty' :
   subtype ty ty' →
   match ty' with
   | sword sz' => ∃ sz, ty = sword sz ∧ (sz ≤ sz')%CMP
-  | sarr n'   => ty = sarr n' 
   | _         => ty = ty'
 end.
 Proof.
   destruct ty; try by move/eqP => <-.
-  + by case: ty'=> //= p' /eqP ->.
   by case: ty' => //; eauto.
 Qed.
 
@@ -266,12 +263,10 @@ Lemma subtypeEl ty ty' :
   subtype ty ty' →
   match ty with
   | sword sz => ∃ sz', ty' = sword sz' ∧ (sz ≤ sz')%CMP
-  | sarr n   => ty' = sarr n 
   | _        => ty' = ty
   end.
 Proof.
   destruct ty; try by move/eqP => <-.
-  + by case: ty'=> //= p' /eqP ->.
   by case: ty' => //; eauto.
 Qed.
 

--- a/proofs/lang/values.v
+++ b/proofs/lang/values.v
@@ -264,7 +264,7 @@ Lemma of_valE t v v' : of_val t v = ok v' ->
   | Vundef t h => False
   end.
 Proof.
-  case: t v' => > /of_val_typeE; try (simpl=> ->; exists erefl; eauto);
+  by case: t v' => > /of_val_typeE; try (simpl=> ->; exists erefl; eauto);
     simpl=> > [? [? [-> ]]]; eexists; exists erefl; eauto.
 Qed.
 
@@ -292,7 +292,7 @@ Qed.
 Lemma of_value_uincl_te ty v v' vt :
   value_uincl v v' -> of_val ty v = ok vt ->
   match ty as ty return sem_t ty -> Prop with
-  | sarr n => fun vt => 
+  | sarr n => fun vt =>
     exists2 vt', of_val (sarr n) v' = ok vt' & WArray.uincl vt vt'
   | _ => fun _ => of_val ty v' = ok vt
   end vt.

--- a/proofs/lang/values.v
+++ b/proofs/lang/values.v
@@ -105,13 +105,15 @@ Definition value_uincl (v1 v2:value) :=
 Lemma value_uinclE v1 v2 :
   value_uincl v1 v2 →
   match v1 with
-  | Varr n1 t1 =>
-    exists n2 t2, v2 = @Varr n2 t2 /\ WArray.uincl t1 t2
+  | Varr n1 t1 => exists2 t2, v2 = @Varr n1 t2 & WArray.uincl t1 t2
   | Vword sz1 w1 => exists sz2 w2, v2 = @Vword sz2 w2 /\ word_uincl w1 w2
   | Vundef t _ => compat_type t (type_of_val v2)
   | _ => v2 = v1
   end.
-Proof. by case: v1 => >; case: v2 => > //=; eauto=> ->. Qed.
+Proof. 
+  case: v1 => >; case: v2 => > //= h; subst; eauto.
+  have ?:= WArray.uincl_len h; subst; eauto. 
+Qed.
 
 Lemma value_uincl_refl v: value_uincl v v.
 Proof. by case: v => //= *; exact: compat_type_undef. Qed.
@@ -124,7 +126,7 @@ Lemma value_uincl_subtype v1 v2 :
   subtype (type_of_val v1) (type_of_val v2).
 Proof.
 case: v1 v2 => [ b | i | n t | s w | ty /= /negP h]; try by case.
-+ by case => //= n' t' [] /ZleP.
++ by case => //= n' t' /WArray.uincl_len ->.
 + by case => //= s' w' /andP[].
 by move => /= v2; apply compat_subtype_undef.
 Qed.
@@ -133,7 +135,7 @@ Lemma value_uincl_trans v2 v1 v3 :
   value_uincl v1 v2 -> value_uincl v2 v3 -> value_uincl v1 v3.
 Proof.
   case: v1 => > /value_uinclE; try by move=> -> /value_uinclE ->.
-  + by move=> [? [? [-> /WArray.uincl_trans h]]] /value_uinclE [? [? [-> /h]]].
+  + by move=> [? -> /WArray.uincl_trans h] /value_uinclE [? -> /h].
   + by move=> [? [? [-> /word_uincl_trans h]]] /value_uinclE [? [? [-> /h]]].
   by move=> /compat_type_trans h /value_uincl_subtype /subtype_compat /h.
 Qed.
@@ -190,9 +192,11 @@ Definition to_arr len v : exec (sem_t (sarr len)) :=
   | _ => type_error
   end.
 
-Lemma to_arrI n v t : to_arr n v = ok t ->
-  exists n' (t':WArray.array n'), v = Varr t' /\ WArray.cast n t' = ok t.
-Proof. by case: v => //= n' t'; eexists; eauto. Qed.
+Lemma to_arrI n v t : to_arr n v = ok t -> v = Varr t.
+Proof. 
+  case: v => //= n' t' /dup [] /WArray.cast_len ?; subst n'.
+  by rewrite WArray.castK => -[<-].
+Qed.
 
 Lemma to_arr_undef p v : to_arr p v <> undef_error.
 Proof. by case: v => //= ??; rewrite /WArray.cast; case: ifP. Qed.
@@ -203,7 +207,6 @@ Definition to_word s v : exec (word s) :=
   | Vundef (sword s') _ => Error (if (s <= s')%CMP then ErrAddrUndef else ErrType)
   | _ => type_error
   end.
-
 
 Notation to_pointer := (to_word Uptr).
 
@@ -237,8 +240,7 @@ Definition of_val t : value -> exec (sem_t t) :=
 
 Lemma of_val_typeE t v v' : of_val t v = ok v' ->
   match t, v' with
-  | sarr len, vt => exists len' (a: WArray.array len'),
-    v = Varr a /\ WArray.cast len a = ok vt
+  | sarr len, vt => v = Varr vt 
   | sword ws, vt => exists ws' (w: word ws'),
     v = Vword w /\ truncate_word ws w = ok vt
   | sbool, vt => v = vt
@@ -256,52 +258,48 @@ Lemma of_valE t v v' : of_val t v = ok v' ->
   match v with
   | Vbool b => exists h: t = sbool, eq_rect _ _ v' _ h = b
   | Vint i => exists h: t = sint, eq_rect _ _ v' _ h = i
-  | Varr len a => exists len' (h: t = sarr len') (a': WArray.array len'),
-    WArray.cast len' a = ok a' /\ eq_rect _ _ v' _ h = a'
+  | Varr len a => exists (h: t = sarr len), eq_rect _ _ v' _ h = a
   | Vword ws w => exists ws' (h: t = sword ws') w',
     truncate_word ws' w = ok w' /\ eq_rect _ _ v' _ h = w'
   | Vundef t h => False
   end.
 Proof.
-  by case: t v' => > /of_val_typeE; try (simpl=> ->; exists erefl; eauto);
+  case: t v' => > /of_val_typeE; try (simpl=> ->; exists erefl; eauto);
     simpl=> > [? [? [-> ]]]; eexists; exists erefl; eauto.
 Qed.
 
 Lemma of_val_subtype t v sv : of_val t v = ok sv -> subtype t (type_of_val v).
 Proof.
   case: t sv => > /of_val_typeE; try by move=> ->.
-  + by case=> ? [? [-> /WArray.cast_len /ZleP]].
   by case=> ? [? [-> /truncate_wordP[]]]. 
 Qed.
 
 Lemma of_value_uincl ty v v' vt :
   value_uincl v v' -> of_val ty v = ok vt ->
   match v' with
-  | Varr len a => exists len' (h: ty = sarr len') a',
-    of_val (sarr len') v' = ok a' /\ WArray.uincl (eq_rect _ _ vt _ h) a'
+  | Varr len a => exists (h: ty = sarr len), WArray.uincl (eq_rect _ _ vt _ h) a
   | _ => of_val ty v' = ok vt
   end.
 Proof.
   case: v => > /value_uinclE + /of_valE //;
-    try (by move=> -> [? ]; subst=> /= ->);
-    move: vt => + [? [? [-> +]]] [s [x [? []]]]; subst=> /= _ ++ ->.
-  + move=> /WArray.uincl_cast h/h [? [??]]; exists s, erefl; eauto.
-  exact: word_uincl_truncate.
+   try (by move=> -> [? ]; subst=> /= ->).
+  + by move=> [t2 ->] h [?]; subst => /= ->; exists erefl.
+  move=> [sz2 [w2 [-> h]]] [ws' [? [w' []]]]; subst => /= h1 ->.
+  exact: word_uincl_truncate h1.
 Qed.
 
 (* can be use to shorten proofs drastically, see psem/vuincl_sem_sop1 *)
 Lemma of_value_uincl_te ty v v' vt :
   value_uincl v v' -> of_val ty v = ok vt ->
   match ty as ty return sem_t ty -> Prop with
-  | sarr n => fun vt =>
+  | sarr n => fun vt => 
     exists2 vt', of_val (sarr n) v' = ok vt' & WArray.uincl vt vt'
   | _ => fun _ => of_val ty v' = ok vt
   end vt.
 Proof.
-  case: v => > /value_uinclE + /of_valE //;
-    try (by move=> -> [? ]; subst=> /= ->);
-    move: vt => + [? [? [-> +]]] [? [? [? []]]]; subst=> /= _ ++ ->.
-  + by move=> /WArray.uincl_cast h/h [a [??]]; exists a.
+  case: v => > /value_uinclE + /of_valE //; try (by move=> -> [? ]; subst=> /= ->).
+  + by move: vt => + [? -> +] [?] => vt ??; subst => /=; rewrite WArray.castK; eauto.
+  move: vt => + [? [? [-> +]]] [? [? [? []]]]; subst=> /= _ ++ ->.
   exact: word_uincl_truncate.
 Qed.
 
@@ -361,29 +359,33 @@ Qed.
 Lemma val_uinclEl t1 t2 v1 v2 :
   val_uincl v1 v2 ->
   match t1 return sem_t t1 -> sem_t t2 -> Prop with
-  | sarr len => fun v1 v2 => exists len' (h: t2 = sarr len'),
+  | sarr len => fun v1 v2 => exists (h: t2 = sarr len),
     WArray.uincl v1 (eq_rect _ _ v2 _ h)
   | sword ws => fun v1 v2 => exists ws' (h: t2 = sword ws'),
     word_uincl v1 (eq_rect _ _ v2 _ h)
   | t => fun v1 v2 => exists h: t2 = t, v1 = eq_rect _ _ v2 _ h
   end v1 v2.
 Proof.
-  by case: t1 v1 => /=; case: t2 v2 => //=; try (exists erefl; done);
-    rewrite /val_uincl /=; eexists; exists erefl.
+  case: t1 v1 => /=; case: t2 v2 => //=; try (exists erefl; done);
+   rewrite /val_uincl /=.
+  + by move=> > /dup [] /WArray.uincl_len ? ?; subst; exists erefl.
+  by eexists; exists erefl.
 Qed.
 
 Lemma val_uinclE t1 t2 v1 v2 :
   val_uincl v1 v2 ->
   match t2 return sem_t t1 -> sem_t t2 -> Prop with
-  | sarr len => fun v1 v2 => exists len' (h: t1 = sarr len'),
+  | sarr len => fun v1 v2 => exists (h: t1 = sarr len),
     WArray.uincl (eq_rect _ _ v1 _ h) v2
   | sword ws => fun v1 v2 => exists ws' (h: t1 = sword ws'),
     word_uincl (eq_rect _ _ v1 _ h) v2
   | t => fun v1 v2 => exists h: t1 = t, v2 = eq_rect _ _ v1 _ h
   end v1 v2.
 Proof.
-  by case: t1 v1 => /=; case: t2 v2 => //=; try (exists erefl; done);
-    rewrite /val_uincl /=; eexists; exists erefl.
+  case: t1 v1 => /=; case: t2 v2 => //=; try (exists erefl; done);
+    rewrite /val_uincl /=.
+  + by move=> > /dup [] /WArray.uincl_len ? ?; subst; exists erefl.
+  by eexists; exists erefl.
 Qed.
 
 Lemma val_uincl_refl t v: @val_uincl t t v v.
@@ -396,9 +398,9 @@ Lemma val_uincl_of_val ty v v' vt :
   exists2 vt', of_val ty v' = ok vt' & val_uincl vt vt'.
 Proof.
   case: v => > /value_uinclE + /of_valE //;
-    try (by move=> -> [? ]; subst => /= ->; eauto);
-    move: vt => + [? [? [-> +]]] [s [x [? []]]]; subst=> /= _ ++ ->.
-  + move=> /WArray.uincl_cast h/h [? [-> ?]]; eauto.
+    try (by move=> -> [? ]; subst => /= ->; eauto).
+  + by move=> [???] [??]; subst => /=; rewrite WArray.castK; eauto.
+  move: vt => + [? [? [-> +]]] [s [x [? []]]]; subst=> /= _ ++ ->.
   move=> /word_uincl_truncate h/h{h} ->; eauto.
 Qed.
 
@@ -413,16 +415,13 @@ Lemma truncate_val_typeE ty v vt :
   match ty with
   | sbool => exists2 b: bool, v = b & vt = b
   | sint => exists2 i: Z, v = i & vt = i
-  | sarr len => exists a len' (a' : WArray.array len'),
-    [/\ WArray.cast len a' = ok a, v = Varr a' & vt = Varr a]
+  | sarr len => exists2 a : WArray.array len, v = Varr a & vt = Varr a 
   | sword ws => exists w ws' (w': word ws'),
     [/\ truncate_word ws w' = ok w, v = Vword w' & vt = Vword w]
   end.
 Proof.
   rewrite /truncate_val; t_xrbindP; case: v => > /of_valE; case=> ?;
     try (by subst=> /= -> <-; eauto); case=> ? [? []]; subst=> /= hv -> <-.
-  + eexists; eexists; eexists; constructor=> //; move: hv.
-    by rewrite /WArray.cast; case: ifP => /ZleP.
   by eexists; eexists; eexists; constructor; auto.
 Qed.
 
@@ -431,16 +430,15 @@ Lemma truncate_valE ty v vt :
   match v with
   | Vbool b => ty = sbool /\ vt = b
   | Vint i => ty = sint /\ vt = i
-  | Varr len a => exists len' a',
-    [/\ ty = sarr len', WArray.cast len' a = ok a' & vt = Varr a']
+  | Varr len a => ty = sarr len /\ vt = Varr a  
   | Vword ws w => exists ws' w',
     [/\ ty = sword ws', truncate_word ws' w = ok w' & vt = Vword w']
   | Vundef _ _ => False
   end.
 Proof.
-  by case: ty => > /truncate_val_typeE
-    => [ [] | [] | [? [? [? []]]] | [? [? [? []]]] ] ? -> -> //;
-    eexists; eexists; split; auto.
+  case: ty => > /truncate_val_typeE
+    => [ [] | [] | [] | [? [? [? []]]] ] ? -> -> //.
+  by eexists; eexists; split; auto.
 Qed.
 
 Lemma truncate_valI ty v vt :
@@ -448,15 +446,14 @@ Lemma truncate_valI ty v vt :
   match vt with
   | Vbool b => ty = sbool /\ v = b
   | Vint i => ty = sint /\ v = i
-  | Varr len a => exists len' (a': WArray.array len'),
-    [/\ ty = sarr len, WArray.cast len a' = ok a & v = Varr a']
+  | Varr len a => ty = sarr len /\ v = Varr a
   | Vword ws w => exists ws' (w': word ws'),
     [/\ ty = sword ws, truncate_word ws w' = ok w & v = Vword w']
   | Vundef _ _ => False
   end.
 Proof.
   by case: ty => > /truncate_val_typeE
-    => [ [] | [] | [? [? [? []]]] | [? [? [? []]]] ] ? -> -> //;
+    => [ [] | [] | [] | [? [? [? []]]] ] ? -> -> //;
     eexists; eexists; split; auto.
 Qed.
 
@@ -465,8 +462,7 @@ Lemma truncate_val_subtype ty v v' :
   subtype ty (type_of_val v).
 Proof.
   by case: v => > /truncate_valE
-    => [[]|[]|[?[?[+/WArray.cast_len/ZleP?]]]|[?[?[+/truncate_wordP[??]]]]|//]
-    => ->.
+   => [ [] | [] | [] | [?[?[+/truncate_wordP[??]]]]|//] => ->.
 Qed.
 
 Lemma truncate_val_has_type ty v v' :
@@ -474,7 +470,7 @@ Lemma truncate_val_has_type ty v v' :
   type_of_val v' = ty.
 Proof.
   by case: v' => > /truncate_valI
-    => [[]|[]|[?[?[+/WArray.cast_len/ZleP?]]]|[?[?[+/truncate_wordP[??]]]]|//]
+    => [[]|[]|[]|[?[?[+/truncate_wordP[??]]]]|//]
     => ->.
 Qed.
 
@@ -485,12 +481,13 @@ Lemma value_uincl_truncate ty x y x' :
   truncate_val ty x = ok x' →
   exists2 y', truncate_val ty y = ok y' & value_uincl x' y'.
 Proof.
-  case: x => > /value_uinclE+ /truncate_valE => [ + [] | + []
-    | [? [? [+ /WArray.uincl_cast h]]] [? [? [+ /h{h} [? [h hui]]]]]
+  case: x => > /value_uinclE+ /truncate_valE => [ + []  | + [] 
+    | [? + ? []]
     | [? [? [+ /word_uincl_truncate h]]] [? [? [+ /h{h} h]]] |//]
     => -> -> ->.
   1,2: by eexists.
-  all: by rewrite /truncate_val /= h /=; eexists=> // /=.
+  + by rewrite /truncate_val /= WArray.castK /=; eexists.
+  by rewrite /truncate_val /= h /=; eexists=> // /=.
 Qed.
 
 Lemma truncate_value_uincl t v1 v2 : truncate_val t v1 = ok v2 -> value_uincl v2 v1.
@@ -498,7 +495,7 @@ Proof.
   rewrite /truncate_val; case: t; t_xrbindP=> > /=.
   + by move=> /to_boolI -> <-.
   + by move=> /to_intI -> <-.
-  + by move=> /to_arrI [n' [t' [-> h <-]]] /=; exact: WArray.cast_uincl.
+  + by move=> /to_arrI -> <-.
   by move=> /to_wordI [? [? [-> ? <-]]] /=; exact: truncate_word_uincl.
 Qed.
 
@@ -589,8 +586,8 @@ Lemma vuincl_copy_eq ws p :
 Proof.
   move=> sz _ _ v [// | v1 v2 [_ /value_uinclE hu /List_Forall2_inv_l -> |]];
     rewrite /app_sopn_v /=; t_xrbindP=> // ??.
-  move: hu => + /to_arrI[? [? [? /WArray.uincl_cast h]]] /WArray.uincl_copy H ?.
-  by subst=> [[? [? [-> /= /h{h}[? [-> /= /H ->]]]]]].
+  move: hu => + /to_arrI ? /WArray.uincl_copy H ?; subst.
+  by move=> /=[? -> /H h] /=; rewrite WArray.castK /= h.
 Qed.
 
 Lemma vuincl_app_sopn_v tin tout (semi: sem_prod tin (exec (sem_tuple tout))) :

--- a/proofs/lang/warray_.v
+++ b/proofs/lang/warray_.v
@@ -213,7 +213,7 @@ Module WArray.
     else Error ErrOob.
 
   Definition cast len len' (a:array len) : result error (array len') :=
-    if (len' <=? len)%Z then ok {| arr_data := a.(arr_data) |}
+    if len' == len then ok {| arr_data := a.(arr_data) |}
     else type_error.
 
   Definition of_list {ws} (l:list (word ws)) : array (Z.to_pos (Z.of_nat (size l) * wsize_size ws)) :=
@@ -227,11 +227,11 @@ Module WArray.
     {| arr_data := m |}.
 
   Definition uincl {len1 len2} (a1 : array len1) (a2 : array len2) :=
-    (len1 <= len2)%Z /\
+    (len1 = len2)%Z /\
     ∀ i w, read a1 i U8 = ok w -> read a2 i U8 = ok w.
 
   Lemma uincl_refl len (a: array len) : uincl a a.
-  Proof. by split => //; reflexivity. Qed.
+  Proof. done. Qed.
 
   Lemma uincl_trans {len1 len2 len3} 
     (a2: array len2) (a1: array len1) (a3: array len3) :
@@ -241,21 +241,25 @@ Module WArray.
     by move=> ?? /h1 /h2.
   Qed.
 
+  Lemma uincl_len {len1 len2}  (a1: array len1) (a2: array len2) :
+    uincl a1 a2 -> len1 = len2.
+  Proof. by case. Qed.
+
   End WITH_POINTER_DATA.
 
   Lemma castK len (a:array len) : WArray.cast len a = ok a.
-  Proof. by rewrite /cast Z.leb_refl; case: a. Qed.
+  Proof. by rewrite /cast eqxx; case: a. Qed.
 
-  Lemma cast_len len1 len2 (t2:WArray.array len2) t1: WArray.cast len1 t2 = ok t1 -> len1 <= len2.
-  Proof. by rewrite /cast; case: ZleP. Qed.
+  Lemma cast_len len1 len2 (t2:WArray.array len2) t1: WArray.cast len1 t2 = ok t1 -> len1 = len2.
+  Proof. by rewrite /cast; case: eqP. Qed. 
 
   Lemma cast_empty len1 len2 : 
-    WArray.cast len1 (empty len2) = if len1 <=? len2 then ok (empty len1) else type_error.
-  Proof. by rewrite /WArray.cast. Qed.
+    WArray.cast len1 (empty len2) = if len1 == len2 then ok (empty len1) else type_error.
+  Proof. done. Qed.
 
   Lemma cast_empty_ok len1 len2 t: 
     WArray.cast len1 (empty len2) = ok t -> t = empty len1.
-  Proof. by move=> /dup[]/cast_len/ZleP; rewrite cast_empty => -> [<-]. Qed.
+  Proof. by move=> /dup[]/cast_len/eqP; rewrite cast_empty => -> [<-]. Qed.
 
   Lemma cast_get8 len1 len2 (m : array len2) m' :
     cast len1 m = ok m' ->
@@ -263,7 +267,7 @@ Module WArray.
       read m' k U8 = 
         if k <? len1 then read m k U8 else Error ErrOob.
   Proof.
-    rewrite /cast; case: ZleP => // hle [<-] k.
+    rewrite /cast; case: eqP => // hle [<-] k.
     rewrite -!get_read8 /memory_model.get /= /get8 /is_init /in_bound /=.
     by case: ZleP => /=; case: ZltP => //=; case: ZltP => //; lia.
   Qed.
@@ -271,22 +275,17 @@ Module WArray.
   Lemma cast_uincl len1 len2 (t2 : WArray.array len2) t1 : 
     cast len1 t2 = ok t1 -> uincl t1 t2.
   Proof.
-    move=> hc; split; first by apply: cast_len hc.
-    by move=> i w; rewrite (cast_get8 hc); case: ifP.
+    move=> hc; have ?:= cast_len hc; subst len2.
+    by move: hc; rewrite castK => -[<-].
   Qed.
 
   Lemma uincl_cast len1 len2 (a1: array len1) (a2:array len2) len a1' : 
     uincl a1 a2 ->
     cast len a1 = ok a1' ->
-    exists a2', cast len a2 = ok a2' /\ uincl a1' a2'.
+    exists2 a2', cast len a2 = ok a2' & uincl a1' a2'.
   Proof.
-    move=> [hle hu] hc.
-    have:= (cast_get8 hc). have:= @cast_get8 len len2 a2.
-    move: hc; rewrite /cast; case: ZleP => // hle1 _. 
-    case: ZleP => hle2 hg2 hg1; last lia.
-    eexists;split; first by eauto.
-    split; first by lia.
-    by move=> ??; rewrite hg1 hg2 //; case: ifP => // _ /hu.
+    move=> /dup [] /uincl_len ? hu /dup [] /cast_len ?; subst len1 len2.
+    rewrite castK => -[<-]; exists a2 => //; apply castK.
   Qed.
 
   Lemma mk_scale_U8 aa : mk_scale aa U8 = 1%Z.
@@ -358,9 +357,9 @@ Module WArray.
   Proof. by rewrite get_empty => -[/ZleP -> /ZltP ->]. Qed.
 
   Lemma uincl_empty len len' (t:array len') : 
-    Zpos len <= len' -> uincl (empty len) t.
-  Proof.  
-    split; first Psatz.lia.
+    len = len' -> uincl (empty len) t.
+  Proof. 
+    move=> ?; subst len'; split => //.
     by move=> i w; rewrite get_empty; case: ifP.
   Qed.
 


### PR DESCRIPTION
WArray.cast fail if the size are not equal. subtype and WArray.uincl and value_uincl require equal size for array.
