### PR TITLE
x86: fix semantics of VPERMD, VPMADDWD, & VPMADDUBSW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@
   ([PR #422](https://github.com/jasmin-lang/jasmin/pull/422);
   fixes [#421](https://github.com/jasmin-lang/jasmin/issues/421)).
 
-- Fix semantics of the `VPERMD` instruction
+- Fix semantics of the `VPERMD` and `VPMADDWD` instructions
   ([PR #442](https://github.com/jasmin-lang/jasmin/pull/442)).
 
 ## Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@
   ([PR #422](https://github.com/jasmin-lang/jasmin/pull/422);
   fixes [#421](https://github.com/jasmin-lang/jasmin/issues/421)).
 
-- Fix semantics of the `VPERMD` and `VPMADDWD` instructions
+- Fix semantics of the `VPERMD`, `VPMADDWD`, and `VPMADDUBSW` instructions
   ([PR #442](https://github.com/jasmin-lang/jasmin/pull/442)).
 
 ## Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,9 @@
   ([PR #422](https://github.com/jasmin-lang/jasmin/pull/422);
   fixes [#421](https://github.com/jasmin-lang/jasmin/issues/421)).
 
+- Fix semantics of the `VPERMD` instruction
+  ([PR #442](https://github.com/jasmin-lang/jasmin/pull/442)).
+
 ## Other changes
 
 - Explicit if-then-else in flag combinations is no longer supported

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1557,9 +1557,9 @@ Definition wpmaddubsw sz (v1 v2: word sz) : word sz :=
   make_vec sz result.
 
 Definition wpmaddwd sz (v1 v2: word sz) : word sz :=
-  let w1 := map wsigned (split_vec VE16 v1) in
-  let w2 := map wsigned (split_vec VE16 v2) in
-  let result := [seq wrepr sz z | z <- add_pairs (map2 *%R w1 w2) ] in
+  let w1 := map wsigned (split_vec U16 v1) in
+  let w2 := map wsigned (split_vec U16 v2) in
+  let result := [seq wrepr U32 z | z <- add_pairs (map2 *%R w1 w2) ] in
   make_vec sz result.
 
 (* Test case from the documentation: VPMADDWD wraps when all inputs are min-signed *)

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1551,9 +1551,9 @@ Fixpoint add_pairs (m: seq Z) : seq Z :=
   else [::].
 
 Definition wpmaddubsw sz (v1 v2: word sz) : word sz :=
-  let w1 := map wunsigned (split_vec VE8 v1) in
-  let w2 := map wsigned (split_vec VE8 v2) in
-  let result := [seq wrepr_saturated_signed sz z | z <- add_pairs (map2 *%R w1 w2) ] in
+  let w1 := map wunsigned (split_vec U8 v1) in
+  let w2 := map wsigned (split_vec U8 v2) in
+  let result := [seq wrepr_saturated_signed U16 z | z <- add_pairs (map2 *%R w1 w2) ] in
   make_vec sz result.
 
 Definition wpmaddwd sz (v1 v2: word sz) : word sz :=

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1499,8 +1499,8 @@ Definition wpermd1 (v: seq u32) (idx: u32) :=
   let off := wunsigned idx mod 8 in
   (v`_(Z.to_nat off))%R.
 
-Definition wpermd sz (w1 idx: word sz) : word sz :=
-  let v := split_vec U32 w1 in
+Definition wpermd sz (idx w: word sz) : word sz :=
+  let v := split_vec U32 w in
   let i := split_vec U32 idx in
   make_vec sz (map (wpermd1 v) i).
 


### PR DESCRIPTION
Reading the doc carefully, it becomes clear that SRC2 is not read from YMM2.