### PR TITLE
x86: fix semantics of SHR, RCL, and RCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@
 - Fix semantics of the `VPSHUFB` and `VPCMPGT` instructions
   ([PR #449](https://github.com/jasmin-lang/jasmin/pull/449)).
 
-- Fix semantics of the `SHR` instruction
+- Fix semantics of the `SHR`, `RCL`, and `RCR` instructions
   ([PR #451](https://github.com/jasmin-lang/jasmin/pull/451)).
 
 ## Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,9 @@
 - Fix semantics of the `VPSHUFB` and `VPCMPGT` instructions
   ([PR #449](https://github.com/jasmin-lang/jasmin/pull/449)).
 
+- Fix semantics of the `SHR` instruction
+  ([PR #451](https://github.com/jasmin-lang/jasmin/pull/451)).
+
 ## Other changes
 
 - Explicit if-then-else in flag combinations is no longer supported

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -1755,9 +1755,9 @@ theory W8.
     let i  = shift_mask i in
     let im = im i in
     let r  = fun j => if j = 0 then cf else v.[j-1] in
-    let r  = fun j => r ((j - i) %% im) in
+    let r  = fun j => r ((j - i) %% 9) in
     let CF = r 0 in 
-    let r  = init (fun j => r (j-1)) in
+    let r  = init (fun j => r (j+1)) in
     let OF = if i = 1 then (ALU.SF_of r <> CF) else undefined_flag in
     (OF, CF, r).
   
@@ -1765,10 +1765,10 @@ theory W8.
     let i  = shift_mask i in
     let im = im i in
     let r  = fun j => if j = 0 then cf else v.[j-1] in
-    let r  = fun j => r ((j + i) %% im) in
+    let r  = fun j => r ((j + i) %% 9) in
     let OF = if i = 1 then ALU.SF_of  v <> cf else undefined_flag in
     let CF = r 0 in 
-    let r  = init (fun j => r (j-1)) in
+    let r  = init (fun j => r (j+1)) in
     (OF, CF, r).
 
   op rflags_OF (i:int) (r:t) (rc OF:bool) =
@@ -2405,22 +2405,22 @@ abstract theory BitWordSH.
 
   op RCL_XX (v: t) (i: W8.t) (cf:bool) =
     let i  = shift_mask i in
-    let im = im i in
+    let i = im i in
     let r  = fun j => if j = 0 then cf else v.[j-1] in
-    let r  = fun j => r ((j - i) %% im) in
+    let r  = fun j => r ((j - i) %% (size + 1)) in
     let CF = r 0 in 
-    let r  = init (fun j => r (j-1)) in
+    let r  = init (fun j => r (j+1)) in
     let OF = if i = 1 then (ALU.SF_of r <> CF) else undefined_flag in
     (OF, CF, r).
   
   op RCR_XX (v: t) (i: W8.t) (cf:bool) =
     let i  = shift_mask i in
-    let im = im i in
+    let i = im i in
     let r  = fun j => if j = 0 then cf else v.[j-1] in
-    let r  = fun j => r ((j + i) %% im) in
+    let r  = fun j => r ((j + i) %% (size + 1)) in
     let OF = if i = 1 then ALU.SF_of  v <> cf else undefined_flag in
     let CF = r 0 in 
-    let r  = init (fun j => r (j-1)) in
+    let r  = init (fun j => r (j+1)) in
     (OF, CF, r).
 
   op rflags_OF (i:int) (r:t) (rc OF:bool) =

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -601,7 +601,7 @@ Definition x86_SHR sz (v: word sz) (i: u8) : ex_tpl (b5w_ty sz) :=
   else
     let rc := lsb (wshr v (wunsigned i - 1)) in
     let r  := wshr v (wunsigned i) in
-    rflags_OF i r rc (msb r).
+    rflags_OF i r rc (msb v).
 
 Definition x86_SHRD sz (v1 v2: word sz) (i: u8) : ex_tpl (b5w_ty sz) :=
   Let _  := check_size_16_64 sz in

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -531,37 +531,33 @@ Definition x86_ROL sz (v: word sz) (i: u8) : ex_tpl (b2w_ty sz) :=
     let OF := if i == 1%R then Some (msb r != CF) else None in
     ok (:: OF, Some CF & r ).
 
-Definition x86_RCL sz (v: word sz) (i: u8) (cf:bool) : ex_tpl (b2w_ty sz) :=
+
+Definition x86_rotate_with_carry (sz: wsize)
+  (rot: word.word.word sz.+1 → nat → word.word.word sz.+1)
+  (ovf: word sz → bool → bool)
+  (v: word sz) (i: u8) (cf: bool)
+  : ex_tpl (b2w_ty sz) :=
   Let _  := check_size_8_64 sz in
   let i := wand i (x86_shift_mask sz) in
-  let im :=
+  let i :=
     match sz with
     | U8 => Zmod (wunsigned i) 9
     | U16 => Zmod (wunsigned i) 17
     | _  => wunsigned i
     end in
   let r := mathcomp.word.word.t2w [tuple of cf::mathcomp.word.word.w2t v] in
-  let r := mathcomp.word.word.rotl r (Z.to_nat im) in
-  let CF := mathcomp.word.word.msb r in
-  let r : word sz := mathcomp.word.word.t2w [tuple of behead (mathcomp.word.word.w2t r)] in
-  let OF := if i == 1%R then Some (msb r != CF) else None in
+  let r := rot r (Z.to_nat i) in
+  let r := mathcomp.word.word.w2t r in
+  let CF := head false r in
+  let r : word sz := mathcomp.word.word.t2w [tuple of behead r] in
+  let OF := if i == 1%R then Some (ovf r CF) else None in
   ok (:: OF, Some CF & r ).
 
+Definition x86_RCL sz (v: word sz) (i: u8) (cf:bool) : ex_tpl (b2w_ty sz) :=
+  @x86_rotate_with_carry sz (@mathcomp.word.word.rotl _) (λ r c, msb r != c) v i cf.
+
 Definition x86_RCR sz (v: word sz) (i: u8) (cf:bool) : ex_tpl (b2w_ty sz) :=
-  Let _  := check_size_8_64 sz in
-  let i := wand i (x86_shift_mask sz) in
-  let im :=
-    match sz with
-    | U8 => Zmod (wunsigned i) 9
-    | U16 => Zmod (wunsigned i) 17
-    | _  => wunsigned i
-    end in
-  let OF := if i == 1%R then Some (msb v != cf) else None in
-  let r := mathcomp.word.word.t2w [tuple of rcons (mathcomp.word.word.w2t v) cf] in
-  let r := mathcomp.word.word.rotr r (Z.to_nat im) in
-  let CF := mathcomp.word.word.lsb r in
-  let r : word sz := mathcomp.word.word.t2w [tuple of rev (behead (rev (mathcomp.word.word.w2t r)))] in
-  ok (:: OF, Some CF & r ).
+  @x86_rotate_with_carry sz (@mathcomp.word.word.rotr _) (λ _ _, msb v != cf) v i cf.
 
 Definition rflags_OF {s} sz (i:word s) (r:word sz) rc OF : ex_tpl (b5w_ty sz) :=
   let OF := if i == 1%R then Some OF else None in


### PR DESCRIPTION
The manual reads: “For the SHR instruction, the OF flag is set to the most-significant bit of the *original* operand.”

I know that RCL and RCR do not compute the `CF` flag correctly, but I still do not understand the details of the issue…