### PR TITLE
Check ARM modified immediate constants before printing (and some fixes)

### DIFF
--- a/compiler/tests/fail/arm-m4/adc_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/adc_imm_too_large.jazz
@@ -1,0 +1,7 @@
+export
+fn main(reg u32 x) -> reg u32 {
+    reg bool c;
+    c, x += x;
+    x = #ADC(x, 0x0000caca, c);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/add_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/add_imm_too_large.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #ADD(x, 0x0000caca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/addw_set_flags.jazz
+++ b/compiler/tests/fail/arm-m4/addw_set_flags.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    ?{}, x = #ADDS(x, 0x00000aca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/and_imm_shifted.jazz
+++ b/compiler/tests/fail/arm-m4/and_imm_shifted.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) -> reg u32 {
+    x = #AND(x, 0x000cb000);
+    return x;
+}

--- a/compiler/tests/fail/arm-m4/and_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/and_imm_too_large.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #AND(x, 0x0000caca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/bic_imm_shifted.jazz
+++ b/compiler/tests/fail/arm-m4/bic_imm_shifted.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #BIC(x, 0x000cb000);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/bic_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/bic_imm_too_large.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #BIC(x, 0x0000caca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/cmp_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/cmp_imm_too_large.jazz
@@ -1,0 +1,6 @@
+export
+fn main(reg u32 x) {
+    reg bool n z c v;
+    n, z, c, v = #CMP(x, 0x0000caca);
+    [x] = x if z;
+}

--- a/compiler/tests/fail/arm-m4/eor_imm_shifted.jazz
+++ b/compiler/tests/fail/arm-m4/eor_imm_shifted.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #EOR(x, 0x000cb000);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/eor_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/eor_imm_too_large.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #EOR(x, 0x0000caca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/mov_imm_shifted.jazz
+++ b/compiler/tests/fail/arm-m4/mov_imm_shifted.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #MOV(0x000cb000);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/mov_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/mov_imm_too_large.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #MOV(0x000acaca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/mov_shiftedw_set_flags.jazz
+++ b/compiler/tests/fail/arm-m4/mov_shiftedw_set_flags.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    ?{}, x = #MOVS(0x0000cb00);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/movw_set_flags.jazz
+++ b/compiler/tests/fail/arm-m4/movw_set_flags.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    ?{}, x = #MOVS(0x0000caca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/mvn_imm_shifted.jazz
+++ b/compiler/tests/fail/arm-m4/mvn_imm_shifted.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #MVN(0x000cb000);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/mvn_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/mvn_imm_too_large.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #MVN(0x0000caca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/orr_imm_shifted.jazz
+++ b/compiler/tests/fail/arm-m4/orr_imm_shifted.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #ORR(x, 0x000cb000);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/orr_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/orr_imm_too_large.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #ORR(x, 0x0000caca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/rsb_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/rsb_imm_too_large.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #RSB(x, 0x0000caca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/sub_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/sub_imm_too_large.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    x = #SUB(x, 0x0000caca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/subw_set_flags.jazz
+++ b/compiler/tests/fail/arm-m4/subw_set_flags.jazz
@@ -1,0 +1,5 @@
+export
+fn main(reg u32 x) {
+    ?{}, x = #SUBS(x, 0x00000aca);
+    [x] = x;
+}

--- a/compiler/tests/fail/arm-m4/tst_imm_shifted.jazz
+++ b/compiler/tests/fail/arm-m4/tst_imm_shifted.jazz
@@ -1,0 +1,6 @@
+export
+fn main(reg u32 x) {
+    reg bool n, z, c, v;
+    n, z, c, v = #TST(x, 0x000cb000);
+    [x] = x if z;
+}

--- a/compiler/tests/fail/arm-m4/tst_imm_too_large.jazz
+++ b/compiler/tests/fail/arm-m4/tst_imm_too_large.jazz
@@ -1,0 +1,6 @@
+export
+fn main(reg u32 x) {
+    reg bool n, z, c, v;
+    n, z, c, v = #TST(x, 0x0000caca);
+    [x] = x if z;
+}

--- a/compiler/tests/success/arm-m4/add.jazz
+++ b/compiler/tests/success/arm-m4/add.jazz
@@ -13,6 +13,11 @@ fn add(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
     x = arg0 + -1;
     x += -1;
+    x += 0xcacacaca; // `bbbb` pattern.
+    x += 0xca00ca00; // `b0b0` pattern.
+    x += 0x00ca00ca; // `0b0b` pattern.
+    x += 0x000cb000; // Shifted.
+    x += 0x00000aca; // W-encoding.
     [x] = x;
 
     // Shifts.

--- a/compiler/tests/success/arm-m4/and.jazz
+++ b/compiler/tests/success/arm-m4/and.jazz
@@ -13,6 +13,9 @@ fn and(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
     x = arg0 & -1;
     x &= -1;
+    x &= 0xcacacaca; // `bbbb` pattern.
+    x &= 0xca00ca00; // `b0b0` pattern.
+    x &= 0x00ca00ca; // `0b0b` pattern.
     [x] = x;
 
     // Shifts.

--- a/compiler/tests/success/arm-m4/eor.jazz
+++ b/compiler/tests/success/arm-m4/eor.jazz
@@ -13,6 +13,9 @@ fn eor(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
     x = arg0 ^ -1;
     x ^= -1;
+    x ^= 0xcacacaca; // `bbbb` pattern.
+    x ^= 0xca00ca00; // `b0b0` pattern.
+    x ^= 0x00ca00ca; // `0b0b` pattern.
     [x] = x;
 
     // Shifts.

--- a/compiler/tests/success/arm-m4/intrinsic_adc.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_adc.jazz
@@ -8,8 +8,13 @@ fn adc(reg u32 arg0, reg u32 arg1) -> reg u32 {
     x = #ADC(arg0, arg1, c);
 
     // Immediates.
+    x = #ADC(x, 0, c);
     x = #ADC(x, 1, c);
-    x = #ADC(x, -1, c);
+    x = #ADC(x, 255, c);
+    x = #ADC(x, 0xcacacaca, c); // `bbbb` pattern.
+    x = #ADC(x, 0xca00ca00, c); // `b0b0` pattern.
+    x = #ADC(x, 0x00ca00ca, c); // `0b0b` pattern.
+    x = #ADC(x, 0x000cb000, c); // Shifted byte.
 
     // Shifts.
     x = #ADC(x, arg0 << 0, c);
@@ -26,6 +31,10 @@ fn adc(reg u32 arg0, reg u32 arg1) -> reg u32 {
     reg bool n, z, v;
     n, z, c, v, x = #ADCS(x, arg0, c);
     n, z, c, v, x = #ADCS(x, 1, c);
+    n, z, c, v, x = #ADCS(x, 0xcacacaca, c);
+    n, z, c, v, x = #ADCS(x, 0xca00ca00, c);
+    n, z, c, v, x = #ADCS(x, 0x00ca00ca, c);
+    n, z, c, v, x = #ADCS(x, 0x000cb000, c);
     n, z, c, v, x = #ADCS(x, arg0 << 3, c);
 
     // Conditions.

--- a/compiler/tests/success/arm-m4/intrinsic_add.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_add.jazz
@@ -11,6 +11,11 @@ fn add(reg u32 arg0, reg u32 arg1) -> reg u32 {
     x = #ADD(arg0, 1);
     [x] = x;
     x = #ADD(arg0, -1);
+    x = #ADD(x, 0xcacacaca); // `bbbb` pattern.
+    x = #ADD(x, 0xca00ca00); // `b0b0` pattern.
+    x = #ADD(x, 0x00ca00ca); // `0b0b` pattern.
+    x = #ADD(x, 0x000cb000); // Shifted.
+    x = #ADD(x, 0x00000aca); // W-encoding of 12-bits.
     [x] = x;
 
     // Shifts.
@@ -71,6 +76,10 @@ fn add(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, vf, x = #ADDScc(x, arg0, nf == vf, nf, zf, cf, vf, x);
     nf, zf, cf, vf, x = #ADDS(x, 2);
+    ?{}, x = #ADDS(x, 0xcacacaca);
+    ?{}, x = #ADDS(x, 0xca00ca00);
+    ?{}, x = #ADDS(x, 0x00ca00ca);
+    ?{}, x = #ADDS(x, 0x00cb0000);
     nf, zf, cf, vf, x = #ADDS(x, arg0 << 3);
     nf, zf, cf, vf, x = #ADDS(x, arg0 >> 3);
     nf, zf, cf, vf, x = #ADDS(x, arg0 >>s 3);

--- a/compiler/tests/success/arm-m4/intrinsic_and.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_and.jazz
@@ -11,6 +11,9 @@ fn and(reg u32 arg0, reg u32 arg1) -> reg u32 {
     x = #AND(arg0, 1);
     [x] = x;
     x = #AND(arg0, -1);
+    x = #AND(x, 0xcacacaca); // `bbbb` pattern.
+    x = #AND(x, 0xca00ca00); // `b0b0` pattern.
+    x = #AND(x, 0x00ca00ca); // `0b0b` pattern.
     [x] = x;
 
     // Shifts.
@@ -71,6 +74,9 @@ fn and(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #ANDScc(x, arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #ANDS(x, 2);
+    ?{}, x = #ANDS(x, 0xcacacaca);
+    ?{}, x = #ANDS(x, 0xca00ca00);
+    ?{}, x = #ANDS(x, 0x00ca00ca);
     nf, zf, cf, x = #ANDS(x, arg0 << 3);
     nf, zf, cf, x = #ANDS(x, arg0 >> 3);
     nf, zf, cf, x = #ANDS(x, arg0 >>s 3);

--- a/compiler/tests/success/arm-m4/intrinsic_bic.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_bic.jazz
@@ -11,6 +11,9 @@ fn bic(reg u32 arg0, reg u32 arg1) -> reg u32 {
     x = #BIC(arg0, 1);
     [x] = x;
     x = #BIC(arg0, -1);
+    x = #BIC(x, 0xcacacaca); // `bbbb` pattern.
+    x = #BIC(x, 0xca00ca00); // `b0b0` pattern.
+    x = #BIC(x, 0x00ca00ca); // `0b0b` pattern.
     [x] = x;
 
     // Shifts.
@@ -71,6 +74,9 @@ fn bic(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #BICScc(x, arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #BICS(x, 2);
+    ?{}, x = #BICS(x, 0xcacacaca);
+    ?{}, x = #BICS(x, 0xca00ca00);
+    ?{}, x = #BICS(x, 0x00ca00ca);
     nf, zf, cf, x = #BICS(x, arg0 << 3);
     nf, zf, cf, x = #BICS(x, arg0 >> 3);
     nf, zf, cf, x = #BICS(x, arg0 >>s 3);

--- a/compiler/tests/success/arm-m4/intrinsic_cmp.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_cmp.jazz
@@ -10,8 +10,15 @@ fn cmp(reg u32 arg0 arg1 p) {
 
     // Immediates.
     n, z, c, v = #CMP(arg0, 3);
-    x = 1 if n;
-    [p] = x;
+    [x] = x if z;
+    n, z, c, v = #CMP(x, 0xcacacaca); // `bbbb` pattern.
+    [x] = x if z;
+    n, z, c, v = #CMP(x, 0xca00ca00); // `b0b0` pattern.
+    [x] = x if z;
+    n, z, c, v = #CMP(x, 0x00ca00ca); // `0b0b` pattern.
+    [x] = x if z;
+    n, z, c, v = #CMP(x, 0x00cb0000); // Shifted.
+    [x] = x if z;
 
     // Conditions.
     n, z, c, v = #CMPcc(arg0, arg1, z, n, z, c, v);            // EQ

--- a/compiler/tests/success/arm-m4/intrinsic_eor.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_eor.jazz
@@ -11,6 +11,9 @@ fn eor(reg u32 arg0, reg u32 arg1) -> reg u32 {
     x = #EOR(arg0, 1);
     [x] = x;
     x = #EOR(arg0, -1);
+    x = #EOR(x, 0xcacacaca); // `bbbb` pattern.
+    x = #EOR(x, 0xca00ca00); // `b0b0` pattern.
+    x = #EOR(x, 0x00ca00ca); // `0b0b` pattern.
     [x] = x;
 
     // Shifts.
@@ -71,6 +74,9 @@ fn eor(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #EORScc(x, arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #EORS(x, 2);
+    ?{}, x = #EORS(x, 0xcacacaca);
+    ?{}, x = #EORS(x, 0xca00ca00);
+    ?{}, x = #EORS(x, 0x00ca00ca);
     nf, zf, cf, x = #EORS(x, arg0 << 3);
     nf, zf, cf, x = #EORS(x, arg0 >> 3);
     nf, zf, cf, x = #EORS(x, arg0 >>s 3);

--- a/compiler/tests/success/arm-m4/intrinsic_mov.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_mov.jazz
@@ -1,14 +1,35 @@
 export
-fn mov() -> reg u32 {
-    reg u32 x y;
-    y = #MOV(1);
+fn mov(reg u32 arg0) -> reg u32 {
+    reg u32 x;
 
-    x = #MOV(y);
+    x = arg0;
+    [x] = x;
+
+    // Immediates.
+    x = #MOV(1);
+    [x] = x;
+    x = #MOV(0xcacacaca); // `bbbb` pattern.
+    [x] = x;
+    x = #MOV(0xca00ca00); // `b0b0` pattern.
+    [x] = x;
+    x = #MOV(0x00ca00ca); // `0b0b` pattern.
+    [x] = x;
+    x = #MOV(0x0000cb00); // Shifted immediate gets converted into W-encoding.
+    [x] = x;
+    x = #MOV(0x0000caca); // W-encoding.
+    [x] = x;
 
     // Set flags.
+    ?{}, x = #MOVS(x);
+    [x] = x;
+    ?{}, x = #MOVS(0xcacacaca);
+    [x] = x;
+    ?{}, x = #MOVS(0xca00ca00);
+    [x] = x;
+    ?{}, x = #MOVS(0x00ca00ca);
+    [x] = x;
     reg bool n, z, v, c;
-    n, z, c, v, x = #MOVS(x);
-    n, z, c, v, _ = #MOVS(1);
+    n, z, c, v, _ = #MOVS(-1);
 
     // Conditions.
     x = #MOVcc(x, z, x);            // EQ
@@ -27,7 +48,7 @@ fn mov() -> reg u32 {
     x = #MOVcc(x, z || n != v, x);  // LE
 
     x = #MOVcc(1, !z, x);
-    n, z, c, v, x = #MOVScc(y, !z, n, z, c, v, x);
+    n, z, c, v, x = #MOVScc(arg0, !z, n, z, c, v, x);
     n, z, c, v, x = #MOVScc(49, !!z, n, z, c, v, x);
 
     reg u32 res;

--- a/compiler/tests/success/arm-m4/intrinsic_mvn.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_mvn.jazz
@@ -12,6 +12,12 @@ fn mvn(reg u32 arg0) -> reg u32 {
     [x] = x;
     x = #MVN(-1);
     [x] = x;
+    x = #MVN(0xcacacaca); // `bbbb` pattern.
+    [x] = x;
+    x = #MVN(0xca00ca00); // `b0b0` pattern.
+    [x] = x;
+    x = #MVN(0x00ca00ca); // `0b0b` pattern.
+    [x] = x;
 
     // Shifts.
     x = #MVN(arg0 << 0);
@@ -71,10 +77,21 @@ fn mvn(reg u32 arg0) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #MVNScc(arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #MVNS(2);
+    [x] = x;
+    ?{}, x = #MVNS(0xcacacaca);
+    [x] = x;
+    ?{}, x = #MVNS(0xca00ca00);
+    [x] = x;
+    ?{}, x = #MVNS(0x00ca00ca);
+    [x] = x;
     nf, zf, cf, x = #MVNS(arg0 << 3);
+    [x] = x;
     nf, zf, cf, x = #MVNS(arg0 >> 3);
+    [x] = x;
     nf, zf, cf, x = #MVNS(arg0 >>s 3);
+    [x] = x;
     nf, zf, cf, x = #MVNS(arg0 >>r 3);
+    [x] = x;
     nf, zf, cf, x = #MVNScc(2, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #MVNScc(arg0 << 3, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #MVNScc(arg0 << 3, !!(nf == vf), nf, zf, cf, x);

--- a/compiler/tests/success/arm-m4/intrinsic_orr.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_orr.jazz
@@ -11,6 +11,9 @@ fn orr(reg u32 arg0, reg u32 arg1) -> reg u32 {
     x = #ORR(arg0, 1);
     [x] = x;
     x = #ORR(arg0, -1);
+    x = #ORR(x, 0xcacacaca); // `bbbb` pattern.
+    x = #ORR(x, 0xca00ca00); // `b0b0` pattern.
+    x = #ORR(x, 0x00ca00ca); // `0b0b` pattern.
     [x] = x;
 
     // Shifts.
@@ -71,6 +74,9 @@ fn orr(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, x = #ORRScc(x, arg0, nf == vf, nf, zf, cf, x);
     nf, zf, cf, x = #ORRS(x, 2);
+    ?{}, x = #ORRS(x, 0xcacacaca);
+    ?{}, x = #ORRS(x, 0xca00ca00);
+    ?{}, x = #ORRS(x, 0x00ca00ca);
     nf, zf, cf, x = #ORRS(x, arg0 << 3);
     nf, zf, cf, x = #ORRS(x, arg0 >> 3);
     nf, zf, cf, x = #ORRS(x, arg0 >>s 3);

--- a/compiler/tests/success/arm-m4/intrinsic_rsb.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_rsb.jazz
@@ -11,6 +11,10 @@ fn rsb(reg u32 arg0, reg u32 arg1) -> reg u32 {
     x = #RSB(arg0, 1);
     [x] = x;
     x = #RSB(arg0, -1);
+    x = #RSB(x, 0xcacacaca); // `bbbb` pattern.
+    x = #RSB(x, 0xca00ca00); // `b0b0` pattern.
+    x = #RSB(x, 0x00ca00ca); // `0b0b` pattern.
+    x = #RSB(x, 0x00cb0000); // Shifted.
     [x] = x;
 
     // Shifts.

--- a/compiler/tests/success/arm-m4/intrinsic_sub.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_sub.jazz
@@ -12,6 +12,11 @@ fn sub(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
     x = #SUB(arg0, -1);
     [x] = x;
+    x = #SUB(x, 0xcacacaca); // `bbbb` pattern.
+    x = #SUB(x, 0xca00ca00); // `b0b0` pattern.
+    x = #SUB(x, 0x00ca00ca); // `0b0b` pattern.
+    x = #SUB(x, 0x000cb000); // Shifted.
+    x = #SUB(x, 0x00000aca); // W-encoding.
 
     // Shifts.
     x = #SUB(arg0, arg1 << 0);
@@ -71,6 +76,10 @@ fn sub(reg u32 arg0, reg u32 arg1) -> reg u32 {
     // Combinations.
     nf, zf, cf, vf, x = #SUBScc(x, arg0, nf == vf, nf, zf, cf, vf, x);
     nf, zf, cf, vf, x = #SUBS(x, 2);
+    ?{}, x = #SUBS(x, 0xcacacaca);
+    ?{}, x = #SUBS(x, 0xca00ca00);
+    ?{}, x = #SUBS(x, 0x00ca00ca);
+    ?{}, x = #SUBS(x, 0x00cb0000);
     nf, zf, cf, vf, x = #SUBS(x, arg0 << 3);
     nf, zf, cf, vf, x = #SUBS(x, arg0 >> 3);
     nf, zf, cf, vf, x = #SUBS(x, arg0 >>s 3);

--- a/compiler/tests/success/arm-m4/intrinsic_tst.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_tst.jazz
@@ -10,8 +10,13 @@ fn tst(reg u32 arg0 arg1 p) {
 
     // Immediates.
     n, z, c = #TST(arg0, 3);
-    x = 1 if n;
-    [p] = x;
+    [x] = x if z;
+    n, z, c = #TST(x, 0xcacacaca); // `bbbb` pattern.
+    [x] = x if z;
+    n, z, c = #TST(x, 0xca00ca00); // `b0b0` pattern.
+    [x] = x if z;
+    n, z, c = #TST(x, 0x00ca00ca); // `0b0b` pattern.
+    [x] = x if z;
 
     // Set flags.
     n, z, c, v, _ = #MOVS(arg0);

--- a/compiler/tests/success/arm-m4/mov.jazz
+++ b/compiler/tests/success/arm-m4/mov.jazz
@@ -1,30 +1,48 @@
 export
-fn mov() -> reg u32 {
-    reg u32 x y;
-    x = 1;
-    y = x;
+fn mov(reg u32 arg0) -> reg u32 {
+    reg u32 x;
+
+    x = arg0;
+    [x] = x;
+
+    // Immediates.
+    x = 0xcacacaca; // `bbbb` pattern.
+    [x] = x;
+    x = 0xca00ca00; // `b0b0` pattern.
+    [x] = x;
+    x = 0x00ca00ca; // `0b0b` pattern.
+    [x] = x;
+    x = 0x0000cb00; // Shifted immediate gets converted into W-encoding.
+    [x] = x;
+    x = 0x0000caca; // W-encoding.
+    [x] = x;
 
     // Set flags.
     reg bool n, z, v, c;
     n, z, c, v, _ = #MOVS(x);
 
     // Conditions.
-    x = y if z;            // EQ
-    x = y if !z;           // NE
-    x = y if c;            // CS
-    x = y if !c;           // CC
-    x = y if n;            // MI
-    x = y if !n;           // PL
-    x = y if v;            // VS
-    x = y if !v;           // VC
-    x = y if c && !z;      // HI
-    x = y if !c || z;      // LS
-    x = y if n == v;       // GE
-    x = y if n != v;       // LT
-    x = y if !z && n == v; // GT
-    x = y if z || n != v;  // LE
+    x = arg0 if z;            // EQ
+    x = arg0 if !z;           // NE
+    x = arg0 if c;            // CS
+    x = arg0 if !c;           // CC
+    x = arg0 if n;            // MI
+    x = arg0 if !n;           // PL
+    x = arg0 if v;            // VS
+    x = arg0 if !v;           // VC
+    x = arg0 if c && !z;      // HI
+    x = arg0 if !c || z;      // LS
+    x = arg0 if n == v;       // GE
+    x = arg0 if n != v;       // LT
+    x = arg0 if !z && n == v; // GT
+    x = arg0 if z || n != v;  // LE
 
     x = 1 if c;
+    x = 0xcacacaca if c;
+    x = 0xca00ca00 if c;
+    x = 0x00ca00ca if c;
+    x = 0x0000cb00 if c;
+    x = 0x0000caca if c;
 
     reg u32 res;
     res = x;

--- a/compiler/tests/success/arm-m4/mvn.jazz
+++ b/compiler/tests/success/arm-m4/mvn.jazz
@@ -8,9 +8,9 @@ fn mvn(reg u32 arg0) -> reg u32 {
     [x] = x;
 
     // Immediates.
-    x = !32u 1;
+    x = 0xfffffffe; // MOV can't do this.
     [x] = x;
-    x = !32u -1;
+    x = 0xffffff00; // MOV can't do this.
     [x] = x;
 
     // Shifts.

--- a/compiler/tests/success/arm-m4/orr.jazz
+++ b/compiler/tests/success/arm-m4/orr.jazz
@@ -13,6 +13,9 @@ fn orr(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
     x = arg0 | -1;
     x |= -1;
+    x |= 0xcacacaca; // `bbbb` pattern.
+    x |= 0xca00ca00; // `b0b0` pattern.
+    x |= 0x00ca00ca; // `0b0b` pattern.
     [x] = x;
 
     // Shifts.

--- a/compiler/tests/success/arm-m4/sub.jazz
+++ b/compiler/tests/success/arm-m4/sub.jazz
@@ -13,6 +13,11 @@ fn sub(reg u32 arg0, reg u32 arg1) -> reg u32 {
     [x] = x;
     x = arg0 - -1;
     x -= -1;
+    x -= 0xcacacaca; // `bbbb` pattern.
+    x -= 0xca00ca00; // `b0b0` pattern.
+    x -= 0x00ca00ca; // `0b0b` pattern.
+    x -= 0x000cb000; // Shifted.
+    x -= 0x00000aca; // W-encoding.
     [x] = x;
 
     // Shifts.

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -33,6 +33,7 @@ compiler/arch_params_proof.v
 compiler/arm_decl.v
 compiler/arm_decl_core.v
 compiler/arm_extra.v
+compiler/arm_facts.v
 compiler/arm_instr_decl.v
 compiler/arm_instr_decl_lemmas.v
 compiler/arm_lowering.v

--- a/proofs/compiler/arm_facts.v
+++ b/proofs/compiler/arm_facts.v
@@ -1,0 +1,71 @@
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+From Coq Require Import ZArith.
+
+Require Import
+  utils
+  word.
+Require Import arm_decl.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Open Scope Z.
+
+Definition u32_to_bytes (w : u32) : u8 * u8 * u8 * u8 :=
+  ( word.subword 24 8 w
+  , word.subword 16 8 w
+  , word.subword 8 8 w
+  , word.subword 0 8 w
+  ).
+
+(* This is the actual definition of [EI_byte] and [EI_pattern]. *)
+Definition u32_is_expandable (w : u32) : bool :=
+  let '(b3, b2, b1, b0) := u32_to_bytes w in
+  [|| [&& b3 == 0, b2 == 0 & b1 == 0 ]
+    , [&& b3 == b0, b2 == b0 & b1 == b0 ]
+    , [&& b3 == 0, b2 == b0 & b1 == 0 ]
+    | [&& b3 == b1, b2 == 0 & b0 == 0 ]
+  ]%R.
+
+Lemma z_to_bytes_u32_to_bytes w :
+  let '(b3, b2, b1, b0) := u32_to_bytes w in
+  let '(b3', b2', b1', b0') := z_to_bytes (wunsigned w) in
+  [/\ b3' = wunsigned b3
+    , b2' = wunsigned b2
+    , b1' = wunsigned b1
+    & b0' = wunsigned b0
+  ].
+Proof.
+  rewrite /z_to_bytes /u32_to_bytes.
+  case: Z.div_eucl (Z_div_mod (wunsigned w) 256 refl_equal) => [q0 b] [hw hb].
+  case: Z.div_eucl (Z_div_mod q0 256 refl_equal) => [q1 b1'] [hq1 hb1'];
+    subst q0.
+  case: Z.div_eucl (Z_div_mod q1 256 refl_equal) => [q2 b2'] [hq2 hb2'];
+    subst q1.
+
+  rewrite /wunsigned /word.subword !word.mkwordK /= -/(wunsigned w) hw {hw}.
+  rewrite -/(wbase U8) -/(wbase U32).
+  rewrite
+    -!(Znumtheory.Zmod_div_mod _ _ _ _ _ (wbase_div_wbase (wsize_le_U8 _))) //.
+  rewrite !Z.shiftr_div_pow2 // Z.mul_comm Z.add_comm.
+  change (2 ^ 16) with (2 ^ 8 * 2 ^ 8).
+  change (2 ^ 24) with (2 ^ 8 * 2 ^ 8 * 2 ^ 8).
+  do 2 rewrite -Z.div_div //.
+  split; last first.
+
+  rewrite Z.div_1_r.
+
+  all: repeat rewrite
+         Z.div_add //
+         Z.mul_comm
+         Z.add_comm
+         (Z.div_small _ 256) //
+         Z.add_0_r
+         Z.add_comm.
+
+  1-3: by rewrite Z.mod_add // Z.mod_small.
+  by rewrite Z.div_add // Z.div_small.
+Qed.

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -60,7 +60,7 @@ Definition arm_op_subi (x y : var_i) (imm : Z) : fopn_args :=
   arm_op_arith_imm SUB x y imm.
 
 Definition arm_op_align (x y : var_i) (al : wsize) :=
-  arm_op_arith_imm AND x y (- wsize_size al).
+  arm_op_arith_imm BIC x y (wsize_size al - 1).
 
 (* Precondition: [0 <= imm < wbase reg_size]. *)
 Definition arm_cmd_load_large_imm (x : var_i) (imm : Z) : seq fopn_args :=

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -189,7 +189,7 @@ Ltac t_arm_op :=
   rewrite /eval_instr /= /sem_sopn /= /get_gvar /=;
   t_rewrite_eqs;
   rewrite /of_estate /= /with_vm /=;
-  rewrite ?zero_extend_u ?pword_of_wordE;
+  rewrite ?zero_extend_u ?pword_of_wordE addn1;
   t_rewrite_eqs.
 
 Lemma arm_op_subi_eval_instr lp ls ii y imm wy :
@@ -198,7 +198,7 @@ Lemma arm_op_subi_eval_instr lp ls ii y imm wy :
      let: wx' := (wy - wrepr reg_size imm)%R in
      let: vm' := (lvm ls).[v_var x <- ok (pword_of_word wx')]%vmap in
      eval_instr lp li ls = ok (next_vm_ls ls vm').
-Proof. move=> hgety. t_arm_op. by rewrite wsub_wnot1 addn1. Qed.
+Proof. move=> hgety. t_arm_op. by rewrite wsub_wnot1. Qed.
 
 Lemma arm_op_align_eval_instr lp ls ii y al wy :
   get_var (lvm ls) (v_var y) = ok (Vword wy)
@@ -206,14 +206,20 @@ Lemma arm_op_align_eval_instr lp ls ii y al wy :
      let: wx' := align_word al wy in
      let: vm' := (lvm ls).[v_var x <- ok (pword_of_word wx')]%vmap in
      eval_instr lp li ls = ok (next_vm_ls ls vm').
-Proof. move=> hgety. t_arm_op. by rewrite addn1. Qed.
+Proof.
+  move=> hgety.
+  Opaque wsize_size.
+  t_arm_op.
+  Transparent wsize_size.
+  by rewrite wrepr_wnot ZlnotE Z.sub_1_r Z.add_1_r Z.succ_pred.
+Qed.
 
 Lemma arm_op_mov_eval_instr lp ls ii y wy :
   get_var (lvm ls) (v_var y) = ok (Vword wy)
   -> let: li := li_of_copn_args ii (arm_op_mov x y) in
      let: vm' := (lvm ls).[v_var x <- ok (pword_of_word wy)]%vmap in
      eval_instr lp li ls = ok (next_vm_ls ls vm').
-Proof. move=> hgety. t_arm_op. by rewrite addn1. Qed.
+Proof. move=> hgety. by t_arm_op. Qed.
 
 Lemma arm_op_str_off_eval_instr lp ls m' ii y off wx (wy : word reg_size) :
   get_var (lvm ls) (v_var x) = ok (Vword wx)
@@ -221,7 +227,7 @@ Lemma arm_op_str_off_eval_instr lp ls m' ii y off wx (wy : word reg_size) :
   -> write (lmem ls) (wx + wrepr Uptr off)%R wy = ok m'
   -> let: li := li_of_copn_args ii (arm_op_str_off y x off) in
      eval_instr lp li ls = ok (next_mem_ls ls m').
-Proof. move=> hgety hgetx hwrite. t_arm_op. by rewrite addn1. Qed.
+Proof. move=> hgety hgetx hwrite. by t_arm_op. Qed.
 
 End ARM_OP.
 


### PR DESCRIPTION
Before printing instructions that use "Modified immediate constants" we check that the immediate argument is in range. 

This is to both avoid printing (some) invalid instructions, and avoid printing instructions for which the Jasmin model differs from the spec (because using certain immediates sets the carry flag). In some cases we can accept the instruction if we force the `W` encoding, which requires that the instruction does not set flags (this is the case for `MOV`, `ADD`, and `SUB`).

The check of whether an immediate sets the carry flag is in `arm_decl.v`, so that eventually it will get used in `arm_instr_decl.v`. For the time being we use it only in `arm_lowering.v` to lower assignments of integers properly.
I also changed the stack alignment to use `BIC` instead of `AND` (which was incorrect but converted into a `BIC` by the assembler).

I added `arm_facts.v` to show that the way we classify immediates corresponds to the spec. We don't use this but I expect that we will once we add the immediate constraints to `arm_instr_decl.v`.