### PR TITLE
Do not use BatIO.to_input_channel

### DIFF
--- a/compiler/src/parseio.ml
+++ b/compiler/src/parseio.ml
@@ -6,7 +6,7 @@ module L = Lexing
 
 (* -------------------------------------------------------------------- *)
 let lexbuf_from_channel = fun name channel ->
-  let lexbuf = Lexing.from_channel channel in
+  let lexbuf = Lexing.from_function channel in
     lexbuf.Lexing.lex_curr_p <- {
         Lexing.pos_fname = name;
         Lexing.pos_lnum  = 1;
@@ -26,5 +26,6 @@ let lexer (lexbuf : L.lexbuf) =
 
 (* -------------------------------------------------------------------- *)
 let parse_program ?(name = "") (inc : IO.input) =
-  let lexbuf = lexbuf_from_channel name (IO.to_input_channel inc) in
+  let lexbuf = lexbuf_from_channel name @@ fun buf n ->
+  try IO.input inc buf 0 n with IO.No_more_input -> 0 in
   parserfun_entry (fun () -> lexer lexbuf)

--- a/compiler/src/parseio.ml
+++ b/compiler/src/parseio.ml
@@ -1,31 +1,14 @@
 (* -------------------------------------------------------------------- *)
 open Utils
 
-module P = Parser
-module L = Lexing
-
 (* -------------------------------------------------------------------- *)
-let lexbuf_from_channel = fun name channel ->
-  let lexbuf = Lexing.from_function channel in
-    lexbuf.Lexing.lex_curr_p <- {
-        Lexing.pos_fname = name;
-        Lexing.pos_lnum  = 1;
-        Lexing.pos_bol   = 0;
-        Lexing.pos_cnum  = 0
-      };
-    lexbuf
-
-(* -------------------------------------------------------------------- *)
-let parserfun_entry =
-    MenhirLib.Convert.Simplified.traditional2revised P.module_
-
-(* -------------------------------------------------------------------- *)
-let lexer (lexbuf : L.lexbuf) =
-  let token = Lexer.main lexbuf in
-  (token, L.lexeme_start_p lexbuf, L.lexeme_end_p lexbuf)
+let lexbuf_from_function = fun name f ->
+  let lexbuf = Lexing.from_function f in
+  Lexing.set_filename lexbuf name;
+  lexbuf
 
 (* -------------------------------------------------------------------- *)
 let parse_program ?(name = "") (inc : IO.input) =
-  let lexbuf = lexbuf_from_channel name @@ fun buf n ->
+  let lexbuf = lexbuf_from_function name @@ fun buf n ->
   try IO.input inc buf 0 n with IO.No_more_input -> 0 in
-  parserfun_entry (fun () -> lexer lexbuf)
+  Parser.module_ Lexer.main lexbuf


### PR DESCRIPTION
Its documentation reads:

> This function is extremely costly and is provided essentially for
> debugging purposes or for reusing legacy libraries which can't be
> adapted. As a general rule, if you can avoid using this function, don't
> use it.

Its implementation has a known bug that leads to exhaustion of available file descriptors and filesystem space (see:
https://github.com/ocaml-batteries-team/batteries-included/blob/134a8873ebdef76117978b61062c8682e3cdac35/src/batIO.ml#L710).