### PR TITLE
Regenerate instruction identifiers on conversion

### DIFF
--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -134,7 +134,7 @@ let expr_of_cexprs es = List.map (expr_of_cexpr) es
 (* ------------------------------------------------------------------------ *)
 
 let rec cinstr_of_instr i c =
-  let n = i.i_loc, i.i_annot in
+  let n = L.refresh_i_loc i.i_loc, i.i_annot in
   cinstr_r_of_instr_r n i.i_desc c
 
 and cinstr_r_of_instr_r p i tl =


### PR DESCRIPTION
Programs entering the “coq” side always get fresh identifiers