### PR TITLE
Improve fresh name generations in make-reference-arguments

### DIFF
--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -208,19 +208,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       List.iter (warn_extra_fd Arch.asmOp) fds
   in
 
-  let fresh_reg =
-    let memo = Hashtbl.create 5 in
-    fun n st ->
-    let k = (n, st) in
-    match Hashtbl.find memo k with
-    | x -> x
-    | exception Not_found ->
-       let ty = Conv.ty_of_cty st in
-       let x = V.mk n (Reg (Normal, Direct)) ty L._dummy [] in
-       Hashtbl.add memo k x;
-       x
-  in
-
   let cparams =
     {
       Compiler.rename_fd;
@@ -262,8 +249,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.is_glob;
       Compiler.fresh_id;
       Compiler.fresh_counter;
-      Compiler.fresh_reg;
-      Compiler.fresh_reg_ptr = Conv.fresh_reg_ptr;
+      Compiler.fresh_reg_ident = Conv.fresh_reg_ident;
       Compiler.is_reg_ptr;
       Compiler.is_ptr;
       Compiler.is_reg_array;

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -148,6 +148,10 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     { Array_expansion.vars; arrs = !arrs }
   in
 
+  let refresh_instr_info fn f =
+    (fn, f) |> Conv.fdef_of_cufdef |> refresh_i_loc_f |> Conv.cufdef_of_fdef |> snd
+  in
+
   let warning ii msg =
     (if not !Glob_options.lea then
      let loc, _ = ii in
@@ -251,6 +255,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
         (fun s p ->
           eprint s pp_linear p;
           p);
+      Compiler.refresh_instr_info;
       Compiler.warning;
       Compiler.inline_var;
       Compiler.lowering_opt = Arch.lowering_opt;

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -342,6 +342,14 @@ let error_of_cerror pp_err e =
   }
 
 (* -------------------------------------------------------------------------- *)
-let fresh_reg_ptr (x: Name.t) ty =
-  let ty = ty_of_cty ty in
-  Prog.V.mk x (Reg (Normal, Pointer Writable)) ty L._dummy []
+let fresh_reg_ident =
+  let memo = Hashtbl.create 5 in
+  fun r (i_loc, _) n st ->
+    let k = (r, i_loc.L.uid_loc, n, st) in
+    match Hashtbl.find memo k with
+    | x -> x
+    | exception Not_found ->
+        let ty = ty_of_cty st in
+        let x = V.mk n (Reg (Normal, r)) ty i_loc.L.base_loc [] in
+        Hashtbl.add memo k x;
+        x

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -62,7 +62,5 @@ val error_of_cerror :
   (Format.formatter -> Compiler_util.pp_error -> unit) ->
    Compiler_util.pp_error_loc -> Utils.hierror
 
-
 (* ---------------------------------------------------- *)
-val fresh_reg_ptr :
-   Name.t -> Type.stype -> Ident.Ident.ident
+val fresh_reg_ident : reference -> IInfo.t -> Name.t -> Type.stype -> var

--- a/compiler/src/coreIdent.ml
+++ b/compiler/src/coreIdent.ml
@@ -36,13 +36,10 @@ let tint  = Bty Int
 
 (* ------------------------------------------------------------------------ *)
 
-type writable = Constant | Writable
-type pointer = Direct | Pointer of writable
-
 type v_kind =
   | Const            (* global parameter  *)
-  | Stack of pointer (* stack variable    *)
-  | Reg   of reg_kind * pointer (* register variable *)
+  | Stack of reference (* stack variable    *)
+  | Reg   of reg_kind * reference (* register variable *)
   | Inline           (* inline variable   *)
   | Global           (* global (in memory) constant *)
 
@@ -100,6 +97,7 @@ module Cident = struct
   let id_name (x: t) : name = x.v_name
 
   let name_of_string = CoreConv.string_of_cstring
+  let string_of_name = CoreConv.cstring_of_string
 
   (* FIXME: can we use something else that L._dummy? *)
   let mk x k t = V.mk (CoreConv.string_of_cstring x) k t L._dummy []

--- a/compiler/src/coreIdent.mli
+++ b/compiler/src/coreIdent.mli
@@ -37,13 +37,10 @@ val tint  : 'len gty
 
 (* ------------------------------------------------------------------------ *)
 
-type writable = Constant | Writable
-type pointer = Direct | Pointer of writable
-
 type v_kind =
   | Const            (* global parameter  *)
-  | Stack of pointer (* stack variable    *)
-  | Reg   of reg_kind * pointer (* register variable *)
+  | Stack of reference (* stack variable    *)
+  | Reg   of reg_kind * reference (* register variable *)
   | Inline           (* inline variable   *)
   | Global           (* global (in memory) constant *)
 
@@ -110,6 +107,7 @@ module Cident : sig
   val id_name : t -> Name.t
 
   val name_of_string : char list -> name
+  val string_of_name : name -> char list
 
 end
 

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -563,13 +563,13 @@ end
 
 
 (* -------------------------------------------------------------------- *)
-let tt_pointer dfl_writable (p:S.ptr) : P.pointer = 
+let tt_pointer dfl_writable (p:S.ptr) : W.reference =
   match p with
-  | `Pointer (Some `Writable) -> P.Pointer P.Writable
-  | `Pointer (Some `Constant) -> P.Pointer P.Constant
+  | `Pointer (Some `Writable) -> W.Pointer W.Writable
+  | `Pointer (Some `Constant) -> W.Pointer W.Constant
   | `Pointer None             -> 
-    P.Pointer (if dfl_writable then P.Writable else P.Constant)
-  | `Direct  -> P.Direct
+    W.Pointer (if dfl_writable then W.Writable else W.Constant)
+  | `Direct  -> W.Direct
 
 let tt_reg_kind annot = 
   match Annot.ensure_uniq1 "mmx" Annot.none annot with

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -1,4 +1,5 @@
 open Utils
+open Wsize
 open Sopn
 open Prog
 
@@ -167,7 +168,7 @@ type ('info, 'asm) collect_equality_constraints_state =
 (* Renaming assignments can be removed between variables of compatible kinds,
 where “compatibility” is defined below and allows the promotion of mutable
 pointers to constant pointers. *)
-let pointer_compatible (x: pointer) (y: pointer) : bool =
+let pointer_compatible (x: reference) (y: reference) : bool =
   match x, y with
   | Direct, Direct
   | Pointer Writable, Pointer Writable

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -1,4 +1,5 @@
 open Utils
+open Wsize
 open Prog
 open Regalloc
 
@@ -167,7 +168,7 @@ let memory_analysis pp_err ~debug up =
 
   let is_regx x = is_regx (Conv.var_of_cvar x) in
   let sp' = 
-    match Stack_alloc.alloc_prog Arch.reg_size Arch.asmOp false (Arch.aparams.ap_sap is_regx) Conv.fresh_reg_ptr crip crsp gao.gao_data cglobs get_sao up with
+    match Stack_alloc.alloc_prog Arch.reg_size Arch.asmOp false (Arch.aparams.ap_sap is_regx) (Conv.fresh_reg_ident (Pointer Writable) IInfo.dummy) crip crsp gao.gao_data cglobs get_sao up with
     | Utils0.Ok sp -> sp 
     | Utils0.Error e ->
       let e = Conv.error_of_cerror pp_err e in

--- a/proofs/compiler/allocation.v
+++ b/proofs/compiler/allocation.v
@@ -592,7 +592,7 @@ Fixpoint check_i (i1 i2:instr_r) r :=
 
 with check_I i1 i2 r :=
   match i1, i2 with
-  | MkI _ i1, MkI ii i2 => check_i i1 i2 r
+  | MkI _ i1, MkI ii i2 => add_iinfo ii (check_i i1 i2 r)
   end.
 
 Definition check_cmd := fold2 E.fold2 check_I.

--- a/proofs/compiler/allocation_proof.v
+++ b/proofs/compiler/allocation_proof.v
@@ -566,7 +566,7 @@ Section PROOF.
 
   Local Lemma HmkI : sem_Ind_mkI p1 ev Pi_r Pi.
   Proof.
-    move=> ii i s1 s2 _ Hi  r1 [? i2] r2 vm1 /Hi Hvm /= /Hvm [vm2 [??]].
+    move=> ii i s1 s2 _ Hi  r1 [? i2] r2 vm1 /Hi Hvm /= /add_iinfoP /Hvm [vm2 [??]].
     by exists vm2;split=>//;constructor.
   Qed.
 

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -172,8 +172,7 @@ Record compiler_params
   lowering_opt     : lowering_options;
   is_glob          : var -> bool;
   fresh_id         : glob_decls -> var -> Ident.ident;
-  fresh_reg        : Ident.name -> stype -> Ident.ident;
-  fresh_reg_ptr    : Ident.name -> stype -> Ident.ident;
+  fresh_reg_ident  : reference -> instr_info -> Ident.name -> stype -> Ident.ident;
   fresh_counter    : Ident.ident;
   is_reg_ptr       : var -> bool;
   is_ptr           : var -> bool;
@@ -269,12 +268,12 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
   Let pg := remove_glob_prog cparams.(is_glob) cparams.(fresh_id) pe in
   let pg := cparams.(print_uprog) RemoveGlobal pg in
 
-  Let pa := makereference_prog cparams.(is_reg_ptr) cparams.(fresh_reg_ptr) pg in
+  Let pa := makereference_prog cparams.(is_reg_ptr) (fresh_reg_ident cparams (wsize.Pointer Writable)) pg in
   let pa := cparams.(print_uprog) MakeRefArguments pa in
 
   Let _ :=
     assert
-      (lop_fvars_correct loparams cparams.(fresh_reg) (p_funcs pa))
+      (lop_fvars_correct loparams (fresh_reg_ident cparams Direct dummy_instr_info) (p_funcs pa))
       (pp_internal_error_s "lowering" "lowering check fails")
   in
 
@@ -283,7 +282,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
       (lop_lower_i loparams (is_regx cparams))
       (lowering_opt cparams)
       (warning cparams)
-      (fresh_reg cparams)
+      (fresh_reg_ident cparams Direct dummy_instr_info)
       (is_var_in_memory cparams)
       pa
   in
@@ -322,7 +321,7 @@ Definition compiler_front_end (entries: seq funname) (p: prog) : cexec sprog :=
     stack_alloc.alloc_prog
       true
       saparams
-      cparams.(fresh_reg)
+      (fresh_reg_ident cparams Direct dummy_instr_info)
       (global_static_data_symbol cparams)
       (stack_register_symbol cparams)
       (ao_globals ao)

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -167,6 +167,7 @@ Record compiler_params
   print_uprog      : compiler_step -> _uprog -> _uprog;
   print_sprog      : compiler_step -> _sprog -> _sprog;
   print_linear     : compiler_step -> lprog -> lprog;
+  refresh_instr_info: funname -> _ufundef -> _ufundef;
   warning          : instr_info -> warning_msg -> instr_info;
   lowering_opt     : lowering_options;
   is_glob          : var -> bool;
@@ -232,6 +233,7 @@ Definition live_range_splitting (p: uprog) : cexec uprog :=
   let pv := cparams.(print_uprog) Renaming pv in
   let pv := remove_phi_nodes_prog pv in
   let pv := cparams.(print_uprog) RemovePhiNodes pv in
+  let pv := map_prog_name (refresh_instr_info cparams) pv in
   Let _ := check_uprog p.(p_extra) p.(p_funcs) pv.(p_extra) pv.(p_funcs) in
   Let pv := dead_code_prog (ap_is_move_op aparams) pv false in
   let p := cparams.(print_uprog) DeadCode_Renaming pv in

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -279,7 +279,7 @@ Qed.
 
 (* TODO: move *)
 Remark sp_globs_stack_alloc rip rsp data ga la (p: uprog) (p': sprog) :
-  alloc_prog (ap_sap aparams (is_regx cparams)) cparams.(fresh_reg) rip rsp data ga la p = ok p' →
+  alloc_prog (ap_sap aparams (is_regx cparams)) (fresh_reg_ident cparams Direct dummy_instr_info) rip rsp data ga la p = ok p' →
   sp_globs (p_extra p') = data.
 Proof.
   by rewrite /alloc_prog; t_xrbindP => ???? _ <-.

--- a/proofs/compiler/makeReferenceArguments.v
+++ b/proofs/compiler/makeReferenceArguments.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
 From mathcomp Require Import all_ssreflect.
+From Coq Require Import HexadecimalString.
 Require Import gen_map expr compiler_util ZArith.
 
 Set Implicit Arguments.
@@ -20,42 +21,43 @@ End E.
 Section Section.
 Context `{asmop:asmOp}.
 Context (is_reg_ptr : var -> bool)
-        (fresh_reg_ptr : Ident.name -> stype -> Ident.ident).
+        (fresh_reg_ptr : instr_info -> Ident.name -> stype -> Ident.ident).
 Context (p : uprog).
 
-Definition with_id vi id ty :=
-  {| v_var := {| vtype := ty; vname := fresh_reg_ptr id ty |};
+Definition with_id ii sfx vi id ty :=
+  let id := Ident.name_of_string (Ident.string_of_name id ++ NilEmpty.string_of_uint sfx) in
+  {| v_var := {| vtype := ty; vname := fresh_reg_ptr ii id ty |};
      v_info := vi |}.
 
-Definition is_reg_ptr_expr doit id ty e :=
+Definition is_reg_ptr_expr ii sfx doit id ty e :=
   match e with
   | Pvar x' =>
     if doit && (is_glob x' || ~~is_reg_ptr x'.(gv)) then
-      Some (with_id x'.(gv).(v_info) id ty)
+      Some (with_id ii sfx x'.(gv).(v_info) id ty)
     else None
-  | Psub _ _ _ x' _ =>  Some (with_id x'.(gv).(v_info) id ty)
-  | _      => None 
+  | Psub _ _ _ x' _ =>  Some (with_id ii sfx x'.(gv).(v_info) id ty)
+  | _      => None
   end.
 
-Definition is_reg_ptr_lval doit id ty r :=
+Definition is_reg_ptr_lval ii sfx doit id ty r :=
   match r with
-  | Lvar x' => if doit && ~~is_reg_ptr x' then Some (with_id x'.(v_info) id ty) else None
-  | Lasub _ _ _ x' _ => Some (with_id x'.(v_info) id ty)
-  | _      => None 
+  | Lvar x' => if doit && ~~is_reg_ptr x' then Some (with_id ii sfx x'.(v_info) id ty) else None
+  | Lasub _ _ _ x' _ => Some (with_id ii sfx x'.(v_info) id ty)
+  | _      => None
   end.
 
-Fixpoint make_prologue ii (X:Sv.t) xtys es :=
+Fixpoint make_prologue ii (X:Sv.t) ctr xtys es :=
   match xtys, es with
   | [::], [::] => ok ([::], [::])
   | (doit, id, ty)::xtys, e::es =>
-    match is_reg_ptr_expr doit id ty e with
-    | Some y => 
+    match is_reg_ptr_expr ii ctr doit id ty e with
+    | Some y =>
       Let _ := assert (~~Sv.mem y X) (make_ref_error ii "bad fresh id (prologue)") in
-      Let pes := make_prologue ii (Sv.add y X) xtys es in
+      Let pes := make_prologue ii (Sv.add y X) (Hexadecimal.Little.succ ctr) xtys es in
       let: (p,es') := pes in 
       ok (MkI ii (Cassgn (Lvar y) AT_rename ty e) :: p, Plvar y :: es')
     | None =>
-      Let pes := make_prologue ii X xtys es in
+      Let pes := make_prologue ii X ctr xtys es in
       let: (p,es') := pes in
       ok (p, e::es')
     end
@@ -66,18 +68,18 @@ Variant pseudo_instr :=
   | PI_lv of lval
   | PI_i  of lval & stype & var_i.
 
-Fixpoint make_pseudo_epilogue (ii:instr_info) (X:Sv.t) xtys rs :=
+Fixpoint make_pseudo_epilogue (ii:instr_info) (X:Sv.t) ctr xtys rs :=
   match xtys, rs with
   | [::], [::] => ok ([::])
   | (doit, id, ty)::xtys, r::rs =>
-     match is_reg_ptr_lval doit id ty r with
+     match is_reg_ptr_lval ii ctr doit id ty r with
      | Some y => 
        Let _ := assert (~~Sv.mem y X)
                        (make_ref_error ii "bad fresh id (epilogue)") in
-       Let pis := make_pseudo_epilogue ii X xtys rs in
+       Let pis := make_pseudo_epilogue ii X (Hexadecimal.Little.succ ctr) xtys rs in
        ok (PI_lv (Lvar y) :: (PI_i r ty y) :: pis)
      | None =>
-       Let pis :=  make_pseudo_epilogue ii X xtys rs in
+       Let pis :=  make_pseudo_epilogue ii X ctr xtys rs in
        ok (PI_lv r :: pis) 
      end
    | _, _ => Error (make_ref_error ii "assert false (epilogue)")
@@ -122,7 +124,7 @@ Fixpoint swapable (ii:instr_info) (pis : seq pseudo_instr) :=
   end.
 
 Definition make_epilogue ii (X:Sv.t) xtys rs :=
-  Let pis := make_pseudo_epilogue ii X xtys rs in
+  Let pis := make_pseudo_epilogue ii X Hexadecimal.Nil xtys rs in
   swapable ii pis.
 
 Definition update_c (update_i : instr -> cexec cmd) (c:cmd) :=
@@ -160,14 +162,14 @@ Fixpoint update_i (X:Sv.t) (i:instr) : cexec cmd :=
     ok [::MkI ii (Cwhile a c e c')]
   | Ccall ini xs fn es =>
     let: (params,returns) := get_sig fn in
-    Let pres := make_prologue ii X params es in
+    Let pres := make_prologue ii X Hexadecimal.Nil params es in
     let: (prologue, es) := pres in
     Let xsep := make_epilogue ii X returns xs in
     let: (xs, epilogue) := xsep in 
     ok (prologue ++ MkI ii (Ccall ini xs fn es) :: epilogue)
   | Csyscall xs o es =>
     let: (params,returns) := get_syscall_sig o in
-    Let: (prologue, es) := make_prologue ii X params es in
+    Let: (prologue, es) := make_prologue ii X Hexadecimal.Nil params es in
     Let: (xs, epilogue) := make_epilogue ii X returns xs in
     ok (prologue ++ MkI ii (Csyscall xs o es) :: epilogue)
   end.

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -49,6 +49,7 @@ Extract Constant ident.Cident.tag     => "CoreIdent.Cident.tag".
 Extract Constant ident.Cident.id_name => "CoreIdent.Cident.id_name".
 
 Extract Constant ident.Cident.name_of_string => "CoreIdent.Cident.name_of_string".
+Extract Constant ident.Cident.string_of_name => "CoreIdent.Cident.string_of_name".
 
 
 Cd  "lang/ocaml".

--- a/proofs/lang/ident.v
+++ b/proofs/lang/ident.v
@@ -20,6 +20,7 @@ Module Type CORE_IDENT.
   Parameter id_name : t -> name.
 
   Parameter name_of_string : string → name.
+  Parameter string_of_name : name → string.
 
 End CORE_IDENT.
 
@@ -38,6 +39,7 @@ Module Cident : CORE_IDENT.
   Definition id_name (x : t) : name := x.
 
   Definition name_of_string of string := 1%uint63.
+  Definition string_of_name of name := ""%string.
 
 End Cident.
 
@@ -66,5 +68,6 @@ Module Ident <: IDENT.
   Module Mid := Tident.Mt.
 
   Definition name_of_string : string → name := Cident.name_of_string.
+  Definition string_of_name : name → string := Cident.string_of_name.
 
 End Ident.

--- a/proofs/lang/wsize.v
+++ b/proofs/lang/wsize.v
@@ -182,6 +182,10 @@ Variant reg_kind : Type :=
 | Normal
 | Extra.
 
+Variant writable : Type := Constant | Writable.
+
+Variant reference : Type := Direct | Pointer of writable.
+
 (* -------------------------------------------------------------------- *)
 Variant safe_cond :=
   | NotZero of wsize & nat  (* the nth argument of size sz is not zero *)


### PR DESCRIPTION
First commit is unrelated.

Instead of relying on the fact that the `fresh_id` oracle returned fresh variable names, it is now called with different arguments:
  - different call sites are distinguished by their `instr_info`;
  - different arguments / return values are distinguished by the value of a (local) counter that is incremented on each call to said oracle.