### PR TITLE
Compiler: define `v_kind` in Coq

### DIFF
--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -176,11 +176,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
 
   let is_regx x = is_regx (Conv.var_of_cvar x) in
 
-  let is_reg_ptr x =
-    let x = Conv.var_of_cvar x in
-    is_reg_ptr_kind x.v_kind
-  in
-
   let is_ptr x =
     let x = Conv.var_of_cvar x in
     is_ptr x.v_kind
@@ -233,7 +228,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.lowering_opt = Arch.lowering_opt;
       Compiler.fresh_id;
       Compiler.fresh_var_ident = Conv.fresh_var_ident;
-      Compiler.is_reg_ptr;
       Compiler.is_ptr;
       Compiler.is_reg_array;
       Compiler.is_regx = is_regx;

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -174,8 +174,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     tokeep
   in
 
-  let is_regx x = is_regx (Conv.var_of_cvar x) in
-
   let is_reg_array x = is_reg_arr (Conv.var_of_cvar x) in
 
   let warn_extra s p =
@@ -224,7 +222,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.fresh_id;
       Compiler.fresh_var_ident = Conv.fresh_var_ident;
       Compiler.is_reg_array;
-      Compiler.is_regx = is_regx;
     }
   in
 

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -100,13 +100,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     fds
   in
 
-  let is_var_in_memory cv : bool =
-    let v = Conv.vari_of_cvari cv |> L.unloc in
-    match v.v_kind with
-    | Stack _ | Reg (_, Pointer _) | Global -> true
-    | Const | Inline | Reg (_, Direct) -> false
-  in
-
   let pp_cuprog s cp =
     Conv.prog_of_cuprog cp |> visit_prog_after_pass ~debug:true s
   in
@@ -202,7 +195,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
         (fun ii ->
           let loc, _ = ii in
           !saved_extra_free_registers loc |> Option.map Conv.cvar_of_var);
-      Compiler.is_var_in_memory;
       Compiler.print_uprog =
         (fun s p ->
           pp_cuprog s p;

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -176,11 +176,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
 
   let is_regx x = is_regx (Conv.var_of_cvar x) in
 
-  let is_ptr x =
-    let x = Conv.var_of_cvar x in
-    is_ptr x.v_kind
-  in
-
   let is_reg_array x = is_reg_arr (Conv.var_of_cvar x) in
 
   let warn_extra s p =
@@ -228,7 +223,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.lowering_opt = Arch.lowering_opt;
       Compiler.fresh_id;
       Compiler.fresh_var_ident = Conv.fresh_var_ident;
-      Compiler.is_ptr;
       Compiler.is_reg_array;
       Compiler.is_regx = is_regx;
     }

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -159,11 +159,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     ii
   in
 
-  let is_glob x =
-    let x = Conv.var_of_cvar x in
-    x.v_kind = Global
-  in
-
   let fresh_id _gd x =
     let x = Conv.var_of_cvar x in
     Prog.V.clone x
@@ -236,7 +231,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.refresh_instr_info;
       Compiler.warning;
       Compiler.lowering_opt = Arch.lowering_opt;
-      Compiler.is_glob;
       Compiler.fresh_id;
       Compiler.fresh_var_ident = Conv.fresh_var_ident;
       Compiler.is_reg_ptr;

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -159,11 +159,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     ii
   in
 
-  let inline_var x =
-    let x = Conv.var_of_cvar x in
-    x.v_kind = Inline
-  in
-
   let is_glob x =
     let x = Conv.var_of_cvar x in
     x.v_kind = Global
@@ -240,7 +235,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
           p);
       Compiler.refresh_instr_info;
       Compiler.warning;
-      Compiler.inline_var;
       Compiler.lowering_opt = Arch.lowering_opt;
       Compiler.is_glob;
       Compiler.fresh_id;

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -174,10 +174,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     Prog.V.clone x
   in
 
-  let fresh_counter =
-    Prog.V.mk "i__copy" Inline tint L._dummy []
-  in
-
   let split_live_ranges_fd fd = Regalloc.split_live_ranges fd in
   let renaming_fd fd = Regalloc.renaming fd in
   let remove_phi_nodes_fd fd = Regalloc.remove_phi_nodes fd in
@@ -248,8 +244,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.lowering_opt = Arch.lowering_opt;
       Compiler.is_glob;
       Compiler.fresh_id;
-      Compiler.fresh_counter;
-      Compiler.fresh_reg_ident = Conv.fresh_reg_ident;
+      Compiler.fresh_var_ident = Conv.fresh_var_ident;
       Compiler.is_reg_ptr;
       Compiler.is_ptr;
       Compiler.is_reg_array;

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -342,7 +342,7 @@ let error_of_cerror pp_err e =
   }
 
 (* -------------------------------------------------------------------------- *)
-let fresh_reg_ident =
+let fresh_var_ident =
   let memo = Hashtbl.create 5 in
   fun r (i_loc, _) n st ->
     let k = (r, i_loc.L.uid_loc, n, st) in
@@ -350,6 +350,6 @@ let fresh_reg_ident =
     | x -> x
     | exception Not_found ->
         let ty = ty_of_cty st in
-        let x = V.mk n (Reg (Normal, r)) ty i_loc.L.base_loc [] in
+        let x = V.mk n r ty i_loc.L.base_loc [] in
         Hashtbl.add memo k x;
         x

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -63,4 +63,4 @@ val error_of_cerror :
    Compiler_util.pp_error_loc -> Utils.hierror
 
 (* ---------------------------------------------------- *)
-val fresh_reg_ident : reference -> IInfo.t -> Name.t -> Type.stype -> var
+val fresh_var_ident : v_kind -> IInfo.t -> Name.t -> Type.stype -> var

--- a/compiler/src/coreIdent.ml
+++ b/compiler/src/coreIdent.ml
@@ -87,6 +87,7 @@ module Cident = struct
   type name = Name.t
 
   let id_name (x: t) : name = x.v_name
+  let id_kind (x: t) : v_kind = x.v_kind
 
   let name_of_string = CoreConv.string_of_cstring
   let string_of_name = CoreConv.cstring_of_string

--- a/compiler/src/coreIdent.ml
+++ b/compiler/src/coreIdent.ml
@@ -36,14 +36,6 @@ let tint  = Bty Int
 
 (* ------------------------------------------------------------------------ *)
 
-type v_kind =
-  | Const            (* global parameter  *)
-  | Stack of reference (* stack variable    *)
-  | Reg   of reg_kind * reference (* register variable *)
-  | Inline           (* inline variable   *)
-  | Global           (* global (in memory) constant *)
-
-
 type 'len gvar = {
   v_name : Name.t;
   v_id   : uid;

--- a/compiler/src/coreIdent.mli
+++ b/compiler/src/coreIdent.mli
@@ -98,6 +98,7 @@ module Cident : sig
 
   val tag : var -> Uint63.t
   val id_name : t -> Name.t
+  val id_kind : t -> v_kind
 
   val name_of_string : char list -> name
   val string_of_name : name -> char list

--- a/compiler/src/coreIdent.mli
+++ b/compiler/src/coreIdent.mli
@@ -37,13 +37,6 @@ val tint  : 'len gty
 
 (* ------------------------------------------------------------------------ *)
 
-type v_kind =
-  | Const            (* global parameter  *)
-  | Stack of reference (* stack variable    *)
-  | Reg   of reg_kind * reference (* register variable *)
-  | Inline           (* inline variable   *)
-  | Global           (* global (in memory) constant *)
-
 type 'len gvar = private {
   v_name : Name.t;
   v_id   : uid;

--- a/compiler/src/printCommon.mli
+++ b/compiler/src/printCommon.mli
@@ -7,7 +7,7 @@ val string_of_op2 : Expr.sop2 -> string
 val pp_opn : 'asm Sopn.asmOp -> Format.formatter -> 'asm Sopn.sopn -> unit
 val pp_syscall : BinNums.positive Syscall_t.syscall_t -> string
 val pp_bool : Format.formatter -> bool -> unit
-val pp_kind : Format.formatter -> Prog.v_kind -> unit
+val pp_kind : Format.formatter -> Wsize.v_kind -> unit
 val pp_btype : Format.formatter -> Prog.base_ty -> unit
 
 val pp_gtype :

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -166,9 +166,8 @@ let memory_analysis pp_err ~debug up =
     Format.eprintf "%a@.@.@." (pp_oracle up) saos
   end;
 
-  let is_regx x = is_regx (Conv.var_of_cvar x) in
-  let sp' = 
-    match Stack_alloc.alloc_prog Arch.reg_size Arch.asmOp false (Arch.aparams.ap_sap is_regx) (Conv.fresh_var_ident (Reg (Normal, Pointer Writable)) IInfo.dummy) crip crsp gao.gao_data cglobs get_sao up with
+  let sp' =
+    match Stack_alloc.alloc_prog Arch.reg_size Arch.asmOp false Arch.aparams.ap_sap (Conv.fresh_var_ident (Reg (Normal, Pointer Writable)) IInfo.dummy) crip crsp gao.gao_data cglobs get_sao up with
     | Utils0.Ok sp -> sp 
     | Utils0.Error e ->
       let e = Conv.error_of_cerror pp_err e in

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -168,7 +168,7 @@ let memory_analysis pp_err ~debug up =
 
   let is_regx x = is_regx (Conv.var_of_cvar x) in
   let sp' = 
-    match Stack_alloc.alloc_prog Arch.reg_size Arch.asmOp false (Arch.aparams.ap_sap is_regx) (Conv.fresh_reg_ident (Pointer Writable) IInfo.dummy) crip crsp gao.gao_data cglobs get_sao up with
+    match Stack_alloc.alloc_prog Arch.reg_size Arch.asmOp false (Arch.aparams.ap_sap is_regx) (Conv.fresh_var_ident (Reg (Normal, Pointer Writable)) IInfo.dummy) crip crsp gao.gao_data cglobs get_sao up with
     | Utils0.Ok sp -> sp 
     | Utils0.Error e ->
       let e = Conv.error_of_cerror pp_err e in

--- a/proofs/arch/arch_sem.v
+++ b/proofs/arch/arch_sem.v
@@ -3,7 +3,7 @@ From mathcomp Require Import word_ssrZ.
 Require oseq.
 Require Import ZArith
 utils
-strings wsize
+strings
 memory_model
 (* word *)
 global
@@ -11,10 +11,9 @@ oseq
 Utf8
 Relation_Operators
 sem_type
-arch_decl
 syscall syscall_sem
 label
-values.
+arch_decl.
 
 Set   Implicit Arguments.
 Unset Strict Implicit.

--- a/proofs/compiler/arch_params.v
+++ b/proofs/compiler/arch_params.v
@@ -24,7 +24,6 @@ Record lowering_params
       lowering_options      (* Lowering options depend on the architecture. *)
       -> (instr_info -> warning_msg -> instr_info)
       -> lowering.fresh_vars
-      -> (var_i -> bool)    (* Whether the variable is in memory. *)
       -> instr              (* Source instruction. *)
       -> cmd;
 

--- a/proofs/compiler/arch_params.v
+++ b/proofs/compiler/arch_params.v
@@ -21,8 +21,7 @@ Record lowering_params
   {
     (* Lower an instruction to architecture-specific instructions. *)
     lop_lower_i :
-      (var -> bool) (* Whether the variable is a register from the extra bank. *)
-      -> lowering_options      (* Lowering options depend on the architecture. *)
+      lowering_options      (* Lowering options depend on the architecture. *)
       -> (instr_info -> warning_msg -> instr_info)
       -> lowering.fresh_vars
       -> (var_i -> bool)    (* Whether the variable is in memory. *)
@@ -43,7 +42,7 @@ Record architecture_params
   (lowering_options : Type) :=
   {
     (* Stack alloc parameters. See stack_alloc.v. *)
-    ap_sap : (var -> bool) -> stack_alloc.stack_alloc_params;
+    ap_sap : stack_alloc.stack_alloc_params;
 
     (* Linearization parameters. See linearization.v. *)
     ap_lip : linearization.linearization_params;

--- a/proofs/compiler/arch_params_proof.v
+++ b/proofs/compiler/arch_params_proof.v
@@ -38,7 +38,6 @@ Record h_lowering_params
         (sCP : semCallParams)
         (p : prog)
         (ev : extra_val_t)
-        (is_regx : var -> bool)
         (options : lowering_options)
         (warning : instr_info -> warning_msg -> instr_info)
         (fv : lowering.fresh_vars)
@@ -51,7 +50,7 @@ Record h_lowering_params
         sem_call p ev scs mem f va scs' mem' vr
         -> let lprog :=
              lowering.lower_prog
-               (lop_lower_i loparams is_regx)
+               (lop_lower_i loparams)
                options
                warning
                fv
@@ -72,8 +71,7 @@ Record h_architecture_params
 
     (* Stack alloc hypotheses. See [stack_alloc_proof.v]. *)
     hap_hsap :
-      forall is_regx,
-        stack_alloc_proof.h_stack_alloc_params (ap_sap aparams is_regx);
+        stack_alloc_proof.h_stack_alloc_params (ap_sap aparams);
 
     (* Linearization hypotheses. See [linearization_proof.v]. *)
     hap_hlip :

--- a/proofs/compiler/arch_params_proof.v
+++ b/proofs/compiler/arch_params_proof.v
@@ -41,7 +41,6 @@ Record h_lowering_params
         (options : lowering_options)
         (warning : instr_info -> warning_msg -> instr_info)
         (fv : lowering.fresh_vars)
-        (is_var_in_memory : var_i -> bool)
         (_ : lop_fvars_correct loparams fv (p_funcs p))
         (f : funname)
         (scs: syscall_state_t) (mem : low_memory.mem)
@@ -54,7 +53,6 @@ Record h_lowering_params
                options
                warning
                fv
-               is_var_in_memory
                p
            in
            sem_call lprog ev scs mem f va scs' mem' vr;

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -56,11 +56,7 @@ Definition fvars (fv : fresh_vars) : Sv.t := sv_of_list id (fresh_flags fv).
 Section ARM_LOWERING.
 
 Context
-  (fv : fresh_vars)
-  (is_var_in_memory : var_i -> bool).
-
-Notation is_lval_in_memory := (is_lval_in_memory is_var_in_memory).
-
+  (fv : fresh_vars).
 
 (* -------------------------------------------------------------------- *)
 (* Lowering of conditions. *)

--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -67,28 +67,23 @@ Context
   (options : lowering_options)
   (warning : instr_info -> warning_msg -> instr_info)
   (fv : fresh_vars)
-  (is_var_in_memory : var_i -> bool)
   (fv_correct : fvars_correct (all_fresh_vars fv) (fvars fv) (p_funcs p)).
 
 Notation fvars := (fvars fv).
-Notation lower_Pvar := (lower_Pvar is_var_in_memory).
-Notation lower_pexpr_aux := (lower_pexpr_aux is_var_in_memory).
-Notation lower_pexpr := (lower_pexpr fv is_var_in_memory).
+Notation lower_pexpr := (lower_pexpr fv).
 Notation lower_cmd :=
   (lower_cmd
      (fun _ _ => lower_i)
      options
      warning
-     fv
-     is_var_in_memory).
+     fv).
 Notation lower_prog :=
   (lower_prog
      (fun _ _ => lower_i)
      options
      warning
-     fv
-     is_var_in_memory).
-Notation lower_i := (lower_i fv is_var_in_memory).
+     fv).
+Notation lower_i := (lower_i fv).
 Notation disj_fvars := (disj_fvars fvars).
 Notation disj_fvars_get_fundef := (disj_fvars_get_fundef fv_correct).
 
@@ -1179,7 +1174,7 @@ Proof.
 Qed.
 
 Lemma lower_cassgnP ii s0 lv tag ty e v v' s0' s1' pre lvs op es :
-  lower_cassgn fv is_var_in_memory lv ty e = Some (pre, (lvs, op, es))
+  lower_cassgn fv lv ty e = Some (pre, (lvs, op, es))
   -> sem_pexpr (p_globs p) s0 e = ok v
   -> truncate_val ty v = ok v'
   -> write_lval (p_globs p) lv v' s0' = ok s1'

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -209,7 +209,7 @@ Definition arm_fvars_correct
 
 Definition arm_loparams : lowering_params lowering_options :=
   {|
-    lop_lower_i _ _ _ := lower_i;
+    lop_lower_i _ _ := lower_i;
     lop_fvars_correct := arm_fvars_correct;
   |}.
 
@@ -323,7 +323,7 @@ Definition arm_is_move_op (o : asm_op_t) : bool :=
 
 Definition arm_params : architecture_params lowering_options :=
   {|
-    ap_sap := (fun _ => arm_saparams);
+    ap_sap := arm_saparams;
     ap_lip := arm_liparams;
     ap_lop := arm_loparams;
     ap_agp := arm_agparams;

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -132,8 +132,8 @@ Proof.
   by rewrite /sem_sopn /= zero_extend_u.
 Qed.
 
-Definition arm_hsaparams is_regx :
-  h_stack_alloc_params (ap_sap arm_params is_regx) :=
+Definition arm_hsaparams :
+  h_stack_alloc_params (ap_sap arm_params) :=
   {|
     mov_ofsP := arm_mov_ofsP;
     sap_immediateP := arm_immediateP;
@@ -958,7 +958,6 @@ Lemma arm_lower_callP
   (sCP : semCallParams)
   (p : prog)
   (ev : extra_val_t)
-  (is_regx : var -> bool)
   (options : lowering_options)
   (warning : instr_info -> warning_msg -> instr_info)
   (fv : fresh_vars)
@@ -970,7 +969,7 @@ Lemma arm_lower_callP
   psem.sem_call p ev scs mem f va scs' mem' vr
   -> let lprog :=
        lowering.lower_prog
-         (lop_lower_i arm_loparams is_regx)
+         (lop_lower_i arm_loparams)
          options
          warning
          fv

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -961,7 +961,6 @@ Lemma arm_lower_callP
   (options : lowering_options)
   (warning : instr_info -> warning_msg -> instr_info)
   (fv : fresh_vars)
-  (is_var_in_memory : var_i -> bool)
   (_ : lop_fvars_correct arm_loparams fv (p_funcs p))
   (f : funname)
   scs mem scs' mem'
@@ -973,7 +972,6 @@ Lemma arm_lower_callP
          options
          warning
          fv
-         is_var_in_memory
          p
      in
      psem.sem_call lprog ev scs mem f va scs' mem' vr.

--- a/proofs/compiler/array_init.v
+++ b/proofs/compiler/array_init.v
@@ -1,7 +1,7 @@
 (* ** Imports and settings *)
 Require Import ZArith.
 From mathcomp Require Import all_ssreflect.
-Require Import expr compiler_util wsize.
+Require Import expr compiler_util.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -93,11 +93,6 @@ Section Section.
     end.
 
 End Section.
-
-Definition is_ptr (x: var) : bool :=
-  match Ident.id_kind x.(vname) with
-  | Reg (_, Pointer _) | Stack (Pointer _) => true
-  | _ => false end.
 
 Definition add_init_aux ii x c :=
   match x.(vtype) with

--- a/proofs/compiler/array_init.v
+++ b/proofs/compiler/array_init.v
@@ -1,7 +1,7 @@
 (* ** Imports and settings *)
 Require Import ZArith.
 From mathcomp Require Import all_ssreflect.
-Require Import expr compiler_util.
+Require Import expr compiler_util wsize.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -94,10 +94,10 @@ Section Section.
 
 End Section.
 
-
-Section Section.
-
-Context (is_ptr : var -> bool).
+Definition is_ptr (x: var) : bool :=
+  match Ident.id_kind x.(vname) with
+  | Reg (_, Pointer _) | Stack (Pointer _) => true
+  | _ => false end.
 
 Definition add_init_aux ii x c :=
   match x.(vtype) with
@@ -143,7 +143,5 @@ Definition add_init_fd (fd:fundef) :=
   |}.
 
 Definition add_init_prog (p:prog) := map_prog add_init_fd p.
-
-End Section.
 
 End ASM_OP.

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -290,11 +290,11 @@ Proof. apply remove_init_fdP; apply wf_inits. Qed.
 
 Section ADD_INIT.
 
-  Context (is_ptr : var -> bool) (p : uprog) (ev:unit).
+  Context (p : uprog) (ev:unit).
 
   Notation gd := (p_globs p).
 
-  Notation p' := (add_init_prog is_ptr p).
+  Notation p' := (add_init_prog p).
 
   Definition undef_except (X:Sv.t) (vm:vmap) := 
    forall x, ~Sv.In x X ->  vm.[x] = pundef_addr (vtype x).
@@ -303,10 +303,10 @@ Section ADD_INIT.
     (forall vm1, evm s1 =v vm1 -> 
        exists2 vm2, evm s2 =v vm2 & sem_I p' ev (with_vm s1 vm1) i (with_vm s2 vm2)) /\
     forall I, undef_except I (evm s1) ->
-      undef_except (add_init_i is_ptr I i).2 (evm s2) /\
+      undef_except (add_init_i I i).2 (evm s2) /\
       forall vm1, evm s1 =v vm1 -> 
         exists2 vm2, evm s2 =v vm2 &
-          sem p' ev (with_vm s1 vm1) (add_init_i is_ptr I i).1 (with_vm s2 vm2).
+          sem p' ev (with_vm s1 vm1) (add_init_i I i).1 (with_vm s2 vm2).
 
   Let Pi_r s1 (i:instr_r) s2 := forall ii, Pi s1 (MkI ii i) s2.
 
@@ -314,10 +314,10 @@ Section ADD_INIT.
     (forall vm1, evm s1 =v vm1 -> 
          exists2 vm2, evm s2 =v vm2 & sem p' ev (with_vm s1 vm1) c (with_vm s2 vm2)) /\
     forall I, undef_except I (evm s1) ->
-      undef_except (add_init_c (add_init_i is_ptr) I c).2 (evm s2) /\
+      undef_except (add_init_c add_init_i I c).2 (evm s2) /\
       forall vm1, evm s1 =v vm1 -> 
         exists2 vm2, evm s2 =v vm2 &
-         sem p' ev (with_vm s1 vm1) (add_init_c (add_init_i is_ptr) I c).1 (with_vm s2 vm2).
+         sem p' ev (with_vm s1 vm1) (add_init_c add_init_i I c).1 (with_vm s2 vm2).
 
   Let Pfor (i:var_i) vs s1 c s2 :=
     forall vm1, evm s1 =v vm1 -> 
@@ -349,7 +349,7 @@ Section ADD_INIT.
     (∀ vm1 : vmap, evm s1 =v vm1 → exists2 vm2 : vmap, evm s2 =v vm2 & sem_I p' ev (with_vm s1 vm1) (MkI ii i) (with_vm s2 vm2)) →
     ∀ vm1 : vmap, evm s1 =v vm1 → 
     exists2 vm2 : vmap,
-        evm s2 =v vm2 & sem p' ev (with_vm s1 vm1) (add_init is_ptr ii I X (MkI ii i)) (with_vm s2 vm2).
+        evm s2 =v vm2 & sem p' ev (with_vm s1 vm1) (add_init ii I X (MkI ii i)) (with_vm s2 vm2).
   Proof.
     move=> hu hs; rewrite /add_init Sv.fold_spec.
     have : forall x:var, x \in Sv.elements (Sv.diff X I) -> (evm s1).[x] = pundef_addr (vtype x).
@@ -389,7 +389,7 @@ Section ADD_INIT.
         exists2 vm2 : vmap,
           evm s2 =v vm2 &
           sem p' ev (with_vm s1 vm1)
-            (add_init is_ptr ii I (Sv.union (write_i i) (read_i i)) (MkI ii i)) (with_vm s2 vm2).
+            (add_init ii I (Sv.union (write_i i) (read_i i)) (MkI ii i)) (with_vm s2 vm2).
   Proof.
     move=> hs hs'; split => //.
     move=> I hu; split.
@@ -561,7 +561,7 @@ Section ADD_INIT.
   Local Lemma RAproc : sem_Ind_proc p ev Pc Pfun.
   Proof.
     move=> scs1 m1 scs2 m2 fn fd vargs vargs' s0 s1 s2 vres vres' Hget Htin Hi Hargs Hsem [] hsi Hrec Hmap Htout Hsys Hfi.
-    have hget : get_fundef (p_funcs p') fn = Some (add_init_fd is_ptr fd).
+    have hget : get_fundef (p_funcs p') fn = Some (add_init_fd fd).
     + by rewrite /p' get_map_prog Hget.
     set I := vrvs [seq (Lvar i) | i <- f_params fd].
     case: (Hrec I).
@@ -571,7 +571,7 @@ Section ADD_INIT.
       + by rewrite -/I /disjoint /is_true Sv.is_empty_spec; SvD.fsetdec.
       by SvD.fsetdec.     
     move=> ?  /(_ (evm s1) (fun _ => erefl)) [vm2] heq2 hsem {Hsem Hget}.    
-    eapply (EcallRun (f := add_init_fd is_ptr fd) (s1:= with_vm s1 (evm s1)) (s2:= (with_vm s2 vm2))); eauto.
+    eapply (EcallRun (f := add_init_fd fd) (s1:= with_vm s1 (evm s1)) (s2:= (with_vm s2 vm2))); eauto.
     + by case: (s1) Hargs.
     by rewrite -Hmap; apply mapM_ext => // y; rewrite /get_var heq2.
   Qed.

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -172,7 +172,6 @@ Record compiler_params
   lowering_opt     : lowering_options;
   fresh_id         : glob_decls -> var -> Ident.ident;
   fresh_var_ident  : v_kind -> instr_info -> Ident.name -> stype -> Ident.ident;
-  is_ptr           : var -> bool;
   is_reg_array     : var -> bool;
   is_regx          : var -> bool;
 }.
@@ -240,7 +239,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
   Let p := array_copy_prog (fresh_var_ident cparams Inline dummy_instr_info (Ident.name_of_string "i__copy") sint) p in
   let p := cparams.(print_uprog) ArrayCopy p in
 
-  let p := add_init_prog cparams.(is_ptr) p in
+  let p := add_init_prog p in
   let p := cparams.(print_uprog) AddArrInit p in
 
   Let p := inline_prog_err cparams.(rename_fd) p in

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -157,7 +157,6 @@ Record compiler_params
   split_live_ranges_fd : funname -> _ufundef -> _ufundef;
   renaming_fd      : funname -> _ufundef -> _ufundef;
   remove_phi_nodes_fd : funname -> _ufundef -> _ufundef;
-  is_var_in_memory : var_i → bool;
   stack_register_symbol: Ident.ident;
   global_static_data_symbol: Ident.ident;
   stackalloc       : _uprog → stack_alloc_oracles;
@@ -278,7 +277,6 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
       (lowering_opt cparams)
       (warning cparams)
       (fresh_var_ident cparams (Reg (Normal, Direct)) dummy_instr_info)
-      (is_var_in_memory cparams)
       pa
   in
   let pl := cparams.(print_uprog) LowerInstruction pl in

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -157,7 +157,6 @@ Record compiler_params
   split_live_ranges_fd : funname -> _ufundef -> _ufundef;
   renaming_fd      : funname -> _ufundef -> _ufundef;
   remove_phi_nodes_fd : funname -> _ufundef -> _ufundef;
-  inline_var       : var -> bool;
   is_var_in_memory : var_i → bool;
   stack_register_symbol: Ident.ident;
   global_static_data_symbol: Ident.ident;
@@ -246,7 +245,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
   let p := add_init_prog cparams.(is_ptr) p in
   let p := cparams.(print_uprog) AddArrInit p in
 
-  Let p := inline_prog_err cparams.(inline_var) cparams.(rename_fd) p in
+  Let p := inline_prog_err cparams.(rename_fd) p in
   let p := cparams.(print_uprog) Inlining p in
 
   Let p := dead_calls_err_seq to_keep p in

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -170,7 +170,6 @@ Record compiler_params
   refresh_instr_info: funname -> _ufundef -> _ufundef;
   warning          : instr_info -> warning_msg -> instr_info;
   lowering_opt     : lowering_options;
-  is_glob          : var -> bool;
   fresh_id         : glob_decls -> var -> Ident.ident;
   fresh_var_ident  : v_kind -> instr_info -> Ident.name -> stype -> Ident.ident;
   is_reg_ptr       : var -> bool;
@@ -264,7 +263,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
 
   Let pe := live_range_splitting pe in
 
-  Let pg := remove_glob_prog cparams.(is_glob) cparams.(fresh_id) pe in
+  Let pg := remove_glob_prog cparams.(fresh_id) pe in
   let pg := cparams.(print_uprog) RemoveGlobal pg in
 
   Let pa := makereference_prog cparams.(is_reg_ptr) (fresh_var_ident cparams (Reg (Normal, Pointer Writable))) pg in

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -172,7 +172,6 @@ Record compiler_params
   lowering_opt     : lowering_options;
   fresh_id         : glob_decls -> var -> Ident.ident;
   fresh_var_ident  : v_kind -> instr_info -> Ident.name -> stype -> Ident.ident;
-  is_reg_ptr       : var -> bool;
   is_ptr           : var -> bool;
   is_reg_array     : var -> bool;
   is_regx          : var -> bool;
@@ -266,7 +265,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
   Let pg := remove_glob_prog cparams.(fresh_id) pe in
   let pg := cparams.(print_uprog) RemoveGlobal pg in
 
-  Let pa := makereference_prog cparams.(is_reg_ptr) (fresh_var_ident cparams (Reg (Normal, Pointer Writable))) pg in
+  Let pa := makereference_prog (fresh_var_ident cparams (Reg (Normal, Pointer Writable))) pg in
   let pa := cparams.(print_uprog) MakeRefArguments pa in
 
   Let _ :=

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -173,7 +173,6 @@ Record compiler_params
   fresh_id         : glob_decls -> var -> Ident.ident;
   fresh_var_ident  : v_kind -> instr_info -> Ident.name -> stype -> Ident.ident;
   is_reg_array     : var -> bool;
-  is_regx          : var -> bool;
 }.
 
 
@@ -188,7 +187,7 @@ Context
   (aparams : architecture_params lowering_options)
   (cparams : compiler_params lowering_options).
 
-Notation saparams := (ap_sap aparams cparams.(is_regx)).
+Notation saparams := (ap_sap aparams).
 Notation liparams := (ap_lip aparams).
 Notation loparams := (ap_lop aparams).
 Notation agparams := (ap_agp aparams).
@@ -275,7 +274,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
 
   let pl :=
     lower_prog
-      (lop_lower_i loparams (is_regx cparams))
+      (lop_lower_i loparams)
       (lowering_opt cparams)
       (warning cparams)
       (fresh_var_ident cparams (Reg (Normal, Direct)) dummy_instr_info)

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -181,7 +181,6 @@ Proof.
          (hap_hlop haparams)
          (lowering_opt cparams)
          (warning cparams)
-         (is_var_in_memory cparams)
          ok_fvars).
   apply: compose_pass;
     first by move=> vr';

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -33,6 +33,7 @@ Require Import
   asm_gen_proof
   sem_params_of_arch_extra.
 Import Utf8.
+Import wsize.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -279,7 +280,7 @@ Qed.
 
 (* TODO: move *)
 Remark sp_globs_stack_alloc rip rsp data ga la (p: uprog) (p': sprog) :
-  alloc_prog (ap_sap aparams (is_regx cparams)) (fresh_reg_ident cparams Direct dummy_instr_info) rip rsp data ga la p = ok p' →
+  alloc_prog (ap_sap aparams (is_regx cparams)) (fresh_var_ident cparams (Reg (Normal, Direct)) dummy_instr_info) rip rsp data ga la p = ok p' →
   sp_globs (p_extra p') = data.
 Proof.
   by rewrite /alloc_prog; t_xrbindP => ???? _ <-.

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -179,7 +179,6 @@ Proof.
     exact:
       (hlop_lower_callP
          (hap_hlop haparams)
-         (is_regx cparams)
          (lowering_opt cparams)
          (warning cparams)
          (is_var_in_memory cparams)
@@ -280,7 +279,7 @@ Qed.
 
 (* TODO: move *)
 Remark sp_globs_stack_alloc rip rsp data ga la (p: uprog) (p': sprog) :
-  alloc_prog (ap_sap aparams (is_regx cparams)) (fresh_var_ident cparams (Reg (Normal, Direct)) dummy_instr_info) rip rsp data ga la p = ok p' →
+  alloc_prog (ap_sap aparams) (fresh_var_ident cparams (Reg (Normal, Direct)) dummy_instr_info) rip rsp data ga la p = ok p' →
   sp_globs (p_extra p') = data.
 Proof.
   by rewrite /alloc_prog; t_xrbindP => ???? _ <-.
@@ -370,7 +369,7 @@ Proof.
   have disjoint_va : disjoint_values (sao_params (ao_stack_alloc (stackalloc cparams p1) fn)) va va.
   - rewrite /disjoint_values => i1 pi1 w1 i2 pi2 w2.
     by rewrite (allNone_nth _ params_noptr).
-  have := alloc_progP (hap_hsap haparams (is_regx cparams)) ok_p2 exec_p1 m_mi.
+  have := alloc_progP (hap_hsap haparams) ok_p2 exec_p1 m_mi.
   move => /(_ va ok_va disjoint_va ok_mi').
   case => mi' [] vr2 [] exec_p2 [] m'_mi' [] ok_vr2 ?.
   have [] := compiler_third_partP ok_p3.

--- a/proofs/compiler/inline.v
+++ b/proofs/compiler/inline.v
@@ -35,12 +35,9 @@ Context
   {asm_op syscall_state : Type}
   {asmop:asmOp asm_op}.
 
-Definition inline_var (x: var) : bool :=
-  if Ident.id_kind x.(vname) is Inline then true else false.
-
 Definition get_flag (x:lval) flag :=
   match x with
-  | Lvar x => if inline_var x then AT_inline else flag
+  | Lvar x => if is_inline_var x then AT_inline else flag
   | _      => flag
   end.
 

--- a/proofs/compiler/inline.v
+++ b/proofs/compiler/inline.v
@@ -33,8 +33,10 @@ Section INLINE.
 
 Context
   {asm_op syscall_state : Type}
-  {asmop:asmOp asm_op}
-  (inline_var : var -> bool).
+  {asmop:asmOp asm_op}.
+
+Definition inline_var (x: var) : bool :=
+  if Ident.id_kind x.(vname) is Inline then true else false.
 
 Definition get_flag (x:lval) flag :=
   match x with

--- a/proofs/compiler/inline_proof.v
+++ b/proofs/compiler/inline_proof.v
@@ -18,16 +18,15 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  (inline_var : var -> bool)
   (rename_fd : instr_info -> funname -> ufundef -> ufundef).
 
 Lemma get_funP p f fd :
   get_fun p f = ok fd -> get_fundef p f = Some fd.
 Proof. by rewrite /get_fun;case:get_fundef => // ? [->]. Qed.
 
-Local Notation inline_i' := (inline_i inline_var rename_fd).
-Local Notation inline_fd' := (inline_fd inline_var rename_fd).
-Local Notation inline_prog' := (inline_prog inline_var rename_fd).
+Local Notation inline_i' := (inline_i rename_fd).
+Local Notation inline_fd' := (inline_fd rename_fd).
+Local Notation inline_prog' := (inline_prog rename_fd).
 
 Section INCL.
 
@@ -205,7 +204,7 @@ Lemma assgn_tuple_Lvar (p:uprog) (ev:unit) ii (xs:seq var_i) flag tys es vs vs' 
   sem_pexprs (p_globs p) s es = ok vs ->
   mapM2 ErrType truncate_val tys vs = ok vs' ->
   write_lvals (p_globs p) s xs vs' = ok s' ->
-  sem p ev s (assgn_tuple inline_var ii xs flag tys es) s'.
+  sem p ev s (assgn_tuple ii xs flag tys es) s'.
 Proof.
   rewrite /disjoint /assgn_tuple /is_true Sv.is_empty_spec.
   elim: xs es tys vs vs' s s' => [ | x xs Hrec] [ | e es] [ | ty tys] [ | v vs] vs' s s' //=;
@@ -236,7 +235,7 @@ Lemma assgn_tuple_Pvar (p:uprog) ev ii xs flag tys rxs vs vs' s s' :
   mapM (fun x : var_i => get_var (evm s) x) rxs = ok vs ->
   mapM2 ErrType truncate_val tys vs = ok vs' ->
   write_lvals (p_globs p) s xs vs' = ok s' ->
-  sem p ev s (assgn_tuple inline_var ii xs flag tys es) s'.
+  sem p ev s (assgn_tuple ii xs flag tys es) s'.
 Proof.
   rewrite /disjoint /assgn_tuple /is_true Sv.is_empty_spec.
   have : evm s = evm s [\vrvs xs] by done.
@@ -598,7 +597,7 @@ Section PROOF.
 End PROOF.
 
 Lemma inline_call_errP p p' f ev scs mem scs' mem' va va' vr:
-  inline_prog_err inline_var rename_fd p = ok p' ->
+  inline_prog_err rename_fd p = ok p' ->
   List.Forall2 value_uincl va va' ->
   sem_call p ev scs mem f va scs' mem' vr ->
   exists vr',

--- a/proofs/compiler/lowering.v
+++ b/proofs/compiler/lowering.v
@@ -13,7 +13,6 @@ Context
     lowering_options
     -> (instr_info -> warning_msg -> instr_info)
     -> fresh_vars
-    -> (var_i -> bool)
     -> instr
     -> cmd)
   (options : lowering_options)
@@ -21,7 +20,6 @@ Context
   (fv : fresh_vars)
   {eft : eqType}
   {pT : progT eft}
-  (is_var_in_memory : var_i -> bool)
   (all_fresh_vars : seq Ident.ident)
   (fvars : Sv.t).
 
@@ -40,7 +38,7 @@ Definition is_lval_in_memory (x : lval) : bool :=
   end.
 
 Notation lower_i :=
-  (lower_i0 options warning fv is_var_in_memory).
+  (lower_i0 options warning fv).
 
 Definition lower_cmd  (c : cmd) : cmd :=
   conc_map lower_i c.

--- a/proofs/compiler/makeReferenceArguments.v
+++ b/proofs/compiler/makeReferenceArguments.v
@@ -1,7 +1,7 @@
 (* ** Imports and settings *)
 From mathcomp Require Import all_ssreflect.
 From Coq Require Import HexadecimalString ZArith.
-Require Import gen_map expr compiler_util wsize.
+Require Import gen_map expr compiler_util.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -17,9 +17,6 @@ Module Import E.
   Definition make_ref_error := pp_internal_error_s_at pass.
 
 End E.
-
-Definition is_reg_ptr (x: var) : bool :=
-  if Ident.id_kind x.(vname) is Reg (_, Pointer _) then true else false.
 
 Section Section.
 Context `{asmop:asmOp}.

--- a/proofs/compiler/makeReferenceArguments.v
+++ b/proofs/compiler/makeReferenceArguments.v
@@ -1,7 +1,7 @@
 (* ** Imports and settings *)
 From mathcomp Require Import all_ssreflect.
-From Coq Require Import HexadecimalString.
-Require Import gen_map expr compiler_util ZArith.
+From Coq Require Import HexadecimalString ZArith.
+Require Import gen_map expr compiler_util wsize.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -18,10 +18,12 @@ Module Import E.
 
 End E.
 
+Definition is_reg_ptr (x: var) : bool :=
+  if Ident.id_kind x.(vname) is Reg (_, Pointer _) then true else false.
+
 Section Section.
 Context `{asmop:asmOp}.
-Context (is_reg_ptr : var -> bool)
-        (fresh_reg_ptr : instr_info -> Ident.name -> stype -> Ident.ident).
+Context (fresh_reg_ptr : instr_info -> Ident.name -> stype -> Ident.ident).
 Context (p : uprog).
 
 Definition with_id ii sfx vi id ty :=

--- a/proofs/compiler/remove_globals.v
+++ b/proofs/compiler/remove_globals.v
@@ -40,10 +40,12 @@ Module Import E.
 
 End E.
 
+Definition is_glob (x: var) : bool :=
+  if Ident.id_kind x.(vname) is Global then true else false.
+
 Section REMOVE.
 
   Context `{asmop:asmOp}.
-  Context (is_glob : var -> bool).
   Context (fresh_id : glob_decls -> var -> Ident.ident).
 
   Notation venv := (Mvar.t var).

--- a/proofs/compiler/remove_globals.v
+++ b/proofs/compiler/remove_globals.v
@@ -40,9 +40,6 @@ Module Import E.
 
 End E.
 
-Definition is_glob (x: var) : bool :=
-  if Ident.id_kind x.(vname) is Global then true else false.
-
 Section REMOVE.
 
   Context `{asmop:asmOp}.
@@ -81,7 +78,7 @@ Section REMOVE.
       match lv with
       | Lvar xi =>
         let x := xi.(v_var) in
-        if is_glob x then
+        if is_glob_var x then
           match e with
           | Papp1 (Oword_of_int ws) (Pconst z) => add_glob ii x gd (wrepr ws z)
           | _                   => Error (rm_glob_error ii xi)
@@ -111,7 +108,7 @@ Section REMOVE.
       if is_lvar xi then
         let vi := xi.(gv) in 
         let x := vi.(v_var) in
-        if is_glob x then
+        if is_glob_var x then
           match Mvar.get env x with
           | Some g => ok (mk_gvar (VarI g vi.(v_info)))
           | None   => Error (rm_glob_error ii vi)
@@ -139,7 +136,7 @@ Section REMOVE.
 
       | Pload ws xi e =>
         let x := xi.(v_var) in
-        if is_glob x then Error (rm_glob_error ii xi)
+        if is_glob_var x then Error (rm_glob_error ii xi)
         else
           Let e := remove_glob_e ii env e in
           ok (Pload ws xi e)
@@ -165,23 +162,23 @@ Section REMOVE.
       | Lnone _ _ => ok lv
       | Lvar xi =>
         let x := xi.(v_var) in
-        if is_glob x then Error (rm_glob_error ii xi)
+        if is_glob_var x then Error (rm_glob_error ii xi)
         else ok lv
       | Lmem ws xi e =>
         let x := xi.(v_var) in
-        if is_glob x then Error (rm_glob_error ii xi)
+        if is_glob_var x then Error (rm_glob_error ii xi)
         else
           Let e := remove_glob_e ii env e in
           ok (Lmem ws xi e)
       | Laset aa ws xi e =>
         let x := xi.(v_var) in
-        if is_glob x then Error (rm_glob_error ii xi)
+        if is_glob_var x then Error (rm_glob_error ii xi)
         else
           Let e := remove_glob_e ii env e in
           ok (Laset aa ws xi e)
       | Lasub aa ws len xi e =>
         let x := xi.(v_var) in
-        if is_glob x then Error (rm_glob_error ii xi)
+        if is_glob_var x then Error (rm_glob_error ii xi)
         else
           Let e := remove_glob_e ii env e in
           ok (Lasub aa ws len xi e)
@@ -256,7 +253,7 @@ Section REMOVE.
           match lv with
           | Lvar xi =>
             let x := xi.(v_var) in
-            if is_glob x then 
+            if is_glob_var x then
               match e with
               | Papp1 (Oword_of_int ws) (Pconst z) =>
                 if (ty == sword ws) && (vtype x == sword ws) then
@@ -301,7 +298,7 @@ Section REMOVE.
           let: (Loop2_r e c1 c2 env) := lr in
           ok (env, [::MkI ii (Cwhile a c1 e c2)])
         | Cfor xi (d,e1,e2) c =>
-          if is_glob xi.(v_var) then Error (rm_glob_error ii xi)
+          if is_glob_var xi.(v_var) then Error (rm_glob_error ii xi)
           else
             Let e1 := remove_glob_e ii env e1 in
             Let e2 := remove_glob_e ii env e2 in
@@ -321,7 +318,7 @@ Section REMOVE.
     Definition remove_glob_fundef (f:ufundef) :=
       let env := Mvar.empty _ in
       let check_var xi :=
-        if is_glob xi.(v_var) then Error (rm_glob_error dummy_instr_info xi) else ok tt in
+        if is_glob_var xi.(v_var) then Error (rm_glob_error dummy_instr_info xi) else ok tt in
       Let _ := mapM check_var f.(f_params) in
       Let _ := mapM check_var f.(f_res) in
       Let envc := remove_glob remove_glob_i env f.(f_body) in

--- a/proofs/compiler/remove_globals_proof.v
+++ b/proofs/compiler/remove_globals_proof.v
@@ -333,8 +333,8 @@ Module RGP. Section PROOFS.
 
   Definition valid (m:venv) (s1 s2:estate) :=
     [/\ s1.(escs) = s2.(escs), s1.(emem) = s2.(emem),
-        (forall x, ~~is_glob x -> get_var (evm s1) x = get_var (evm s2) x),
-        (forall x g, Mvar.get m x = Some g -> is_glob x) &
+        (forall x, ~~is_glob_var x -> get_var (evm s1) x = get_var (evm s2) x),
+        (forall x g, Mvar.get m x = Some g -> is_glob_var x) &
         (forall x g v,
            Mvar.get m x = Some g ->
            get_var (evm s1) x = ok v ->
@@ -409,7 +409,7 @@ Module RGP. Section PROOFS.
     (@remove_glob_e_esP m ii s1 s2 h).2 es es' vs.
 
   Lemma write_var_remove (x:var_i) m s1 s2 v vm :
-    ~~ is_glob x ->
+    ~~ is_glob_var x ->
     valid m s1 s2 ->
     set_var (evm s1) x v = ok vm ->
     exists s2', valid m (with_vm s1 vm) s2' /\ write_var x v s2 = ok s2'.
@@ -498,7 +498,7 @@ Module RGP. Section PROOFS.
   Let Pi_r s1 i s2 := forall ii, Pi s1 (MkI ii i) s2.
 
   Let Pfor xi vs s1 c s2 :=
-    ~~is_glob xi.(v_var) ->
+    ~~is_glob_var xi.(v_var) ->
     forall m m' c', remove_glob (remove_glob_i gd) m c = ok (m', c') ->
     Mincl m m' ->
     forall s1', valid m s1 s1' ->

--- a/proofs/compiler/remove_globals_proof.v
+++ b/proofs/compiler/remove_globals_proof.v
@@ -210,19 +210,18 @@ Context `{asmop:asmOp}.
 
 Section PROOFS.
 
-  Context (is_glob : var -> bool).
   Context (fresh_id : glob_decls -> var -> Ident.ident).
 
   Let Pi (i:instr) :=
     forall gd1 gd2,
-      extend_glob_i is_glob fresh_id i gd1 = ok gd2 ->
+      extend_glob_i fresh_id i gd1 = ok gd2 ->
       gd_incl gd1 gd2.
 
   Let Pr (i:instr_r) := forall ii, Pi (MkI ii i).
 
   Let Pc (c:cmd) :=
     forall gd1 gd2,
-      foldM (extend_glob_i is_glob fresh_id) gd1 c = ok gd2 ->
+      foldM (extend_glob_i fresh_id) gd1 c = ok gd2 ->
       gd_incl gd1 gd2.
 
   Local Lemma Hmk  : forall i ii, Pr i -> Pi (MkI ii i).
@@ -289,7 +288,7 @@ Section PROOFS.
   Proof. by move=> i xs f es ii gd1 gd2 /= [<-]. Qed.
 
   Local Lemma extend_glob_cP c gd1 gd2 :
-    foldM (extend_glob_i is_glob fresh_id) gd1 c = ok gd2 ->
+    foldM (extend_glob_i fresh_id) gd1 c = ok gd2 ->
     gd_incl gd1 gd2.
   Proof.
     exact: (cmd_rect Hmk Hnil Hcons Hasgn Hopn Hsyscall Hif Hfor Hwhile Hcall).
@@ -297,8 +296,8 @@ Section PROOFS.
 
 End PROOFS.
 
-Lemma extend_glob_progP is_glob fresh_id P gd' :
-  extend_glob_prog is_glob fresh_id P = ok gd' ->
+Lemma extend_glob_progP fresh_id P gd' :
+  extend_glob_prog fresh_id P = ok gd' ->
   gd_incl (p_globs P) gd'.
 Proof.
   rewrite /extend_glob_prog.
@@ -317,7 +316,6 @@ Module RGP. Section PROOFS.
     {ep : EstateParams syscall_state}
     {spp : SemPexprParams}
     {sip : SemInstrParams asm_op syscall_state}
-    (is_glob : var -> bool)
     (fresh_id : glob_decls -> var -> Ident.ident).
 
   Notation venv := (Mvar.t var).
@@ -329,7 +327,7 @@ Module RGP. Section PROOFS.
   Context (fds: ufun_decls).
   Notation gd := (p_globs P).
 
-  Hypothesis fds_ok : map_cfprog (remove_glob_fundef is_glob gd) (p_funcs P) = ok fds.
+  Hypothesis fds_ok : map_cfprog (remove_glob_fundef gd) (p_funcs P) = ok fds.
   Hypothesis uniq_gd : uniq (map fst gd).
   Notation P' := {|p_globs := gd; p_funcs := fds; p_extra := p_extra P |}.
 
@@ -347,13 +345,13 @@ Module RGP. Section PROOFS.
 
     Let Pe e : Prop :=
       ∀ e' v,
-        remove_glob_e is_glob ii m e = ok e' →
+        remove_glob_e ii m e = ok e' →
         sem_pexpr gd s1 e = ok v →
         sem_pexpr gd s2 e' = ok v.
 
     Let Pes es : Prop :=
       ∀ es' vs,
-        mapM (remove_glob_e is_glob ii m) es = ok es' →
+        mapM (remove_glob_e ii m) es = ok es' →
         sem_pexprs gd s1 es = ok vs →
         sem_pexprs gd s2 es' = ok vs.
 
@@ -440,7 +438,7 @@ Module RGP. Section PROOFS.
 
   Lemma remove_glob_lvP m ii s1 s1' s2 lv lv' v :
     valid m s1 s2 ->
-    remove_glob_lv is_glob ii m lv = ok lv' ->
+    remove_glob_lv ii m lv = ok lv' ->
     write_lval gd lv v s1 = ok s1' ->
     exists s2',
       valid m s1' s2' /\ write_lval gd lv' v s2 = ok s2'.
@@ -472,7 +470,7 @@ Module RGP. Section PROOFS.
 
   Lemma remove_glob_lvsP  m ii s1 s1' s2 lv lv' v :
     valid m s1 s2 ->
-    mapM (remove_glob_lv is_glob ii m) lv = ok lv' ->
+    mapM (remove_glob_lv ii m) lv = ok lv' ->
     write_lvals gd s1 lv v = ok s1' ->
     exists s2',
       valid m s1' s2' /\ write_lvals gd s2 lv' v = ok s2'.
@@ -488,12 +486,12 @@ Module RGP. Section PROOFS.
   Qed.
 
   Let Pc s1 c s2 :=
-    forall m m' c', remove_glob (remove_glob_i is_glob gd) m c = ok (m', c') ->
+    forall m m' c', remove_glob (remove_glob_i gd) m c = ok (m', c') ->
     forall s1', valid m s1 s1' ->
     exists s2', valid m' s2 s2' /\ sem P' ev s1' c' s2'.
 
   Let Pi s1 i s2 :=
-    forall m m' c', remove_glob_i is_glob gd m i = ok (m', c') ->
+    forall m m' c', remove_glob_i gd m i = ok (m', c') ->
     forall s1', valid m s1 s1' ->
     exists s2', valid m' s2 s2' /\ sem P' ev s1' c' s2'.
 
@@ -501,7 +499,7 @@ Module RGP. Section PROOFS.
 
   Let Pfor xi vs s1 c s2 :=
     ~~is_glob xi.(v_var) ->
-    forall m m' c', remove_glob (remove_glob_i is_glob gd) m c = ok (m', c') ->
+    forall m m' c', remove_glob (remove_glob_i gd) m c = ok (m', c') ->
     Mincl m m' ->
     forall s1', valid m s1 s1' ->
     exists s2', valid m s2 s2' /\ sem_for P' ev xi vs s1' c' s2'.
@@ -544,7 +542,7 @@ Module RGP. Section PROOFS.
     move=> s1 s2 x tag ty e v v' he hv hw ii m m' c' /= hrm s1' hval.
     move: hrm; t_xrbindP => e' /(remove_glob_eP hval) -/(_ _ he) he'.
     have :
-      (Let lv := remove_globals.remove_glob_lv is_glob ii m x in
+      (Let lv := remove_globals.remove_glob_lv ii m x in
       ok (m, [:: MkI ii (Cassgn lv tag ty e')])) = ok (m', c') ->
       exists s2', valid m' s2 s2' /\ sem P' ev s1' c' s2'.
     + t_xrbindP => x' /(remove_glob_lvP hval) -/(_ _ _ hw) [s2' [hs2' hw' ]] <- <-.
@@ -684,7 +682,7 @@ Module RGP. Section PROOFS.
     have /h1' [s2' [hs2 hc1]]: valid m3 s1 s1' by apply: valid_Mincl hval.
     have he' := remove_glob_eP hs2 he1 he.
     have [s3' [hs3 hc2]]:= h2' _ hs2.
-    have : remove_glob_i is_glob gd m3 (MkI ii (Cwhile a c e c')) =
+    have : remove_glob_i gd m3 (MkI ii (Cwhile a c e c')) =
              ok (m', [::MkI ii (Cwhile a c1' e' c2')]).
     + by rewrite /= Loop.nbP /= h1 /= he1 /= h2 /= hm.
     move=> /hw{hw}hw; have /hw : valid m3 s3 s3' by apply: (valid_Mincl hm).
@@ -764,7 +762,7 @@ Module RGP. Section PROOFS.
     get_fundef (p_funcs P) fn = Some f ->
     exists f',
        get_fundef (p_funcs P') fn = Some f' /\
-       remove_glob_fundef is_glob gd f = ok f'.
+       remove_glob_fundef gd f = ok f'.
   Proof.
     move=> hget.
     have [f' hget' hremove] := get_map_cfprog_gen fds_ok hget.
@@ -812,7 +810,7 @@ Module RGP. Section PROOFS.
   End FDS.
 
   Lemma remove_globP P P' f ev scs mem scs' mem' va vr :
-    remove_glob_prog is_glob fresh_id P = ok P' ->
+    remove_glob_prog fresh_id P = ok P' ->
     sem_call P ev scs mem f va scs' mem' vr ->
     sem_call P' ev scs mem f va scs' mem' vr.
   Proof.

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -192,16 +192,13 @@ Variant lower_cassgn_t : Type :=
   | LowerConcat of pexpr & pexpr
   | LowerAssgn.
 
-Context (is_var_in_memory : var_i → bool).
-Notation is_lval_in_memory := (is_lval_in_memory is_var_in_memory).
-
 (* -------------------------------------------------------------------- *)
 
 Definition is_lea sz x e :=
   if ((U16 ≤ sz)%CMP && (sz ≤ U64)%CMP) && ~~ is_lval_in_memory x then
     match mk_lea sz e with
     | Some (MkLea d b sc o) =>
-      let check o := match o with Some x => ~~(is_var_in_memory x) | None => true end in
+      let check o := match o with Some x => ~~(is_var_in_memory x.(v_var)) | None => true end in
       (* FIXME: check that d is not to big *)
       if check_scale sc && check b && check o then  Some (MkLea d b sc o)
       else None

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -8,9 +8,6 @@ Section Section.
 
 Context {atoI : arch_toIdent}.
 
-Definition is_regx (x: var) : bool :=
-  if Ident.id_kind x.(vname) is wsize.Reg(Extra, _) then true else false.
-
 Definition is_regx_e (e:pexpr) := 
   if e is Pvar x then is_regx x.(gv)
   else false.

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -8,9 +8,8 @@ Section Section.
 
 Context {atoI : arch_toIdent}.
 
-Section IS_REGX.
-
-Context (is_regx : var -> bool).
+Definition is_regx (x: var) : bool :=
+  if Ident.id_kind x.(vname) is wsize.Reg(Extra, _) then true else false.
 
 Definition is_regx_e (e:pexpr) := 
   if e is Pvar x then is_regx x.(gv)
@@ -623,7 +622,5 @@ Fixpoint lower_i (i:instr) : cmd :=
   end.
 
 End LOWERING.
-
-End IS_REGX.
 
 End Section.

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -33,15 +33,15 @@ Section PROOF.
   Variable p : prog.
   Variable ev : extra_val_t.
   Notation gd := (p_globs p).
-  Context (is_regx: var -> bool) (options: lowering_options).
+  Context (options: lowering_options).
   Context (warning: instr_info -> warning_msg -> instr_info).
   Variable fv : fresh_vars.
   Context (is_var_in_memory: var_i → bool).
 
   Notation lower_prog :=
-    (lower_prog (asmop := _asmop) (lower_i is_regx) options warning fv is_var_in_memory).
+    (lower_prog (asmop := _asmop) lower_i options warning fv is_var_in_memory).
   Notation lower_cmd :=
-    (lower_cmd (asmop := _asmop) (lower_i is_regx) options warning fv is_var_in_memory).
+    (lower_cmd (asmop := _asmop) lower_i options warning fv is_var_in_memory).
 
   Hypothesis fvars_correct: fvars_correct fv (p_funcs p).
 
@@ -121,7 +121,7 @@ Section PROOF.
   Let Pi s (i:instr) s' :=
     disj_fvars (vars_I i) ->
     forall s1, eq_exc_fresh s1 s ->
-      exists s1', sem p' ev s1 (lower_i is_regx options warning fv is_var_in_memory i) s1' /\ eq_exc_fresh s1' s'.
+      exists s1', sem p' ev s1 (lower_i options warning fv is_var_in_memory i) s1' /\ eq_exc_fresh s1' s'.
 
   Let Pi_r s (i:instr_r) s' :=
     forall ii, Pi s (MkI ii i) s'.
@@ -1187,7 +1187,7 @@ Section PROOF.
     (ws <= U64)%CMP -> 
     (Let i' := sem_pexpr (p_globs p1) s1 e in to_word ws i') = ok i
     -> write_lval (p_globs p1) x (Vword i) s1 = ok s2
-    -> sem_i p1 w s1 (mov_ws is_regx ws x e tag) s2.
+    -> sem_i p1 w s1 (mov_ws ws x e tag) s2.
   Proof.
     by move=> hws he hx; rewrite /mov_ws; case: ifP => [ /andP [] _ h | _];
      constructor; rewrite /sem_sopn /= /exec_sopn /=;

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -41,10 +41,6 @@ Definition x86_op_align (x : var_i) (ws : wsize) (al : wsize) : fopn_args :=
 Definition lea_ptr x y tag ofs : instr_r :=
   Copn [:: x] tag (Ox86 (LEA Uptr)) [:: add y (cast_const ofs)].
 
-Section IS_REGX.
-
-Context (is_regx : var -> bool).
-
 Definition x86_mov_ofs x tag vpk y ofs :=
   let addr :=
     if mk_mov vpk is MK_LEA
@@ -52,20 +48,18 @@ Definition x86_mov_ofs x tag vpk y ofs :=
       lea_ptr x y tag ofs
     else
       if ofs == 0%Z
-      then mov_ws is_regx Uptr x y tag
+      then mov_ws Uptr x y tag
       else lea_ptr x y tag ofs
   in
   Some addr.
 
 Definition x86_immediate x z :=
-  mov_ws is_regx Uptr (Lvar x) (cast_const z) AT_none.
+  mov_ws Uptr (Lvar x) (cast_const z) AT_none.
 
-End IS_REGX.
-
-Definition x86_saparams is_regx : stack_alloc_params :=
+Definition x86_saparams : stack_alloc_params :=
   {|
-    sap_mov_ofs := x86_mov_ofs is_regx;
-    sap_immediate := x86_immediate is_regx;
+    sap_mov_ofs := x86_mov_ofs;
+    sap_immediate := x86_immediate;
   |}.
 
 (* ------------------------------------------------------------------------ *)

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -80,7 +80,7 @@ Definition x86_hpiparams : h_propagate_inline_params :=
 
 Section STACK_ALLOC.
 
-  Variable (is_regx : var -> bool) (P' : sprog).
+  Variable (P' : sprog).
 
   Lemma lea_ptrP s1 e i x tag ofs w s2 :
     P'.(p_globs) = [::]
@@ -98,7 +98,7 @@ Section STACK_ALLOC.
 Lemma x86_mov_ofsP s1 e i x tag ofs w vpk s2 ins :
   p_globs P' = [::]
   -> (Let i' := sem_pexpr [::] s1 e in to_pointer i') = ok i
-  -> sap_mov_ofs (x86_saparams is_regx) x tag vpk e ofs = Some ins
+  -> sap_mov_ofs x86_saparams x tag vpk e ofs = Some ins
   -> write_lval [::] x (Vword (i + wrepr Uptr ofs)) s1 = ok s2
   -> psem.sem_i (pT := progStack) P' w s1 ins s2.
 Proof.
@@ -113,10 +113,10 @@ Qed.
 
 Lemma x86_immediateP w s (x: var_i) z :
   vtype x = sword Uptr
-  -> psem.sem_i (pT := progStack) P' w s (x86_immediate is_regx x z) (with_vm s (evm s).[x <- pof_val x.(vtype) (Vword (wrepr Uptr z))])%vmap.
+  -> psem.sem_i (pT := progStack) P' w s (x86_immediate x z) (with_vm s (evm s).[x <- pof_val x.(vtype) (Vword (wrepr Uptr z))])%vmap.
 Proof.
   case: x => - [] [] // [] // x xi _ /=.
-  have := mov_wsP (pT := progStack) is_regx AT_none _ (cmp_le_refl _).
+  have := mov_wsP (pT := progStack) AT_none _ (cmp_le_refl _).
   move => /(_ _ _ _ _ _ P').
   apply; last reflexivity.
   by rewrite /= truncate_word_u.
@@ -124,10 +124,10 @@ Qed.
 
 End STACK_ALLOC.
 
-Definition x86_hsaparams is_regx : h_stack_alloc_params (ap_sap x86_params is_regx) :=
+Definition x86_hsaparams : h_stack_alloc_params (ap_sap x86_params) :=
   {|
-    mov_ofsP := x86_mov_ofsP (is_regx := is_regx);
-    sap_immediateP := x86_immediateP is_regx;
+    mov_ofsP := x86_mov_ofsP;
+    sap_immediateP := x86_immediateP;
   |}.
 
 (* ------------------------------------------------------------------------ *)

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -47,6 +47,7 @@ Extract Constant ident.WrapIdent.name => "CoreIdent.Cident.name".
 
 Extract Constant ident.Cident.tag     => "CoreIdent.Cident.tag".
 Extract Constant ident.Cident.id_name => "CoreIdent.Cident.id_name".
+Extract Constant ident.Cident.id_kind => "CoreIdent.Cident.id_kind".
 
 Extract Constant ident.Cident.name_of_string => "CoreIdent.Cident.name_of_string".
 Extract Constant ident.Cident.string_of_name => "CoreIdent.Cident.string_of_name".

--- a/proofs/lang/ident.v
+++ b/proofs/lang/ident.v
@@ -18,6 +18,7 @@ Module Type CORE_IDENT.
   Parameter name : Type.
 
   Parameter id_name : t -> name.
+  Parameter id_kind : t -> wsize.v_kind.
 
   Parameter name_of_string : string → name.
   Parameter string_of_name : name → string.
@@ -37,6 +38,7 @@ Module Cident : CORE_IDENT.
   Definition name : Type := int.
 
   Definition id_name (x : t) : name := x.
+  Definition id_kind of t := wsize.Const.
 
   Definition name_of_string of string := 1%uint63.
   Definition string_of_name of name := ""%string.
@@ -64,6 +66,7 @@ Module Ident <: IDENT.
   Definition ident := WrapIdent.t.
   Definition name  := WrapIdent.name.
   Definition id_name : ident -> name := Cident.id_name.
+  Definition id_kind : ident → wsize.v_kind := Cident.id_kind.
 
   Module Mid := Tident.Mt.
 

--- a/proofs/lang/var.v
+++ b/proofs/lang/var.v
@@ -340,6 +340,24 @@ Proof. by apply: contra => /eqP ->. Qed.
 Lemma vname_diff x x': vname x != vname x' -> x != x'.
 Proof. by apply: contra => /eqP ->. Qed.
 
+(* ------------------------------------------------------------------------- *)
+Definition is_glob_var (x: var) : bool :=
+  if Ident.id_kind x.(vname) is Global then true else false.
+
+Definition is_inline_var (x: var) : bool :=
+  if Ident.id_kind x.(vname) is Inline then true else false.
+
+Definition is_ptr (x: var) : bool :=
+  match Ident.id_kind x.(vname) with
+  | Reg (_, Pointer _) | Stack (Pointer _) => true
+  | _ => false end.
+
+Definition is_reg_ptr (x: var) : bool :=
+  if Ident.id_kind x.(vname) is Reg (_, Pointer _) then true else false.
+
+Definition is_regx (x: var) : bool :=
+  if Ident.id_kind x.(vname) is Reg(Extra, _) then true else false.
+
 (* ** Variables function: to be not used if computation is needed,
  *                       but extentianality is permited
  * -------------------------------------------------------------------- *)

--- a/proofs/lang/var.v
+++ b/proofs/lang/var.v
@@ -347,6 +347,12 @@ Definition is_glob_var (x: var) : bool :=
 Definition is_inline_var (x: var) : bool :=
   if Ident.id_kind x.(vname) is Inline then true else false.
 
+Definition is_var_in_memory (x: var) : bool :=
+  match Ident.id_kind x.(vname) with
+  | Stack _ | Reg (_, Pointer _) | Global => true
+  | Const | Inline | Reg (_, Direct) => false
+  end.
+
 Definition is_ptr (x: var) : bool :=
   match Ident.id_kind x.(vname) with
   | Reg (_, Pointer _) | Stack (Pointer _) => true

--- a/proofs/lang/wsize.v
+++ b/proofs/lang/wsize.v
@@ -186,6 +186,14 @@ Variant writable : Type := Constant | Writable.
 
 Variant reference : Type := Direct | Pointer of writable.
 
+Variant v_kind :=
+| Const            (* global parameter  *)
+| Stack of reference (* stack variable    *)
+| Reg   of reg_kind * reference (* register variable *)
+| Inline           (* inline variable   *)
+| Global           (* global (in memory) constant *)
+.
+
 (* -------------------------------------------------------------------- *)
 Variant safe_cond :=
   | NotZero of wsize & nat  (* the nth argument of size sz is not zero *)


### PR DESCRIPTION
This way, a few classification functions on variables can be directly implemented instead of assumed as external oracles.