### PR TITLE
CI: push eclib to the jasmin-compiler repository

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -268,7 +268,6 @@ push-compiler-code:
     variables:
     - $DEPLOY_KEY
   variables:
-    GIT_STRATEGY: none
     TARBALL: jasmin-compiler-$CI_COMMIT_SHORT_SHA
   needs:
   - tarball
@@ -286,9 +285,10 @@ push-compiler-code:
   - git clone git@gitlab.com:jasmin-lang/jasmin-compiler.git _deploy
   - cd _deploy
   - git checkout $CI_COMMIT_REF_NAME || git checkout --orphan $CI_COMMIT_REF_NAME
-  - rm -rf compiler
+  - rm -rf compiler eclib
   - tar xzvf ../compiler/$TARBALL.tgz
   - mv $TARBALL/ compiler
-  - git add compiler
+  - mv ../eclib .
+  - git add compiler eclib
   - git commit -m "Jasmin compiler on branch “$CI_COMMIT_REF_NAME” at $CI_COMMIT_SHORT_SHA"  || true
   - git push --set-upstream origin $CI_COMMIT_REF_NAME


### PR DESCRIPTION
With this change, the [jasmin-compiler](https://gitlab.com/jasmin-lang/jasmin-compiler/) git repository tracks the OCaml source code as well as the EasyCrypt support library.

Next step would be to include said EasyCrypt library in the release artifacts.