### PR TITLE
Reg. allocation: remove “extra free registers”

### DIFF
--- a/compiler/src/regalloc.mli
+++ b/compiler/src/regalloc.mli
@@ -34,7 +34,6 @@ module type Regalloc = sig
     (Var0.Var.var -> var) -> ((unit, extended_op) func -> 'a -> bool) ->
     ('a * (unit, extended_op) func) list ->
     ('a * reg_oracle_t * (unit, extended_op) func) list
-    * (L.i_loc -> var option)
 end
 
 module Regalloc (Arch : Arch_full.Arch) :

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -197,9 +197,7 @@ let memory_analysis pp_err ~debug up =
   (* register allocation *)
   let translate_var = Conv.var_of_cvar in
   let has_stack f = f.f_cc = Export && (Hf.find sao f.f_name).sao_modify_rsp in
-  let fds, _extra_free_registers =
-    Regalloc.alloc_prog translate_var (fun fd _ -> has_stack fd) fds in
-  
+  let fds = Regalloc.alloc_prog translate_var (fun fd _ -> has_stack fd) fds in
   let fix_csao (_, ro, fd) =
     let fn = fd.f_name in
     let sao = Hf.find sao fn in

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -162,7 +162,6 @@ Record compiler_params
   stackalloc       : _uprog → stack_alloc_oracles;
   removereturn     : _sprog -> (funname -> option (seq bool));
   regalloc         : seq _sfun_decl -> seq _sfun_decl;
-  extra_free_registers : instr_info → option var;
   print_uprog      : compiler_step -> _uprog -> _uprog;
   print_sprog      : compiler_step -> _sprog -> _sprog;
   print_linear     : compiler_step -> lprog -> lprog;
@@ -340,9 +339,8 @@ Definition check_export entries (p: sprog) : cexec unit :=
 Definition compiler_back_end entries (pd: sprog) :=
   Let _ := check_export entries pd in
   (* linearisation                     *)
-  (* FIXME: we can certainly remove cparams.(extra_free_registers) from merge_varmaps *)
-  Let _ := merge_varmaps.check pd cparams.(extra_free_registers) var_tmp in
-  Let pl := linear_prog liparams pd (* cparams.(extra_free_registers) *) in
+  Let _ := merge_varmaps.check pd var_tmp in
+  Let pl := linear_prog liparams pd in
   let pl := cparams.(print_linear) Linearization pl in
   (* tunneling                         *)
   Let pl := tunnel_program pl in

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -494,7 +494,7 @@ Proof.
   have vtmp_not_magic : ~~ Sv.mem vtmp (magic_variables p).
   - apply/Sv_memP; exact: var_tmp_not_magic checked_p.
   have p_call :
-    sem_export_call p (extra_free_registers cparams) vtmp rip scs m fn args scs' m' res.
+    sem_export_call p vtmp rip scs m fn args scs' m' res.
   - apply: (merge_varmaps_export_callP checked_p _ exec_p).
     move/allMP: ok_export => /(_ _ ok_fn).
     rewrite /is_export.

--- a/proofs/compiler/merge_varmaps.v
+++ b/proofs/compiler/merge_varmaps.v
@@ -44,20 +44,13 @@ End E.
 
 Section PROG.
 Context {pd: PointerData} {syscall_state : Type} {asm_op} {asmop : asmOp asm_op} {ovm_i : one_varmap_info}.
-Context (p: sprog) (extra_free_registers: instr_info → option var).
+Context (p: sprog).
 Context (var_tmp : var).
-
-(** Set of variables written by a function (including RA and extra registers),
-      assuming this information is known for the called functions. *)
-
-Definition add_extra_free_registers ii (D:Sv.t) :=
-  if extra_free_registers ii is Some r then Sv.add r D
-  else D.
-
-Local Notation extra_free_registers_at := (extra_free_registers_at extra_free_registers).
 
 Let magic_variables : Sv.t := magic_variables p.
 
+(** Set of variables written by a function (including RA and extra registers),
+      assuming this information is known for the called functions. *)
 Section WRITE1.
 
   Context (writefun: funname → Sv.t).
@@ -82,7 +75,7 @@ Section WRITE1.
     end
   with write_I_rec s i :=
     match i with
-    | MkI ii i => add_extra_free_registers ii (write_i_rec s i)
+    | MkI ii i => write_i_rec s i
     end.
 
   Definition write_I := write_I_rec Sv.empty.
@@ -158,13 +151,7 @@ Section CHECK.
 
   Fixpoint check_i (sz: wsize) (D:Sv.t) (i: instr) : cexec Sv.t :=
     let: MkI ii ir := i in
-    Let _ :=
-      if extra_free_registers ii is Some r
-      then
-        assert (vtype r == sword Uptr) (E.internal_error ii "bad type for extra free register") >>
-        assert (if ir is Cwhile _ _ _ _ then false else true) (E.internal_error ii "loops need no extra register")
-      else ok tt in
-    check_ir sz ii (add_extra_free_registers ii D) ir
+    check_ir sz ii D ir
 
   with check_ir sz ii D ir :=
     match ir with


### PR DESCRIPTION
These registers where use to compute the return address before we used the CALL instruction.