### PR TITLE
ARM/lowering: High-level syntax for 32→64-bit multiplication

### DIFF
--- a/compiler/tests/success/arm-m4/mulu.jazz
+++ b/compiler/tests/success/arm-m4/mulu.jazz
@@ -1,0 +1,7 @@
+export
+fn test(reg u32 x y) -> reg u32 {
+  reg u32 lo hi;
+  hi, lo = x * y;
+  lo ^= hi;
+  return lo;
+}

--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -807,7 +807,7 @@ Definition arm_UMULL_semi (wn wm : ty_r) : exec ty_rr :=
   let res := (zero_extend U64 wn * zero_extend U64 wm)%R in
   let lo := zero_extend U32 res in
   let hi := zero_extend U32 (wshr res 32) in
-  ok (lo, hi).
+  ok (hi, lo).
 
 Definition arm_UMULL_instr : instr_desc_t :=
   let mn := UMULL in
@@ -816,7 +816,7 @@ Definition arm_UMULL_instr : instr_desc_t :=
     id_tin := [:: sreg; sreg ];
     id_in := [:: E 2; E 3 ];
     id_tout := [:: sreg; sreg ];
-    id_out := [:: E 0; E 1 ];
+    id_out := [:: E 1; E 0 ];
     id_semi := arm_UMULL_semi;
     id_nargs := 4;
     id_args_kinds := ak_reg_reg_reg_reg;

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -416,6 +416,9 @@ Definition lower_add_carry
       None
   end.
 
+Definition lower_mulu (lvs : seq lval) (es : seq pexpr) : option copn_args :=
+  Some (lvs, Oasm (BaseOp (None, ARM_op UMULL default_opts)), es).
+
 Definition with_shift opts sh :=
   {| set_flags := set_flags opts; is_conditional := is_conditional opts; has_shift := Some sh |}.
 
@@ -458,6 +461,7 @@ Definition lower_copn
   (lvs : seq lval) (op : sopn) (es : seq pexpr) : option copn_args :=
   match op with
   | Oaddcarry U32 => lower_add_carry lvs es
+  | Omulu U32 => lower_mulu lvs es
   | Oasm (BaseOp (None, aop)) => lower_base_op lvs aop es
   | _ => None
   end.


### PR DESCRIPTION
This is much more complex than expected as the order of the destinations is different for the jasmin operator and the ARM instruction.