### PR TITLE
ARM: add instructions MLA and MLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # [unreleased]
 
+## New features
+
+- More arm instructions are available:
+  `MLA`, `MLS`
+  ([PR #480](https://github.com/jasmin-lang/jasmin/pull/480)).
+
 ## Other changes
 
 - Various improvements related to ARMv7

--- a/compiler/tests/success/arm-m4/multiply-and.jazz
+++ b/compiler/tests/success/arm-m4/multiply-and.jazz
@@ -1,0 +1,21 @@
+export
+fn f(reg u32 a b c) -> reg u32 {
+  reg u32 d;
+  reg bool cond;
+  cond = a == 0;
+
+  // MLA
+  d = a * b + c;
+  d += b * c;
+  a = b * c + d if cond;
+  a += b * c if cond;
+
+  // MLS
+  b = c - d * a;
+  b -= c * d;
+  c = d - a * b if cond;
+  c -= a * b if cond;
+
+  d = c;
+  return d;
+}

--- a/eclib/JModel_m4.ec
+++ b/eclib/JModel_m4.ec
@@ -102,6 +102,14 @@ op MOVT (old: W32.t) (hi: W16.t) : W32.t =
   pack2 [old \bits16 0 ; hi].
 op MOVTcc x y g o = if g then MOVT x y else o.
 
+op MLA (m n a: W32.t) : W32.t =
+  a + m * n.
+op MLAcc m n a g o = if g then MLA m n a else o.
+
+op MLS (m n a: W32.t) : W32.t =
+  a - m * n.
+op MLScc m n a g o = if g then MLS m n a else o.
+
 op MULS (x y: W32.t) : bool * bool * W32.t =
   with_nz (x * y).
 op MUL x y = let (_n, _z, r) = MULS x y in r.


### PR DESCRIPTION
Lowering introduce these instructions when compiling expressions of the form: x ± y * z.