### PR TITLE
Improvements to casted primitive operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
   `UMLAL`, `SMULL`, `SMLAL`, `SMMUL`, `SMMULR`
   ([PR #481](https://github.com/jasmin-lang/jasmin/pull/481)).
 
+## Bug fixes
+
+- Type-checking rejects wrongly casted primitive operators
+  ([PR #489](https://github.com/jasmin-lang/jasmin/pull/488);
+  fixes [#69](https://github.com/jasmin-lang/jasmin/issues/69)).
+
 ## Other changes
 
 - Various improvements related to ARMv7

--- a/compiler/src/compile.mli
+++ b/compiler/src/compile.mli
@@ -14,9 +14,24 @@ val preprocess : wsize -> 'asm asmOp -> (unit, 'asm) pprog -> (unit, 'asm) prog
 
 val parse_file :
   wsize ->
-  'a sopn asmOp ->
+  ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op
+  sopn
+  asmOp ->
   string ->
-  'a Pretyping.Env.env * (unit, 'a) pmod_item list * Syntax.pprogram
+  ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op
+  Pretyping.Env.env
+  * ( unit,
+      ( 'reg,
+        'regx,
+        'xreg,
+        'rflag,
+        'cond,
+        'asm_op,
+        'extra_op )
+      Arch_extra.extended_op )
+    pmod_item
+    list
+  * Syntax.pprogram
 (** Parsing and pre-typing of a complete file.
 
   Raises `Pretyping.TyError` and `Syntax.ParseError`.

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -57,6 +57,8 @@ type tyerror =
   | PackWrongWS of int
   | PackWrongPE of int
   | PackWrongLength of int * int
+  | UnsupportedZeroExtend of (F.formatter -> unit)
+  | InvalidZeroExtend of W.wsize * W.wsize * (F.formatter -> unit)
   | StringError of string
 
 exception TyError of L.t * tyerror
@@ -220,7 +222,13 @@ let pp_tyerror fmt (code : tyerror) =
 
   | PackWrongLength (e, f) ->
     F.fprintf fmt "wrong length of pack; expected: %d; found: %d" e f
-  
+
+  | UnsupportedZeroExtend name ->
+      F.fprintf fmt "primitive operator %t does not support zero-extension" name
+
+  | InvalidZeroExtend (src, dst, name) ->
+      F.fprintf fmt "primitive operator %t returns an output of size %a; it cannot be zero-extended to size %a" name PrintCommon.pp_wsize src PrintCommon.pp_wsize dst
+
   | StringError s ->
     F.fprintf fmt "%s" s
 
@@ -1220,13 +1228,13 @@ let extract_size str : string * S.size_annotation =
     | SA -> str, SA
     | sz -> String.concat "_" (List.rev s), sz
 
-let tt_prim asmOp ws id args =
+let tt_prim asmOp id args =
   let { L.pl_loc = loc ; L.pl_desc = s } = id in
   let name, sz = extract_size s in
   let c =
     match List.assoc name (prim_string asmOp) with
     | PrimP (d, pr) ->
-        pr ws (match sz with
+        pr None (match sz with
           | SAw sz -> sz
           | SA -> d
           | SAv (s, ve, sz) ->
@@ -1235,10 +1243,10 @@ let tt_prim asmOp ws id args =
               sz
           | SAvv _ -> rs_tyerror ~loc (PrimNotVector s)
           | SAx _ -> rs_tyerror ~loc (PrimNotX s))
-    | PrimM pr -> if sz = SA then pr ws else rs_tyerror ~loc (PrimNoSize s)
-    | PrimV pr -> (match sz with SAv (s, ve, sz) -> pr ws s ve sz | _ -> rs_tyerror ~loc (PrimIsVector s))
-    | PrimX pr -> (match sz with SAx(sz1, sz2) -> pr ws sz1 sz2 | _ -> rs_tyerror ~loc (PrimIsX s))
-    | PrimVV pr -> (match sz with SAvv (ve, sz, ve', sz') -> pr ws ve sz ve' sz' | _ -> rs_tyerror ~loc (PrimIsVectorVector s))
+    | PrimM pr -> if sz = SA then pr None else rs_tyerror ~loc (PrimNoSize s)
+    | PrimV pr -> (match sz with SAv (s, ve, sz) -> pr None s ve sz | _ -> rs_tyerror ~loc (PrimIsVector s))
+    | PrimX pr -> (match sz with SAx(sz1, sz2) -> pr None sz1 sz2 | _ -> rs_tyerror ~loc (PrimIsX s))
+    | PrimVV pr -> (match sz with SAvv (ve, sz, ve', sz') -> pr None ve sz ve' sz' | _ -> rs_tyerror ~loc (PrimIsVectorVector s))
     | PrimARM _ | exception Not_found ->
         oget
           ~exn:(tyerror ~loc (UnknownPrim s))
@@ -1324,6 +1332,21 @@ let prim_of_pe pe =
     L.mk_loc (L.loc pe) desc
   | _ -> raise exn
 
+let cast_opn ~loc id ws =
+  let open Sopn in
+  let name fmt = PrintCommon.pp_string0 fmt (id.str ()) in
+  let invalid () = rs_tyerror ~loc (UnsupportedZeroExtend name) in
+  let open Arch_extra in
+  function
+  | Oasm (BaseOp (None, op)) ->
+    begin match List.last id.tout with
+      | Coq_sword from ->
+          if wsize_le ws from then rs_tyerror ~loc(InvalidZeroExtend (from, ws, name))
+          else Oasm (BaseOp (Some ws, op))
+      | _ -> invalid ()
+  end
+  | Oasm (BaseOp (Some _, _)) -> assert false
+  | _ -> invalid ()
 
 (* -------------------------------------------------------------------- *)
 let pexpr_of_plvalue exn l =
@@ -1592,7 +1615,7 @@ let rec tt_instr pd asmOp (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm En
       env, [mk_i (P.Csyscall([x], Syscall_t.RandomBytes (Conv.pos_of_int 1), es))]
 
   | S.PIAssign (ls, `Raw, { pl_desc = PEPrim (f, args) }, None) ->
-      let p, args = tt_prim asmOp None f args in
+      let p, args = tt_prim asmOp f args in
       let tlvs, tes, arguments = prim_sig asmOp p in
       let lvs, einstr = tt_lvalues pd env (L.loc pi) ls (Some arguments) tlvs in
       let es  = tt_exprs_cast pd env (L.loc pi) args tes in
@@ -1603,7 +1626,9 @@ let rec tt_instr pd asmOp (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm En
       let ws, s = ct in
       let ws = tt_ws ws in
       assert (s = `Unsigned); (* FIXME *)
-      let p, args = tt_prim asmOp (Some ws) f args in
+      let p, args = tt_prim asmOp f args in
+      let id = Sopn.asm_op_instr asmOp p in
+      let p = cast_opn ~loc:(L.loc pi) id ws p in
       let tlvs, tes, arguments = prim_sig asmOp p in
       let lvs, einstr = tt_lvalues pd env (L.loc pi) ls (Some arguments) tlvs in
       let es  = tt_exprs_cast pd env (L.loc pi) args tes in

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1234,7 +1234,7 @@ let tt_prim asmOp id args =
   let c =
     match List.assoc name (prim_string asmOp) with
     | PrimP (d, pr) ->
-        pr None (match sz with
+        pr (match sz with
           | SAw sz -> sz
           | SA -> d
           | SAv (s, ve, sz) ->
@@ -1243,10 +1243,11 @@ let tt_prim asmOp id args =
               sz
           | SAvv _ -> rs_tyerror ~loc (PrimNotVector s)
           | SAx _ -> rs_tyerror ~loc (PrimNotX s))
-    | PrimM pr -> if sz = SA then pr None else rs_tyerror ~loc (PrimNoSize s)
-    | PrimV pr -> (match sz with SAv (s, ve, sz) -> pr None s ve sz | _ -> rs_tyerror ~loc (PrimIsVector s))
-    | PrimX pr -> (match sz with SAx(sz1, sz2) -> pr None sz1 sz2 | _ -> rs_tyerror ~loc (PrimIsX s))
-    | PrimVV pr -> (match sz with SAvv (ve, sz, ve', sz') -> pr None ve sz ve' sz' | _ -> rs_tyerror ~loc (PrimIsVectorVector s))
+    | PrimM pr -> if sz = SA then pr else rs_tyerror ~loc (PrimNoSize s)
+    | PrimV pr -> (match sz with SAv (_s, ve, sz) -> pr ve sz | _ -> rs_tyerror ~loc (PrimIsVector s))
+    | PrimSV pr -> (match sz with SAv (s, ve, sz) -> pr s ve sz | _ -> rs_tyerror ~loc (PrimIsVector s))
+    | PrimX pr -> (match sz with SAx(sz1, sz2) -> pr sz1 sz2 | _ -> rs_tyerror ~loc (PrimIsX s))
+    | PrimVV pr -> (match sz with SAvv (ve, sz, ve', sz') -> pr ve sz ve' sz' | _ -> rs_tyerror ~loc (PrimIsVectorVector s))
     | PrimARM _ | exception Not_found ->
         oget
           ~exn:(tyerror ~loc (UnknownPrim s))

--- a/compiler/src/pretyping.mli
+++ b/compiler/src/pretyping.mli
@@ -27,23 +27,26 @@ val tt_ws : Annotations.wsize -> Wsize.wsize
 
 val tt_item :
   Wsize.wsize ->
-  'asm Sopn.sopn Sopn.asmOp ->
-  'asm Env.env ->
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op Sopn.sopn Sopn.asmOp ->
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op Env.env ->
   Syntax.pitem Location.located ->
-  'asm Env.env
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op Env.env
 
 val tt_program :
   Wsize.wsize ->
-  'asm Sopn.sopn Sopn.asmOp ->
-  'asm Env.env ->
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op Sopn.sopn Sopn.asmOp ->
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op Env.env ->
   string ->
-  'asm Env.env * (unit, 'asm) Prog.pmod_item list * Syntax.pprogram
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op Env.env
+  * (unit, ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op) Prog.pmod_item
+    list
+  * Syntax.pprogram
 
 val tt_file :
   Wsize.wsize ->
-  'asm Sopn.sopn Sopn.asmOp ->
-  'asm Env.env ->
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op Sopn.sopn Sopn.asmOp ->
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op Env.env ->
   Annotations.pident option ->
   Location.t option ->
   string ->
-  'asm Env.env * Syntax.pprogram
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g) Arch_extra.extended_op Env.env * Syntax.pprogram

--- a/compiler/tests/fail/typing/x86-64/bug_69.jazz
+++ b/compiler/tests/fail/typing/x86-64/bug_69.jazz
@@ -1,0 +1,7 @@
+export fn f (reg u64 x y) -> reg u64 {
+   reg u64 z;
+   x = x;
+   y = y;
+   ?{}, z = (32u)#AND(x, y);
+   return z;
+}

--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -16,6 +16,7 @@ Require Import
   utils
   word.
 Require Import
+  sopn
   flag_combination
   shift_kind.
 
@@ -409,22 +410,6 @@ Record instr_desc_t := {
   id_safe       : seq safe_cond;
   id_pp_asm     : asm_args -> pp_asm_op;
 }.
-
-
-(* -------------------------------------------------------------------- *)
-
-Variant prim_constructor (asm_op:Type) :=
-  | PrimP of wsize & (wsize -> asm_op)
-  | PrimM of asm_op
-  | PrimV of (velem -> wsize -> asm_op)
-  | PrimSV of (signedness -> velem -> wsize -> asm_op)
-  | PrimX of (wsize -> wsize -> asm_op)
-  | PrimVV of (velem → wsize → velem → wsize → asm_op)
-  | PrimARM of
-    (bool                 (* set_flags *)
-     -> bool              (* is_conditional *)
-     -> option shift_kind (* has_shift *)
-     -> asm_op).
 
 
 (* -------------------------------------------------------------------- *)

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -301,21 +301,9 @@ Definition get_instr_desc (o: extended_op) : instruction_desc :=
  | ExtOp o => asm_op_instr o
  end.
 
-(* FIXME: remove this duplication (cf src/pretyping.ml) -> should be okay now *)
-Definition sopn_prim_constructor (f:option wsize -> asm_op -> extended_op) (p : prim_constructor asm_op) : sopn.prim_constructor extended_op :=
-  match p with
-  | PrimP x1 x2 => sopn.PrimP x1 (fun ws1 ws2 => f ws1 (x2 ws2))
-  | PrimM x => sopn.PrimM (fun ws => f ws x)
-  | PrimV x => sopn.PrimV (fun ws1 _ v ws2 => f ws1 (x v ws2))
-  | PrimSV x => sopn.PrimV (fun ws1 s v ws2 => f ws1 (x s v ws2))
-  | PrimX x => sopn.PrimX (fun ws1 ws2 ws3 => f ws1 (x ws2 ws3))
-  | PrimVV x => sopn.PrimVV (fun ws1 v1 ws2 v2 ws3 => f ws1 (x v1 ws2 v2 ws3))
-  | PrimARM x => sopn.PrimARM (fun sf ic hs => f None (x sf ic hs))
-  end.
-
 Definition sopn_prim_string_base (o : seq (string * prim_constructor asm_op)) :=
-  let to_ex ws o := BaseOp (ws, o) in
-  map (fun '(s, p) => (s, sopn_prim_constructor to_ex p)) o.
+  let to_ex o := BaseOp (None, o) in
+  map (fun '(s, p) => (s, map_prim_constructor to_ex p)) o.
 Definition sopn_prim_string_extra (o : seq (string * sopn.prim_constructor extra_op)) :=
   let to_ex o := ExtOp o in
   map (fun '(s, p) => (s, map_prim_constructor to_ex p)) o.

--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -16,6 +16,7 @@ Require Import
   word.
 Require xseq.
 Require Import
+  sopn
   arch_decl
   arch_utils.
 Require Import arm_decl.

--- a/proofs/compiler/x86_extra.v
+++ b/proofs/compiler/x86_extra.v
@@ -184,8 +184,8 @@ Definition get_instr_desc o :=
 
 Definition prim_string :=
   [::
-    ("set0"%string, PrimP U64 (fun _ sz => Oset0 sz));
-    ("concat_2u128"%string, PrimM (fun _ => Oconcat128))
+    ("set0"%string, PrimP U64 (fun sz => Oset0 sz));
+    ("concat_2u128"%string, PrimM Oconcat128)
     (* Ox86MOVZX32 is ignored on purpose *)
     (* SLH operators are ignored on purpose. *)
   ].

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -1,7 +1,7 @@
 From mathcomp Require Import all_ssreflect all_algebra.
 From mathcomp Require Import word_ssrZ.
-Require Import ZArith utils strings word waes sem_type global oseq.
-Import Utf8 Relation_Operators.
+Require Import utils strings word waes sem_type global oseq sopn.
+Import Utf8 Relation_Operators ZArith.
 
 Set   Implicit Arguments.
 Unset Strict Implicit.


### PR DESCRIPTION
 - Pre-typing now rejects some silly programs (#69)
 - There is now a single type `prim_constructors`