### PR TITLE
Select which dune files are included in the tarball

### DIFF
--- a/compiler/MANIFEST
+++ b/compiler/MANIFEST
@@ -5,9 +5,8 @@ README.md
 default.nix
 Makefile
 dune-project
+dune
 jasmin.opam
-
-find:.:dune
 
 find:entry:*.ml
 find:safetylib:*.ml
@@ -17,6 +16,9 @@ find:src:*.mli
 find:src:*.mll
 find:src:*.mly
 
+safetylib/dune
+
+src/dune
 src/LICENSE.puf
 src/CIL/LICENSE.coq
 src/CIL/LICENSE.coqword


### PR DESCRIPTION
Before this change, the dune files from the tests directories got included in the tarball altough the source and data of the tests are not.