### PR TITLE
Fix wsmul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   `MLA`, `MLS`
   ([PR #480](https://github.com/jasmin-lang/jasmin/pull/480)), 
   `UMLAL`, `SMULL`, `SMLAL`, `SMMUL`, `SMMULR`
-  ([PR #481](https://github.com/jasmin-lang/jasmin/pull/481)).
+  ([PR #481](https://github.com/jasmin-lang/jasmin/pull/481),
+   [PR #514](https://github.com/jasmin-lang/jasmin/pull/514)).
 
 - Register arrays can appear as arguments and return values of local functions;
   the “make-reference-arguments” pass is now run before expansion of register

--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -914,8 +914,7 @@ Definition arm_UMLAL_instr : instr_desc_t :=
   |}.
 
 Definition arm_SMULL_semi (wn wm : ty_r) : exec ty_rr :=
-  let (hi, lo) := wsmul wn wm in
-  ok (lo, hi).
+  ok (wsmul wn wm).
 
 Definition arm_SMULL_instr : instr_desc_t :=
   let mn := SMULL in
@@ -924,7 +923,7 @@ Definition arm_SMULL_instr : instr_desc_t :=
     id_tin := [:: sreg; sreg ];
     id_in := [:: E 2; E 3 ];
     id_tout := [:: sreg; sreg ];
-    id_out := [:: E 0; E 1 ];
+    id_out := [:: E 1; E 0 ];
     id_semi := arm_SMULL_semi;
     id_nargs := 4;
     id_args_kinds := ak_reg_reg_reg_reg;


### PR DESCRIPTION
The behavior was wrong on negative results.

The `wsmulP` lemma is never used, but good to have, I believe.