### PR TITLE
FIX LZCNT semantics to handle the size parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 ## Bug fixes
 
+- Handle the size parameter in LZCNT semantic
+  ([PR #516](https://github.com/jasmin-lang/jasmin/pull/516);
+  fixes [#515](https://github.com/jasmin-lang/jasmin/issues/515)).
+
 - Type-checking rejects wrongly casted primitive operators
   ([PR #489](https://github.com/jasmin-lang/jasmin/pull/488);
   fixes [#69](https://github.com/jasmin-lang/jasmin/issues/69)).

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -500,15 +500,15 @@ Definition x86_DEC sz (w: word sz) : ex_tpl (b4w_ty sz) :=
     (wsigned w - 1)%Z).
 
 
-Fixpoint leading_zero_aux (n: Z) (k : nat) :=
-  if (n <? 2^(64 - k))%Z then k 
+Fixpoint leading_zero_aux (n: Z) (k : nat) (sz : nat) :=
+  if (n <? 2^(sz - k))%Z then k 
   else match k with 
   | 0 => 0
-  | S k' => leading_zero_aux n k'
+  | S k' => leading_zero_aux n k' sz
   end.
       
 Definition leading_zero sz (w: word sz) : word sz := 
-  wrepr sz (leading_zero_aux (wunsigned w) sz).
+  wrepr sz (leading_zero_aux (wunsigned w) sz sz).
 
 Definition x86_LZCNT sz (w: word sz) : ex_tpl (b5w_ty sz) := 
    Let _ := check_size_16_64 sz in


### PR DESCRIPTION
This pull request is to fix #515. The patch has been validated against single-instruction fuzz-test with sizes 16, 32 and 64 variants.

Apologies for the large diff as my editor removes white spaces on save automatically. 
Actual diff is between lines 503 to 512.