### PR TITLE
Enable inspection API in parser

### DIFF
--- a/compiler/src/dune
+++ b/compiler/src/dune
@@ -4,7 +4,7 @@
  (modules lexer))
 
 (menhir
- (flags "--table" "--explain")
+ (flags "--table" "--explain" "--inspection")
  (modules parser))
 
 (library

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -1,13 +1,11 @@
 %{
-  module L = Location
-  module S = Syntax
 
   open Syntax
   open Annotations
 
   let setsign c s = 
     match c with
-    | None -> Some (L.mk_loc (L.loc s) (CSS(None, L.unloc s)))
+    | None -> Some (Location.mk_loc (Location.loc s) (CSS(None, Location.unloc s)))
     | _    -> c
 
 %}
@@ -134,7 +132,7 @@ simple_attribute:
 
 attribute:
   | EQ ap=loc(simple_attribute) { ap }
-  | EQ s=loc(braces(struct_annot)) { L.mk_loc (L.loc s) (Astruct (L.unloc s)) }
+  | EQ s=loc(braces(struct_annot)) { Location.mk_loc (Location.loc s) (Astruct (Location.unloc s)) }
 
 annotation:
   | k=annotationlabel v=attribute? { k, v }
@@ -344,8 +342,8 @@ pinstr_r:
 
 | fc=loc(f=var args=parens_tuple(pexpr) { (f, args) })
     c=prefix(IF, pexpr)? SEMICOLON
-    { let { L.pl_loc = loc; L.pl_desc = (f, args) } = fc in
-      PIAssign ((None, []), `Raw, L.mk_loc loc (PECall (f, args)), c) }
+    { let { Location.pl_loc = loc; Location.pl_desc = (f, args) } = fc in
+      PIAssign ((None, []), `Raw, Location.mk_loc loc (PECall (f, args)), c) }
 
 | s=pif { s }
 
@@ -482,18 +480,18 @@ prequire:
 
 (* -------------------------------------------------------------------- *)
 top:
-| x=pfundef  { S.PFundef x }
-| x=pparam   { S.PParam  x }
-| x=pglobal  { S.PGlobal x }
-| x=pexec    { S.Pexec   x }
-| x=prequire { S.Prequire x}
+| x=pfundef  { Syntax.PFundef x }
+| x=pparam   { Syntax.PParam  x }
+| x=pglobal  { Syntax.PGlobal x }
+| x=pexec    { Syntax.Pexec   x }
+| x=prequire { Syntax.Prequire x}
 (* -------------------------------------------------------------------- *)
 module_:
 | pfs=loc(top)* EOF
     { pfs }
 
 | error
-   { S.parse_error (L.make $startpos $endpos) }
+   { Syntax.parse_error (Location.make $startpos $endpos) }
 
 (* -------------------------------------------------------------------- *)
 %inline empty:
@@ -503,7 +501,7 @@ module_:
 | s=separated_nonempty_list(S, X) { s }
 
 %inline loc(X):
-| x=X { L.mk_loc (L.make $startpos $endpos) x }
+| x=X { Location.mk_loc (Location.make $startpos $endpos) x }
 
 %inline prefix(S, X):
 | S x=X { x }


### PR DESCRIPTION
The inspection API is useful for the language server to be able to derive a concrete syntax tree (for e.g. semantic highlighting, refactorings, etc) as part of the parsing phase.

It will also help generating nicer error messages without manually crafting messages. But that part is waiting on a license clarification on the Menhir side (some relevant code we'd need to reuse is currently GPL 2).

Note: the changes in `parser.mly` are required because Menhir doesn't seem to support module definitions when it generates the `.mli` files for the interpreter API.