### PR TITLE
Add escaping to jasmin strings

### DIFF
--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -191,17 +191,13 @@ and comment lvl = parse
   | [^'\n']          { comment lvl lexbuf }
   | eof              { unterminated_comment (L.of_lexbuf lexbuf) }
 and read_string buf = parse
-  | '"'       { STRING (B.contents buf) }
-  | '\\' '\\' { Buffer.add_char buf '\\'; read_string buf lexbuf }
-  | '\\' '\"' { Buffer.add_char buf '\"'; read_string buf lexbuf }
-  (** | '\\' ['x' 'X']  { read_escaped_character buf lexbuf } *)
+  | '"'       { STRING (Scanf.unescaped (B.contents buf)) }
+  | '\\' '\"' { Buffer.add_string buf "\\\""; read_string buf lexbuf }
+  | '\\' '\\' { Buffer.add_string buf "\\\\"; read_string buf lexbuf }
+  | '\\' 'x'  { Buffer.add_string buf "\\x"; read_string buf lexbuf }
   | [^ '"' '\\']+
     { Buffer.add_string buf (Lexing.lexeme lexbuf);
       read_string buf lexbuf
     }
   | _ as c { invalid_char (L.of_lexbuf lexbuf) c }
   | eof { unterminated_string (L.of_lexbuf lexbuf) }
-(** and read_escaped_character buf = parse
-  | hexdigit as a hexdigit as b { }
-  | _ as c { invalid_char (L.of_lexbuf lexbuf) c }
-  | eof { unterminated_string (L.of_lexbuf lexbuf) } *)

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -128,7 +128,7 @@ rule main = parse
   | "//" [^'\n']* newline { Lexing.new_line lexbuf; main lexbuf }
   | "//" [^'\n']* eof     { main lexbuf }
 
-  | '"' { read_string (B.create 256) lexbuf } (* TODO: escape sequences *)
+  | '"' { read_string (B.create 256) lexbuf }
 
   (* Why this is needed *)
   | ((*'-'?*) digit+) as s   

--- a/compiler/tests/success/arm-m4/test_escaped_strings.jazz
+++ b/compiler/tests/success/arm-m4/test_escaped_strings.jazz
@@ -1,0 +1,12 @@
+u8[3] test = "\x00\\\"";
+
+export fn main() -> reg u32
+{
+    reg u32 res tmp;
+    res = 0x00;
+
+    tmp = (32u)test[0];
+    res = res ^ tmp;
+
+    return res;
+}

--- a/compiler/tests/success/x86-64/test_escaped_strings.jazz
+++ b/compiler/tests/success/x86-64/test_escaped_strings.jazz
@@ -1,0 +1,12 @@
+u8[3] test = "\x00\\\"";
+
+export fn main() -> reg u8
+{
+    reg u8 res tmp;
+    res = 0x00;
+
+    tmp = test[0];
+    res = res ^ tmp;
+
+    return res;
+}


### PR DESCRIPTION
This pull request adds escaping to jasmin strings.

- Quotes are escaped using "\\""
- Backslashes are escaped as "\\\\"
- Non printable chars can be escaped using their hex values, e.g. "\x00"