### PR TITLE
Constant-propagation: propagate global values in “inline” context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 	
 ## Bug fixes
 
+- Constant propagation handles global variables assigned to inline variables
+  ([PR #541](https://github.com/jasmin-lang/jasmin/pull/541);
+  fixes [#540](https://github.com/jasmin-lang/jasmin/issues/540)).
+
 - Fix semantics of the `MULX` instruction
   ([PR #531](https://github.com/jasmin-lang/jasmin/pull/531);
   fixes [#525](https://github.com/jasmin-lang/jasmin/issues/525)).

--- a/compiler/src/sct_checker_forward.ml
+++ b/compiler/src/sct_checker_forward.ml
@@ -649,7 +649,7 @@ let expr_equal a b =
     | X86_64 -> X86_decl.x86_fcp
     | ARM_M4 -> Arm_decl.arm_fcp in
   let normalize e =
-    e |> Conv.cexpr_of_expr |> Constant_prop.(const_prop_e fcp empty_cpm) in
+    e |> Conv.cexpr_of_expr |> Constant_prop.(const_prop_e fcp None empty_cpm) in
   Expr.eq_expr (normalize a) (normalize b)
 
 (* ------------------------------------------------------------- *)

--- a/compiler/tests/success/common/bug_540.jazz
+++ b/compiler/tests/success/common/bug_540.jazz
@@ -1,0 +1,10 @@
+u32 g = 540;
+
+export fn bug_540() -> reg u32 {
+  inline int i;
+  reg u32 r;
+  r = 0;
+  i = g;
+  r += i;
+  return r;
+}

--- a/compiler/tests/success/common/inline-global.jazz
+++ b/compiler/tests/success/common/inline-global.jazz
@@ -1,0 +1,22 @@
+u8[10] rcon = { 1, 2, 4, 8, 16, 32, 64, 128, 27, 54 };
+
+inline
+fn RCON(inline int i) -> inline int {
+  inline int c;
+  c = rcon[i - 1];
+  return c;
+}
+
+export
+fn test(reg u32 x) -> reg u32 {
+  inline int j v;
+  reg u32 r;
+  r = x;
+  for j = 1 to 11 {
+    v = RCON(j);
+    r += v;
+    v = RCON((rcon[j % 10] % 10) + 1);
+    r += v;
+  }
+  return r;
+}

--- a/proofs/compiler/constant_prop.v
+++ b/proofs/compiler/constant_prop.v
@@ -356,6 +356,13 @@ Section GLOBALS.
 
 Context (globs: globals).
 
+Let pget_global aa sz x e : pexpr :=
+  if globs is Some f then if f x.(gv) is Some (Garr len a) then if e is Pconst i then if WArray.get aa sz a i is Ok w then wconst w
+  else Pget aa sz x e
+  else Pget aa sz x e
+  else Pget aa sz x e
+  else Pget aa sz x e.
+
 Fixpoint const_prop_e (m:cpm) e :=
   match e with
   | Pconst _
@@ -367,7 +374,11 @@ Fixpoint const_prop_e (m:cpm) e :=
       | Slocal => if Mvar.get m x is Some n then const n else e
       | Sglob => if globs is Some f then if f x is Some (Gword ws w) then const (Cword w) else e else e
       end
-  | Pget aa sz x e => Pget aa sz x (const_prop_e m e)
+  | Pget aa sz x e =>
+      let e := const_prop_e m e in
+      if is_glob x
+      then pget_global aa sz x e
+      else Pget aa sz x e
   | Psub aa sz len x e => Psub aa sz len x (const_prop_e m e)
   | Pload sz x e  => Pload sz x (const_prop_e m e)
   | Papp1 o e     => s_op1 o (const_prop_e m e)

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -555,10 +555,22 @@ Section CONST_PROP_EP.
       by case: n => [ b | n | sz w ]; rewrite /sem_sop1 /= ?wrepr_unsigned;
            eexists;(split;first reflexivity) => //=; rewrite wrepr_unsigned.
     - move => aa sz x e He v.
-      apply:on_arr_gvarP; rewrite /on_arr_var => n t ? -> /=.
-      t_xrbindP => z w /(He _) [v'] [->] /[swap] /to_intI -> /value_uinclE ->.
-      move => a ha ?; subst; rewrite /= ha.
-      by eexists; (split; first reflexivity) => /=.
+      apply: on_arr_gvarP => n t wt ok_x.
+      t_xrbindP => z w /(He _) {He} [v'] [] ok_v' /[swap] /to_intI ? /value_uinclE; subst => ?; subst.
+      move => a ha ?; subst.
+      have default : ∃ v' : value, sem_pexpr wdb gd s (Pget aa sz x (const_prop_e globs m e)) = ok v' ∧ value_uincl (Vword a) v'.
+      + by rewrite /= /on_arr_var ok_x /= ok_v' /= ha /=; eexists; split; [ reflexivity | simpl ].
+      case x_glob: is_glob; last exact: default.
+      case: globs default Gvalid ok_v'; last by [].
+      move => f + /(_ x.(gv)).
+      case: (f _); last by [].
+      case; first by [].
+      move => len arr.
+      rewrite (get_gvar_glob _ _ _ x_glob) in ok_x.
+      case: (const_prop_e _) => // i _ /(_ _ _ erefl ok_x) /= /Varr_inj[] ??; subst => /= /ok_inj[] ?; subst.
+      rewrite ha /=.
+      eexists; split; first reflexivity.
+      by rewrite /= wrepr_unsigned.
     - move => aa sz len x e He v.
       apply:on_arr_gvarP; rewrite /on_arr_var => n t ? -> /=.
       t_xrbindP => z w /(He _) [v'] [->] /[swap] /to_intI -> /value_uinclE ->.

--- a/proofs/compiler/slh_lowering.v
+++ b/proofs/compiler/slh_lowering.v
@@ -383,7 +383,7 @@ Section CHECK_WHILE.
     (check_c0 check_c1 : Env.t -> cexec Env.t).
 
   Definition neg_const_prop (e : pexpr) : pexpr :=
-    constant_prop.const_prop_e constant_prop.empty_cpm (enot e).
+    constant_prop.const_prop_e None constant_prop.empty_cpm (enot e).
 
   (* Similarly to the for loop case, we use the argument [env] as an initial
      guess for [env*], and if it is not a fixed point we guess the intersection

--- a/proofs/compiler/slh_lowering_proof.v
+++ b/proofs/compiler/slh_lowering_proof.v
@@ -141,6 +141,8 @@ Section CONST_PROP.
 
     - by case: x => x [] //; case: Mvar.get => // - [].
 
+    - by move => sz [] x [].
+
     - rewrite use_mem_s_op1. exact: (hinde h).
 
     - move: h => /norP [] /hinde0 h0 /hinde1 h1.

--- a/proofs/compiler/slh_lowering_proof.v
+++ b/proofs/compiler/slh_lowering_proof.v
@@ -129,7 +129,7 @@ Section CONST_PROP.
   #[local]
   Lemma use_mem_const_prop_e {_ : FlagCombinationParams} cpm e :
     ~~ use_mem e ->
-    ~~ use_mem (const_prop_e cpm e).
+    ~~ use_mem (const_prop_e None cpm e).
   Proof.
     elim: e =>
       [||| x
@@ -139,7 +139,7 @@ Section CONST_PROP.
       | ty e hinde e0 hinde0 e1 hinde1
       ] //= h.
 
-    - case: is_lvar; last done. by case: Mvar.get => [[]|].
+    - by case: x => x [] //; case: Mvar.get => // - [].
 
     - rewrite use_mem_s_op1. exact: (hinde h).
 
@@ -182,7 +182,7 @@ Section CONST_PROP.
       sem_pexpr true gd s (enot e) = ok (Vbool (~~ b)).
     - by rewrite /= h.
 
-    move=> /(const_prop_eP (valid_cpm_empty _)) [v' [? /value_uinclE ?]].
+    move=> /(const_prop_eP (valid_cpm_empty _) (I: valid_globs _ None)) [v' [? /value_uinclE ?]].
     by subst v'.
   Qed.
 


### PR DESCRIPTION
This makes constant-propagation stronger: when global data (word or array) is accessed in an inline computation (assignment to inline variables, including inline arguments to (inline) functions), its value is computed at compile-time.

Caveat: global variables that are never accessed excepted in such “inline” situations are still present in the assembly code.

Fixes #540.