### PR TITLE
x86-linearization: do not allocate empty stack frame

### DIFF
--- a/compiler/tests/success/subroutines/x86-64/nolea.jazz
+++ b/compiler/tests/success/subroutines/x86-64/nolea.jazz
@@ -1,0 +1,13 @@
+/* This example saves a return address on the stack, therefore it needs to save
+and align the original stack pointer. However, as it does not use the stack
+otherwise, there is no need for an instruction to allocate a stack frame. */
+
+#[returnaddress=stack]
+fn id(reg u32 x) -> reg u32 { return x; }
+
+export fn main(reg u32 a) -> reg u32 {
+  reg u32 r;
+  r = a;
+  r = id(r);
+  return r;
+}

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -88,9 +88,8 @@ Definition x86_lassign (x: lexpr) (ws: wsize) (e: rexpr) :=
 Definition x86_set_up_sp_register
   (rspi : var_i) (sf_sz : Z) (al : wsize) (r : var_i) : seq fopn_args :=
   let i0 := x86_lassign (LLvar r) Uptr (Rexpr (Fvar rspi)) in
-  let i1 := x86_allocate_stack_frame rspi sf_sz in
   let i2 := x86_op_align rspi Uptr al in
-  [:: i0; i1; i2 ].
+  i0 :: rcons (if sf_sz != 0 then [:: x86_allocate_stack_frame rspi sf_sz ] else [::]) i2.
 
 Definition x86_set_up_sp_stack
   (rspi : var_i) (sf_sz : Z) (al : wsize) (off : Z) : seq fopn_args :=


### PR DESCRIPTION
Before:

~~~
        movq    %rsp, %rsi
        leaq    (%rsp), %rsp
        andq    $-8, %rsp
~~~

After:

~~~
        movq    %rsp, %rsi
        andq    $-8, %rsp
~~~