### PR TITLE
Gimli: proofs for the AVX implementation

### DIFF
--- a/compiler/examples/gimli/proofs/.gitignore
+++ b/compiler/examples/gimli/proofs/.gitignore
@@ -1,6 +1,8 @@
 Array12.ec
 WArray48.ec
 gimli_arm.ec
+gimli_avx.ec
 gimli_x86.ec
 gimli_arm_ct.ec
+gimli_avx_ct.ec
 gimli_x86_ct.ec

--- a/compiler/examples/gimli/proofs/Makefile
+++ b/compiler/examples/gimli/proofs/Makefile
@@ -4,7 +4,7 @@ JASMINC := ../../../jasminc
 
 .SUFFIXES: .jazz .ec
 
-all: gimli_arm.ec gimli_x86.ec gimli_x86_ct.ec gimli_arm_ct.ec
+all: gimli_arm.ec gimli_x86.ec gimli_x86_ct.ec gimli_arm_ct.ec gimli_avx.ec gimli_avx_ct.ec
 	ec-runtest --bin-args="$(ECARGS)" ec.config $@
 
 gimli_arm.ec: ../arm-m4/gimli.jazz
@@ -18,3 +18,9 @@ gimli_x86.ec: ../x86-64/gimli.jazz
 
 gimli_x86_ct.ec: ../x86-64/gimli.jazz
 	$(JASMINC) -arch x86-64 -CT -oec $@ $^
+
+gimli_avx.ec: ../x86-64/gimliv.jazz ../x86-64/gimliv.jinc
+	$(JASMINC) -arch x86-64 -oec $@ $<
+
+gimli_avx_ct.ec: ../x86-64/gimliv.jazz ../x86-64/gimliv.jinc
+	$(JASMINC) -arch x86-64 -CT -oec $@ $<

--- a/compiler/examples/gimli/proofs/gimli_ct.ec
+++ b/compiler/examples/gimli/proofs/gimli_ct.ec
@@ -1,5 +1,5 @@
-require Gimli_x86_ct Gimli_arm_ct.
-from Jasmin require import JModel.
+require Gimli_x86_ct Gimli_arm_ct Gimli_avx_ct.
+from Jasmin require import JLeakage.
 
 (** The [io] argument holds a pointer to the data that undergoes the permutation.
   * Since it is an address, its value is leaked, and should be public. *)
@@ -10,4 +10,8 @@ proof. proc; inline *; sim. qed.
 
 equiv gimli_arm_ref_ct :
   Gimli_arm_ct.M.gimli ~ Gimli_arm_ct.M.gimli : ={ io, Gimli_arm_ct.M.leakages } ==> ={ Gimli_arm_ct.M.leakages }.
+proof. proc; inline *; sim. qed.
+
+equiv gimli_avx_ct :
+  Gimli_avx_ct.M.gimli ~ Gimli_avx_ct.M.gimli : ={ io, Gimli_avx_ct.M.leakages } ==> ={ Gimli_avx_ct.M.leakages }.
 proof. proc; inline *; sim. qed.

--- a/compiler/examples/gimli/proofs/gimliv.ec
+++ b/compiler/examples/gimli/proofs/gimliv.ec
@@ -1,0 +1,23 @@
+require Gimli_avx Gimli_x86.
+import List Int JWord JModel_x86.
+
+import Array12.
+
+lemma zeroextu128E (x: W32.t) :
+  zeroextu128 x = pack4[ x; W32.zero; W32.zero; W32.zero ].
+proof. by rewrite W4u32.zeroextu128E of_listE. qed.
+
+op eqstate (v: W128.t * W128.t * W128.t) (s: W32.t Array12.t) =
+  v.`1 = pack4 [ s.[0]; s.[1]; s.[2]; s.[3] ] /\
+  v.`2 = pack4 [ s.[4]; s.[5]; s.[6]; s.[7] ] /\
+  v.`3 = pack4 [ s.[8]; s.[9]; s.[10]; s.[11] ].
+
+ equiv gimli_ref_equiv :
+    Gimli_avx.M.gimli_body ~ Gimli_x86.M.gimli_ref :
+    eqstate arg{1} arg{2} ==> eqstate res{1} res{2}.
+proof.
+  proc; inline *; wp.
+  while (={round} /\ eqstate (x{1}, y{1}, z{1}) state{2}); auto.
+  unroll for{2} ^while; wp; skip => />.
+  by rewrite !/VPSHUFD_128 !/VPSHUFD_128_B /= zeroextu128E.
+qed.

--- a/compiler/examples/gimli/x86-64/gimliv.jinc
+++ b/compiler/examples/gimli/x86-64/gimliv.jinc
@@ -64,7 +64,7 @@ fn gimli_body (reg u128 x, reg u128 y, reg u128 z) -> reg u128, reg u128, reg u1
 
     if (round % 4) == 0 { // add constant: pattern c...c...c... etc.
       reg u32 m;
-      m = 0x9e377900 ^32u round;
+      m = 0x9e377900 +32u round;
       a = (128u)m;
       x ^= a;
     }
@@ -74,16 +74,16 @@ fn gimli_body (reg u128 x, reg u128 y, reg u128 z) -> reg u128, reg u128, reg u1
 }
 
 export
-fn gimli(reg u64 state) {
+fn gimli(reg u64 io) {
   reg u128 x, y, z;
 
-  x = (u128)[state + 16 * 0];
-  y = (u128)[state + 16 * 1];
-  z = (u128)[state + 16 * 2];
+  x = (u128)[io + 16 * 0];
+  y = (u128)[io + 16 * 1];
+  z = (u128)[io + 16 * 2];
 
   (x,y,z) = gimli_body(x,y,z); 
 
-  (u128)[state + 16 * 0] = x;
-  (u128)[state + 16 * 1] = y;
-  (u128)[state + 16 * 2] = z;
+  (u128)[io + 16 * 0] = x;
+  (u128)[io + 16 * 1] = y;
+  (u128)[io + 16 * 2] = z;
 }

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -2197,6 +2197,25 @@ abstract theory W_WS.
      smt (ler_weexpn2l le_size WS.gt0_size).
    qed.
 
+  lemma nosmt zeroextu'BE (x: WS.t) :
+     zeroextu'B x = pack'R_t (Pack.init (fun i => if i = 0 then x else WS.of_int 0)).
+  proof.
+     apply/wordP => i h.
+     rewrite pack'RbE // of_int_bits'S_div // initE h /=.
+     move/mem_range: h.
+     rewrite range_ltn; first exact: gt0_r.
+     case.
+     + by move => ->; rewrite /= to_uintK.
+     rewrite /= => /mem_range h.
+     have -> /= : (i = 0) = false; first smt().
+     rewrite divz_small; last by [].
+     have [-> /= /ltr_le_trans ] := WS.to_uint_cmp x.
+     apply.
+     apply: (ler_trans (2 ^ (sizeS * i))); last exact: ler_norm.
+     apply: ler_weexpn2l; first by [].
+     smt(WS.gt0_size).
+ qed.
+
    lemma zeroextu'B_bit (w:WS.t) i: (zeroextu'B w).[i] = ((0 <= i < sizeS) /\ w.[i]).
    proof.
      rewrite /zeroextu'B WB.of_intwE /WB.int_bit (modz_small (to_uint w)).

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -2207,7 +2207,7 @@ abstract theory W_WS.
      case.
      + by move => ->; rewrite /= to_uintK.
      rewrite /= => /mem_range h.
-     have -> /= : (i = 0) = false; first smt().
+     have -> /= : i <> 0; first smt().
      rewrite divz_small; last by [].
      have [-> /= /ltr_le_trans ] := WS.to_uint_cmp x.
      apply.


### PR DESCRIPTION
I thought that the lemma about `zeroextu128` could be useful in other contexts, so I put it in the `JWord` library.