### PR TITLE
Use high_bits instead of wrepr and Z.shiftr or Z.quot

### DIFF
--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -893,7 +893,7 @@ Definition arm_UMULL_instr : instr_desc_t :=
 
 Definition arm_UMAAL_semi (wa wb wn wm : ty_r) : exec ty_rr :=
   let r := (wunsigned wa + wunsigned wb + wunsigned wn * wunsigned wm)%Z in
-  ok (wrepr reg_size r, wrepr reg_size (Z.shiftr r (wsize_bits reg_size))).
+  ok (wrepr reg_size r, high_bits reg_size r).
 
 Definition arm_UMAAL_instr : instr_desc_t :=
   let mn := UMAAL in
@@ -1012,7 +1012,7 @@ Definition arm_SMMUL_instr : instr_desc_t :=
 
 
 Definition arm_SMMULR_semi (wn wm : ty_r) : exec ty_r :=
-  ok (wrepr U32 (Z.shiftr (wsigned wn * wsigned wm + 0x80000000) 32)).
+  ok (high_bits reg_size (wsigned wn * wsigned wm + 0x80000000)).
 
 Definition arm_SMMULR_instr : instr_desc_t :=
   let mn := SMMULR in

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -1678,7 +1678,7 @@ Section PROOF.
             rewrite /= /read_es /= in Hdisje.
             rewrite /sem_sopn /sem_pexprs /= He2' /=.
             rewrite /get_gvar get_var_eq /= cmp_le_refl orbT //=.
-            rewrite /exec_sopn /sopn_sem /= !truncate_word_le // {hsz2} /x86_MUL hsz /= zero_extend_u wmulhuE Z.mul_comm GRing.mulrC wmulE.
+            rewrite /exec_sopn /sopn_sem /= !truncate_word_le // {hsz2} /x86_MUL hsz /= zero_extend_u /wmulhu Z.mul_comm GRing.mulrC wmulE.
             exact Hw''.
         + exact: (eeq_excT Hs3'' Hs2').
       have! := (is_wconstP true gd s1' (sz := sz) (e := e2)).
@@ -1704,12 +1704,12 @@ Section PROOF.
             rewrite /= /read_es /= in Hdisje.
             rewrite /sem_sopn /sem_pexprs /= He1' /=.
             rewrite /get_gvar get_var_eq /= cmp_le_refl orbT //.
-            rewrite /exec_sopn /sopn_sem /= !truncate_word_le // /x86_MUL hsz /= zero_extend_u wmulhuE wmulE.
+            rewrite /exec_sopn /sopn_sem /= !truncate_word_le // /x86_MUL hsz /= zero_extend_u /wmulhu wmulE.
             exact: Hw''.
         + exact: (eeq_excT Hs3'' Hs2').
       exists s2'; split=> //; apply: sem_seq1; apply: EmkI; apply: Eopn.
       rewrite /sem_sopn Hx' /= /exec_sopn /sopn_sem /= !truncate_word_le // {hsz1 hsz2} /x86_MUL hsz /=.
-      by rewrite /wumul -wmulhuE in Hw'.
+      by rewrite /wumul -/wmulhu in Hw'.
     (* Oaddcarry *)
     + case: (lower_addcarry_correct ii t (sub:= false) Hs1' Hdisjl Hdisje Hx' Hv Hw').
       exact: (aux_eq_exc_trans Hs2').

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -820,7 +820,7 @@ Proof.
     case: xs hargs hwhi => // v1; t_xrbindP => -[] // v2; t_xrbindP => -[] // hargs w1 hv1 w2 hv2.
     rewrite /x86_MULX_hi; t_xrbindP => hsz hwhi; pose wlo := (wumul w1 w2).2.
     have hex: exec_sopn (Oasm (BaseOp (None, MULX_lo_hi sz))) [:: v1; v2] = ok [:: Vword wlo; Vword whi].
-    + by rewrite /exec_sopn /sopn_sem /= hv1 hv2 /= /x86_MULX_lo_hi hsz /= -hwhi /wlo wmulhuE /wumul /=.
+    + by rewrite /exec_sopn /sopn_sem /= hv1 hv2 /= /x86_MULX_lo_hi hsz /= -hwhi /wlo /wmulhu /wumul /=.
     have hw' :
        write_lexprs [:: LLvar hi; LLvar hi] [:: Vword wlo; Vword whi] m =
        ok (with_vm m ((evm m).[hi <- Vword wlo]).[hi <- Vword whi]).


### PR DESCRIPTION
This changes the specification for two word operations: `wdaddu` and `wumul`. Now we use `Z.shiftr` instead of `Z.quot`. I feel that the former is a more natural way of modelling these operations. I can roll back the changes for these two if not.
This removes the need for `wmulhuE`.