### PR TITLE
Array-copy: no ArrayInit when LHS is a ptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 - Fix printing to EasyCrypt of ARMv7 instruction `bic`
   ([PR #554](https://github.com/jasmin-lang/jasmin/pull/554)).
 
+- Fix expansion of `#copy` operators when target is marked as `ptr`
+  ([PR #550](https://github.com/jasmin-lang/jasmin/pull/550);
+  fixes [#499](https://github.com/jasmin-lang/jasmin/pull/499)).
+
 ## Other changes
 
 - Pretty-printing of Jasmin programs is more precise

--- a/compiler/tests/success/common/bug_499.jazz
+++ b/compiler/tests/success/common/bug_499.jazz
@@ -1,0 +1,18 @@
+fn aux(reg ptr u32[2] out in) -> reg ptr u32[2] {
+  reg u32[2] x y;
+  x = #copy_32(in);
+  y[0], y[1] = x[0] * 32u x[1];
+  out = #copy_32(y);
+  return out;
+}
+
+export fn test(reg u32 t) -> reg u32 {
+  stack u32[2] a b;
+  inline int i;
+  for i = 0 to 2 { a[i] = t; }
+  b = aux(b, a);
+  reg u32 res;
+  res = 0;
+  for i = 0 to 2 { t = b[i]; res |= t; }
+  return res;
+}

--- a/proofs/compiler/array_copy.v
+++ b/proofs/compiler/array_copy.v
@@ -42,7 +42,9 @@ Definition array_copy ii (x: var_i) (ws: wsize) (n: positive) (y: gvar) :=
   let ei := Pvar (mk_lvar i) in
   let sz := Z.to_pos (wsize_size ws * n) in
   let pre := 
-    if eq_gvar (mk_lvar x) y then Copn [::] AT_none sopn_nop [::]
+    if eq_gvar (mk_lvar x) y
+    || is_ptr x
+    then Copn [::] AT_none sopn_nop [::]
     else Cassgn (Lvar x) AT_none (sarr sz) (Parr_init sz) in
   [:: MkI ii pre;
       MkI ii 

--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -153,6 +153,8 @@ Proof.
   + rewrite /ipre; case: ifPn => hxy.
     + exists vm1; last by constructor; econstructor.
       split => //.
+      case/orP: hxy => hxy; last first.
+      * by have /compat_valEl := Vm.getP vm1 x.
       case/andP: hxy => /= /eqP hl /eqP /= heq; subst vx.
       move: hv1; rewrite /= /get_gvar /is_lvar hl eqxx /get_var; t_xrbindP => _.
       rewrite -heq; eauto.
@@ -160,7 +162,7 @@ Proof.
     + split; last by rewrite Vm.setP_eq /= eqxx; eauto.
       move=> z hz; rewrite Vm.setP_neq //; apply /eqP => heq; subst z.
       have : Sv.In x (read_e y) by SvD.fsetdec.
-      by move: hxy; rewrite read_e_var /eq_gvar /= /read_gvar; case: (y) => /= vy [/= /eqP | /=]; SvD.fsetdec.
+      by case/norP: hxy; rewrite read_e_var /eq_gvar /= /read_gvar; case: (y) => /= vy [/= /eqP | /=]; SvD.fsetdec.
     constructor; apply: Eassgn => //=; first by rewrite /truncate_val /= WArray.castK.
     by rewrite write_var_eq_type.
   move: hcopy; rewrite /WArray.copy -/len => /(WArray.fcopy_uincl (WArray.uincl_empty tx0 erefl)) 


### PR DESCRIPTION
Fixes #499.

~Currently a draft as it depends of #549 to avoid conflicts. (This did not work as expected…)~