### PR TITLE
Add option to inline functions that are called only once

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -5,7 +5,17 @@ JSJOBS    ?= 2
 CHECKPY   ?=
 CHECK     := $(CHECKPY) scripts/runtest --jobs="$(JSJOBS)"
 CHECK     += config/tests.config
-CHECKCATS ?= safety CCT x86-64-ATT x86-64-Intel x86-64-print x86-64-nolea arm-m4 arm-m4-print
+CHECKCATS ?= \
+	safety \
+	CCT \
+	x86-64-ATT \
+	x86-64-Intel \
+	x86-64-print \
+	x86-64-nolea \
+	arm-m4 \
+	arm-m4-print \
+	x86-64-inline-single-calls \
+	arm-m4-inline-single-calls
 
 # --------------------------------------------------------------------
 DESTDIR  ?=

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -53,3 +53,13 @@ bin = ./scripts/extract-and-check
 args = arm
 okdirs = examples/**/arm-m4 tests/success/**/arm-m4 tests/success/**/common
 exclude = !tests/success/noextract
+
+[test-x86-64-inline-single-calls]
+bin = ./scripts/check-x86-64
+args = -inline-single-calls
+okdirs = tests/success/inline_single_calls/**/common
+
+[test-arm-m4-inline-single-calls]
+bin = ./scripts/check-arm-m4
+args = -inline-single-calls
+okdirs = tests/success/inline_single_calls/**/common

--- a/compiler/safetylib/safetyInterpreter.ml
+++ b/compiler/safetylib/safetyInterpreter.ml
@@ -355,7 +355,7 @@ let safe_instr ginstr = match ginstr.i_desc with
   | Copn (lvs,_,opn,es) -> safe_opn (safe_lvals lvs @ safe_es es) opn es
   | Cif(e, _, _) -> safe_e e
   | Cwhile(_,_, _, _) -> []       (* We check the while condition later. *)
-  | Ccall(_, lvs, _, es) | Csyscall(lvs, _, es) -> safe_lvals lvs @ safe_es es
+  | Ccall(lvs, _, es) | Csyscall(lvs, _, es) -> safe_lvals lvs @ safe_es es
   | Cfor (_, (_, e1, e2), _) -> safe_es [e1;e2]
 
 let safe_return main_decl =
@@ -1446,7 +1446,7 @@ end = struct
       | Cfor (i, _, st)         -> nm_stmt (i :: vs_for) st
       | Cwhile (_, st1, e, st2) -> 
         nm_e vs_for e && nm_stmt vs_for st1 && nm_stmt vs_for st2
-      | Ccall (_, lvs, fn, es)  -> 
+      | Ccall (lvs, fn, es)  -> 
         let f' = get_fun_def prog fn |> oget in
         nm_lvs vs_for lvs && nm_es vs_for es && nm_fdecl f'
 
@@ -1876,7 +1876,7 @@ end = struct
         { state with abs = abs; } 
 
 
-      | Ccall(_, lvs, f, es) ->
+      | Ccall(lvs, f, es) ->
         let f_decl = get_fun_def state.prog f |> oget in
         let fn = f_decl.f_name in
 

--- a/compiler/safetylib/safetyPreanalysis.ml
+++ b/compiler/safetylib/safetyPreanalysis.ml
@@ -89,8 +89,8 @@ end = struct
       Cif (mk_expr fn e, mk_stmt fn st, mk_stmt fn st')
     | Cfor (v, r, st) ->
       Cfor (mk_v_loc fn v, mk_range fn r, mk_stmt fn st)
-    | Ccall (inlinf, lvs, c_fn, es) ->
-      Ccall (inlinf, mk_lvals fn lvs, c_fn, mk_exprs fn es)
+    | Ccall (lvs, c_fn, es) ->
+      Ccall (mk_lvals fn lvs, c_fn, mk_exprs fn es)
     | Cwhile (a, st1, e, st2) ->
       Cwhile (a, mk_stmt fn st1, mk_expr fn e, mk_stmt fn st2)
 
@@ -341,7 +341,7 @@ end = struct
     | Cwhile (_, c1, _, c2) ->
       pa_flag_setfrom v ((List.rev c1) @ (List.rev c2))
         
-    | Ccall (_, lvs, _, _) | Csyscall(lvs, _, _) ->
+    | Ccall (lvs, _, _) | Csyscall(lvs, _, _) ->
       if flag_mem_lvs v lvs then raise Flag_set_from_failure else None
       
   let rec pa_instr fn (prog : ('info, 'asm) prog option) st instr =
@@ -404,7 +404,7 @@ end = struct
       pa_stmt fn prog st' (c1 @ c2)
       |> set_ct st.ct
 
-    | Ccall (_, lvs, fn', es) ->   
+    | Ccall (lvs, fn', es) ->   
       let st = { st with cfg = add_call st.cfg fn fn' } in
       let f_decl = get_fun_def (oget prog) fn' |> oget in
 

--- a/compiler/src/alias.ml
+++ b/compiler/src/alias.ml
@@ -195,7 +195,7 @@ let opn_cc o =
 let rec analyze_instr_r params cc a =
   function
   | Cfor _ -> assert false
-  | Ccall (_, xs, fn, es) -> link_array_return params a xs es (cc fn)
+  | Ccall (xs, fn, es) -> link_array_return params a xs es (cc fn)
   | Csyscall (xs, o, es) -> link_array_return params a xs es (syscall_cc o)
   | Cassgn (x, _, ty, e) -> if is_ty_arr ty then assign_arr params a x e else a
   (* A special case for protect_ptr which is a kind of move *)

--- a/compiler/src/checkAnnot.ml
+++ b/compiler/src/checkAnnot.ml
@@ -85,12 +85,12 @@ let check_no_for_loop (_, fds) =
 let rec check_no_inline_instr ~funname s =
   List.iter (check_no_inline_instr_i ~funname) s
 
-and check_no_inline_instr_i ~funname { i_desc; i_loc; i_annot; _ } =
-  if List.exists (fun (k, _) -> String.equal "inline" (L.unloc k)) i_annot then
-    hierror ~funname ~loc:(Lmore i_loc) ~internal:false
+and check_no_inline_instr_i ~funname i =
+  if has_annot "inline" i then
+    hierror ~funname ~loc:(Lmore i.i_loc) ~internal:false
       ~kind:"compilation error" ~sub_kind:"loop unrolling"
       "“inline”-annotated instructions remain";
-  check_no_inline_instr_i_r ~funname i_desc
+  check_no_inline_instr_i_r ~funname i.i_desc
 
 and check_no_inline_instr_i_r ~funname = function
   | Cassgn _ | Copn _ | Csyscall _ | Cfor _ | Ccall _ -> ()

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -210,6 +210,17 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       try Hf.find ttbl fn with Not_found -> assert false
   in
 
+  let is_inline up =
+    let tbl = Hf.create 17 in
+    let _, fs = Conv.prog_of_cuprog up in
+    List.iter (fun f -> Hf.add tbl f.f_name f.f_cc) fs;
+    fun (loc, annot) fn ->
+      let cc = try Hf.find tbl fn with Not_found -> assert false in
+      if is_inline annot cc
+      then Some (loc, Annot.consume "inline" annot)
+      else None
+  in
+
   let cparams =
     {
       Compiler.rename_fd;
@@ -245,6 +256,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.fresh_id;
       Compiler.fresh_var_ident = Conv.fresh_var_ident;
       Compiler.slh_info;
+      Compiler.is_inline;
     }
   in
 

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -172,10 +172,8 @@ and cinstr_r_of_instr_r p i =
     let ir = C.Cwhile(a, cstmt_of_stmt c, cexpr_of_expr e,
                       cstmt_of_stmt c') in
     C.MkI(p,ir)
-  | Ccall(ii, x, f, e) ->
-    let ir =
-      C.Ccall(ii, clval_of_lvals x, f, cexpr_of_exprs e)
-    in
+  | Ccall(x, f, e) ->
+    let ir = C.Ccall(clval_of_lvals x, f, cexpr_of_exprs e) in
     C.MkI(p,ir)
 
 and cstmt_of_stmt c =
@@ -212,8 +210,8 @@ and instr_r_of_cinstr_r = function
   | Cwhile(a, c, e, c') ->
     Cwhile(a, stmt_of_cstmt c, expr_of_cexpr e, stmt_of_cstmt c')
 
-  | Ccall(ii, x, f, e) ->
-    Ccall(ii, lval_of_clvals x, f, expr_of_cexprs e)
+  | Ccall(x, f, e) ->
+    Ccall(lval_of_clvals x, f, expr_of_cexprs e)
 
 and stmt_of_cstmt c =
   List.map instr_of_cinstr c

--- a/compiler/src/ct_checker_forward.ml
+++ b/compiler/src/ct_checker_forward.ml
@@ -552,7 +552,7 @@ let rec ty_instr fenv env i =
       else loop (Env.max env2 env) in
     loop env
 
-  | Ccall (_, xs, f, es) ->
+  | Ccall (xs, f, es) ->
     let fty = get_fun fenv f in
     (* Check the arguments *)
     let do_e env e (_,lvl) = ty_expr ~public:(lvl=Public) env e in

--- a/compiler/src/evaluator.ml
+++ b/compiler/src/evaluator.ml
@@ -124,7 +124,7 @@ let small_step1 ep spp sip s =
     | Cwhile (_, c1, e, c2) ->
       { s with s_cmd = c1 @ MkI(ii, Cif(e, c2@[i],[])) :: c }
 
-    | Ccall(_,xs,fn,es) ->
+    | Ccall(xs,fn,es) ->
       let vargs' = exn_exec ii (sem_pexprs nosubword ep spp true gd s1 es) in
       let f = 
         match get_fundef s.s_prog.p_funcs fn with

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -140,6 +140,7 @@ let print_strings = function
   | Compiler.Inlining                    -> "inline"   , "inlining"
   | Compiler.RemoveUnusedFunction        -> "rmfunc"   , "remove unused function"
   | Compiler.Unrolling                   -> "unroll"   , "unrolling"
+  | Compiler.InlineSingleCalls           -> "inlinesinglecalls", "inline single calls"
   | Compiler.Splitting                   -> "splitting", "liverange splitting"
   | Compiler.Renaming                    -> "renaming" , "variable renaming to remove copies"
   | Compiler.RemovePhiNodes              -> "rmphi"    , "remove phi nodes introduced by splitting"
@@ -169,6 +170,8 @@ let symbol2pass =
 
 let set_sct_comp_pass s =
  sct_comp_pass := symbol2pass s
+
+let inline_single_calls = ref false
 
 let print_option p =
   let s, msg = print_strings p in
@@ -228,6 +231,9 @@ let options = [
     "-ATT", Arg.Unit (set_syntax `ATT), "use AT&T syntax (default is AT&T)"; 
     "-call-conv", Arg.Symbol (["windows"; "linux"], set_cc), ": select calling convention (default depend on host architecture)";
     "-arch", Arg.Symbol (["x86-64"; "arm-m4"], set_target_arch), ": select target arch (default is x86-64)";
+    "-inline-single-calls",
+       Arg.Set inline_single_calls,
+       ": inline functions that are called only once"
   ] @  List.map print_option Compiler.compiler_step_list @ List.map stop_after_option Compiler.compiler_step_list
 
 let usage_msg = "Usage : jasminc [option] filename"

--- a/compiler/src/liveness.ml
+++ b/compiler/src/liveness.ml
@@ -61,9 +61,9 @@ and live_d weak d (s_o: Sv.t) =
     let s_i, (c,c') = loop s_o in
     s_i, s_o, Cwhile(a, c, e, c')
 
-  | Ccall(ii,xs,f,es) ->
+  | Ccall(xs,f,es) ->
     let s_i = Sv.union (vars_es es) (dep_lvs s_o xs) in
-    s_i, (if weak then writev_lvals s_o xs else s_o), Ccall(ii,xs,f,es)
+    s_i, (if weak then writev_lvals s_o xs else s_o), Ccall(xs,f,es)
 
   | Csyscall(xs,o,es) ->
     let s_i = Sv.union (vars_es es) (dep_lvs s_o xs) in
@@ -94,7 +94,7 @@ let iter_call_sites (cbf: L.i_loc -> funname -> lvals -> Sv.t * Sv.t -> unit)
     | (Cassgn _ | Copn _) -> ()
     | (Cif (_, s1, s2) | Cwhile (_, s1, _, s2)) -> iter_stmt s1; iter_stmt s2
     | Cfor (_, _, s) -> iter_stmt s
-    | Ccall (_, xs, fn, _) ->
+    | Ccall (xs, fn, _) ->
        cbf loc fn xs ii
     | Csyscall (xs, op, _) ->
        cbs loc op xs ii

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -189,12 +189,11 @@ let rec pp_gi pp_info pp_len pp_opn pp_var fmt i =
       (pp_cblock pp_info pp_len pp_opn pp_var) c (pp_ge pp_len pp_var) e
       (pp_cblock pp_info pp_len pp_opn pp_var) c'
 
-  | Ccall(ii, x, f, e) ->
+  | Ccall(x, f, e) ->
     let pp_x fmt = function
       | [] -> ()
       | x -> F.fprintf fmt "%a =@ " (pp_glvs pp_len pp_var) x in
-    F.fprintf fmt "@[<hov 2>%s%a%s(%a);@]"
-      (match ii with | E.InlineFun -> "#inline " | E.DoNotInline -> "")
+    F.fprintf fmt "@[<hov 2>%a%s(%a);@]"
       pp_x x f.fn_name (pp_ges pp_len pp_var) e
 
 (* -------------------------------------------------------------------- *)

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -100,7 +100,7 @@ type ('len,'info,'asm) ginstr_r =
   | Cif    of 'len gexpr * ('len,'info,'asm) gstmt * ('len,'info,'asm) gstmt
   | Cfor   of 'len gvar_i * 'len grange * ('len,'info,'asm) gstmt
   | Cwhile of E.align * ('len,'info,'asm) gstmt * 'len gexpr * ('len,'info,'asm) gstmt
-  | Ccall  of E.inline_info * 'len glvals * funname * 'len gexprs
+  | Ccall  of 'len glvals * funname * 'len gexprs
 
 and ('len,'info,'asm) ginstr = {
     i_desc : ('len,'info,'asm) ginstr_r;
@@ -256,7 +256,7 @@ let rec rvars_i f s i =
   | Cfor(x,(_,e1,e2), c) ->
     rvars_c f (rvars_e f (rvars_e f (f (L.unloc x) s) e1) e2) c
   | Cwhile(_,c,e,c')    -> rvars_c f (rvars_e f (rvars_c f s c') e) c
-  | Ccall(_,x,_,e) -> rvars_es f (rvars_lvs f s x) e
+  | Ccall(x,_,e) -> rvars_es f (rvars_lvs f s x) e
 
 and rvars_c f s c =  List.fold_left (rvars_i f) s c
 
@@ -293,7 +293,7 @@ let rec written_vars_i ((v, f) as acc) i =
   | Cassgn(x, _, _, _) -> written_lv v x, f
   | Copn(xs, _, _, _) | Csyscall(xs, _, _)
     -> List.fold_left written_lv v xs, f
-  | Ccall(_, xs, fn, _) ->
+  | Ccall(xs, fn, _) ->
      List.fold_left written_lv v xs, Mf.modify_def [] fn (fun old -> i.i_loc :: old) f
   | Cif(_, s1, s2)
   | Cwhile(_, s1, _, s2)
@@ -463,8 +463,12 @@ let rec has_call_or_syscall_i i =
 
 and has_call_or_syscall c = List.exists has_call_or_syscall_i c
 
-let has_annot a { i_annot ; _ } =
-  List.exists (fun (k, _) -> String.equal (L.unloc k) a) i_annot
+let has_annot_aux a annot =
+  List.exists (fun (k, _) -> String.equal (L.unloc k) a) annot
+
+let has_annot a { i_annot } = has_annot_aux a i_annot
+
+let is_inline annot cc = has_annot_aux "inline" annot || cc = FInfo.Internal
 
 (* -------------------------------------------------------------------- *)
 let clamp (sz : wsize) (z : Z.t) =

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -64,7 +64,7 @@ type ('len,'info,'asm) ginstr_r =
   | Cif    of 'len gexpr * ('len,'info,'asm) gstmt * ('len,'info,'asm) gstmt
   | Cfor   of 'len gvar_i * 'len grange * ('len,'info,'asm) gstmt
   | Cwhile of E.align * ('len,'info,'asm) gstmt * 'len gexpr * ('len,'info,'asm) gstmt
-  | Ccall  of E.inline_info * 'len glvals * funname * 'len gexprs
+  | Ccall  of 'len glvals * funname * 'len gexprs
 
 and ('len,'info,'asm) ginstr = {
   i_desc : ('len,'info,'asm) ginstr_r;
@@ -269,13 +269,12 @@ val has_call_or_syscall : ('len, 'info, 'asm) gstmt -> bool
 val has_annot : Annotations.symbol -> ('len, 'info, 'asm) ginstr -> bool
 
 (* -------------------------------------------------------------------- *)
+val is_inline : Annotations.annotations -> FInfo.call_conv -> bool
+
+(* -------------------------------------------------------------------- *)
 val clamp : wsize -> Z.t -> Z.t
 val clamp_pe : pelem -> Z.t -> Z.t
 
 (* -------------------------------------------------------------------- *)
 type ('info,'asm) sfundef = Expr.stk_fun_extra * ('info,'asm) func 
 type ('info,'asm) sprog   = ('info,'asm) sfundef list * Expr.sprog_extra
-
-
-
-

--- a/compiler/src/sct_checker_forward.ml
+++ b/compiler/src/sct_checker_forward.ml
@@ -150,7 +150,7 @@ let rec modmsf_i fenv i =
     | Mov_msf | Protect | Other -> false
     end
   | Cfor(_, _, c) -> modmsf_c fenv c
-  | Ccall (_, _, f, _) -> (FEnv.get_fty fenv f).modmsf
+  | Ccall (_, f, _) -> (FEnv.get_fty fenv f).modmsf
 
 and modmsf_c fenv c =
   List.exists (modmsf_i fenv) c
@@ -244,7 +244,7 @@ let rec infer_msf_i fenv (tbl:(L.i_loc, Sv.t) Hashtbl.t) i ms =
   | Cassgn _ ->
     ms
 
-  | Ccall(_, xs, f, es) ->
+  | Ccall(xs, f, es) ->
     let fty = FEnv.get_fty fenv f in
     let ms =
       let doout ms vfty x =
@@ -985,7 +985,7 @@ let rec ty_instr fenv env ((msf,venv) as msf_e :msf_e) i =
     Env.ensure_le loc venv' venv1; (* venv' <= venv1 *)
     MSF.enter_if msf' (Papp1(Onot, e)), venv1
 
-  | Ccall (_, xs, f, es) ->
+  | Ccall (xs, f, es) ->
     let fty = FEnv.get_fty fenv f in
     let modmsf = fty.modmsf in
     let tyout, tyin, resulting_corruption = Env.clone_for_call env fty in

--- a/compiler/src/slicing.ml
+++ b/compiler/src/slicing.ml
@@ -36,7 +36,7 @@ and inspect_instr_r k = function
   | Cif (g, a, b) | Cwhile (_, a, g, b) ->
       inspect_stmt (inspect_stmt (inspect_e k g) a) b
   | Cfor (_, (_, e1, e2), s) -> inspect_stmt (inspect_es k [ e1; e2 ]) s
-  | Ccall (_, xs, fn, es) -> with_fun (inspect_lvs (inspect_es k es) xs) fn
+  | Ccall (xs, fn, es) -> with_fun (inspect_lvs (inspect_es k es) xs) fn
 
 let slice fs (gd, fds) =
   let funs =

--- a/compiler/src/ssa.ml
+++ b/compiler/src/ssa.ml
@@ -37,7 +37,7 @@ let rec written_vars_instr_r allvars w =
   | Cassgn (x, _, _, _) -> written_vars_lvar allvars w x
   | Copn (xs, _, _, _)
   | Csyscall(xs,_,_)
-  | Ccall (_, xs, _, _)
+  | Ccall (xs, _, _)
     -> written_vars_lvars allvars w xs
   | Cif (_, s1, s2)
   | Cwhile (_, s1, _, s2)
@@ -68,10 +68,10 @@ let split_live_ranges (allvars: bool) (f: ('info, 'asm) func) : (unit, 'asm) fun
       let es = List.map (rename_expr m) es in
       let m, ys = rename_lvals allvars m xs in
       m, Csyscall(ys, op, es)
-    | Ccall (ii, xs, n, es) ->
+    | Ccall (xs, n, es) ->
       let es = List.map (rename_expr m) es in
       let m, ys = rename_lvals allvars m xs in
-      m, Ccall (ii, ys, n, es)
+      m, Ccall (ys, n, es)
     | Cfor _ -> assert false
     | Cif (e, s1, s2) ->
       let os = written_vars_stmt allvars (written_vars_stmt allvars Sv.empty s1) s2 in

--- a/compiler/src/subst.ml
+++ b/compiler/src/subst.ml
@@ -60,7 +60,7 @@ let rec gsubst_i flen f i =
         Cfor(gsubst_vdest f x, (d, gsubst_e flen f e1, gsubst_e flen f e2), gsubst_c flen f c)
     | Cwhile(a, c, e, c') -> 
       Cwhile(a, gsubst_c flen f c, gsubst_e flen f e, gsubst_c flen f c')
-    | Ccall(ii,x,fn,e) -> Ccall(ii, gsubst_lvals flen f x, fn, gsubst_es flen f e) in
+    | Ccall(x,fn,e) -> Ccall(gsubst_lvals flen f x, fn, gsubst_es flen f e) in
   { i with i_desc }
 
 and gsubst_c flen f c = List.map (gsubst_i flen f) c

--- a/compiler/src/typing.ml
+++ b/compiler/src/typing.ml
@@ -206,7 +206,7 @@ let rec check_instr pd asmOp env i =
     check_cmd pd asmOp env c1;
     check_cmd pd asmOp env c2
 
-  | Ccall(_,xs,fn,es) -> 
+  | Ccall(xs,fn,es) ->
     let fd = getfun env fn in
     check_exprs pd loc es fd.f_tyin;
     check_lvals pd loc xs fd.f_tyout

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -178,7 +178,7 @@ let classes_alignment (onfun : funname -> param_info option list) (gtbl: alignme
     | Cif(e,c1,c2) | Cwhile (_,c1,e,c2) -> 
       add_e e; add_c c1; add_c c2
     | Cfor _ -> assert false 
-    | Ccall(_, xs, fn, es) -> 
+    | Ccall(xs, fn, es) ->
       add_lvs xs;
       calls := Sf.add fn !calls; 
       List.iter2 add_p (onfun fn) es 

--- a/compiler/tests/success/inline_single_calls/common/inline_single_calls.jazz
+++ b/compiler/tests/success/inline_single_calls/common/inline_single_calls.jazz
@@ -1,0 +1,50 @@
+fn f0() -> reg u32 { reg u32 r; r = 0; return r; }
+fn f1() -> reg u32 { reg u32 r; r = 1; return r; }
+fn f2() -> reg u32 { reg u32 r; r = 2; return r; }
+fn f3() -> reg u32 { reg u32 r; r = 3; return r; }
+fn f4() -> reg u32 { reg u32 r; r = 4; return r; }
+fn f5() -> reg u32 { reg u32 r; r = 5; return r; }
+fn f6() -> reg u32 { reg u32 r; r = 6; return r; }
+
+
+export
+fn main() -> reg u32 {
+    reg u32 p tmp;
+
+    p = f0(); // Gets inlined.
+
+    tmp = f1(); // Does not get inlined.
+    p += tmp;
+
+    tmp = f1();
+    p += tmp;
+
+    inline int i;
+    for i = 0 to 1 {
+        tmp = f2(); // Gets inlined.
+        p += tmp;
+    }
+
+    for i = 0 to 2 {
+        tmp = f3(); // Does not get inlined.
+        p += tmp;
+    }
+
+    while (p == 0) {
+        tmp = f4(); // Gets inlined.
+        p += tmp;
+    }
+
+    if (p == 0) {
+        tmp = f5(); // Gets inlined.
+        p += tmp;
+    }
+
+    if (p == 0) {
+        p = 1;
+    } else {
+        tmp = f6(); // Gets inlined.
+        p += tmp;
+    }
+    return p;
+}

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -59,6 +59,8 @@ compiler/dead_code_proof.v
 compiler/direct_call_proof.v
 compiler/inline.v
 compiler/inline_proof.v
+compiler/inline_single_calls.v
+compiler/inline_single_calls_proof.v
 compiler/jasmin_compiler.v
 compiler/lea.v
 compiler/lea_proof.v

--- a/proofs/compiler/allocation.v
+++ b/proofs/compiler/allocation.v
@@ -557,7 +557,7 @@ Fixpoint check_i (i1 i2:instr_r) r :=
     Let _ := assert (o1 == o2) (alloc_error "syscall not equals") in
     check_es es1 es2 r >>= check_lvals xs1 xs2
 
-  | Ccall _ x1 f1 arg1, Ccall _ x2 f2 arg2 =>
+  | Ccall x1 f1 arg1, Ccall x2 f2 arg2 =>
     Let _ := assert (f1 == f2) (alloc_error "functions not equals") in
     check_es arg1 arg2 r >>= check_lvals x1 x2
 

--- a/proofs/compiler/allocation_proof.v
+++ b/proofs/compiler/allocation_proof.v
@@ -606,7 +606,8 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p1 ev Pi_r Pfun.
   Proof.
-    move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hes Hsc Hfun Hw r1 [] //= ii2 xs2 fn2 args2 r2 vm1 Hr1.
+    move=> s1 scs2 m2 s2 xs fn args vargs vs Hes Hsc Hfun Hw r1
+      [] //= xs2 fn2 args2 r2 vm1 Hr1.
     rewrite /check_i -/check_I; t_xrbindP => r1' /eqP ? Hca Hcxs; subst fn2.
     have [Hr1' /(_ _ Hes) [vargs2 [Hargs2 Hvargs]]] := check_esP (~~direct_call) Hca Hr1.
     have [v' Hs2 Hvs]:= Hfun _ Hvargs.

--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -1913,7 +1913,7 @@ Qed.
 #[ local ]
 Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
 Proof.
-  move=> s0 scs0 m0 s1 inli lvs fn args vargs vs hsemargs _ hfun hwrite.
+  move=> s0 scs0 m0 s1 lvs fn args vargs vs hsemargs _ hfun hwrite.
   move=> ii hfv s0' hs0'.
   rewrite /=.
 

--- a/proofs/compiler/array_copy.v
+++ b/proofs/compiler/array_copy.v
@@ -112,7 +112,7 @@ Fixpoint array_copy_i (i:instr) : cexec cmd :=
       Let c1 := array_copy_c array_copy_i c1 in
       Let c2 := array_copy_c array_copy_i c2 in
       ok [:: MkI ii (Cwhile a c1 e c2)]
-  | Ccall _ _ _ _ => ok [:: i]
+  | Ccall _ _ _ => ok [:: i]
   end.
 
 Context {T} {pT:progT T}.

--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -308,7 +308,7 @@ Qed.
 
 Local Lemma Hcall : sem_Ind_call p1 ev Pi_r Pfun.
 Proof.
-  move=> s1 scs2 m2 s2 ii xs fn args vargs vs he _ hfun hw ii'.
+  move=> s1 scs2 m2 s2 xs fn args vargs vs he _ hfun hw ii.
   rewrite /Pi vars_I_call /vars_lvals => hsub _ [<-] vm1 hvm1.
   have [|vargs' he' uvars]:= sem_pexprs_uincl_on (uincl_onI _ hvm1) he; first by SvD.fsetdec.
   have [vs' hfun' uvs']:= hfun _ uvars.

--- a/proofs/compiler/array_expansion.v
+++ b/proofs/compiler/array_expansion.v
@@ -309,11 +309,11 @@ Fixpoint expand_i (m : t) (i : instr) : cexec instr :=
     Let c' := mapM (expand_i m) c' in 
     ok (MkI ii (Cwhile a c e c'))
 
-  | Ccall ini xs fn es =>
+  | Ccall xs fn es =>
     if Mf.get fsigs fn is Some (expdin, expdout) then
       Let xs := add_iinfo ii (rmap flatten (mapM2 length_mismatch (expand_return m) expdout xs)) in
       Let es := add_iinfo ii (rmap flatten (mapM2 length_mismatch (expand_param m) expdin es)) in
-      ok (MkI ii (Ccall ini xs fn es))
+      ok (MkI ii (Ccall xs fn es))
     else Error (reg_ierror_no_var "function not found")
   end.
 

--- a/proofs/compiler/array_expansion_proof.v
+++ b/proofs/compiler/array_expansion_proof.v
@@ -711,7 +711,7 @@ Qed.
 
 Local Lemma Hcall : sem_Ind_call p1 ev Pi_r Pfun.
 Proof.
-  move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hes Hsc Hfun Hw ii1 m ii2 i2 s1' hwf heqa /=.
+  move=> s1 scs2 m2 s2 xs fn args vargs vs Hes Hsc Hfun Hw ii1 m ii2 i2 s1' hwf heqa /=.
   case hgfn: Mf.get => [[ei eo]|//].
   t_xrbindP=> xs' sxs' hxs <- es' ses' hes <- _.
   have [? heva]:= expand_paramsP hwf heqa hes Hes.
@@ -915,4 +915,3 @@ Proof.
 Qed.
 
 End WITH_PARAMS.
-

--- a/proofs/compiler/array_init.v
+++ b/proofs/compiler/array_init.v
@@ -47,7 +47,7 @@ Fixpoint remove_init_i i :=
       let c := foldr (fun i c => remove_init_i i ++ c) [::] c in
       let c' := foldr (fun i c => remove_init_i i ++ c) [::] c' in
       [:: MkI ii (Cwhile a c e c') ]
-    | Ccall _ _ _ _  => [::i]
+    | Ccall _ _ _  => [::i]
     end
   end.
 

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -193,7 +193,7 @@ Section REMOVE_INIT.
 
   Local Lemma Rcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hargs Hcall Hfd Hxs ii' vm1 Hvm1.
+    move=> s1 scs2 m2 s2 xs fn args vargs vs Hargs Hcall Hfd Hxs ii' vm1 Hvm1.
     have [vargs' Hsa /Hfd [vres' [Hc Hvres]]]:= sem_pexprs_uincl Hvm1 Hargs.
     have /(_ _ Hvm1) [vm2' Hw ?] := writes_uincl _ Hvres Hxs.
     exists vm2' => //=; apply: sem_seq1; constructor; econstructor; eauto.
@@ -469,7 +469,7 @@ Section ADD_INIT.
 
   Local Lemma RAcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hargs Hcall Hfd Hxs ii'.
+    move=> s1 scs2 m2 s2 xs fn args vargs vs Hargs Hcall Hfd Hxs ii'.
     apply aux.
     + constructor; econstructor;eauto.
     move=> vm1 heq1.

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -176,7 +176,8 @@ Record compiler_params
   lowering_opt     : lowering_options;
   fresh_id         : glob_decls -> var -> Ident.ident;
   fresh_var_ident  : v_kind -> instr_info -> Ident.name -> stype -> Ident.ident;
-  slh_info         : _uprog → funname → seq slh_t * seq slh_t
+  slh_info         : _uprog → funname → seq slh_t * seq slh_t;
+  is_inline        : _uprog -> instr_info -> funname -> option instr_info;
 }.
 
 Context
@@ -245,7 +246,13 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
   let p := add_init_prog p in
   let p := cparams.(print_uprog) AddArrInit p in
 
-  Let p := inline_prog_err (wsw:= withsubword) cparams.(rename_fd) p in
+  Let p :=
+    inline_prog_err
+      (wsw := withsubword)
+      (is_inline cparams p)
+      cparams.(rename_fd)
+      p
+  in
   let p := cparams.(print_uprog) Inlining p in
 
   Let p := dead_calls_err_seq to_keep p in

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -15,6 +15,7 @@ Require Import
   array_copy_proof
   array_init_proof
   unrolling_proof
+  inline_single_calls_proof
   constant_prop_proof
   propagate_inline_proof
   dead_code_proof
@@ -167,7 +168,7 @@ Proof.
   rewrite print_uprogP => ok_pa0 pa.
   rewrite print_uprogP => ok_pa pb.
   rewrite print_uprogP => ok_pb pc.
-  rewrite print_uprogP => ok_pc.
+  rewrite !print_uprogP => ok_pc ? ?.
   rewrite !print_uprogP => pd ok_pd.
   rewrite !print_uprogP => pe ok_pe.
   rewrite !print_uprogP => pf ok_pf.
@@ -203,6 +204,8 @@ Proof.
   apply: compose_pass_uincl'.
   - move => vr' Hvr'.
     apply: (live_range_splittingP ok_pd); exact: Hvr'.
+  apply: compose_pass_uincl'.
+  - move=> vr'. apply: isc_prog_sem_call; eassumption.
   apply: compose_pass_uincl; first by move=> vr' Hvr'; apply: (unrollP ok_pc _ va_refl); exact: Hvr'.
   apply: compose_pass.
   - by move => vr'; exact: (dead_calls_err_seqP (sip := sip_of_asm_e) (sCP := sCP_unit) ok_pb).

--- a/proofs/compiler/constant_prop.v
+++ b/proofs/compiler/constant_prop.v
@@ -527,10 +527,10 @@ Fixpoint const_prop_ir (m:cpm) ii (ir:instr_r) : cpm * cmd :=
       end in
     (m', cw)
 
-  | Ccall fi xs f es =>
+  | Ccall xs f es =>
     let es := map (const_prop_e without_globals m) es in
     let (m,xs) := const_prop_rvs without_globals m xs in
-    (m, [:: MkI ii (Ccall fi xs f es) ])
+    (m, [:: MkI ii (Ccall xs f es) ])
 
   end
 

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -920,7 +920,7 @@ Section PROPER.
     by case: is_bool => //= ?; case:ifP.
   Qed.
 
-  Local Lemma Wcall i xs f es: Pr (Ccall i xs f es).
+  Local Lemma Wcall xs f es: Pr (Ccall xs f es).
   Proof.
     move=> ii m1 m2 Heq /=;have := const_prop_rvs_m (erefl None) Heq (refl_equal xs).
     rewrite /const_prop_ir.
@@ -1250,7 +1250,7 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hargs Hcall Hfun Hvs m ii' Hm.
+    move=> s1 scs2 m2 s2 xs fn args vargs vs Hargs Hcall Hfun Hvs m ii' Hm.
     rewrite /const_prop_ir -/const_prop_i.
     have [vargs' Hargs' Hall] := const_prop_esP Hm valid_without_globals Hargs.
     have /(_ _ Hm) [] /=:= const_prop_rvsP _ valid_without_globals Hvs.

--- a/proofs/compiler/dead_calls.v
+++ b/proofs/compiler/dead_calls.v
@@ -34,7 +34,7 @@ with i_calls_r (c : Sf.t) (i : instr_r) {struct i} : Sf.t :=
   | Cif    _  c1 c2   => c_calls (c_calls c c1) c2
   | Cfor   _  _  c1   => c_calls c c1
   | Cwhile _ c1 _  c2   => c_calls (c_calls c c1) c2
-  | Ccall  _  _  f  _ => Sf.add f c
+  | Ccall _ f _ => Sf.add f c
   end.
 
 Definition c_calls (c : Sf.t) (cmd : cmd) :=

--- a/proofs/compiler/dead_calls_proof.v
+++ b/proofs/compiler/dead_calls_proof.v
@@ -38,7 +38,7 @@ with i_Calls_r (i : instr_r) {struct i} : Sf.t :=
   | Cif    _  c1 c2   => Sf.union (c_Calls c1) (c_Calls c2)
   | Cfor   _  _  c1   => c_Calls c1
   | Cwhile _ c1 _  c2 => Sf.union (c_Calls c1) (c_Calls c2)
-  | Ccall  _  _  f  _ => Sf.singleton f
+  | Ccall _ f _ => Sf.singleton f
   end.
 
 Definition c_Calls (cmd : cmd) :=
@@ -73,8 +73,8 @@ Lemma i_Calls_while a c1 e c2 :
   i_Calls_r (Cwhile a c1 e c2) = Sf.union (c_Calls c1) (c_Calls c2).
 Proof. by []. Qed.
 
-Lemma i_Calls_call ii lv f es :
-  i_Calls_r (Ccall ii lv f es) = Sf.singleton f.
+Lemma i_Calls_call lv f es :
+  i_Calls_r (Ccall lv f es) = Sf.singleton f.
 Proof. by []. Qed.
 
 Lemma c_Calls_nil : c_Calls [::] = Sf.empty.
@@ -307,7 +307,7 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hargs Hcall Hfun Hres Hincl.
+    move=> s1 scs2 m2 s2 xs fn args vargs vs Hargs Hcall Hfun Hres Hincl.
     econstructor; eauto.
   Qed.
 

--- a/proofs/compiler/dead_code.v
+++ b/proofs/compiler/dead_code.v
@@ -159,14 +159,14 @@ Fixpoint dead_code_i (i:instr) (s:Sv.t) {struct i} : cexec (Sv.t * option instr)
     let: (s, (c,c')) := sc in
     ok (s, Some (MkI ii (Cwhile a c e c')))
 
-  | Ccall ini xs fn es =>
+  | Ccall xs fn es =>
     Let sxs := 
       match onfun fn with
       | None => ok (read_rvs_rec (Sv.diff s (vrvs xs)) xs, xs)
       | Some bs => add_iinfo ii (check_keep_only xs bs s)
       end in
     let '(si,xs) := sxs in
-    ok (read_es_rec si es, Some (MkI ii (Ccall ini xs fn es)))
+    ok (read_es_rec si es, Some (MkI ii (Ccall xs fn es)))
 
   end.
 

--- a/proofs/compiler/dead_code_proof.v
+++ b/proofs/compiler/dead_code_proof.v
@@ -475,7 +475,7 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hexpr Hcall Hfun Hw ii' sv0 /=.
+    move=> s1 scs2 m2 s2 xs fn args vargs vs Hexpr Hcall Hfun Hw ii sv0 /=.
     set sxs := (X in Let sxs := X in _).
     case heq: sxs => [ [I xs'] | ] //= => vm1' Hvm.
     rewrite (surj_estate s1) in Hexpr.

--- a/proofs/compiler/direct_call_proof.v
+++ b/proofs/compiler/direct_call_proof.v
@@ -220,7 +220,7 @@ Qed.
 
 Local Lemma Hcall : sem_Ind_call (dc:=indirect_c) p ev Pi_r Pfun.
 Proof.
-  move=> s1 scs2 m2 s2 ii xs fn args vargs vs hargs _ hrec hws vm1 hle.
+  move=> s1 scs2 m2 s2 xs fn args vargs vs hargs _ hrec hws vm1 hle.
   have [vargs' /(sem_pexprs_weak false) hargs1 /hrec[vres' hc hu]]:= sem_pexprs_uincl hle hargs.
   have [vm2 /(write_lvals_weak false)hws2 hle2]:= writes_uincl (s1 := with_scs (with_mem s1 m2) scs2) hle hu hws.
   exists vm2 => //; econstructor; eauto.

--- a/proofs/compiler/inline_proof.v
+++ b/proofs/compiler/inline_proof.v
@@ -18,15 +18,16 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
+  (is_inline : instr_info -> funname -> option instr_info)
   (rename_fd : instr_info -> funname -> ufundef -> ufundef).
 
 Lemma get_funP p f fd :
   get_fun p f = ok fd -> get_fundef p f = Some fd.
 Proof. by rewrite /get_fun;case:get_fundef => // ? [->]. Qed.
 
-Local Notation inline_i' := (inline_i rename_fd).
-Local Notation inline_fd' := (inline_fd rename_fd).
-Local Notation inline_prog' := (inline_prog rename_fd).
+Notation inline_i' := (inline_i is_inline rename_fd).
+Notation inline_fd' := (inline_fd is_inline rename_fd).
+Notation inline_prog' := (inline_prog is_inline rename_fd).
 
 #[local] Existing Instance indirect_c.
 
@@ -62,8 +63,9 @@ Section INCL.
       by t_xrbindP => -[Xc c'] /Hc -> /= <- <-.
     + move=> a c e c' Hc Hc' ii X1 c0 X2 /=.
       by t_xrbindP => -[Xc1 c1] /Hc -> /= -[Xc1' c1'] /Hc' -> /= <- <-.
-    move=> i xs f es ii X1 c' X2 /=.
-    case: i => //; t_xrbindP => fd /get_funP -/Incl.
+    move=> xs f es ii X1 c' X2 /=.
+    case: is_inline => [?|//].
+    t_xrbindP=> fd /get_funP -/Incl.
     by rewrite /get_fun => -> h <- <- /=; rewrite h.
   Qed.
 
@@ -175,9 +177,10 @@ Section SUBSET.
     by apply: rbindP=> Hc'' /Hc' ? [<-].
   Qed.
 
-  Local Lemma Scall  : forall i xs f es, Pr (Ccall i xs f es).
+  Local Lemma Scall : forall xs f es, Pr (Ccall xs f es).
   Proof.
-    move=> i xs f es ii X2 Xc /=;case: i => [ | [<-] //].
+    move=> xs f es ii X2 Xc /=.
+    case: is_inline => [? | [<-] //].
     by apply:rbindP => fd _;apply: rbindP => ?? [<-].
   Qed.
 
@@ -458,8 +461,9 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move => s1 scs2 m2 s2 ii xs fn args vargs vs.
-    case:s1 => scs1 sm1 svm1 /= Hes Hsc Hfun Hw ii' X1 X2 c' /=;case:ii;last first.
+    move=> s1 scs2 m2 s2 xs fn args vargs vs.
+    case: s1 => scs1 sm1 svm1 /= Hes Hsc Hfun Hw ii' X1 X2 c' /=.
+    case: is_inline => [?|]; last first.
     + move=> [<- <-] vm1 Hvm1.
       have /(_ Sv.empty vm1) [|vargs' /= Hvargs' Huargs]:= sem_pexprs_uincl_on' _ Hes.
       + by apply: uincl_onI Hvm1;rewrite read_i_call;SvD.fsetdec.
@@ -581,7 +585,7 @@ Section PROOF.
 End PROOF.
 
 Lemma inline_call_errP p p' f ev scs mem scs' mem' va va' vr:
-  inline_prog_err rename_fd p = ok p' ->
+  inline_prog_err is_inline rename_fd p = ok p' ->
   List.Forall2 value_uincl va va' ->
   sem_call p ev scs mem f va scs' mem' vr ->
   exists vr',

--- a/proofs/compiler/inline_single_calls.v
+++ b/proofs/compiler/inline_single_calls.v
@@ -1,0 +1,38 @@
+From Coq Require Import ZArith.
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+
+Require Import
+  compiler_util
+  expr
+  utils.
+Require
+  dead_calls
+  inline.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Section WITH_PARAMS.
+
+Context
+  {wsw : WithSubWord}
+  {asm_op : Type}
+  {asmop : asmOp asm_op}.
+
+Definition isc_prog
+  (single_calls : seq funname)
+  (rename_fd : instr_info -> funname -> ufundef -> ufundef)
+  (to_keep : seq funname)
+  (p : uprog) :
+  cexec uprog :=
+  if nilp single_calls
+  then ok p
+  else
+    let is_inline ii fn := if fn \in single_calls then Some ii else None in
+    Let p := inline.inline_prog_err is_inline rename_fd p in
+    dead_calls.dead_calls_err_seq to_keep p.
+
+End WITH_PARAMS.

--- a/proofs/compiler/inline_single_calls_proof.v
+++ b/proofs/compiler/inline_single_calls_proof.v
@@ -1,0 +1,50 @@
+From Coq Require Import ZArith.
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+
+Require Import
+  psem
+  compiler_util.
+Require
+  inline_proof
+  dead_calls_proof.
+Require Export inline_single_calls.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Section WITH_PARAMS.
+
+Context
+  {wsw : WithSubWord}
+  {asm_op syscall_state : Type}
+  {ep : EstateParams syscall_state}
+  {spp : SemPexprParams}
+  {sip : SemInstrParams asm_op syscall_state}.
+
+#[local]
+Existing Instance indirect_c.
+
+Lemma isc_prog_sem_call
+  single_calls rename_fd to_keep p p' fn ev scs mem scs' mem' va va' vr :
+  isc_prog single_calls rename_fd to_keep p = ok p' ->
+  fn \in to_keep ->
+  List.Forall2 value_uincl va va' ->
+  sem_call p ev scs mem fn va scs' mem' vr ->
+  exists2 vr',
+    List.Forall2 value_uincl vr vr'
+    & sem_call p' ev scs mem fn va' scs' mem' vr'.
+Proof.
+  rewrite /isc_prog.
+  case: nilp.
+  - move=> [->] _ h0 h1. have [? []] := sem_call_uincl h0 h1. by eauto.
+
+  t_xrbindP=> p0 hinline hdeadcalls hto_keep hargs hcall.
+  have [? [hcall' ?]] := inline_proof.inline_call_errP hinline hargs hcall.
+  have := dead_calls_proof.dead_calls_err_seqP hdeadcalls hto_keep hcall'.
+  by eauto.
+Qed.
+
+End WITH_PARAMS.

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -337,7 +337,7 @@ Definition stack_frame_allocation_size (e: stk_fun_extra) : Z :=
       | Some true => check_c check_i c >> check_c check_i c'
       | None => check_fexpr ii e >> check_c check_i c >> check_c check_i c'
       end
-    | Ccall _ xs fn es =>
+    | Ccall xs fn es =>
       Let _ := assert (fn != this) (E.ii_error ii "call to self") in
       if get_fundef (p_funcs p) fn is Some fd then
         let e := f_extra fd in
@@ -626,7 +626,7 @@ Fixpoint linear_i (i:instr) (lbl:label) (lc:lcmd) :=
       end
     end
 
-  | Ccall _ xs fn' es =>
+  | Ccall xs fn' es =>
     if get_fundef (p_funcs p) fn' is Some fd then
       let e := f_extra fd in
       let ra := sf_return_address e in

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -204,9 +204,9 @@ Section CAT.
     by case: a; rewrite /= cats1 -catA /= cat_rcons.
   Qed.
 
-  Let Hcall : forall i xs f es, Pr (Ccall i xs f es).
+  Let Hcall : forall xs f es, Pr (Ccall xs f es).
   Proof.
-    move => ini xs fn es ii fn' lbl tail /=.
+    move=> xs fn es ii fn' lbl tail /=.
     case: get_fundef => // fd; case: ifP => //.
     by case: sf_return_address => // [ ra | ra ra_ofs ] _; rewrite cats0 -catA.
   Qed.
@@ -663,7 +663,7 @@ Section VALIDITY.
     valid fn lbl (lbl + 1)%positive (allocate_stack_frame liparams p b ii z rastack).
   Proof. by rewrite /allocate_stack_frame; case: eqP. Qed.
 
-  Let Hcall (i : inline_info) (xs : lvals) (f : funname) (es : pexprs) : Pr (Ccall i xs f es).
+  Let Hcall (xs : lvals) (f : funname) (es : pexprs) : Pr (Ccall xs f es).
   Proof.
     move => ii fn lbl /=.
     case: get_fundef => [ fd | ]; last by split => //; lia.
@@ -826,7 +826,7 @@ Section NUMBER_OF_LABELS.
     by rewrite /lload get_label_lassign /=.
   Qed.
 
-  Let Hcall (i : inline_info) (xs : lvals) (f : funname) (es : pexprs) : Pr (Ccall i xs f es).
+  Let Hcall (xs : lvals) (f : funname) (es : pexprs) : Pr (Ccall xs f es).
   Proof.
     move => ii fn lbl /=.
     case: get_fundef => [ fd | ]; last by apply Z.le_refl.
@@ -2416,7 +2416,8 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p var_tmp Pi_r Pfun.
   Proof.
-    move => ii k s1 s2 ini res fn' args xargs xres ok_xargs ok_xres exec_call ih fn lbl /checked_iE[] fd ok_fd chk_call.
+    move=> ii k s1 s2 res fn' args xargs xres
+      ok_xargs ok_xres exec_call ih fn lbl /checked_iE[] fd ok_fd chk_call.
     case linear_eq: linear_i => [lbli li].
     move => m1 vm2 P Q M X D C.
     move: chk_call => /=.

--- a/proofs/compiler/makeReferenceArguments.v
+++ b/proofs/compiler/makeReferenceArguments.v
@@ -148,13 +148,13 @@ Fixpoint update_i (X:Sv.t) (i:instr) : cexec cmd :=
     Let c  := update_c (update_i X) c in
     Let c' := update_c (update_i X) c' in
     ok [::MkI ii (Cwhile a c e c')]
-  | Ccall ini xs fn es =>
+  | Ccall xs fn es =>
     let: (params,returns) := get_sig fn in
     Let pres := make_prologue ii X Hexadecimal.Nil params es in
     let: (prologue, es) := pres in
     Let xsep := make_epilogue ii X returns xs in
     let: (xs, epilogue) := xsep in 
-    ok (prologue ++ MkI ii (Ccall ini xs fn es) :: epilogue)
+    ok (prologue ++ MkI ii (Ccall xs fn es) :: epilogue)
   | Csyscall xs o es =>
     let: (params,returns) := get_syscall_sig o in
     Let: (prologue, es) := make_prologue ii X Hexadecimal.Nil params es in

--- a/proofs/compiler/makeReferenceArguments_proof.v
+++ b/proofs/compiler/makeReferenceArguments_proof.v
@@ -542,7 +542,7 @@ Context
 
   Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move=> s1 scs m s2 ii lv fn args vargs aout eval_args h1 h2 h3.
+    move=> s1 scs m s2 lv fn args vargs aout eval_args h1 h2 h3.
     move=> ii' X c' hupd; rewrite !(read_Ii, write_Ii).
     rewrite !(read_i_call, write_i_call) => le_X vm1 eq_s1_vm1.
     case: (sem_callE h1) hupd => fnd [fnE] [vs] [s1'] [s2'] [s3'] [vres] [vsE] [_ hwrinit] _ [hgetout aoutE] _.

--- a/proofs/compiler/merge_varmaps.v
+++ b/proofs/compiler/merge_varmaps.v
@@ -71,7 +71,7 @@ Section WRITE1.
     | Cif   _ c1 c2   => foldl write_I_rec (foldl write_I_rec s c2) c1
     | Cfor  x _ c     => foldl write_I_rec (Sv.add x s) c
     | Cwhile _ c _ c' => foldl write_I_rec (foldl write_I_rec s c') c
-    | Ccall _ _ fn _  => Sv.union s (writefun_ra fn)
+    | Ccall _ fn _  => Sv.union s (writefun_ra fn)
     end
   with write_I_rec s i :=
     match i with
@@ -185,7 +185,7 @@ Section CHECK.
       if is_false e then check_c (check_i sz) D c
       else wloop (check_i sz) ii c (read_e e) c' Loop.nb D
 
-    | Ccall _ xs fn es =>
+    | Ccall xs fn es =>
       if get_fundef (p_funcs p) fn is Some fd then
         Let _ := check_es ii D es in
         Let _ := assert (sf_align (f_extra fd) ≤ sz)%CMP

--- a/proofs/compiler/merge_varmaps_proof.v
+++ b/proofs/compiler/merge_varmaps_proof.v
@@ -152,7 +152,7 @@ Section LEMMA.
     - by move => e c1 c2 h1 h2 s; rewrite /write_i /write_i_rec -!/write_c_rec -/write_c !h1 h2; SvD.fsetdec.
     - by move => v d lo hi body h s; rewrite /write_i /write_i_rec -!/write_c_rec !h; SvD.fsetdec.
     - by move => a c1 e c2  h1 h2 s; rewrite /write_i /write_i_rec -!/write_c_rec -/write_c !h1 h2; SvD.fsetdec.
-    by move => i xs fn es s; rewrite /write_i /write_i_rec; SvD.fsetdec.
+    by move=> xs fn es s; rewrite /write_i /write_i_rec; SvD.fsetdec.
   Qed.
 
   Lemma write_I_recE ii i s :
@@ -589,7 +589,8 @@ Section LEMMA.
 
   Lemma Hcall: sem_Ind_call p global_data Pi_r Pfun.
   Proof.
-    move => s1 scs2 m2 s2 jj xs fn args vargs vs ok_vargs sexec ih ok_s2 sz ii I O t1.
+    move=>
+      s1 scs2 m2 s2 xs fn args vargs vs ok_vargs sexec ih ok_s2 sz ii I O t1.
     rewrite /check_instr_r /=; case heq : get_fundef => [ fd | //].
     t_xrbindP => hces hal hargs hres hxs pre sim.
     have [vargs' hvargs' hincl]:= check_esP hces sim ok_vargs.

--- a/proofs/compiler/propagate_inline.v
+++ b/proofs/compiler/propagate_inline.v
@@ -193,10 +193,10 @@ Fixpoint pi_i (pi:pimap) (i:instr) :=
     let:(pi, c1, e, c2) := pic in
     ok (pi, MkI ii (Cwhile a c1 e c2))
 
-  | Ccall inline xs f es =>
+  | Ccall xs f es =>
     let es := pi_es pi es in
     let (pi, xs) := pi_lvs (remove_m pi) xs in
-    ok (pi, MkI ii (Ccall inline xs f es))
+    ok (pi, MkI ii (Ccall xs f es))
 
   end.
 

--- a/proofs/compiler/propagate_inline_proof.v
+++ b/proofs/compiler/propagate_inline_proof.v
@@ -721,7 +721,7 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p1 ev Pi_r Pfun.
   Proof.
-    move=> s1 scs m2 s2 iif xs fn args vargs vs hargs _ hf hwr ii pi pi2 vm1 /=.
+    move=> s1 scs m2 s2 xs fn args vargs vs hargs _ hf hwr ii pi pi2 vm1 /=.
     case heq : pi_lvs => [pi' xs'] [<-] hu hv.
     have [vargs' hargs' hus]:= pi_esP_uincl hv hu hargs.
     have [vs' hvs' hc]:= hf _ hus.

--- a/proofs/compiler/remove_globals.v
+++ b/proofs/compiler/remove_globals.v
@@ -86,7 +86,7 @@ Section REMOVE.
         else ok gd
       | _ => ok gd
       end
-    | Copn _ _ _ _ | Csyscall _ _ _ | Ccall _ _ _ _ => ok gd
+    | Copn _ _ _ _ | Csyscall _ _ _ | Ccall _ _ _ => ok gd
     | Cif _ c1 c2 =>
       Let gd := foldM extend_glob_i gd c1 in
       foldM extend_glob_i gd c2
@@ -306,10 +306,10 @@ Section REMOVE.
             Let envc := loop check_c Loop.nb env in
             let: (env, c) := envc in
             ok (env, [::MkI ii (Cfor xi (d,e1,e2) c)])
-        | Ccall i lvs fn es =>
+        | Ccall lvs fn es =>
           Let lvs := mapM (remove_glob_lv ii env) lvs in
           Let es  := mapM (remove_glob_e ii env) es in
-          ok (env, [::MkI ii (Ccall i lvs fn es)])
+          ok (env, [::MkI ii (Ccall lvs fn es)])
         end
       end.
 

--- a/proofs/compiler/remove_globals_proof.v
+++ b/proofs/compiler/remove_globals_proof.v
@@ -175,7 +175,7 @@ Module INCL. Section INCL.
 
   Local Lemma Hcall : sem_Ind_call P1 ev Pi_r Pfun.
   Proof.
-    move=> ?????????? /(gd_incl_es hincl) h1 ? h2 /(gd_incl_wls hincl) h3.
+    move=> ????????? /(gd_incl_es hincl) h1 ? h2 /(gd_incl_wls hincl) h3.
     econstructor;eauto.
   Qed.
 
@@ -286,8 +286,8 @@ Section PROOFS.
     by t_xrbindP => gd3 /hc h1 /hc'; apply gd_inclT.
   Qed.
 
-  Local Lemma Hcall: forall i xs f es, Pr (Ccall i xs f es).
-  Proof. by move=> i xs f es ii gd1 gd2 /= [<-]. Qed.
+  Local Lemma Hcall: forall xs f es, Pr (Ccall xs f es).
+  Proof. by move=> xs f es ii gd1 gd2 /= [<-]. Qed.
 
   Local Lemma extend_glob_cP c gd1 gd2 :
     foldM (extend_glob_i fresh_id) gd1 c = ok gd2 ->
@@ -725,7 +725,8 @@ Module RGP. Section PROOFS.
 
   Local Lemma Hcall : sem_Ind_call P ev Pi_r Pfun.
   Proof.
-    move=> s1 scs2 m2 s2 fii xs fn args vargs rvs hargs _ hfun hres ii m m' c' /= hrm s1' hval.
+    move=> s1 scs2 m2 s2 xs fn args vargs rvs hargs _ hfun hres ii m m' c' /=
+      hrm s1' hval.
     move: hrm; t_xrbindP => xs' hxs es' hes ??;subst m' c'.
     have hes' := remove_glob_esP hval hes hargs.
     have hval' : valid m (with_scs (with_mem s1 m2) scs2) (with_scs (with_mem s1' m2) scs2).

--- a/proofs/compiler/slh_lowering.v
+++ b/proofs/compiler/slh_lowering.v
@@ -450,7 +450,7 @@ Fixpoint check_i (i : instr) (env : Env.t) : cexec Env.t :=
       Let _ := chk_mem ii cond in
       check_while ii cond (check_cmd c0) (check_cmd c1) Loop.nb env
 
-  | Ccall _ xs fn es =>
+  | Ccall xs fn es =>
       let '(in_t, out_t) := fun_info fn in
       Let _ := check_f_args ii env es in_t in
       check_f_lvs ii env xs out_t
@@ -516,7 +516,7 @@ Fixpoint lower_i (i : instr) : cexec instr :=
       Let c1' := lower_cmd c1 in
       ok (Cwhile al c0' b c1')
 
-    | Ccall _ _ _ _ =>
+    | Ccall _ _ _ =>
         ok ir
     end
   in

--- a/proofs/compiler/slh_lowering_proof.v
+++ b/proofs/compiler/slh_lowering_proof.v
@@ -1130,7 +1130,7 @@ Qed.
 
 Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
 Proof.
-  move=> s scs2 m2 s' ? lvs fn args vargs vargs' hsemargs _ hrec hwrite.
+  move=> s scs2 m2 s' lvs fn args vargs vargs' hsemargs _ hrec hwrite.
   move=> ? env env' c hwf /=.
   case heq: fun_info => [tin tout]; t_xrbindP => t hargs hres <-.
   move: hrec; rewrite /Pfun heq => /(_ (check_f_argsP hwf hargs hsemargs)) [h1 h2].

--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -1118,7 +1118,7 @@ Definition alloc_call_res rmap srs ret_pos rs :=
 Definition is_RAnone ral :=
   if ral is RAnone then true else false.
 
-Definition alloc_call (sao_caller:stk_alloc_oracle_t) rmap ini rs fn es := 
+Definition alloc_call (sao_caller:stk_alloc_oracle_t) rmap rs fn es :=
   let sao_callee := local_alloc fn in
   Let es  := alloc_call_args rmap sao_callee.(sao_params) es in
   let '(rmap, es) := es in
@@ -1140,7 +1140,7 @@ Definition alloc_call (sao_caller:stk_alloc_oracle_t) rmap ini rs fn es :=
                           (stk_ierror_no_var "non aligned function call")
   in
   let es  := map snd es in
-  ok (rs.1, Ccall ini rs.2 fn es).
+  ok (rs.1, Ccall rs.2 fn es).
 
 (* Before stack_alloc :
      Csyscall [::x] (getrandom len) [::t] 
@@ -1217,8 +1217,8 @@ Fixpoint alloc_i sao (rmap:region_map) (i: instr) : cexec (region_map * cmd) :=
       Let r := loop2 ii check_c Loop.nb rmap in
       ok (r.1, [:: MkI ii (Cwhile a (flatten r.2.2.1) r.2.1 (flatten r.2.2.2))])
 
-    | Ccall ini rs fn es =>
-      Let ri := add_iinfo ii (alloc_call sao rmap ini rs fn es) in
+    | Ccall rs fn es =>
+      Let ri := add_iinfo ii (alloc_call sao rmap rs fn es) in
       ok (ri.1, [::MkI ii ri.2])                            
 
     | Cfor _ _ _  => Error (pp_at_ii ii (stk_ierror_no_var "don't deal with for loop"))

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -2090,7 +2090,7 @@ Proof. by case. Qed.
 (* TODO: in [vundef_type], we could maybe change the [sarr] case, now [is_sarr t = false] is an argument of Vundef *)
 Local Lemma Hcall : sem_Ind_call P ev Pi_r Pfun.
 Proof.
-  move=> s1 scs2 m1 s1' ii rs fn args vargs1 vres1 hvargs1 hsem1 Hf hs1'.
+  move=> s1 scs2 m1 s1' rs fn args vargs1 vres1 hvargs1 hsem1 Hf hs1'.
   move=> pmap rsp Slots Addr Writable Align rmap0 rmap2 ii1 c hpmap hwfsl sao /=.
   t_xrbindP => -[rmap2' i2'] /= halloc ?? m0 s2 hvs hext hsao; subst rmap2' c.
   move: halloc; rewrite /alloc_call /assert_check.

--- a/proofs/compiler/unrolling.v
+++ b/proofs/compiler/unrolling.v
@@ -58,7 +58,7 @@ Fixpoint unroll_i (i: instr) : cmd * bool :=
   | Cassgn _ _ _ _
   | Copn _ _ _ _
   | Csyscall _ _ _
-  | Ccall _ _ _ _
+  | Ccall _ _ _
     => ([:: i ], false)
   | Cif b c1 c2  =>
       let: (c1', b1) := unroll_cmd unroll_i c1 in

--- a/proofs/compiler/unrolling_proof.v
+++ b/proofs/compiler/unrolling_proof.v
@@ -172,7 +172,7 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hexpr _ Hfun Hw ii' /=.
+    move=> s1 scs2 m2 s2 xs fn args vargs vs Hexpr _ Hfun Hw ii' /=.
     by apply: sem_seq1; apply: EmkI; apply: Ecall; rewrite ?p'_globs; eassumption.
   Qed.
 

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -1847,7 +1847,7 @@ Section PROOF.
 
   Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
   Proof.
-    move=> s1 scs m2 s2 ii xs fn args vargs vs Harg _ Hfun Hret ii' Hdisj s1' Hs1'; move: Hdisj.
+    move=> s1 scs m2 s2 xs fn args vargs vs Harg _ Hfun Hret ii' Hdisj s1' Hs1'; move: Hdisj.
     rewrite /disj_fvars /x86_lowering.disj_fvars vars_I_call=> /disjoint_union [Hxs Hargs].
     have Heq: eq_exc_fresh (with_scs (with_mem s1' m2) scs) (with_scs (with_mem s1 m2) scs).
     + by case: Hs1' => * /=.

--- a/proofs/lang/expr_facts.v
+++ b/proofs/lang/expr_facts.v
@@ -276,8 +276,8 @@ Proof.
     clear; SvD.fsetdec.
 Qed.
 
-Lemma write_i_call ii xs f es :
-  write_i (Ccall ii xs f es) = vrvs xs.
+Lemma write_i_call xs f es :
+  write_i (Ccall xs f es) = vrvs xs.
 Proof. done. Qed.
 
 Lemma write_Ii ii i: write_I (MkI ii i) = write_i i.
@@ -427,8 +427,8 @@ Proof.
   rewrite /read_i /read_i_rec -/read_c_rec !read_eE read_cE; clear; SvD.fsetdec.
 Qed.
 
-Lemma read_i_call ii xs f es :
-  Sv.Equal (read_i (Ccall ii xs f es)) (Sv.union (read_rvs xs) (read_es es)).
+Lemma read_i_call xs f es :
+  Sv.Equal (read_i (Ccall xs f es)) (Sv.union (read_rvs xs) (read_es es)).
 Proof. rewrite /read_i /read_i_rec read_esE read_rvsE; clear; SvD.fsetdec. Qed.
 
 Lemma read_Ii ii i: read_I (MkI ii i) = read_i i.
@@ -486,8 +486,8 @@ Lemma vars_I_for ii i d lo hi c:
            (Sv.union (Sv.union (vars_c c) (Sv.singleton i)) (Sv.union (read_e lo) (read_e hi))).
 Proof. rewrite /vars_I read_Ii write_Ii read_i_for write_i_for /vars_c; clear; SvD.fsetdec. Qed.
 
-Lemma vars_I_call ii ii' xs fn args:
-  Sv.Equal (vars_I (MkI ii (Ccall ii' xs fn args))) (Sv.union (vars_lvals xs) (read_es args)).
+Lemma vars_I_call ii xs fn args:
+  Sv.Equal (vars_I (MkI ii (Ccall xs fn args))) (Sv.union (vars_lvals xs) (read_es args)).
 Proof. rewrite /vars_I read_Ii write_Ii read_i_call write_i_call /vars_lvals; clear; SvD.fsetdec. Qed.
 
 Lemma vars_pP p fn fd : get_fundef p fn = Some fd -> Sv.Subset (vars_fd fd) (vars_p p).

--- a/proofs/lang/lowering_lemmas.v
+++ b/proofs/lang/lowering_lemmas.v
@@ -270,11 +270,11 @@ Proof.
   exact: SvP.MP.add_union_singleton.
 Qed.
 
-Lemma disj_fvars_vars_I_Ccall ii inli lvs fn args :
-  disj_fvars (vars_I (MkI ii (Ccall inli lvs fn args)))
+Lemma disj_fvars_vars_I_Ccall ii lvs fn args :
+  disj_fvars (vars_I (MkI ii (Ccall lvs fn args)))
   -> disj_fvars (vars_lvals lvs) /\ disj_fvars (read_es args).
 Proof.
-  move=> /(disjoint_equal_l (vars_I_call ii inli lvs fn args)).
+  move=> /(disjoint_equal_l (vars_I_call ii lvs fn args)).
   by move=> /disjoint_union.
 Qed.
 

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -211,11 +211,11 @@ with sem_i : estate -> instr_r -> estate -> Prop :=
     sem_for i (wrange d vlo vhi) s1 c s2 ->
     sem_i s1 (Cfor i (d, lo, hi) c) s2
 
-| Ecall s1 scs2 m2 s2 ii xs f args vargs vs :
+| Ecall s1 scs2 m2 s2 xs f args vargs vs :
     sem_pexprs (~~direct_call) gd s1 args = ok vargs ->
     sem_call s1.(escs) s1.(emem) f vargs scs2 m2 vs ->
     write_lvals (~~direct_call) gd (with_scs (with_mem s1 m2) scs2) xs vs = ok s2 ->
-    sem_i s1 (Ccall ii xs f args) s2
+    sem_i s1 (Ccall xs f args) s2
 
 with sem_for : var_i -> seq Z -> estate -> cmd -> estate -> Prop :=
 | EForDone s i c :
@@ -344,13 +344,12 @@ Section SEM_IND.
 
   Definition sem_Ind_call : Prop :=
     forall (s1 : estate) (scs2 : syscall_state_t) (m2 : mem) (s2 : estate) 
-           (ii : inline_info) (xs : lvals)
-           (fn : funname) (args : pexprs) (vargs vs : seq value),
+           (xs : lvals) (fn : funname) (args : pexprs) (vargs vs : seq value),
       sem_pexprs (~~direct_call) gd s1 args = ok vargs →
       sem_call (escs s1) (emem s1) fn vargs scs2 m2 vs → 
       Pfun (escs s1) (emem s1) fn vargs scs2 m2 vs →
       write_lvals (~~direct_call) gd (with_scs (with_mem s1 m2) scs2) xs vs = ok s2 →
-      Pi_r s1 (Ccall ii xs fn args) s2.
+      Pi_r s1 (Ccall xs fn args) s2.
 
   Definition sem_Ind_proc : Prop :=
     forall (scs1 : syscall_state_t) (m1 : mem) (scs2 : syscall_state_t) (m2 : mem)
@@ -402,8 +401,8 @@ Section SEM_IND.
     | @Efor s1 s2 i0 d lo hi c vlo vhi e1 e2 s0 =>
       @Hfor s1 s2 i0 d lo hi c vlo vhi e1 e2 s0
         (@sem_for_Ind i0 (wrange d vlo vhi) s1 c s2 s0)
-    | @Ecall s1 scs2 m2 s2 ii xs f13 args vargs vs e2 s0 e3 =>
-      @Hcall s1 scs2 m2 s2 ii xs f13 args vargs vs e2 s0
+    | @Ecall s1 scs2 m2 s2 xs f13 args vargs vs e2 s0 e3 =>
+      @Hcall s1 scs2 m2 s2 xs f13 args vargs vs e2 s0
         (@sem_call_Ind (escs s1) (emem s1) f13 vargs scs2 m2 vs s0) e3
     end
 
@@ -618,7 +617,7 @@ Lemma sem_iE s i s' :
     ∃ si b,
        [/\ sem s c si, sem_pexpr true gd si e = ok (Vbool b) &
                        if b then ∃ sj, sem si c' sj ∧ sem_i sj (Cwhile a c e c') s' else si = s' ]
-  | Ccall _ xs f es =>
+  | Ccall xs f es =>
     ∃ vs scs2 m2 rs,
     [/\ sem_pexprs (~~direct_call) gd s es = ok vs,
         sem_call s.(escs) s.(emem) f vs scs2 m2 rs &
@@ -633,7 +632,7 @@ Proof.
   - by move => s si sj s' c e c' hc he hc' hrec; exists si, true; constructor => //; exists sj.
   - by move => s s' c e c' hc he; exists s', false.
   - by move => s s' i d lo hi c vlo vhi hlo hhi hc; exists vlo, vhi.
-  by move => s scs m s' _ xs f es vs rs hvs h hrs; exists vs, scs, m, rs.
+  by move=> s scs m s' xs f es vs rs hvs h hrs; exists vs, scs, m, rs.
 Qed.
 
 Lemma sem_forE i ws s c s' :
@@ -997,7 +996,7 @@ Proof.
   + by move=> s1 s2 i d lo hi c vlo vhi _ _ _ Hrec z;rewrite write_i_for;apply Hrec.
   + move=> s1 s1' s2 s3 i w ws c Hw _ Hc _ Hf z Hnin.
     by rewrite (vrvP_var Hw) ?Hc ?Hf //;SvD.fsetdec.
-  move=> s1 scs2 m2 s2 ii xs fn args vargs vs _ _ _ Hw z.
+  move=> s1 scs2 m2 s2 xs fn args vargs vs _ _ _ Hw z.
   rewrite write_i_call. apply (vrvsP Hw).
 Qed.
 
@@ -1896,7 +1895,7 @@ Proof.
     have [|vm3 ? heq3] := ihc vm2 X hsub; first by apply: eq_onI heq2; SvD.fsetdec.
     have [vm4 ? heq4] := ihf vm3 X hsub heq3; exists vm4 => //.
     by econstructor; eauto.
-  + move=> s1 scs2 m2 s2 ii xs fn args vargs vs hargs hcall _ hw vm1 X.
+  + move=> s1 scs2 m2 s2 xs fn args vargs vs hargs hcall _ hw vm1 X.
     rewrite read_i_call => hsub heq1.
     case: (write_lvals_eq_on _ hw heq1); first by SvD.fsetdec.
     move=> vm2 hw2 heq2; exists vm2; last by apply: eq_onI heq2; SvD.fsetdec.
@@ -2069,7 +2068,7 @@ Qed.
 
 Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
 Proof.
-  move=> s1 scs2 m2 s2 ii xs fn args vargs vs Hargs Hcall Hfd Hxs vm1 Hvm1.
+  move=> s1 scs2 m2 s2 xs fn args vargs vs Hargs Hcall Hfd Hxs vm1 Hvm1.
   have [vargs' Hsa /Hfd [vs' [Hc Hvres]]]:= sem_pexprs_uincl Hvm1 Hargs.
   have Hvm1' : vm_uincl (evm (with_scs (with_mem s1 m2) scs2)) vm1 by done.
   have [vm2' ??] := writes_uincl Hvm1' Hvres Hxs.

--- a/proofs/lang/psem_facts.v
+++ b/proofs/lang/psem_facts.v
@@ -228,7 +228,11 @@ Proof.
 Qed.
 
 Lemma mem_equiv_call : sem_Ind_call P ev Pi_r Pfun.
-Proof. move=> s1 scs2 m2 s2 ii xs fn args vargs vres _ _ ? /dup[] /write_lvals_validw ? /write_lvals_stack_stable ?; red; etransitivity; [|split]; eassumption. Qed.
+Proof.
+  move=> s1 scs2 m2 s2 xs fn args vargs vres _ _
+    ? /dup[] /write_lvals_validw ? /write_lvals_stack_stable ?.
+  red. etransitivity; by eauto.
+Qed.
 
 Lemma mem_equiv_proc : sem_Ind_proc P ev Pc Pfun.
 Proof.
@@ -590,7 +594,8 @@ Qed.
 
 Local Lemma sem_deter_call : sem_Ind_call p ev Pi_r Pfun.
 Proof.
-  red => s1 scs2 m2 s2 ii xs fn args vargs vs ok_vargs _ ih ok_s2 s2' /sem_iE[] ? [] ? [] ? [] ?[].
+  red=> s1 scs2 m2 s2 xs fn args vargs vs ok_vargs _
+    ih ok_s2 s2' /sem_iE[] ? [] ? [] ? [] ?[].
   rewrite ok_vargs => /ok_inj <- /ih[] <- <- <-.
   rewrite ok_s2.
   exact: ok_inj.

--- a/proofs/lang/psem_of_sem_proof.v
+++ b/proofs/lang/psem_of_sem_proof.v
@@ -296,7 +296,8 @@ apply:
   case: (ih' _ hss'3) => s4' [hss'4 hf].
   exists s4'; split; first exact: hss'4.
   econstructor; eauto.
-- move => s1 scs2 m2 s2 ii xs fn args vargs vs /sem_pexprs_sim hargs _ ih /write_lvals_sim hres s1' [hscs hm hvm].
+- move=> s1 scs2 m2 s2 xs fn args vargs vs
+    /sem_pexprs_sim hargs _ ih /write_lvals_sim hres s1' [hscs hm hvm].
   rewrite hscs hm in ih.
   case: (hres (with_scs (with_mem s1' m2) scs2) (And3 erefl erefl hvm)) => s2' [hss'2 hw].
   exists s2'; split; first exact: hss'2.

--- a/proofs/lang/sem_one_varmap.v
+++ b/proofs/lang/sem_one_varmap.v
@@ -176,11 +176,11 @@ with sem_i : instr_info → Sv.t → estate → instr_r → estate → Prop :=
     sem_pexpr true gd s2 e = ok (Vbool false) →
     sem_i ii k s1 (Cwhile a c e c') s2
 
-| Ecall ii k s1 s2 ini res f args xargs xres :
+| Ecall ii k s1 s2 res f args xargs xres :
     mapM get_pvar args = ok xargs →
     mapM get_lvar res = ok xres →
     sem_call ii k s1 f s2 →
-    sem_i ii k s1 (Ccall ini res f args) s2
+    sem_i ii k s1 (Ccall res f args) s2
 
 with sem_call : instr_info → Sv.t → estate → funname → estate → Prop :=
 | EcallRun ii k s1 s2 fn f (* args *) m1 s2' (* res *) :
@@ -280,7 +280,7 @@ Lemma sem_iE ii k s i s' :
     ∃ kc si b,
        [/\ sem kc s c si, sem_pexpr true gd si e = ok (Vbool b) &
                        if b then ex3_3 (λ k' krec _, k = Sv.union (Sv.union kc k') krec) (λ k' _ sj, sem k' si c' sj) (λ _ krec sj, sem_I krec sj (MkI ii (Cwhile a c e c')) s') else si = s' ∧ kc = k ]
-  | Ccall ini res f args =>
+  | Ccall res f args =>
     exists2 xargs,
     mapM get_pvar args = ok xargs &
     exists2 xres,
@@ -412,12 +412,12 @@ Section SEM_IND.
   .
 
   Definition sem_Ind_call : Prop :=
-    ∀ (ii: instr_info) (k: Sv.t) (s1 s2: estate) ini res fn args xargs xres,
+    ∀ (ii: instr_info) (k: Sv.t) (s1 s2: estate) res fn args xargs xres,
       mapM get_pvar args = ok xargs →
       mapM get_lvar res = ok xres →
       sem_call ii k s1 fn s2 →
       Pfun ii k s1 fn s2 →
-      Pi_r ii k s1 (Ccall ini res fn args) s2.
+      Pi_r ii k s1 (Ccall res fn args) s2.
 
   Definition sem_Ind_proc : Prop :=
     ∀ (ii: instr_info) (k: Sv.t) (s1 s2: estate) (fn: funname) fd m1 s2',
@@ -464,8 +464,8 @@ Section SEM_IND.
           (@sem_I_Ind krec s3 (MkI ii (Cwhile a c e1 c')) s4 s6)
     | @Ewhile_false ii k s1 s2 a c e1 c' s0 e2 =>
       @Hwhile_false ii k s1 s2 a c e1 c' s0 (@sem_Ind k s1 c s2 s0) e2
-    | @Ecall ii k s1 s2 ini res fn args xargs xres hargs hres exec =>
-      @Hcall ii k s1 s2 ini res fn args xargs xres hargs hres exec (@sem_call_Ind ii k s1 fn s2 exec)
+    | @Ecall ii k s1 s2 res fn args xargs xres hargs hres exec =>
+      @Hcall ii k s1 s2 res fn args xargs xres hargs hres exec (@sem_call_Ind ii k s1 fn s2 exec)
     end
 
   with sem_I_Ind (k: Sv.t) (s1 : estate) (i : instr) (s2 : estate) (s : sem_I k s1 i s2) {struct s} : Pi k s1 i s2 :=


### PR DESCRIPTION
Discussing with Peter, we realized that
> There's actually a somewhat legit reason to have a function in libjade that is called just once and not inlined: say, we have a function that is used by both Dilithium and Kyber, so it's in some high-level ```common``` directory. If this function is used 3x by Dilithium, but only 1x by Kyber, we can either inline it everywhere (resulting in a significant code-size increase in Dilithium) or not inline it everywhere (leading to Kyber having a non-inlined function that is used just once).

(This particular example is easy to solve with the `inline` annotation, but this makes it easier when this happens in many different places.)