### PR TITLE
Implement is_reg_array in Coq

### DIFF
--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -197,8 +197,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     tokeep
   in
 
-  let is_reg_array x = is_reg_arr (Conv.var_of_cvar x) in
-
   let warn_extra s p =
     if s = Compiler.DeadCode_RegAllocation then
       let fds, _ = Conv.prog_of_csprog p in
@@ -246,7 +244,6 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.lowering_opt = Arch.lowering_opt;
       Compiler.fresh_id;
       Compiler.fresh_var_ident = Conv.fresh_var_ident;
-      Compiler.is_reg_array;
       Compiler.slh_info;
     }
   in

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -176,7 +176,6 @@ Record compiler_params
   lowering_opt     : lowering_options;
   fresh_id         : glob_decls -> var -> Ident.ident;
   fresh_var_ident  : v_kind -> instr_info -> Ident.name -> stype -> Ident.ident;
-  is_reg_array     : var -> bool;
   slh_info         : _uprog → funname → seq slh_t * seq slh_t
 }.
 
@@ -257,7 +256,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
 
   Let pv := live_range_splitting p in
 
-  let pr := remove_init_prog cparams.(is_reg_array) pv in
+  let pr := remove_init_prog is_reg_array pv in
   let pr := cparams.(print_uprog) RemoveArrInit pr in
 
   Let pa := makereference_prog (fresh_var_ident cparams (Reg (Normal, Pointer Writable))) pr in

--- a/proofs/lang/var.v
+++ b/proofs/lang/var.v
@@ -116,6 +116,10 @@ Definition is_reg_ptr (x: var) : bool :=
 Definition is_regx (x: var) : bool :=
   if Ident.id_kind x.(vname) is Reg(Extra, _) then true else false.
 
+Definition is_reg_array x :=
+  if Ident.id_kind x.(vname) is Reg (_, Direct) then
+    if x.(vtype) is sarr _ then true else false
+  else false.
 
 (* ** Finite set of variables (computable)
  *


### PR DESCRIPTION
Remove one more field from compiler params. And some cleaning too. `is_reg_array` still exists on the OCaml side (and is used), so it's not 100% clear to me that this PR is worth it, but every field removed from compiler params is a small victory.