### PR TITLE
Coq: remove uses of :> to declare instances

### DIFF
--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -33,9 +33,12 @@ Unset Printing Implicit Defensive.
  *)
 Class ToString (t: stype) (T: Type) :=
   { category      : string    (* Name of the "register" used to print errors. *)
-  ; _finC         :> finTypeC T
+  ; _finC         : finTypeC T
   ; to_string     : T -> string
   }.
+
+#[global]
+Existing Instance _finC.
 
 Definition rtype {t T} `{ToString t T} := t.
 
@@ -47,15 +50,18 @@ Definition rtype {t T} `{ToString t T} := t.
 Class arch_decl (reg regx xreg rflag cond : Type) :=
   { reg_size : wsize     (* Register size. Also used as pointer size. *)
   ; xreg_size : wsize    (* Extended registers size. *)
-  ; cond_eqC :> eqTypeC cond
-  ; toS_r :> ToString (sword reg_size) reg
-  ; toS_rx :> ToString (sword reg_size) regx
-  ; toS_x :> ToString (sword xreg_size) xreg
-  ; toS_f :> ToString sbool rflag
+  ; cond_eqC : eqTypeC cond
+  ; toS_r : ToString (sword reg_size) reg
+  ; toS_rx : ToString (sword reg_size) regx
+  ; toS_x : ToString (sword xreg_size) xreg
+  ; toS_f : ToString sbool rflag
   ; reg_size_neq_xreg_size : reg_size != xreg_size
   ; ad_rsp : reg
-  ; ad_fcp :> FlagCombinationParams
+  ; ad_fcp : FlagCombinationParams
   }.
+
+#[global]
+Existing Instances cond_eqC toS_r toS_rx toS_x toS_f ad_fcp.
 
 #[export]
 Instance arch_pd `{arch_decl} : PointerData := { Uptr := reg_size }.
@@ -415,10 +421,13 @@ Record instr_desc_t := {
 (* -------------------------------------------------------------------- *)
 (* Architecture operand declaration. *)
 Class asm_op_decl (asm_op: Type) :=
-  { _eqT          :> eqTypeC asm_op
+  { _eqT          : eqTypeC asm_op
   ; instr_desc_op : asm_op -> instr_desc_t
   ; prim_string   : list (string * prim_constructor asm_op)
   }.
+
+#[global]
+Existing Instance _eqT.
 
 Definition asm_op_t' {asm_op} {asm_op_d : asm_op_decl asm_op} := asm_op.
 (* We extend [asm_op] in order to deal with msb flags *)
@@ -678,7 +687,10 @@ Canonical rflagv_eqType := EqType _ rflagv_eqMixin.
 (* Assembly declaration. *)
 
 Class asm (reg regx xreg rflag cond asm_op: Type) :=
-  { _arch_decl   :> arch_decl reg regx xreg rflag cond
-  ; _asm_op_decl :> asm_op_decl asm_op
+  { _arch_decl   : arch_decl reg regx xreg rflag cond
+  ; _asm_op_decl : asm_op_decl asm_op
   ; eval_cond   : (rflag_t -> exec bool) -> cond_t -> exec bool
   }.
+
+#[global]
+Existing Instances _arch_decl _asm_op_decl.

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -153,12 +153,15 @@ Section ARCH.
 Context `{arch : arch_decl}.
 
 Class arch_toIdent :=
-  { toI_r  :> ToIdent reg
-  ; toI_rx :> ToIdent regx
-  ; toI_x  :> ToIdent xreg
-  ; toI_f  :> ToIdent rflag
+  { toI_r  : ToIdent reg
+  ; toI_rx : ToIdent regx
+  ; toI_x  : ToIdent xreg
+  ; toI_f  : ToIdent rflag
   ; inj_toI_reg_regx : forall (r:reg) (rx:regx), to_ident r <> to_ident rx
   }.
+
+#[global]
+Existing Instances toI_r toI_rx toI_x toI_f.
 
 End ARCH.
 
@@ -249,9 +252,9 @@ End ARCH.
  * replace by real asm instructions during the asmgen pass.
  *)
 Class asm_extra (reg regx xreg rflag cond asm_op extra_op : Type) :=
-  { _asm   :> asm reg regx xreg rflag cond asm_op
-  ; _atoI  :> arch_toIdent
-  ; _extra :> asmOp extra_op (* description of extra ops *)
+  { _asm   : asm reg regx xreg rflag cond asm_op
+  ; _atoI  : arch_toIdent
+  ; _extra : asmOp extra_op (* description of extra ops *)
   (* How to compile extra ops into a assembly instructions. *)
   ; to_asm :
     instr_info
@@ -260,6 +263,9 @@ Class asm_extra (reg regx xreg rflag cond asm_op extra_op : Type) :=
     -> rexprs
     -> cexec (seq (asm_op_msb_t * lexprs * rexprs))
   }.
+
+#[global]
+Existing Instances _asm _atoI _extra.
 
 Definition extra_op_t {reg regx xreg rflag cond asm_op extra_op} {asm_e : asm_extra reg regx xreg rflag cond asm_op extra_op} := extra_op.
 

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -350,7 +350,7 @@ Class valid_state (rmap : region_map) (m0 : mem) (s1 s2 : estate) := {
   vs_eq_vm       : eq_vm s1.(evm) s2.(evm);
     (* registers already present in the source program store the same values
        in the source and in the target *)
-  vs_wf_region   :> wf_rmap rmap s1 s2;
+  vs_wf_region   : wf_rmap rmap s1 s2;
     (* cf. [wf_rmap) definition *)
   vs_eq_mem      : eq_mem_source s1.(emem) s2.(emem);
     (* the memory that is already valid in the source is the same in the target *)
@@ -359,6 +359,8 @@ Class valid_state (rmap : region_map) (m0 : mem) (s1 s2 : estate) := {
   vs_top_stack   : rsp = top_stack (emem s2);
     (* [rsp] is the stack pointer, it points to the top of the stack *)
 }.
+
+Existing Instance vs_wf_region.
 
 (* We extend some predicates with the global case. *)
 (* -------------------------------------------------------------------------- *)

--- a/proofs/lang/sem_params.v
+++ b/proofs/lang/sem_params.v
@@ -22,17 +22,23 @@ Require Import
    [syscall_state] as a parameter instead of a record field. *)
 Class EstateParams (syscall_state : Type) := mk_ep
   {
-    _pd :> PointerData | 1000;
-    _msf_size :> MSFsize | 1000;
+    _pd : PointerData;
+    _msf_size : MSFsize;
   }.
+
+#[global]
+Existing Instances _pd _msf_size | 1000.
 
 Arguments mk_ep {_ _}.
 
 (* Parameters needed to evaluate expressions. *)
 Class SemPexprParams := mk_spp
   {
-    _fcp :> FlagCombinationParams | 1000;
+    _fcp : FlagCombinationParams;
   }.
+
+#[global]
+Existing Instance _fcp | 1000.
 
 Arguments mk_spp {_}.
 
@@ -42,8 +48,11 @@ Arguments mk_spp {_}.
    [syscall_state] are parameters instead of record fields. *)
 Class SemInstrParams (asm_op syscall_state : Type) := mk_sip
   {
-    _asmop :> asmOp asm_op | 1000;
-    _sc_sem :> syscall_sem syscall_state | 1000;
+    _asmop : asmOp asm_op;
+    _sc_sem : syscall_sem syscall_state;
   }.
+
+#[global]
+Existing Instances _asmop _sc_sem | 1000.
 
 Arguments mk_sip {_ _ _ _}.

--- a/proofs/lang/sopn.v
+++ b/proofs/lang/sopn.v
@@ -69,10 +69,13 @@ Variant prim_constructor (asm_op:Type) :=
      -> asm_op).
 
 Class asmOp (asm_op : Type) := {
-  _eqT           :> eqTypeC asm_op
+  _eqT           : eqTypeC asm_op
   ; asm_op_instr : asm_op -> instruction_desc
   ; prim_string   : list (string * prim_constructor asm_op)
 }.
+
+#[global]
+Existing Instance _eqT.
 
 Definition asm_op_t {asm_op} {asmop : asmOp asm_op} := asm_op.
 

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -55,11 +55,14 @@ Notation "x == y ::> T" := (eq_op (T:= @ceqT_eqType T _) x y)
 Notation "x == y ::>" := (eq_op (T:= @ceqT_eqType _ _) x y)
   (at level 70, y at next level) : bool_scope.
 
-Class finTypeC (T:Type) := 
-  { _eqC   :> eqTypeC T
+Class finTypeC (T:Type) :=
+  { _eqC   : eqTypeC T
   ; cenum  : seq T
   ; cenumP : @Finite.axiom ceqT_eqType cenum
   }.
+
+#[global]
+Existing Instance _eqC.
 
 Section FinType.
 


### PR DESCRIPTION
This is to prepare for future versions of Coq