### PR TITLE
Remove propagate inline parameters and remove CBC_O

### DIFF
--- a/proofs/compiler/arch_params_proof.v
+++ b/proofs/compiler/arch_params_proof.v
@@ -15,7 +15,6 @@ Require
   linearization
   linearization_proof
   lowering
-  propagate_inline_proof
   stack_alloc
   stack_alloc_proof
   slh_lowering_proof.
@@ -67,9 +66,6 @@ Record h_architecture_params
   (lowering_options : Type)
   (aparams : architecture_params lowering_options) :=
   {
-    (* Propagate inline hypotheses. See [propagate_inline_proof.v]. *)
-    hap_hpip : propagate_inline_proof.h_propagate_inline_params;
-
     (* Stack alloc hypotheses. See [stack_alloc_proof.v]. *)
     hap_hsap :
         stack_alloc_proof.h_stack_alloc_params (ap_sap aparams);

--- a/proofs/compiler/arm_decl.v
+++ b/proofs/compiler/arm_decl.v
@@ -258,7 +258,6 @@ Definition shift_of_sop2 (ws : wsize) (op : sop2) : option shift_kind :=
 (* Flag combinations.
    The ARM terminology is different from Intel's (chapter A7.3 from the
    ARMv7-M reference manual).
-   - [CFC_O] is Overflow.
    - [CFC_B] is Carry clear (unsigned lower).
    - [CFC_E] is Equal.
    - [CFC_S] is Minus (negative).
@@ -272,7 +271,6 @@ Definition arm_fc_of_cfc (cfc : combine_flags_core) : flag_combination :=
   let vcf := FCVar2 in
   let vvf := FCVar3 in
   match cfc with
-  | CFC_O => vvf
   | CFC_B => FCNot vcf
   | CFC_E => vzf
   | CFC_S => vnf

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -18,7 +18,6 @@ Require Import
   linearization
   linearization_proof
   lowering
-  propagate_inline_proof
   stack_alloc
   stack_alloc_proof.
 Require
@@ -49,39 +48,7 @@ Context
   {sc_sem : syscall_sem syscall_state}
   {call_conv : calling_convention}.
 
-(* ------------------------------------------------------------------------ *)
-(* Flag combination hypotheses. *)
 #[local] Existing Instance withsubword.
-
-Lemma arm_cf_xsemP wdb gd s e0 e1 e2 e3 cf v :
-  let: e := PappN (Ocombine_flags cf) [:: e0; e1; e2; e3 ] in
-  let: e' := cf_xsem enot eand eor expr.eeq e0 e1 e2 e3 cf in
-  sem_pexpr wdb gd s e = ok v
-  -> sem_pexpr wdb gd s e' = ok v.
-Proof.
-  rewrite /=.
-
-  t_xrbindP=> vs0 v0 hv0 vs1 v1 hv1 vs2 v2 hv2 vs3 v3 hv3 ? ? ? ?;
-    subst vs0 vs1 vs2 vs3.
-  rewrite /sem_opN /=.
-  t_xrbindP=> b b0 hb0 b1 hb1 b2 hb2 b3 hb3 hb ?; subst v.
-  move: hb0 => /to_boolI ?; subst v0.
-  move: hb1 => /to_boolI ?; subst v1.
-  move: hb2 => /to_boolI ?; subst v2.
-  move: hb3 => /to_boolI ?; subst v3.
-
-  move: hb.
-  rewrite /sem_combine_flags.
-  rewrite /cf_xsem.
-
-  case: cf_tbl => -[] [] [?] /=; subst b.
-  all: by rewrite ?hv0 ?hv1 ?hv2 ?hv3.
-Qed.
-
-Definition arm_hpiparams {dc : DirectCall} : h_propagate_inline_params :=
-  {|
-    pip_cf_xsemP := arm_cf_xsemP;
-  |}.
 
 (* ------------------------------------------------------------------------ *)
 (* Stack alloc hypotheses. *)
@@ -1261,7 +1228,6 @@ Proof. by constructor; move=> ???? []. Qed.
 
 Definition arm_h_params {dc : DirectCall} : h_architecture_params arm_params :=
   {|
-    hap_hpip := arm_hpiparams;
     hap_hsap := arm_hsaparams;
     hap_hlip := arm_hliparams;
     ok_lip_tmp := arm_ok_lip_tmp;

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -193,7 +193,7 @@ Proof.
 
   have va_refl := List_Forall2_refl va value_uincl_refl.
   apply: compose_pass_uincl.
-  - move=> vr'; apply: (pi_callP (sCP := sCP_unit) (hpip := hap_hpip haparams) ok_pp va_refl).
+  - move=> vr'; apply: (pi_callP (sCP := sCP_unit) ok_pp va_refl).
    apply: compose_pass.
   - move=> vr'.
     assert (h := lower_slh_prog_sem_call (dc:=direct_c) (hap_hshp haparams) (ev:= tt) ok_pi).

--- a/proofs/compiler/propagate_inline_proof.v
+++ b/proofs/compiler/propagate_inline_proof.v
@@ -12,22 +12,6 @@ Unset Printing Implicit Defensive.
 Local Open Scope seq_scope.
 
 
-Record h_propagate_inline_params
-  {wsw : WithSubWord}
-  {dc:DirectCall}
-  {asm_op syscall_state : Type}
-  {ep : EstateParams syscall_state}
-  {spp : SemPexprParams}
-  {sip : SemInstrParams asm_op syscall_state} :=
-  {
-    pip_cf_xsemP :
-      forall wdb gd s e0 e1 e2 e3 cf v,
-        let e := PappN (Ocombine_flags cf) [:: e0; e1; e2; e3 ] in
-        let e' := cf_xsem enot eand eor expr.eeq e0 e1 e2 e3 cf in
-        sem_pexpr wdb gd s e = ok v
-        -> sem_pexpr wdb gd s e' = ok v;
-  }.
-
 Section WITH_PARAMS.
 
 Context
@@ -40,8 +24,7 @@ Context
   {T : eqType}
   {pT : progT T}
   {sCP : semCallParams}
-  {hpip : h_propagate_inline_params}.
-
+.
 
 Definition dfl_cel := 
   {| pi_def := Pconst 0; pi_fv := Sv.empty; pi_m := false; pi_fv_ok := erefl _; pi_m_ok := erefl _|}.
@@ -165,49 +148,42 @@ Proof.
   by move=> /sandP [v] [-> /value_uinclE ->]. 
 Qed.
 
-Lemma fc_esem_ssem wdb e0 e1 e2 e3 fc b :
-  let esem := fc_sem enot eand eor expr.eeq  in
-  let ssem := fc_sem snot sand sor sbeq in
-  sem_pexpr wdb gd s (esem e0 e1 e2 e3 fc) = ok (Vbool b)
-  -> sem_pexpr wdb gd s (ssem e0 e1 e2 e3 fc) = ok (Vbool b).
+(* Interpreting the flag combination as an expression and evaluating it
+   coincides with interpreting as a boolean. *)
+Lemma sem_pexpr_fc_sem wsb b0 b1 b2 b3 e0 e1 e2 e3 fc :
+  sem_pexpr wsb gd s e0 = ok (Vbool b0) ->
+  sem_pexpr wsb gd s e1 = ok (Vbool b1) ->
+  sem_pexpr wsb gd s e2 = ok (Vbool b2) ->
+  sem_pexpr wsb gd s e3 = ok (Vbool b3) ->
+  let: e := fc_sem snot sand sor sbeq e0 e1 e2 e3 fc in
+  let: b := fc_sem negb andb orb (fun x y => x == y) b0 b1 b2 b3 fc in
+  sem_pexpr wsb gd s e = ok (Vbool b).
 Proof.
-  rewrite /=.
-  elim: fc b
-    => //= [fc ih | fc0 ih0 fc1 ih1 | fc0 ih0 fc1 ih1 | fc0 ih0 fc1 ih1] b.
-  all: t_xrbindP.
-
-  - move=> v hv hnot.
-    move: hnot => /sem_sop1I /= [nb hnb [?]]; subst b.
-    move: hnb => /to_boolI ?; subst v.
-    apply: snotE.
-    exact: (ih nb hv).
-
-  all: move=> v0 hv0 v1 hv1 h.
-  all: move: h => /sem_sop2I /= [b0 [b1 [b' [hb0 hb1 hb [?]]]]]; subst b'.
-  all: move: hb0 => /to_boolI ?; subst v0.
-  all: move: hb1 => /to_boolI ?; subst v1.
-  all: move: hb => [?]; subst b.
-  all: have h0 := ih0 b0 hv0.
-  all: have h1 := ih1 b1 hv1.
-  all:
-    solve
-      [ exact: (sandE h0 h1) | exact: (sorE h0 h1) | exact: (sbeqE h0 h1) ].
+  move=> ????.
+  elim: fc => * /=;
+    t_simpl_rewrites;
+    by [| exact: snotE | exact: sandE | exact: sorE | exact: sbeqE ].
 Qed.
 
-Lemma cf_esem_ssem wdb e0 e1 e2 e3 cf b :
-  let esem := cf_xsem enot eand eor expr.eeq  in
-  let ssem := cf_xsem snot sand sor sbeq in
-  sem_pexpr wdb gd s (esem e0 e1 e2 e3 cf) = ok (Vbool b)
-  -> sem_pexpr wdb gd s (ssem e0 e1 e2 e3 cf) = ok (Vbool b).
+Lemma sem_pexpr_cf_xsem wdb e0 e1 e2 e3 cf v :
+  let: e := PappN (Ocombine_flags cf) [:: e0; e1; e2; e3 ] in
+  let: e' := cf_xsem snot sand sor sbeq e0 e1 e2 e3 cf in
+  sem_pexpr wdb gd s e = ok v ->
+  sem_pexpr wdb gd s e' = ok v.
 Proof.
-  rewrite /cf_xsem.
-  case: cf_tbl => -[] cfc; last exact: fc_esem_ssem.
   rewrite /=.
-  t_xrbindP=> v hv hnot.
-  move: hnot => /sem_sop1I /= [nb hnb [?]]; subst b.
-  move: hnb => /to_boolI ?; subst v.
-  apply: snotE.
-  exact: (fc_esem_ssem hv).
+  t_xrbindP=> vs0 v0 hv0 vs1 v1 hv1 vs2 v2 hv2 vs3 v3 hv3 ? ? ? ?;
+    subst.
+
+  rewrite /sem_opN /=.
+  t_xrbindP=> b ? /to_boolI ?? /to_boolI ?? /to_boolI ?? /to_boolI ? hb ?;
+    subst.
+
+  move: hb.
+  rewrite /sem_combine_flags /cf_xsem.
+  case: cf_tbl => -[] ? [?];
+    subst b;
+    by auto using snotE, sandE, sorE, sbeqE, sem_pexpr_fc_sem.
 Qed.
 
 Lemma scfcP wdb c es vs v :
@@ -215,34 +191,19 @@ Lemma scfcP wdb c es vs v :
   -> sem_opN (Ocombine_flags c) vs = ok v
   -> sem_pexpr wdb gd s (scfc c es) = ok v.
 Proof.
-  rewrite /scfc.
-  case: es => /= [[<-] | eof es]; first done.
-  t_xrbindP=> vof hvof {vs} vs h <-.
-  case: es h => /= [[<-] | ecf es]; first by rewrite hvof.
-  t_xrbindP=> vcf hvcf {vs} vs h <-.
-  case: es h => /= [[<-] | esf es]; first by rewrite hvof hvcf.
-  t_xrbindP=> vsf hvsf {vs} vs h <-.
-  case: es h => /= [[<-] | ezf es]; first by rewrite hvof hvcf hvsf.
-  t_xrbindP=> vzf hvzf {vs} vs h <-.
+  move=> h.
+  repeat (
+    case: es h => /= [[<-] | ? es];
+      first (by t_simpl_rewrites);
+      t_xrbindP=> ?? {vs} vs h <-
+  ).
 
-  case: es h => /= [[<-] | ? ?]; first last.
+  case: es h => /= [[<-] | ??]; first last.
   - t_xrbindP=> ???? <-. rewrite /sem_opN /=. by t_xrbindP.
 
   move=> h.
-  have hv := h.
-  move: h.
-  rewrite /sem_opN /=.
-  t_xrbindP=> b bof hof bcf hcf bsf hsf bzf hzf hb ?; subst v.
-  move: hof => /to_boolI ?; subst vof.
-  move: hcf => /to_boolI ?; subst vcf.
-  move: hsf => /to_boolI ?; subst vsf.
-  move: hzf => /to_boolI ?; subst vzf.
-
-  apply: cf_esem_ssem.
-  apply: (pip_cf_xsemP hpip).
-  rewrite /=.
-  rewrite hvof hvcf hvsf hvzf {hvof hvcf hvsf hvzf} /=.
-  exact: hv.
+  apply: sem_pexpr_cf_xsem => /=.
+  by t_simpl_rewrites.
 Qed.
 
 End SCFC.

--- a/proofs/compiler/x86_decl.v
+++ b/proofs/compiler/x86_decl.v
@@ -345,7 +345,6 @@ Definition x86_fc_of_cfc (cfc : combine_flags_core) : flag_combination :=
   let vsf := FCVar2 in
   let vzf := FCVar3 in
   match cfc with
-  | CFC_O => vof
   | CFC_B => vcf
   | CFC_E => vzf
   | CFC_S => vsf

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -16,7 +16,6 @@ Require Import
   linearization
   linearization_proof
   lowering
-  propagate_inline_proof
   slh_lowering
   slh_lowering_proof
   stack_alloc
@@ -46,39 +45,6 @@ Unset Printing Implicit Defensive.
 Section Section.
 Context {atoI : arch_toIdent} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
 
-
-(* ------------------------------------------------------------------------ *)
-(* Flag combination hypotheses. *)
-
-Lemma x86_cf_xsemP wdb gd s e0 e1 e2 e3 cf v :
-  let e := PappN (Ocombine_flags cf) [:: e0; e1; e2; e3 ] in
-  let e' := cf_xsem enot eand eor expr.eeq e0 e1 e2 e3 cf in
-  sem_pexpr wdb gd s e = ok v
-  -> sem_pexpr wdb gd s e' = ok v.
-Proof.
-  rewrite /=.
-
-  t_xrbindP=> vs0 v0 hv0 vs1 v1 hv1 vs2 v2 hv2 vs3 v3 hv3 ? ? ? ?;
-    subst vs0 vs1 vs2 vs3.
-  rewrite /sem_opN /=.
-  t_xrbindP=> b b0 hb0 b1 hb1 b2 hb2 b3 hb3 hb ?; subst v.
-  move: hb0 => /to_boolI ?; subst v0.
-  move: hb1 => /to_boolI ?; subst v1.
-  move: hb2 => /to_boolI ?; subst v2.
-  move: hb3 => /to_boolI ?; subst v3.
-
-  move: hb.
-  rewrite /sem_combine_flags.
-  rewrite /cf_xsem.
-
-  case: cf_tbl => -[] [] [?] /=; subst b.
-  all: by rewrite ?hv0 ?hv1 ?hv2 ?hv3.
-Qed.
-
-Definition x86_hpiparams {dc: DirectCall} : h_propagate_inline_params :=
-  {|
-    pip_cf_xsemP := x86_cf_xsemP;
-  |}.
 
 (* ------------------------------------------------------------------------ *)
 (* Stack alloc hypotheses. *)
@@ -1060,7 +1026,6 @@ Qed.
 
 Definition x86_h_params {dc : DirectCall} {call_conv : calling_convention} : h_architecture_params x86_params :=
   {|
-    hap_hpip := x86_hpiparams;
     hap_hsap := x86_hsaparams;
     hap_hlip := x86_hliparams;
     ok_lip_tmp := x86_ok_lip_tmp;

--- a/proofs/lang/flag_combination.v
+++ b/proofs/lang/flag_combination.v
@@ -79,11 +79,9 @@ Section SEM.
     | FCEq fc0 fc1 => xeq (fc_sem fc0) (fc_sem fc1)
     end.
 
-  Definition cfc_xsem (cfc : combine_flags_core) : X :=
-    fc_sem (fc_of_cfc cfc).
-
   Definition cf_xsem (cf : combine_flags) : X :=
     let '(n, cfc) := cf_tbl cf in
     let x := fc_sem (fc_of_cfc cfc) in
     if n then xnot x else x.
+
 End SEM.

--- a/proofs/lang/flag_combination.v
+++ b/proofs/lang/flag_combination.v
@@ -9,15 +9,14 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 
-(* We distinguish 7 different conditions that can potentially be expressed with
+(* We distinguish 6 different conditions that can potentially be expressed with
    flags, these are [combine_flags_core], but provide the user with these and
-   their negations, [combine_flags]. Their correspondence is specified by
-   [cf_tbl].
+   their negations, [combine_flags].
+   Their correspondence is specified by [cf_tbl].
    The correspondence between these conditions and flags is
    architecture-specific. *)
 
 Variant combine_flags_core :=
-| CFC_O      (* Overflow. *)
 | CFC_B      (* Below (not above or equal). *)
 | CFC_E      (* Equal (zero). *)
 | CFC_S      (* Sign (negative). *)

--- a/proofs/lang/sem_op_typed.v
+++ b/proofs/lang/sem_op_typed.v
@@ -128,17 +128,15 @@ Section WITH_PARAMS.
 Context {cfcd : FlagCombinationParams}.
 
 Definition sem_combine_flags
-  (o : combine_flags) (bof bcf bsf bzf : bool) : exec bool :=
-  let '(n, cfc) := cf_tbl o in
-  let b := cfc_xsem negb andb orb (fun x y => x == y) bof bcf bsf bzf cfc in
-  ok (if n then ~~ b else b).
+  (cf : combine_flags) (b0 b1 b2 b3 : bool) : exec bool :=
+  ok (cf_xsem negb andb orb (fun x y => x == y) b0 b1 b2 b3 cf).
 
 Definition sem_opN_typed (o: opN) :
   let t := type_of_opN o in
   sem_prod t.1 (exec (sem_t t.2)) :=
   match o with
   | Opack sz pe => curry (A := sint) (sz %/ pe) (λ vs, ok (wpack sz pe vs))
-  | Ocombine_flags o => sem_combine_flags o
+  | Ocombine_flags cf => sem_combine_flags cf
   end.
 
 End WITH_PARAMS.


### PR DESCRIPTION
There are two parts to this PR, I can split it if it's worth it.

The propagate inline pass relies on the fact that interpreting a flag combination as an expression and evaluating it is the same as interpreting the values as a booleans (`sem_pexpr` composed with `fc_sem enot eand eor eeq` is `fc_sem negb andb orb eqb`). This uses an architecture parameter but is true regardless of what it does.

I removed the `CFC_O` constructor because `combine_flags_core` is how we represent conditions (`==`, `!=`, `<=`, `<`, etc.) and there is no condition for overflow (i.e. it's inaccessible from the source). The overflow flag is needed to compute some conditions, but we don't need the condition by itself. You can see this in the definition of `cf_tbl`: `CFC_O` is not the image of any `combine_flags`.