### PR TITLE
extra-fun-t needs not be an eqType

### DIFF
--- a/proofs/compiler/allocation.v
+++ b/proofs/compiler/allocation.v
@@ -599,15 +599,16 @@ Section PROG.
 Context {T:eqType} {pT:progT T}.
 
 Variable (init_alloc : extra_fun_t -> extra_prog_t -> extra_prog_t -> cexec M.t).
+Variable (check_f_extra: M.t → extra_fun_t → extra_fun_t → seq var_i → seq var_i → cexec M.t).
 
 Definition check_fundef (ep1 ep2 : extra_prog_t) (f1 f2: funname * fundef) (_:Datatypes.unit) :=
   let (f1,fd1) := f1 in
   let (f2,fd2) := f2 in
   add_funname f1 (add_finfo fd1.(f_info) (
-    Let _ := assert [&& f1 == f2, fd1.(f_tyin) == fd2.(f_tyin), fd1.(f_tyout) == fd2.(f_tyout) &
-                        fd1.(f_extra) == fd2.(f_extra)] (E.error "functions not equal") in
+    Let _ := assert [&& f1 == f2, fd1.(f_tyin) == fd2.(f_tyin) & fd1.(f_tyout) == fd2.(f_tyout) ]
+                        (E.error "functions not equal") in
     Let r := init_alloc fd1.(f_extra) ep1 ep2 in
-    Let r := check_vars fd1.(f_params) fd2.(f_params) r in
+    Let r := check_f_extra r fd1.(f_extra) fd2.(f_extra) fd1.(f_params) fd2.(f_params) in
     Let r := check_cmd fd1.(f_body) fd2.(f_body) r in
     let es1 := map Plvar fd1.(f_res) in
     let es2 := map Plvar fd2.(f_res) in
@@ -626,10 +627,15 @@ Section UPROG.
 #[local]
 Existing Instance progUnit.
 
-Definition init_alloc_uprog (ef: extra_fun_t) (ep1 ep2: extra_prog_t) : cexec M.t :=
+Definition init_alloc_uprog (_: extra_fun_t) (_ _: extra_prog_t) : cexec M.t :=
   ok M.empty.
-Definition check_ufundef := check_fundef init_alloc_uprog.
-Definition check_uprog := check_prog init_alloc_uprog.
+
+Definition check_f_extra_u (r: M.t) (e1 e2: extra_fun_t) p1 p2 :=
+  Let _ := assert (e1 == e2) (E.error "extra not equal") in
+  check_vars p1 p2 r.
+
+Definition check_ufundef := check_fundef init_alloc_uprog check_f_extra_u.
+Definition check_uprog := check_prog init_alloc_uprog check_f_extra_u.
 
 End UPROG.
 
@@ -643,8 +649,27 @@ Existing Instance progStack.
 Definition init_alloc_sprog (ef: extra_fun_t) (ep1 ep2: extra_prog_t) : cexec M.t :=
   check_vars [:: vid ep1.(sp_rsp); vid ep1.(sp_rip)]
              [:: vid ep2.(sp_rsp); vid ep2.(sp_rip)] M.empty.
-Definition check_sfundef := check_fundef init_alloc_sprog.
-Definition check_sprog := check_prog init_alloc_sprog.
+
+Definition check_f_extra_s (r: M.t) (e1 e2: extra_fun_t) p1 p2 : cexec M.t :=
+  Let _ :=
+    assert [&&
+  (e1.(sf_align) == e2.(sf_align)),
+  (e1.(sf_stk_sz) == e2.(sf_stk_sz)),
+  (e1.(sf_stk_ioff) == e2.(sf_stk_ioff)),
+  (e1.(sf_stk_max) == e2.(sf_stk_max)),
+  (e1.(sf_max_call_depth) == e2.(sf_max_call_depth)),
+  (e1.(sf_stk_extra_sz) == e2.(sf_stk_extra_sz)),
+  (e1.(sf_to_save) == e2.(sf_to_save)),
+  (e1.(sf_save_stack) == e2.(sf_save_stack)) &
+  (e1.(sf_return_address) == e2.(sf_return_address)) ]
+      (E.error "extra not equal") in
+  if e1.(sf_return_address) == RAnone then
+    check_vars p1 p2 r
+  else
+    check_vars p1 p2 r.
+
+Definition check_sfundef := check_fundef init_alloc_sprog check_f_extra_s.
+Definition check_sprog := check_prog init_alloc_sprog check_f_extra_s.
 
 End SPROG.
 

--- a/proofs/compiler/allocation.v
+++ b/proofs/compiler/allocation.v
@@ -596,7 +596,7 @@ Definition check_cmd := fold2 E.fold2 check_I.
 
 Section PROG.
 
-Context {T:eqType} {pT:progT T}.
+Context {pT: progT}.
 
 Variable (init_alloc : extra_fun_t -> extra_prog_t -> extra_prog_t -> cexec M.t).
 Variable (check_f_extra: M.t → extra_fun_t → extra_fun_t → seq var_i → seq var_i → cexec M.t).

--- a/proofs/compiler/allocation_proof.v
+++ b/proofs/compiler/allocation_proof.v
@@ -328,7 +328,7 @@ Qed.
 Section PROG.
 
 Context
-  {T:eqType} {pT:progT T}
+  {pT: progT}
   {sCP : semCallParams}.
 
 Variable init_alloc : extra_fun_t -> extra_prog_t -> extra_prog_t -> cexec M.t.

--- a/proofs/compiler/arch_params.v
+++ b/proofs/compiler/arch_params.v
@@ -32,7 +32,7 @@ Record lowering_params
      from those in a list of function declarations. *)
     lop_fvars_correct :
       lowering.fresh_vars
-      -> forall (eft : eqType) (pT : progT eft),
+      -> forall (pT : progT),
            seq fun_decl
            -> bool;
   }.

--- a/proofs/compiler/arch_params_proof.v
+++ b/proofs/compiler/arch_params_proof.v
@@ -35,8 +35,7 @@ Record h_lowering_params
   {
     hlop_lower_callP :
       forall
-        (eft : eqType)
-        (pT : progT eft)
+        (pT : progT)
         (sCP : semCallParams)
         (p : prog)
         (ev : extra_val_t)

--- a/proofs/compiler/arm_instr_decl_lemmas.v
+++ b/proofs/compiler/arm_instr_decl_lemmas.v
@@ -40,8 +40,7 @@ Context
   {atoI : arch_toIdent}
   {syscall_state : Type}
   {sc_sem : syscall_sem syscall_state}
-  {eft : eqType}
-  {pT : progT eft}
+  {pT : progT}
   {sCP : semCallParams}.
 
 Definition truncate_args

--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -61,8 +61,7 @@ Context
   {atoI : arch_toIdent}
   {syscall_state : Type}
   {sc_sem : syscall_sem syscall_state}
-  {eft : eqType}
-  {pT : progT eft}
+  {pT : progT}
   {sCP : semCallParams}
   (p : prog)
   (ev : extra_val_t)

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -202,8 +202,7 @@ End LINEARIZATION.
 #[ local ]
 Definition arm_fvars_correct
   (fv : fresh_vars)
-  {eft : eqType}
-  {pT : progT eft}
+  {pT : progT}
   (fds : seq fun_decl) :
   bool :=
   fvars_correct (all_fresh_vars fv) (fvars fv) fds.

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -886,8 +886,7 @@ Qed.
 
 Lemma arm_lower_callP
   { dc : DirectCall }
-  (eft : eqType)
-  (pT : progT eft)
+  (pT : progT)
   (sCP : semCallParams)
   (p : prog)
   (ev : extra_val_t)

--- a/proofs/compiler/array_copy.v
+++ b/proofs/compiler/array_copy.v
@@ -115,7 +115,7 @@ Fixpoint array_copy_i (i:instr) : cexec cmd :=
   | Ccall _ _ _ _ => ok [:: i]
   end.
 
-Context {T} {pT:progT T}.
+Context {pT: progT}.
 
 Definition array_copy_fd (f:fundef) :=
   let 'MkFun fi tyin params c tyout res ev := f in

--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -21,8 +21,7 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  {T : eqType}
-  {pT : progT T}
+  {pT : progT}
   {sCP : semCallParams}.
 
 Context (fresh_counter: Ident.ident) (p1 p2: prog) (ev: extra_val_t).

--- a/proofs/compiler/array_init.v
+++ b/proofs/compiler/array_init.v
@@ -53,7 +53,7 @@ Fixpoint remove_init_i i :=
 
 Definition remove_init_c c :=  foldr (fun i c => remove_init_i i ++ c) [::] c.
 
-Context {T} {pT:progT T}.
+Context {pT: progT}.
 
 Definition remove_init_fd (fd:fundef) :=
   {| f_info   := fd.(f_info);
@@ -116,7 +116,7 @@ Fixpoint add_init_i I (i:instr) :=
     (add_init ii I extra i, Sv.union I Wi)
   end.
 
-Context {T} {pT:progT T}.
+Context {pT: progT}.
 
 Definition add_init_fd (fd:fundef) :=
   let I := vrvs [seq (Lvar i) | i <- f_params fd] in

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -22,7 +22,7 @@ Context
 
 Section Section.
 
-Context {T:eqType} {pT:progT T} {sCP: semCallParams}.
+Context {pT: progT} {sCP: semCallParams}.
 
 Section REMOVE_INIT.
   

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -279,7 +279,7 @@ Proof.
     (dead_code_prog_tokeep_get_fundef ok_pc get_fdb).
   move: (alloc_pc _ get_fdc).
   have [_ _ ->]:= dead_code_fd_meta ok_fdc.
-  have /=[_ _ _ <-] := check_fundef_meta ok_fdb.
+  have [ <- <- <- ] := @check_fundef_meta _ _ _ _ _ _ _ (_, fda) _ _ _ ok_fdb.
   have [_ _ ->]:= dead_code_fd_meta ok_fda.
   done.
 Qed.

--- a/proofs/compiler/compiler_util.v
+++ b/proofs/compiler/compiler_util.v
@@ -163,7 +163,7 @@ Proof. by case: e. Qed.
 Section ASM_OP.
 
 Context `{asmop:asmOp}.
-Context {eft} {pT:progT eft}.
+Context {pT: progT}.
 
 Definition map_prog_name (F: funname -> fundef -> fundef) (p:prog) :prog :=
   {| p_funcs := map (fun f => (f.1, F f.1 f.2)) (p_funcs p);

--- a/proofs/compiler/constant_prop.v
+++ b/proofs/compiler/constant_prop.v
@@ -542,7 +542,7 @@ End GLOBALS.
 
 Section Section.
 
-Context {T} {pT:progT T}.
+Context {pT: progT}.
 
 Definition const_prop_fun (gd: glob_decls) (f: fundef) :=
   let 'MkFun ii si p c so r ev := f in

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -26,8 +26,7 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  {T : eqType}
-  {pT : progT T}
+  {pT : progT}
   {sCP : semCallParams}.
 
 Section GLOB_DEFS.

--- a/proofs/compiler/dead_calls.v
+++ b/proofs/compiler/dead_calls.v
@@ -44,7 +44,7 @@ Definition c_calls (c : Sf.t) (cmd : cmd) :=
 
 Section Section.
 
-Context {T} {pT:progT T}.
+Context {pT: progT}.
 
 Definition live_calls (s: Sf.t) (p: fun_decls) : Sf.t :=
   foldl (λ c x, let '(n, d) := x in if Sf.mem n c then c_calls c (f_body d) else c) s p.

--- a/proofs/compiler/dead_calls_proof.v
+++ b/proofs/compiler/dead_calls_proof.v
@@ -122,7 +122,7 @@ End CALLS.
 
 Section Section.
 
-Context {T:eqType} {pT:progT T} {sCP: semCallParams}.
+Context {pT: progT} {sCP: semCallParams}.
 
 #[local]
 Instance live_calls_m : Proper (Sf.Equal ==> eq ==> Sf.Equal) live_calls.

--- a/proofs/compiler/dead_code.v
+++ b/proofs/compiler/dead_code.v
@@ -172,7 +172,7 @@ Fixpoint dead_code_i (i:instr) (s:Sv.t) {struct i} : cexec (Sv.t * option instr)
 
 Section Section.
 
-Context {T} {pT:progT T}.
+Context {pT: progT}.
 
 Definition dead_code_fd {eft} fn (fd: _fundef eft) : cexec (_fundef eft) :=
   let 'MkFun ii tyi params c tyo res ef := fd in
@@ -190,7 +190,7 @@ End Section.
 
 End ONFUN.
 
-Definition dead_code_prog {T} {pT:progT T} (p:prog) do_nop :=
-  @dead_code_prog_tokeep do_nop (fun _ => None) T pT p.
+Definition dead_code_prog {pT:progT} (p:prog) do_nop :=
+  @dead_code_prog_tokeep do_nop (fun _ => None) pT p.
 
 End ASM_OP.

--- a/proofs/compiler/dead_code_proof.v
+++ b/proofs/compiler/dead_code_proof.v
@@ -29,8 +29,7 @@ Context
 Section Section.
 
 Context
-  {T:eqType}
-  {pT:progT T}
+  {pT: progT}
   {sCP: semCallParams}.
 
 Section PROOF.

--- a/proofs/compiler/direct_call_proof.v
+++ b/proofs/compiler/direct_call_proof.v
@@ -20,8 +20,7 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  {T : eqType}
-  {pT : progT T}
+  {pT : progT}
   {sCP : semCallParams}.
 
 Context (p:prog) (ev:extra_val_t).

--- a/proofs/compiler/lowering.v
+++ b/proofs/compiler/lowering.v
@@ -18,8 +18,7 @@ Context
   (options : lowering_options)
   (warning : instr_info -> warning_msg -> instr_info)
   (fv : fresh_vars)
-  {eft : eqType}
-  {pT : progT eft}
+  {pT : progT}
   (all_fresh_vars : seq Ident.ident)
   (fvars : Sv.t).
 

--- a/proofs/compiler/makeReferenceArguments_proof.v
+++ b/proofs/compiler/makeReferenceArguments_proof.v
@@ -19,8 +19,7 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  (T : eqType)
-  (pT : progT T)
+  (pT : progT)
   (cs : semCallParams)
   (p : prog)
   (ev : extra_val_t).

--- a/proofs/compiler/propagate_inline.v
+++ b/proofs/compiler/propagate_inline.v
@@ -202,7 +202,7 @@ Fixpoint pi_i (pi:pimap) (i:instr) :=
 
 Section Section.
 
-Context {T} {pT:progT T}.
+Context {pT:progT}.
 
 Definition pi_fun  (f:fundef) :=
   let 'MkFun ii si p c so r ev := f in

--- a/proofs/compiler/propagate_inline_proof.v
+++ b/proofs/compiler/propagate_inline_proof.v
@@ -21,8 +21,7 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  {T : eqType}
-  {pT : progT T}
+  {pT : progT}
   {sCP : semCallParams}
 .
 

--- a/proofs/compiler/slh_lowering.v
+++ b/proofs/compiler/slh_lowering.v
@@ -205,7 +205,7 @@ Context
   {asm_op : Type}
   {asmop : asmOp asm_op}
   {msfsz : MSFsize}
-  {eft : eqType} {pT : progT eft}.
+  {pT : progT}.
 
 Section CHECK_SLHO.
 

--- a/proofs/compiler/slh_lowering_proof.v
+++ b/proofs/compiler/slh_lowering_proof.v
@@ -474,8 +474,7 @@ Qed.
 Section CHECK_PROOF.
 
 Context
-  {eft : eqType}
-  {pT : progT eft}
+  {pT : progT}
   {dc: DirectCall}
   {sCP : semCallParams}
   (shparams : sh_params)
@@ -791,8 +790,7 @@ End CHECK_PROOF.
 Section PASS_PROOF.
 
 Context
-  {eft : eqType}
-  {pT : progT eft}
+  {pT : progT}
   {sCP : semCallParams}
   {dc : DirectCall}
   (shparams : sh_params)

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -257,7 +257,7 @@ Definition eq_sub_region_val ty m2 sr bytes v :=
   *)
   type_of_val v = ty.
 
-Variable (P: uprog) (ev: @extra_val_t _ progUnit).
+Variable (P: uprog) (ev: @extra_val_t progUnit).
 Notation gd := (p_globs P).
 
 (* TODO: could we have this in stack_alloc.v ?

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -45,7 +45,7 @@ Context
   (rip : pointer)
   (no_overflow_glob_size : no_overflow rip glob_size)
   (mglob : Mvar.t (Z * wsize))
-  (P : uprog) (ev: @extra_val_t _ progUnit)
+  (P : uprog) (ev: @extra_val_t progUnit)
   (hmap : init_map global_alloc global_data (p_globs P) = ok mglob).
 
 Notation gd := (p_globs P).

--- a/proofs/compiler/unrolling.v
+++ b/proofs/compiler/unrolling.v
@@ -81,7 +81,7 @@ Fixpoint unroll_i (i: instr) : cmd * bool :=
 
 Section Section.
 
-Context {T} {pT:progT T}.
+Context {pT: progT}.
 
 Definition unroll_fun (f: fun_decl) :=
   let: (fn, MkFun ii si p c so r ev) := f in

--- a/proofs/compiler/unrolling_proof.v
+++ b/proofs/compiler/unrolling_proof.v
@@ -18,8 +18,7 @@ Section PROOF.
     {ep : EstateParams syscall_state}
     {spp : SemPexprParams}
     {sip : SemInstrParams asm_op syscall_state}
-    {T : eqType}
-    {pT : progT T}
+    {pT : progT}
     {sCP : semCallParams}.
 
   Variable (p : prog) (ev:extra_val_t).

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -58,7 +58,7 @@ Definition fvars :=
 
 Definition disj_fvars v := disjoint v fvars.
 
-Context {T} {pT:progT T}.
+Context {pT: progT}.
 
 Definition fvars_correct p :=
   [&& disj_fvars (vars_p p),

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -29,7 +29,7 @@ Section PROOF.
     {dc : DirectCall}
     {atoI : arch_toIdent}
     {syscall_state : Type} {sc_sem : syscall_sem syscall_state}
-    {T:eqType} {pT:progT T} {sCP: semCallParams}.
+    {pT: progT} {sCP: semCallParams}.
 
   Variable p : prog.
   Variable ev : extra_val_t.

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -586,27 +586,6 @@ Record stk_fun_extra := MkSFun {
   sf_return_address : return_address_location;
 }.
 
-Definition sfe_beq (e1 e2: stk_fun_extra) : bool :=
-  (e1.(sf_align) == e2.(sf_align)) &&
-  (e1.(sf_stk_sz) == e2.(sf_stk_sz)) &&
-  (e1.(sf_stk_ioff) == e2.(sf_stk_ioff)) &&
-  (e1.(sf_stk_max) == e2.(sf_stk_max)) &&
-  (e1.(sf_max_call_depth) == e2.(sf_max_call_depth)) &&
-  (e1.(sf_stk_extra_sz) == e2.(sf_stk_extra_sz)) &&
-  (e1.(sf_to_save) == e2.(sf_to_save)) &&
-  (e1.(sf_save_stack) == e2.(sf_save_stack)) &&
-  (e1.(sf_return_address) == e2.(sf_return_address)).
-
-Lemma sfe_eq_axiom : Equality.axiom sfe_beq.
-Proof.
-  case => a b c d e f g h i [] a' b' c' d' e' f' g' h' i'; apply: (equivP andP) => /=; split.
-  + by case => /andP[] /andP[] /andP[] /andP[] /andP[] /andP[] /andP[] /eqP <- /eqP <- /eqP <- /eqP <- /eqP <- /eqP <- /eqP <- /eqP <- /eqP <-.
-  by case => <- <- <- <- <- <- <- <- <-; rewrite !eqxx.
-Qed.
-
-Definition sfe_eqMixin   := Equality.Mixin sfe_eq_axiom.
-Canonical  sfe_eqType    := Eval hnf in EqType stk_fun_extra sfe_eqMixin.
-
 Record sprog_extra := {
   sp_rsp   : Ident.ident;
   sp_rip   : Ident.ident;

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -449,12 +449,11 @@ Context `{asmop:asmOp}.
 
 Definition fun_info := FunInfo.t.
 
-Class progT (eft:eqType) := {
+Class progT := {
+  extra_fun_t : Type;
   extra_prog_t : Type;
   extra_val_t  : Type;
 }.
-
-Definition extra_fun_t {eft} {pT: progT eft} := eft.
 
 Record _fundef (extra_fun_t: Type) := MkFun {
   f_info   : fun_info;
@@ -476,7 +475,7 @@ Record _prog (extra_fun_t: Type) (extra_prog_t: Type):= {
 
 Section PROG.
 
-Context {eft} {pT:progT eft}.
+Context {pT: progT}.
 
 Definition fundef := _fundef extra_fun_t.
 
@@ -506,21 +505,22 @@ Context `{asmop:asmOp}.
 (* ** Programs before stack/memory allocation 
  * -------------------------------------------------------------------- *)
 
-Definition progUnit : progT [eqType of unit] :=
-  {| extra_val_t := unit;
+Definition progUnit : progT :=
+  {| extra_fun_t := unit;
+     extra_val_t := unit;
      extra_prog_t := unit;
   |}.
 
-Definition ufundef     := @fundef _ _ _ progUnit.
-Definition ufun_decl   := @fun_decl _ _ _ progUnit.
-Definition ufun_decls  := seq (@fun_decl _ _ _ progUnit).
-Definition uprog       := @prog _ _ _ progUnit.
+Definition ufundef     := @fundef _ _ progUnit.
+Definition ufun_decl   := @fun_decl _ _ progUnit.
+Definition ufun_decls  := seq (@fun_decl _ _ progUnit).
+Definition uprog       := @prog _ _ progUnit.
 
 (* For extraction *)
-Definition _ufundef    := _fundef unit. 
+Definition _ufundef    := _fundef unit.
 Definition _ufun_decl  := _fun_decl unit.
 Definition _ufun_decls :=  seq (_fun_decl unit).
-Definition _uprog      := _prog unit unit. 
+Definition _uprog      := _prog unit unit.
 Definition to_uprog (p:_uprog) : uprog := p.
 
 (* ** Programs after stack/memory allocation 
@@ -613,19 +613,20 @@ Record sprog_extra := {
   sp_globs : seq u8;
 }.
 
-Definition progStack : progT [eqType of stk_fun_extra] := 
-  {| extra_val_t := pointer;
+Definition progStack : progT :=
+  {| extra_fun_t := stk_fun_extra;
+     extra_val_t := pointer;
      extra_prog_t := sprog_extra  |}.
 
-Definition sfundef     := @fundef _ _ _ progStack.
-Definition sfun_decl   := @fun_decl _ _ _ progStack.
-Definition sfun_decls  := seq (@fun_decl _ _ _ progStack).
-Definition sprog       := @prog _ _ _ progStack.
+Definition sfundef     := @fundef _ _ progStack.
+Definition sfun_decl   := @fun_decl _ _ progStack.
+Definition sfun_decls  := seq (@fun_decl _ _ progStack).
+Definition sprog       := @prog _ _ progStack.
 
 (* For extraction *)
 
 Definition _sfundef    := _fundef stk_fun_extra.
-Definition _sfun_decl  := _fun_decl stk_fun_extra. 
+Definition _sfun_decl  := _fun_decl stk_fun_extra.
 Definition _sfun_decls := seq (_fun_decl stk_fun_extra).
 Definition _sprog      := _prog stk_fun_extra sprog_extra.
 Definition to_sprog (p:_sprog) : sprog := p.
@@ -656,7 +657,7 @@ End ASM_OP.
 Section ASM_OP.
 
 Context `{asmop:asmOp}.
-Context {eft} {pT : progT eft}.
+Context {pT: progT}.
 
 (* ** Some smart constructors
  * -------------------------------------------------------------------------- *)

--- a/proofs/lang/expr_facts.v
+++ b/proofs/lang/expr_facts.v
@@ -103,9 +103,9 @@ End PEXPRS_IND.
 Section ASM_OP.
 
 Context `{asmop:asmOp}.
-Context {eft} {pT : progT eft}.
+Context {pT: progT}.
 
-Lemma surj_prog (p:prog) : 
+Lemma surj_prog (p:prog) :
   {| p_globs := p_globs p; p_funcs := p_funcs p; p_extra := p_extra p |} = p.
 Proof. by case: p. Qed.
 

--- a/proofs/lang/lowering_lemmas.v
+++ b/proofs/lang/lowering_lemmas.v
@@ -169,8 +169,7 @@ End ESTATE_EQ_EXCEPT.
 Section DISJ_FVARS.
 
 Context
-  {eft : eqType}
-  {pT : progT eft}
+  {pT : progT}
   {asmop : Type}
   {asm_op : asmOp asmop}
   (all_fresh_vars : seq Ident.ident)

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -101,8 +101,7 @@ Class semCallParams
   {syscall_state : Type}
   {ep : EstateParams syscall_state}
   {scs : syscall_sem syscall_state}
-  {T : eqType}
-  {pT : progT T}
+  {pT : progT}
   := SemCallParams
   {
   init_state : extra_fun_t -> extra_prog_t -> extra_val_t -> estate -> exec estate;
@@ -139,8 +138,7 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  {T : eqType}
-  {pT : progT T}
+  {pT : progT}
   {scP : semCallParams}
   (P : prog)
   (ev : extra_val_t).
@@ -569,8 +567,7 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  {T : eqType}
-  {pT : progT T}
+  {pT : progT}
   {scP : semCallParams}
   (P : prog)
   (ev : extra_val_t).
@@ -942,8 +939,7 @@ Section Write.
 Context
   {dc:DirectCall}
   {sip : SemInstrParams asm_op syscall_state}
-  {T}
-  {pT : progT T}
+  {pT : progT}
   {sCP : semCallParams}.
 
 Variable P : prog.
@@ -1786,8 +1782,7 @@ Section Sem_eqv.
 Context
   {dc:DirectCall}
   {sip : SemInstrParams asm_op syscall_state}
-  {T}
-  {pT : progT T}
+  {pT : progT}
   {sCP : semCallParams}
   (p:prog) (ev : extra_val_t).
 
@@ -1931,8 +1926,7 @@ Section UNDEFINCL.
 Context
   {dc:DirectCall}
   {sip : SemInstrParams asm_op syscall_state}
-  {T}
-  {pT : progT T}
+  {pT : progT}
   {sCP : semCallParams}.
 Variable p : prog.
 Variable ev : extra_val_t.

--- a/proofs/lang/psem_facts.v
+++ b/proofs/lang/psem_facts.v
@@ -150,7 +150,7 @@ Qed.
 
 Section MEM_EQUIV.
 
-Context {T:eqType} {pT:progT T} {sCP: semCallParams}.
+Context {pT: progT} {sCP: semCallParams}.
 
 Variable P : prog.
 Variable ev : extra_val_t.
@@ -492,8 +492,7 @@ Qed.
 Section DETERMINISM.
 
 Context
-  {T}
-  {pT:progT T}
+  {pT: progT}
   {sCP : semCallParams}.
 Variable p : prog.
 Variable ev : extra_val_t.

--- a/proofs/lang/psem_of_sem_proof.v
+++ b/proofs/lang/psem_of_sem_proof.v
@@ -14,8 +14,7 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  {T : eqType}
-  {pT : progT T}
+  {pT : progT}
   {sCP : forall {wsw : WithSubWord}, semCallParams}.
 
 Variable (p:prog) (ev:extra_val_t).

--- a/proofs/lang/sem_one_varmap.v
+++ b/proofs/lang/sem_one_varmap.v
@@ -221,7 +221,7 @@ Variant sem_export_call_conclusion (scs: syscall_state_t) (m: mem) (fd: sfundef)
     valid_RSP m2 vm2 &
     m' = free_stack m2.
 
-Variant sem_export_call (gd: @extra_val_t _ progStack)  (scs: syscall_state_t) (m: mem) (fn: funname) (args: values)  (scs': syscall_state_t) (m': mem) (res: values) : Prop :=
+Variant sem_export_call (gd: @extra_val_t progStack)  (scs: syscall_state_t) (m: mem) (fn: funname) (args: values)  (scs': syscall_state_t) (m': mem) (res: values) : Prop :=
   | SemExportCall (fd: sfundef) of
                   get_fundef p.(p_funcs) fn = Some fd &
       fd.(f_extra).(sf_return_address) == RAnone &


### PR DESCRIPTION
There are two things in this PR:

  - generalize the check done in allocation for the extra information of functions (this will be useful for export functions with arguments on the stack);
  - move extra-fun-t inside the `progT` class and drop its `EqType` constraint.