### PR TITLE
Add monadic let for options

### DIFF
--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -17,7 +17,6 @@ module Arm_core = struct
   type cond = condt
   type asm_op = Arm_instr_decl.arm_op
   type extra_op = Arm_extra.__
-  type fresh_vars = Arm_lowering.fresh_vars
   type lowering_options = Arm_lowering.lowering_options
 
   let atoI = X86_arch_full.atoI arm_decl

--- a/proofs/compiler/arm_decl.v
+++ b/proofs/compiler/arm_decl.v
@@ -246,12 +246,13 @@ Definition shift_op (sk: shift_kind) :
   end.
 
 Definition shift_of_sop2 (ws : wsize) (op : sop2) : option shift_kind :=
-  match ws, op with
-  | U32, Olsl (Op_w U32) => Some SLSL
-  | U32, Olsr U32 => Some SLSR
-  | U32, Oasr (Op_w U32) => Some SASR
-  | U32, Oror U32 => Some SROR
-  | _, _ => None
+  let%opt _ := oassert (ws == U32) in
+  match op with
+  | Olsl (Op_w U32) => Some SLSL
+  | Olsr U32 => Some SLSR
+  | Oasr (Op_w U32) => Some SASR
+  | Oror U32 => Some SROR
+  | _ => None
   end.
 
 (* -------------------------------------------------------------------- *)

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -116,13 +116,9 @@ Definition lower_condition_Papp2
 
 Definition lower_condition_pexpr
   (e : pexpr) : option (seq lval * sopn * seq pexpr * pexpr) :=
-  if e is Papp2 op e0 e1
-  then
-    if lower_condition_Papp2 op e0 e1 is Some (mn, e', es)
-    then Some (lflags_of_mn mn, Oarm (ARM_op mn default_opts), es, e')
-    else None
-  else
-    None.
+  let%opt (op, e0, e1) := is_Papp2 e in
+  let%opt (mn, e', es) := lower_condition_Papp2 op e0 e1 in
+  Some (lflags_of_mn mn, Oarm (ARM_op mn default_opts), es, e').
 
 Definition lower_condition (e : pexpr) : seq instr_r * pexpr :=
   if lower_condition_pexpr e is Some (lvs, op, es, c)
@@ -133,16 +129,17 @@ Definition lower_condition (e : pexpr) : seq instr_r * pexpr :=
 (* -------------------------------------------------------------------- *)
 (* Lowering of assignments. *)
 
+Definition chk_ws_reg (ws : wsize) : option unit :=
+  oassert (ws == reg_size)%CMP.
+
 Definition get_arg_shift
   (ws : wsize) (e : pexprs) : option (pexpr * shift_kind * pexpr) :=
   if e is
     [:: Papp2 op ((Pvar _) as v) ((Papp1 (Oword_of_int U8) (Pconst z)) as n) ]
   then
-    if shift_of_sop2 ws op is Some sh
-    then
-      if check_shift_amount sh z then Some (v, sh, n) else None
-    else
-      None
+    let%opt sh := shift_of_sop2 ws op in
+    let%opt _ := oassert (check_shift_amount sh z) in
+    Some (v, sh, n)
   else
     None.
 
@@ -168,18 +165,14 @@ Definition arg_shift
      + a register.
      + a stack variable. *)
 Definition lower_Pvar (ws : wsize) (v : gvar) : lowered_pexpr :=
-  if ws is U32
-  then
-    let mn := if is_var_in_memory (gv v) then LDR else MOV in
-    Some (ARM_op mn default_opts, [:: Pvar v ])
-  else
-    None.
+  let%opt _ := chk_ws_reg ws in
+  let mn := if is_var_in_memory (gv v) then LDR else MOV in
+  Some (ARM_op mn default_opts, [:: Pvar v ]).
 
 (* Lower an expression of the form [(ws)[v + e]] or [tab[ws e]]. *)
 Definition lower_load (ws: wsize) (e: pexpr) : lowered_pexpr :=
-  if ws is U32
-  then Some (ARM_op LDR default_opts, [:: e ])
-  else None.
+  let%opt _ := chk_ws_reg ws in
+  Some (ARM_op LDR default_opts, [:: e ]).
 
 Definition is_load (e: pexpr) : bool :=
   match e with
@@ -212,47 +205,32 @@ Definition mov_imm_mnemonic (e : pexpr) : option (arm_mnemonic * pexpr) :=
       then Some (MOV, e)
       else
         let nz := Z_mod_lnot z reg_size in
-        if is_expandable nz
-        then Some (MVN, Pconst nz)
-        else None
+        let%opt _ := oassert (is_expandable nz) in
+        Some (MVN, Pconst nz)
   else Some (MOV, e).
 
 Definition lower_Papp1 (ws : wsize) (op : sop1) (e : pexpr) : lowered_pexpr :=
-  if ws is U32
-  then
-    match op with
-    | Oword_of_int ws' =>
-        if (U32 <= ws')%CMP
-        then
-          if mov_imm_mnemonic e is Some (mn, e')
-          then Some (ARM_op mn default_opts, [:: Papp1 (Oword_of_int U32) e' ])
-          else None
-        else None
-    | Osignext U32 ws' =>
-        if is_load e
-        then
-          if sload_mn_of_wsize ws' is Some mn
-          then Some (ARM_op mn default_opts, [:: e ])
-          else None
-        else
-          None
-    | Ozeroext U32 ws' =>
-        if is_load e
-        then
-          if uload_mn_of_wsize ws' is Some mn
-          then Some (ARM_op mn default_opts, [:: e ])
-          else None
-        else
-          None
-    | Olnot U32 =>
-        Some (arg_shift MVN U32 [:: e ])
-    | Oneg (Op_w U32) =>
-        Some (ARM_op RSB default_opts, [:: e; wconst (wrepr U32 0) ])
-    | _ =>
-        None
-    end
-  else
-    None.
+  let%opt _ := chk_ws_reg ws in
+  match op with
+  | Oword_of_int ws' =>
+      let%opt _ := oassert (U32 <= ws')%CMP in
+      let%opt (mn, e') := mov_imm_mnemonic e in
+      Some (ARM_op mn default_opts, [:: Papp1 (Oword_of_int U32) e' ])
+  | Osignext U32 ws' =>
+      let%opt _ := oassert (is_load e) in
+      let%opt mn := sload_mn_of_wsize ws' in
+      Some (ARM_op mn default_opts, [:: e ])
+  | Ozeroext U32 ws' =>
+      let%opt _ := oassert (is_load e) in
+      let%opt mn := uload_mn_of_wsize ws' in
+      Some (ARM_op mn default_opts, [:: e ])
+  | Olnot U32 =>
+      Some (arg_shift MVN U32 [:: e ])
+  | Oneg (Op_w U32) =>
+      Some (ARM_op RSB default_opts, [:: e; wconst (wrepr U32 0) ])
+  | _ =>
+      None
+  end.
 
 Definition is_mul (e: pexpr) : option (pexpr * pexpr) :=
   if e is Papp2 (Omul (Op_w U32)) x y then Some (x, y) else None.
@@ -260,54 +238,50 @@ Definition is_mul (e: pexpr) : option (pexpr * pexpr) :=
 Definition lower_Papp2_op
   (ws : wsize) (op : sop2) (e0 e1 : pexpr) :
   option (arm_mnemonic * pexpr * pexprs) :=
-  if ws is U32
-  then
-    match op with
-    | Oadd (Op_w _) =>
-        if is_mul e0 is Some (x, y)
-        then Some (MLA, x, [:: y; e1 ])
-        else if is_mul e1 is Some (x, y)
-        then Some (MLA, x, [:: y; e0 ])
-        else
-        Some (ADD, e0, [:: e1 ])
-    | Omul (Op_w _) =>
-        Some (MUL, e0, [:: e1 ])
-    | Osub (Op_w _) =>
-        if is_mul e1 is Some (x, y)
-        then Some (MLS, x, [:: y; e0 ])
-        else
-        Some (SUB, e0, [:: e1 ])
-    | Odiv (Cmp_w Signed U32) =>
-        Some (SDIV, e0, [:: e1 ])
-    | Odiv (Cmp_w Unsigned U32) =>
-        Some (UDIV, e0, [:: e1 ])
-    | Oland _ =>
-        Some (AND, e0, [:: e1 ])
-    | Olor _ =>
-        Some (ORR, e0, [:: e1 ])
-    | Olxor _ =>
-        Some (EOR, e0, [:: e1 ])
-    | Olsr U32 =>
-        if is_zero U8 e1 then Some (MOV, e0, [::])
-        else Some (LSR, e0, [:: e1 ])
-    | Olsl (Op_w U32) =>
-        Some (LSL, e0, [:: e1 ])
-    | Oasr (Op_w U32) =>
-        if is_zero U8 e1 then Some (MOV, e0, [::])
-        else Some (ASR, e0, [:: e1 ])
-    | Oror U32 =>
-        if is_zero U8 e1 then Some (MOV, e0, [::])
-        else Some (ROR, e0, [:: e1 ])
-    | Orol U32 =>
-        if is_wconst U8 e1 is Some c then
-        if c == 0%R then Some (MOV, e0, [::])
-        else Some (ROR, e0, [:: wconst (32 - c) ])
-        else None
-    | _ =>
-        None
-    end
-  else
-    None.
+  let%opt _ := chk_ws_reg ws in
+  match op with
+  | Oadd (Op_w _) =>
+      if is_mul e0 is Some (x, y)
+      then Some (MLA, x, [:: y; e1 ])
+      else if is_mul e1 is Some (x, y)
+      then Some (MLA, x, [:: y; e0 ])
+      else
+      Some (ADD, e0, [:: e1 ])
+  | Omul (Op_w _) =>
+      Some (MUL, e0, [:: e1 ])
+  | Osub (Op_w _) =>
+      if is_mul e1 is Some (x, y)
+      then Some (MLS, x, [:: y; e0 ])
+      else
+      Some (SUB, e0, [:: e1 ])
+  | Odiv (Cmp_w Signed U32) =>
+      Some (SDIV, e0, [:: e1 ])
+  | Odiv (Cmp_w Unsigned U32) =>
+      Some (UDIV, e0, [:: e1 ])
+  | Oland _ =>
+      Some (AND, e0, [:: e1 ])
+  | Olor _ =>
+      Some (ORR, e0, [:: e1 ])
+  | Olxor _ =>
+      Some (EOR, e0, [:: e1 ])
+  | Olsr U32 =>
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else Some (LSR, e0, [:: e1 ])
+  | Olsl (Op_w U32) =>
+      Some (LSL, e0, [:: e1 ])
+  | Oasr (Op_w U32) =>
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else Some (ASR, e0, [:: e1 ])
+  | Oror U32 =>
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else Some (ROR, e0, [:: e1 ])
+  | Orol U32 =>
+      let%opt c := is_wconst U8 e1 in
+      if c == 0%R then Some (MOV, e0, [::])
+      else Some (ROR, e0, [:: wconst (32 - c) ])
+  | _ =>
+      None
+  end.
 
 (* Lower an expression of the form [a <+> b].
    Precondition:
@@ -318,11 +292,9 @@ Definition lower_Papp2_op
      + an immediate word. *)
 Definition lower_Papp2
   (ws : wsize) (op : sop2) (e0 e1 : pexpr) : lowered_pexpr :=
-  if lower_Papp2_op ws op e0 e1 is Some (mn, e0', e1')
-  then
-    let '(aop, es) := arg_shift mn ws e1' in Some (aop, e0' :: es)
-  else
-    None.
+  let%opt (mn, e0', e1') := lower_Papp2_op ws op e0 e1 in
+  let '(aop, es) := arg_shift mn ws e1' in
+  Some (aop, e0' :: es).
 
 Definition lower_pexpr_aux (ws : wsize) (e : pexpr) : lowered_pexpr :=
   match e with
@@ -336,21 +308,15 @@ Definition lower_pexpr_aux (ws : wsize) (e : pexpr) : lowered_pexpr :=
 
 Definition no_pre (ole : lowered_pexpr) :
   option (seq instr_r * arm_op * seq pexpr) :=
-  if ole is Some (aop, es) then Some ([::], aop, es) else None.
+  let%opt (aop, es) := ole in Some ([::], aop, es).
 
 Definition lower_pexpr (ws : wsize) (e : pexpr) :
   option (seq instr_r * arm_op * seq pexpr) :=
   if e is Pif (sword ws') c e0 e1 then
-    if lower_pexpr_aux ws e0 is Some (ARM_op mn opts, es)
-    then
-      if ws == ws'
-      then
-        let '(pre, c') := lower_condition c in
-        Some (pre, ARM_op mn (set_is_conditional opts), es ++ [:: c'; e1 ])
-      else
-        None
-    else
-      None
+    let%opt _ := oassert (ws == ws')%CMP in
+    let%opt (ARM_op mn opts, es) := lower_pexpr_aux ws e0 in
+    let '(pre, c') := lower_condition c in
+    Some (pre, ARM_op mn (set_is_conditional opts), es ++ [:: c'; e1 ])
   else
     no_pre (lower_pexpr_aux ws e).
 
@@ -363,37 +329,29 @@ Definition lower_pexpr (ws : wsize) (e : pexpr) :
      + a register.
      + an if expression. *)
 Definition lower_store (ws : wsize) (e : pexpr) : option (arm_op * seq pexpr) :=
-  if store_mn_of_wsize ws is Some mn
-  then
-    let args :=
-      match e with
-      | Pvar _ => Some (default_opts, [:: e ])
-      | Pif _ c e0 e1 => Some (set_is_conditional default_opts, [:: e0; c; e1 ])
-      | _ => None
-      end
-    in
-    if args is Some (opts, es)
-    then Some (ARM_op mn opts, es)
-    else None
-  else
-    None.
+  let%opt mn := store_mn_of_wsize ws in
+  let%opt (opts, es) :=
+    match e with
+    | Pvar _ => Some (default_opts, [:: e ])
+    | Pif _ c e0 e1 => Some (set_is_conditional default_opts, [:: e0; c; e1 ])
+    | _ => None
+    end
+  in
+  Some (ARM_op mn opts, es).
 
 (* Convert an assignment into an architecture-specific operation. *)
 Definition lower_cassgn_word
   (lv : lval) (ws : wsize) (e : pexpr) : option (seq instr_r * copn_args) :=
-  let le :=
+  let%opt (pre, aop, es) :=
     if is_lval_in_memory lv
     then no_pre (lower_store ws e)
     else lower_pexpr ws e
   in
-  if le is Some (pre, aop, es)
-  then Some (pre, ([:: lv ], Oarm aop, es))
-  else None.
+  Some (pre, ([:: lv ], Oarm aop, es)).
 
 Definition lower_cassgn_bool (lv : lval) (tag: assgn_tag) (e : pexpr) : option (seq instr_r) :=
-  if lower_condition_pexpr e is Some (lvs, op, es, c)
-  then Some [:: Copn lvs tag op es ; Cassgn lv AT_inline sbool c ]
-  else None.
+  let%opt (lvs, op, es, c) := lower_condition_pexpr e in
+  Some [:: Copn lvs tag op es; Cassgn lv AT_inline sbool c ].
 
 (* -------------------------------------------------------------------- *)
 (* Lowering of architecture-specific operations. *)
@@ -402,23 +360,19 @@ Definition lower_add_carry
   (lvs : seq lval) (es : seq pexpr) : option copn_args :=
   match lvs, es with
   | [:: cf; r ], [:: x; y; b ] =>
-      let args :=
+      let%opt (mn, es') :=
         match b with
         | Pbool false => Some (ADD, [:: x; y ])
         | Pvar _ => Some (ADC, es)
         | _ => None
         end
       in
-      if args is Some (mn, es')
-      then
-        let opts :=
-          {| set_flags := true; is_conditional := false; has_shift := None; |}
-        in
-        let lnoneb := Lnone dummy_var_info sbool in
-        let lvs' := [:: lnoneb; lnoneb; cf; lnoneb; r ] in
-        Some (lvs', Oasm (BaseOp (None, ARM_op mn opts)), es')
-      else
-        None
+      let opts :=
+        {| set_flags := true; is_conditional := false; has_shift := None; |}
+      in
+      let lnoneb := Lnone dummy_var_info sbool in
+      let lvs' := [:: lnoneb; lnoneb; cf; lnoneb; r ] in
+      Some (lvs', Oasm (BaseOp (None, ARM_op mn opts)), es')
   | _, _ =>
       None
   end.
@@ -434,9 +388,8 @@ Definition lower_base_op
   let: ARM_op mn opts := aop in
   if has_shift opts != None
   then
-    if mn \in has_shift_mnemonics
-    then Some (lvs, Oasm (BaseOp (None, ARM_op mn opts)), es)
-    else None
+    let%opt _ := oassert (mn \in has_shift_mnemonics) in
+    Some (lvs, Oasm (BaseOp (None, ARM_op mn opts)), es)
   else
     if MVN == mn
     then
@@ -491,9 +444,8 @@ Fixpoint lower_i (i : instr) : cmd :=
       let oirs :=
         match ty with
         | sword ws =>
-            if lower_cassgn_word lv ws e is Some (pre, (lvs, op, es))
-            then Some (pre ++ [:: Copn lvs tag op es ])
-            else None
+            let%opt (pre, (lvs, op, es)) := lower_cassgn_word lv ws e in
+            Some (pre ++ [:: Copn lvs tag op es ])
         | sbool => lower_cassgn_bool lv tag e
         | _ => None
         end

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -31,8 +31,6 @@ Context {atoI : arch_toIdent}.
 (* This pass is parameterized by four variable names that will be used to create
    variables for the processor flags. *)
 
-Definition fresh_vars : Type := Ident.name -> stype -> Ident.ident.
-
 Definition fv_NF (fv: fresh_vars) := fv (Ident.name_of_string "__n__") sbool.
 Definition fv_ZF (fv: fresh_vars) := fv (Ident.name_of_string "__z__") sbool.
 Definition fv_CF (fv: fresh_vars) := fv (Ident.name_of_string "__c__") sbool.
@@ -63,10 +61,7 @@ Context
 (* Lowering of conditions. *)
 
 #[ local ]
-Definition mk_fv_vari x := {| v_var := x; v_info := dummy_var_info; |}.
-
-#[ local ]
-Definition mk_fv_gvar x := {| gv := mk_fv_vari x; gs := Slocal; |}.
+Definition mk_fv_gvar x := {| gv := mk_var_i x; gs := Slocal; |}.
 
 Definition lflags_of_mn (mn : arm_mnemonic) : seq lval :=
   let ids :=
@@ -76,7 +71,7 @@ Definition lflags_of_mn (mn : arm_mnemonic) : seq lval :=
     | _ => [::]
     end
   in
-  map (fun x => Lvar (mk_fv_vari (vbool (x fv)))) ids.
+  map (fun x => Lvar (mk_var_i (vbool (x fv)))) ids.
 
 Definition lower_TST (e0 e1 : pexpr) : option (seq pexpr) :=
   match e0, e1 with

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -113,7 +113,7 @@ Definition arm_saparams : stack_alloc_params :=
 
 Section LINEARIZATION.
 
-Notation vtmpi := {| v_var := to_var R12; v_info := dummy_var_info; |}.
+Notation vtmpi := (mk_var_i (to_var R12)).
 
 (* TODO_ARM: This assumes 0 <= sz < 4096. *)
 Definition arm_allocate_stack_frame (rspi : var_i) (sz : Z) :=

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -126,31 +126,22 @@ Definition arm_free_stack_frame (rspi : var_i) (sz : Z) :=
 (* TODO_ARM: Review. This seems unnecessary. *)
 Definition arm_lassign
   (lv : lexpr) (ws : wsize) (e : rexpr) : option _ :=
-  let args :=
+  let%opt (mn, e') :=
     match lv with
     | LLvar _ =>
-        if ws is U32
-        then
-          match e with
-          | Rexpr (Fapp1 (Oword_of_int U32) (Fconst _))
-          | Rexpr (Fvar _) =>
-              Some (MOV, e)
-          | Load _ _ _ =>
-              Some (LDR, e)
-          | _ =>
-              None
-          end
-        else
-          None
+        let%opt _ := chk_ws_reg ws in
+        match e with
+        | Rexpr (Fapp1 (Oword_of_int U32) (Fconst _))
+        | Rexpr (Fvar _) => Some (MOV, e)
+        | Load _ _ _ => Some (LDR, e)
+        | _ => None
+        end
     | Store _ _ _ =>
-        if store_mn_of_wsize ws is Some mn
-        then Some (mn, e)
-        else None
+        let%opt mn := store_mn_of_wsize ws in
+        Some (mn, e)
     end
   in
-  if args is Some (mn, e')
-  then Some ([:: lv ], Oarm (ARM_op mn default_opts), [:: e' ])
-  else None.
+  Some ([:: lv ], Oarm (ARM_op mn default_opts), [:: e' ]).
 
 Definition arm_set_up_sp_register
   (rspi : var_i)
@@ -158,27 +149,21 @@ Definition arm_set_up_sp_register
   (al : wsize)
   (r : var_i) :
   option (seq fopn_args) :=
-  if (0 <=? sf_sz)%Z && (sf_sz <? wbase reg_size)%Z
-  then
-    let i0 := arm_op_mov r rspi in
-    let load_imm := arm_cmd_large_subi vtmpi rspi sf_sz in
-    let i1 := arm_op_align vtmpi vtmpi al in
-    let i2 := arm_op_mov rspi vtmpi in
-    Some (i0 :: load_imm ++ [:: i1; i2 ])
-  else
-    None.
+  let%opt _ := oassert ((0 <=? sf_sz)%Z && (sf_sz <? wbase reg_size)%Z) in
+  let i0 := arm_op_mov r rspi in
+  let load_imm := arm_cmd_large_subi vtmpi rspi sf_sz in
+  let i1 := arm_op_align vtmpi vtmpi al in
+  let i2 := arm_op_mov rspi vtmpi in
+  Some (i0 :: load_imm ++ [:: i1; i2 ]).
 
 Definition arm_set_up_sp_stack
   (rspi : var_i) (sf_sz : Z) (al : wsize) (off : Z) : option (seq fopn_args) :=
-  if (0 <=? sf_sz)%Z && (sf_sz <? wbase reg_size)%Z
-  then
-    let load_imm := arm_cmd_large_subi vtmpi rspi sf_sz in
-    let i0 := arm_op_align vtmpi vtmpi al in
-    let i1 := arm_op_str_off rspi vtmpi off in
-    let i2 := arm_op_mov rspi vtmpi in
-    Some (load_imm ++ [:: i0; i1; i2 ])
-  else
-    None.
+  let%opt _ := oassert ((0 <=? sf_sz)%Z && (sf_sz <? wbase reg_size)%Z) in
+  let load_imm := arm_cmd_large_subi vtmpi rspi sf_sz in
+  let i0 := arm_op_align vtmpi vtmpi al in
+  let i1 := arm_op_str_off rspi vtmpi off in
+  let i2 := arm_op_mov rspi vtmpi in
+  Some (load_imm ++ [:: i0; i1; i2 ]).
 
 Definition arm_tmp : Ident.ident := vname (v_var vtmpi).
 

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -515,9 +515,7 @@ Proof.
     hbody hset_up ? hneq_tmp_rsp hnot_saved_stack hneq_r_rsp hgetrsp;
     subst rtype.
 
-  move: hset_up.
-  rewrite /arm_set_up_sp_register.
-  case: ifP => // hset_up _.
+  move: hset_up => /oassertP_isSome [hset_up _].
 
   have hneq_r_tmp :
     v_var r <> vtmp.
@@ -686,9 +684,7 @@ Proof.
   set ts' := align_word _ _.
   move=> hbody hset_up hneq_tmp_rsp hgetrsp hwrite.
 
-  move: hset_up.
-  rewrite /= /arm_set_up_sp_stack.
-  case: ifP => // hset_up _.
+  move: hset_up => /oassertP_isSome [hset_up _].
 
   move: hbody.
   rewrite /set_up_sp_stack /= /arm_set_up_sp_stack hset_up /= -/vtmpi.

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -314,7 +314,7 @@ Qed.
 
 Lemma arm_cmd_load_large_imm_lsem lp fn s ii P Q xname imm :
   let: x := {| vname := xname; vtype := sword reg_size; |} in
-  let: xi := {| v_var := x; v_info := dummy_var_info; |} in
+  let: xi := mk_var_i x in
   let: lcmd := map (li_of_copn_args ii) (arm_cmd_load_large_imm xi imm) in
   is_linear_of lp fn (P ++ lcmd ++ Q)
   -> (0 <= imm < wbase reg_size)%Z
@@ -334,7 +334,7 @@ Lemma arm_cmd_load_large_imm_lsem lp fn s ii P Q xname imm :
          & get_var true vm' x = ok (Vword (wrepr reg_size imm))
        ].
 Proof.
-  set x := {| v_var := _; |}.
+  set x := {| vname := _; |}.
   rewrite /arm_cmd_load_large_imm /=.
 
   case hdivmod: Z.div_eucl => [hbs lbs] /=.
@@ -367,7 +367,7 @@ Qed.
 
 Lemma arm_cmd_large_subi_lsem lp fn s ii P Q xname y imm wy :
   let: x := {| vname := xname; vtype := sword Uptr; |} in
-  let: xi := {| v_var := x; v_info := dummy_var_info; |} in
+  let: xi := mk_var_i x in
   let: lcmd := map (li_of_copn_args ii) (arm_cmd_large_subi xi y imm) in
   is_linear_of lp fn (P ++ lcmd ++ Q)
   -> x <> v_var y
@@ -389,7 +389,7 @@ Lemma arm_cmd_large_subi_lsem lp fn s ii P Q xname y imm wy :
          & get_var true vm' x = ok (Vword (wy - wrepr reg_size imm)%R)
        ].
 Proof.
-  set x := {| v_var := _; |}.
+  set x := {| vname := _; |}.
   move=> hbody hxy hgety himm.
 
   move: hbody.
@@ -443,9 +443,9 @@ Context
   (fn : funname).
 
 Let vrsp : var := mk_ptr sp_rsp.
-Let vrspi : var_i := VarI vrsp dummy_var_info.
+Let vrspi : var_i := mk_var_i vrsp.
 Let vtmp : var := mk_ptr (lip_tmp arm_liparams).
-Let vtmpi : var_i := VarI vtmp dummy_var_info.
+Let vtmpi : var_i := mk_var_i vtmp.
 
 Lemma arm_spec_lip_allocate_stack_frame s pc ii ts sz :
   let args := lip_allocate_stack_frame arm_liparams vrspi sz in

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -924,7 +924,7 @@ Section PROOF.
 
   Let vgd : var := Var (sword Uptr) (sp_rip (p_extra p)).
   Let vrsp : var := Var (sword Uptr) (sp_rsp (p_extra p)).
-  Let vrspi : var_i := {| v_var := vrsp; v_info := dummy_var_info; |}.
+  Let vrspi : var_i := mk_var_i vrsp.
   Let vrspg : gvar := {| gv := vrspi; gs := Slocal; |}.
 
   Let var_tmp : var_i := vid (lip_tmp liparams).
@@ -1692,7 +1692,7 @@ Section PROOF.
       mapM (get_var true vm2) xs = ok vs2 & List.Forall2 value_uincl vs1 vs2.
   Proof.
     move=> h1 h2;
-    have := get_vars_uincl (wdb:=true) (xs := map (fun x => {| v_var := x; v_info := dummy_var_info |}) xs) h1.
+    have := get_vars_uincl (wdb:=true) (xs := map mk_var_i xs) h1.
     by rewrite !mapM_map => /(_ _ h2).
   Qed.
 
@@ -2779,7 +2779,7 @@ Section PROOF.
 
   Lemma check_to_save_slotP x ofs ofs' ws :
     check_to_save_slot liparams p (x, ofs) = ok (ofs', ws)
-    -> let: xi := {| v_var := x; v_info := dummy_var_info; |} in
+    -> let: xi := mk_var_i x in
        exists xname,
          [/\ x = {| vtype := sword ws; vname := xname; |}
            , isSome (lload liparams xi ws vrspi ofs)

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -270,6 +270,7 @@ Section PROOF.
     + by move=> _ [ -> ->]; exists s1' => /=; split => //; constructor.
     move=> hws [??]; subst i e'.
     case: e He heq => // o e1 e2 /=; t_xrbindP => v1 hv1 v2 hv2.
+    rewrite /lower_cond_classify.
     set Of := {| v_var := fv_of _ |}.
     set Cf := {| v_var := fv_cf _ |}.
     set Sf := {| v_var := fv_sf _ |}.
@@ -375,10 +376,11 @@ Section PROOF.
          Sv.Subset (read_lea l) (read_e e),
          mk_lea sz e = Some l & check_scale l.(lea_scale)].
   Proof.
-    rewrite /is_lea; case: ifP => // /andP [-> _].
+    rewrite /is_lea.
+    move=> /oassertP [] /and3P [-> -> _].
     case h: mk_lea => [[d b sc o]|] //.
     move /mk_lea_read in h.
-    by case: ifP => // /andP [] /andP [] heq _ _ [<-].
+    by move=> /oassertP [] /and3P [? _ _] [<-].
   Qed.
 
   Lemma zquot_bound m x y :

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -30,7 +30,7 @@ Context {atoI : arch_toIdent}.
 
 (* Used to set up stack. *)
 Definition x86_op_align (x : var_i) (ws : wsize) (al : wsize) : fopn_args :=
-  let f_to_lvar x := LLvar (VarI (to_var x) dummy_var_info) in
+  let f_to_lvar x := LLvar (mk_var_i (to_var x)) in
   let eflags := map f_to_lvar [:: OF; CF; SF; PF; ZF ] in
   let ex := Rexpr (Fvar x) in
   let emask := fconst ws (- wsize_size al) in
@@ -68,7 +68,7 @@ Definition x86_saparams : stack_alloc_params :=
 
 Section LINEARIZATION.
 
-Notation vtmpi := {| v_var := to_var RAX; v_info := dummy_var_info; |}.
+Notation vtmpi := (mk_var_i (to_var RAX)).
 
 Definition x86_allocate_stack_frame (rspi: var_i) (sz: Z) :=
   let p := Fapp2 (Osub (Op_w Uptr)) (Fvar rspi) (fconst Uptr sz) in

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -187,9 +187,9 @@ Context
   (fn : funname).
 
 Let vrsp : var := mk_ptr sp_rsp.
-Let vrspi : var_i := VarI vrsp dummy_var_info.
+Let vrspi : var_i := mk_var_i vrsp.
 Let vtmp : var := mk_ptr (lip_tmp x86_liparams).
-Let vtmpi : var_i := VarI vtmp dummy_var_info.
+Let vtmpi : var_i := mk_var_i vtmp.
 
 Definition x86_spec_lip_allocate_stack_frame s pc ii ts sz :
   let: args := lip_allocate_stack_frame x86_liparams vrspi sz in
@@ -591,14 +591,14 @@ Lemma check_sopn_dests_xmm rip ii oargs xs ads cond n k ws:
   n < size xs ->
   exists (r: xreg_t),
    exists2 vi,
-    nth (LLvar {| v_var := rip; v_info := dummy_var_info|}) xs n =
+    nth (LLvar (mk_var_i rip)) xs n =
        LLvar {| v_var := to_var r;  v_info := vi |} &
     oseq.onth oargs k = Some (XReg r).
 Proof.
   rewrite /= orbF => hca hc hE hxmm hn.
   have /(_ n):= all2_nth (Rexpr (Fconst 0)) (E 0, sword8) _ hca.
   rewrite size_map hn => /(_ erefl).
-  rewrite (nth_map (LLvar {| v_var := rip; v_info := dummy_var_info |})) //.
+  rewrite (nth_map (LLvar (mk_var_i rip))) //.
   set e := nth (LLvar _) _ _.
   rewrite /check_sopn_dest hE /=.
   case H : oseq.onth => [a | //].

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -672,6 +672,9 @@ Definition is_bool (e:pexpr) :=
   | _ => None
   end.
 
+Definition is_Papp2 (e : pexpr) : option (sop2 * pexpr * pexpr) :=
+  if e is Papp2 op e0 e1 then Some (op, e0, e1) else None.
+
 Definition is_array_init e :=
   match e with
   | Parr_init _ => true

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -204,15 +204,14 @@ Record var_i := VarI {
   v_info : var_info
 }.
 
-Notation vid ident :=
+Definition mk_var_i (x : var) :=
   {|
-    v_var :=
-      {|
-        vtype := sword Uptr;
-        vname := ident%string;
-      |};
+    v_var := x;
     v_info := dummy_var_info;
   |}.
+
+Notation vid ident :=
+  (mk_var_i {| vtype := sword Uptr; vname := ident%string; |}).
 
 Variant v_scope := 
   | Slocal 
@@ -908,7 +907,7 @@ Fixpoint eq_expr e e' :=
 
 (* ------------------------------------------------------------------- *)
 Definition to_lvals (l:seq var) : seq lval := 
-  map (fun x => Lvar {|v_var := x; v_info := dummy_var_info |}) l.
+  map (fun x => Lvar (mk_var_i x)) l.
 
 (* ------------------------------------------------------------------- *)
 Definition is_false (e: pexpr) : bool :=

--- a/proofs/lang/expr_facts.v
+++ b/proofs/lang/expr_facts.v
@@ -163,6 +163,11 @@ Proof. by case: e=>*;constructor. Qed.
 Lemma is_array_initP e : reflect (exists n, e = Parr_init n) (is_array_init e).
 Proof. by case: e => * /=; constructor; try (by move=> []); eexists. Qed.
 
+Lemma is_Papp2P e op e0 e1 :
+  is_Papp2 e = Some (op, e0, e1) ->
+  e = Papp2 op e0 e1.
+Proof. by case: e => // ??? [-> -> ->]. Qed.
+
 Lemma is_reflect_some_inv {A P e a} (H: @is_reflect A P e (Some a)) : e = P a.
 Proof.
   set (d e m := match m with None => True | Some a => e = P a end).

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -1871,6 +1871,33 @@ Proof. by case: u; constructor. Qed.
 
 End Option.
 
+Notation "'let%opt' x ':=' ox 'in' body" :=
+  (if ox is Some x then body else None)
+  (x strict pattern, at level 25).
+
+Notation "'let%opt '_' ':=' ox 'in' body" :=
+  (if ox is Some tt then body else None)
+  (at level 25).
+
+Lemma obindP aT bT oa (f : aT -> option bT) a (P : Type) :
+  (forall z, oa = Some z -> f z = Some a -> P) ->
+  (let%opt a' := oa in f a') = Some a ->
+  P.
+Proof. case: oa => // a' h h'. exact: (h _ _ h'). Qed.
+
+Definition oassert (b : bool) : option unit :=
+  if b then Some tt else None.
+
+Lemma oassertP {A b a} {oa : option A} :
+  (let%opt _ := oassert b in oa) = Some a ->
+  b /\ oa = Some a.
+Proof. by case: b. Qed.
+
+Lemma oassertP_isSome {A b} {oa : option A} :
+  isSome (let%opt _ := oassert b in oa) ->
+  b /\ isSome oa.
+Proof. by case: b. Qed.
+
 Lemma cat_inj_head T (x y z : seq T) : x ++ y = x ++ z -> y = z.
 Proof. by elim: x y z => // > hrec >; rewrite !cat_cons => -[/hrec]. Qed.
 


### PR DESCRIPTION
While working on lowering for OTBN and some other lowering changes related to combine flags, I felt like we could simplify the code by adding an equivalent to `Let` but for options.

I think it's clearer because we indent less, avoid intermediate definitions (to later match against `Some`), and use `subst` instead of `case` in proofs (so we don't need to care about dependencies in hypotheses).

For the definition of `let%opt` I tried using `obind` instead of matching, but it blocked reduction in many places and I felt using `match` made things simpler. I couldn't get `Option.obindP` to work, that's why I defined one outside the module. We don't seem to use `Option.obindP`, but I would like to know how to use it instead of the one I defined.

Also, we defined `VarI _ dummy_var_info`  in several places, so I moved it to `expr.v`.