### PR TITLE
Use combine_flags in lowering

### DIFF
--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -236,7 +236,9 @@ Proof.
     | [ |- forall (_ : cmp_kind), _ -> _ ] => move=> [|[] []] //=
     end.
 
-  1: case hTST: lower_TST => [es'|] //.
+  - rewrite /lower_condition_Papp2.
+    case hTST: lower_TST => [es'|] //.
+
   all: move=> [? ? ?] hsemop; subst mn e es.
 
   all: move: hsemop => /sem_sop2I /= [w0 [w1 [b [hw0 hw1 hop]]]].
@@ -277,7 +279,7 @@ Proof.
       first reflexivity.
     clear hws00 hws01.
 
-    rewrite /get_gvar /=.
+    rewrite /pexpr_of_cf /= /get_gvar /=.
     repeat t_get_var => //.
 
     rewrite wrepr0 zero_extend0.
@@ -296,40 +298,40 @@ Proof.
   all: rewrite /get_gvar /=.
   all: repeat t_get_var => //.
 
-  (* Case [w0 == w1]. *)
-  - by rewrite wsub_wnot1 -GRing.Theory.subr_eq0.
-
-  (* Case [w0 != w1]. *)
-  - by rewrite wsub_wnot1 -GRing.Theory.subr_eq0.
+  all: rewrite
+    /sem_opN /= /sem_combine_flags /cf_xsem /NF_of_word /ZF_of_word /=
+    1?wsub_wnot1
+    1?nzcv_of_aluop_CF_sub
+    1?wsigned_wsub_wnot1
+    ?GRing.Theory.subr_eq0
+    //.
+  all: clear.
+  all: set w0 := zero_extend _ w0'.
+  all: set w1 := zero_extend _ w1'.
 
   (* Case [w0 <s w1]. *)
-  - by rewrite /sem_sop1 /NF_of_word /= wsub_wnot1 wsigned_wsub_wnot1 wltsE.
+  - by rewrite wltsE.
 
   (* Case [w0 <u w1]. *)
-  - by rewrite /sem_sop1 /= wsub_wnot1 nzcv_of_aluop_CF_sub wleuE ltNge.
+  - by rewrite wleuE ltNge.
 
   (* Case [w0 <=s w1]. *)
-  - rewrite /sem_sop2 /NF_of_word /ZF_of_word /=.
-    by rewrite wsub_wnot1 wsigned_wsub_wnot1 GRing.subr_eq0 wlesE'.
+  - by rewrite wlesE'.
 
   (* Case [w0 <=u w1]. *)
-  - rewrite /sem_sop2 /ZF_of_word /=.
-    by rewrite wsub_wnot1 nzcv_of_aluop_CF_sub GRing.subr_eq0 wleuE'.
+  - by rewrite wleuE'.
 
   (* Case [w0 >s w1]. *)
-  - rewrite /sem_sop2 /NF_of_word /ZF_of_word /=.
-    by rewrite wsub_wnot1 wsigned_wsub_wnot1 GRing.subr_eq0 wltsE'.
+  - by rewrite wlesE' ltNge.
 
   (* Case [w0 >u w1]. *)
-  - rewrite /sem_sop2 /ZF_of_word /=.
-    by rewrite wsub_wnot1 nzcv_of_aluop_CF_sub GRing.subr_eq0 -wltuE'.
+  - by rewrite wleuE' ltNge.
 
   (* Case [w0 >=s w1]. *)
-  - rewrite /sem_sop2 /NF_of_word /=.
-    by rewrite wsub_wnot1 wsigned_wsub_wnot1 wlesE.
+  - by rewrite wltsE leNgt.
 
   (* Case [w0 >=u w1]. *)
-  by rewrite wsub_wnot1 nzcv_of_aluop_CF_sub wleuE.
+  by rewrite -word.wltuE leNgt.
 Qed.
 
 Lemma sem_lower_condition_pexpr tag s0 s0' ii e v lvs aop es c :

--- a/proofs/compiler/propagate_inline_proof.v
+++ b/proofs/compiler/propagate_inline_proof.v
@@ -178,10 +178,8 @@ Proof.
   t_xrbindP=> b ? /to_boolI ?? /to_boolI ?? /to_boolI ?? /to_boolI ? hb ?;
     subst.
 
-  move: hb.
   rewrite /sem_combine_flags /cf_xsem.
-  case: cf_tbl => -[] ? [?];
-    subst b;
+  case: cf_tbl => -[] ?;
     by auto using snotE, sandE, sorE, sbeqE, sem_pexpr_fc_sem.
 Qed.
 

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -258,6 +258,22 @@ Definition eand e1 e2 := Papp2 Oand e1 e2.
 Definition eeq e1 e2 := Papp2 Obeq e1 e2.
 Definition eneq e1 e2 := enot (eeq e1 e2).
 
+Definition cf_of_condition (op : sop2) : option (combine_flags * wsize) :=
+  match op with
+  | Oeq (Op_w ws) => Some (CF_EQ, ws)
+  | Oneq (Op_w ws) => Some (CF_NEQ, ws)
+  | Olt (Cmp_w s ws) => Some (CF_LT s, ws)
+  | Ole (Cmp_w s ws) => Some (CF_LE s, ws)
+  | Ogt (Cmp_w s ws) => Some (CF_GT s, ws)
+  | Oge (Cmp_w s ws) => Some (CF_GE s, ws)
+  | _ => None
+  end.
+
+Definition pexpr_of_cf (cf : combine_flags) (flags : seq var) : pexpr :=
+  let eflags := [seq Plvar (mk_var_i x) | x <- flags ] in
+  PappN (Ocombine_flags cf) eflags.
+
+
 (* ** Left values
  * -------------------------------------------------------------------- *)
 
@@ -277,6 +293,8 @@ Definition get_pvar (e: pexpr) : exec var :=
 
 Definition get_lvar (x: lval) : exec var :=
   if x is Lvar x then ok (v_var x) else type_error.
+
+Definition Lnone_b (vi : var_info) : lval := Lnone vi sbool.
 
 (* ** Instructions
  * -------------------------------------------------------------------- *)

--- a/proofs/lang/sem_op_typed.v
+++ b/proofs/lang/sem_op_typed.v
@@ -127,16 +127,16 @@ Section WITH_PARAMS.
 
 Context {cfcd : FlagCombinationParams}.
 
-Definition sem_combine_flags
-  (cf : combine_flags) (b0 b1 b2 b3 : bool) : exec bool :=
-  ok (cf_xsem negb andb orb (fun x y => x == y) b0 b1 b2 b3 cf).
+Definition sem_combine_flags (cf : combine_flags) (b0 b1 b2 b3 : bool) : bool :=
+  cf_xsem negb andb orb (fun x y => x == y) b0 b1 b2 b3 cf.
 
 Definition sem_opN_typed (o: opN) :
   let t := type_of_opN o in
   sem_prod t.1 (exec (sem_t t.2)) :=
   match o with
   | Opack sz pe => curry (A := sint) (sz %/ pe) (λ vs, ok (wpack sz pe vs))
-  | Ocombine_flags cf => sem_combine_flags cf
+  | Ocombine_flags cf =>
+      fun b0 b1 b2 b3 => ok (sem_combine_flags cf b0 b1 b2 b3)
   end.
 
 End WITH_PARAMS.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1142,24 +1142,14 @@ Qed.
 
 (* -------------------------------------------------------------------*)
 
-Lemma wltuE' sz (α β: word sz) :
-  wlt Unsigned α β = (wunsigned (β - α) == (wunsigned β - wunsigned α)%Z) && (β != α).
-Proof.
-  by rewrite -[X in X && _]negbK -wltuE /= -leNgt andbC eq_sym -lt_neqAle.
-Qed.
-
 Lemma wleuE sz (w1 w2: word sz) :
  (wunsigned (w2 - w1) == (wunsigned w2 - wunsigned w1))%Z = wle Unsigned w1 w2.
-Proof.
-  rewrite /= le_eqVlt -/(wlt Unsigned _ _) wltuE'.
-  rewrite orb_andr /= [w2 == w1]eq_sym orbN andbT.
-  by rewrite orb_idl // => /eqP /val_inj ->; rewrite subZE !subrr.
-Qed.
+Proof. by rewrite /= leNgt wltuE negbK. Qed.
 
 Lemma wleuE' sz (w1 w2 : word sz) :
   (wunsigned (w1 - w2) != (wunsigned w1 - wunsigned w2)%Z) || (w1 == w2)
   = wle Unsigned w1 w2.
-Proof. by rewrite /wle le_eqVlt wleuE ltNge orbC. Qed.
+Proof. by rewrite -wltuE /= le_eqVlt orbC. Qed.
 
 Lemma wltsE_aux sz (α β: word sz) : α ≠ β →
   wlt Signed α β = (msb (α - β) != (wsigned (α - β) != (wsigned α - wsigned β)%Z)).


### PR DESCRIPTION
The logic to replace conditions with flags was duplicated: `fc_of_cfc` (in arch decl) and `lower_cond` (in each lowering pass). I changed this so that lowering maps conditions to flag combinations (`==` to `CF_EQ`) that then get lowered to flag combinations by Propagate Inline. A good thing now is that we prove that `fc_of_cfc` maps high-level conditions to flags correctly (previously we didn't need to because the semantics of `combine_flags` is architecture specific).