### PR TITLE
Optimize arm_cmd_large_arith_imm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
   other parameters. See `tests/success/common/test_globals.jazz`.
   ([PR #595](https://github.com/jasmin-lang/jasmin/pull/595)).
 
+- The generated code for allocating and freeing stack frames in ARM has been
+  slightly optimized: small constants are used as immediates, 16-bit or
+  Thumb-expandable constants loaded with `MOV`, and bigger ones constructed
+  with `MOV` and `MOVT`.
+  ([PR #597](https://github.com/jasmin-lang/jasmin/pull/597)).
+
 ## Bug fixes
 
 - Type-checking rejects wrongly casted primitive operators

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -65,24 +65,38 @@ Definition arm_op_align (x y : var_i) (al : wsize) :=
 
 (* Precondition: [0 <= imm < wbase reg_size]. *)
 Definition arm_cmd_load_large_imm (x : var_i) (imm : Z) : seq fopn_args :=
-  let '(hbs, lbs) := Z.div_eucl imm (wbase U16) in
-  [:: arm_op_movi x lbs; arm_op_movt x hbs ].
+  if is_expandable imm || is_w16_encoding imm
+  then [:: arm_op_movi x imm ]
+  else
+    let '(hbs, lbs) := Z.div_eucl imm (wbase U16) in
+    [:: arm_op_movi x lbs; arm_op_movt x hbs ].
 
 (* Return a command that performs an operation with an immediate argument,
    loading it into a register if needed.
    In symbols,
        R[x] := R[y] <+> imm
- *)
+   Precondition: if [imm] is large, [x <> y].
+
+   We use [is_expandable] but this is an more restrictive than necessary, for
+   some mnemonics we could use [is_wXX_encoding]. *)
 Definition arm_cmd_large_arith_imm
   (on_reg : var_i -> var_i -> var_i -> fopn_args)
   (on_imm : var_i -> var_i -> Z -> fopn_args)
+  (neutral : option Z)
   (x y : var_i)
   (imm : Z) :
   seq fopn_args :=
-  arm_cmd_load_large_imm x imm ++ [:: on_reg x y x ].
+  let is_mov := if neutral is Some x then (imm =? x)%Z else false in
+  if is_mov
+  then [:: arm_op_mov x y ]
+  else
+    if is_expandable imm
+    then [:: on_imm x y imm ]
+    else arm_cmd_load_large_imm x imm ++ [:: on_reg x y x ].
 
-Definition arm_cmd_large_subi (x y : var_i) (imm : Z) : seq fopn_args :=
-  arm_cmd_large_arith_imm arm_op_sub arm_op_subi x y imm.
+(* Precondition: if [imm] is large, [x <> y]. *)
+Definition arm_cmd_large_subi :=
+  arm_cmd_large_arith_imm arm_op_sub arm_op_subi (Some 0%Z).
 
 (* ------------------------------------------------------------------------ *)
 (* Stack alloc parameters. *)


### PR DESCRIPTION
Now `$ ./jasminc -arch arm-m4 tests/success/arm-m4/memcmp.jazz -pasm` gives
```
memcmp:
	push	{lr}
	SUB 	r12, sp, #8
```
instead of
```
memcmp:
	push	{lr}
	MOV 	r12, #8
	MOVT	r12, #0
	SUB 	r12, sp, r12
```

Closes #379.