### PR TITLE
more flexibility for (s)ct checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   We now support operators SLH operators as in [Typing High-Speed Cryptography
   against Spectre v1](https://ia.cr/2022/1270).
   The compilation of these is proven to preserve functional semantics.
-  We also provide a speculative CCT checker, via the compiler flag `-checkSCT`.
+  We also provide a speculative CCT checker, via the compiler flag `-check SCT`.
   ([PR #447](https://github.com/jasmin-lang/jasmin/pull/447)).
 
 - Register arrays can appear as arguments and return values of local functions;
@@ -33,6 +33,25 @@
   Thumb-expandable constants loaded with `MOV`, and bigger ones constructed
   with `MOV` and `MOVT`.
   ([PR #597](https://github.com/jasmin-lang/jasmin/pull/597)).
+
+- The option `-checkCT` has been removed, use `-check CT` instead.
+
+- The option `-checkCTon` has been removed, use `-slice` instead.
+
+- The option `-check sectypes` has been added, this allows to check
+  (speculative) constant time on all functions annotated with `#CT` or `#SCT`.
+  Both annotations accept as option argument a compilation pass, for example:
+	`#CT = unroll` or `#SCT = inline`.
+  In this case the checking will be performed after this compilation pass.
+  It is possible to specify meany compilation passes:
+	`#[CT, CT=inline, CT=unroll]`.
+
+- The option `-checkafter` has been added, this allows to check (speculative) constant time
+  after a given compilation pass.
+
+- The option `-print-sectypes [list | full | no]` has been added.
+
+
 
 ## Bug fixes
 

--- a/compiler/scripts/check-cct
+++ b/compiler/scripts/check-cct
@@ -2,4 +2,4 @@
 
 set -ex
 
-exec $(dirname $0)/../jasminc -checkCT "$@"
+exec $(dirname $0)/../jasminc -check CT "$@"

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -467,6 +467,14 @@ let has_annot a { i_annot ; _ } =
   List.exists (fun (k, _) -> String.equal (L.unloc k) a) i_annot
 
 (* -------------------------------------------------------------------- *)
+let get_fun prog fn =
+  List.find (fun f -> F.equal f.f_name fn) (snd prog)
+
+let get_fun_s prog fn =
+  List.find (fun f -> String.equal f.f_name.fn_name fn) (snd prog)
+
+
+(* -------------------------------------------------------------------- *)
 let clamp (sz : wsize) (z : Z.t) =
   Z.erem z (Z.shift_left Z.one (int_of_ws sz))
 

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -269,6 +269,10 @@ val has_call_or_syscall : ('len, 'info, 'asm) gstmt -> bool
 val has_annot : Annotations.symbol -> ('len, 'info, 'asm) ginstr -> bool
 
 (* -------------------------------------------------------------------- *)
+val get_fun : ('info,'asm) prog -> funname -> ('info,'asm) func
+val get_fun_s : ('info,'asm) prog -> string -> ('info,'asm) func
+
+(* -------------------------------------------------------------------- *)
 val clamp : wsize -> Z.t -> Z.t
 val clamp_pe : pelem -> Z.t -> Z.t
 

--- a/compiler/src/sct_checker_forward.mli
+++ b/compiler/src/sct_checker_forward.mli
@@ -1,9 +1,25 @@
 open Prog
 
-type ty_fun
+type signature
+(** Speculative Security type of a function *)
 
-val pp_funty : Format.formatter -> Name.t * ty_fun -> unit
-val ty_prog : ('info, 'asm) prog -> Name.t list -> (Name.t * ty_fun) list
+val pp_signature : _ prog -> Format.formatter -> funname * signature -> unit
+
+val ty_prog :
+  infer:bool ->
+  _ prog ->
+  Name.t list ->
+  (funname * signature) list * (L.t * (Format.formatter -> unit)) option
+(** Type-check (for speculative constant-time) a list of functions in the given program
+  (defaults to all functions if the list is empty).
+
+  Returns the signature of all functions that have been successfully
+  type-checked and an optional error message in case of failure (type-checking
+  aborts after the first error).
+
+  When [infer] is false, checking of export functions fails unless they are correctly annotated.
+*)
 
 val compile_infer_msf :
   ('info, 'asm) prog -> (Slh_lowering.slh_t list * Slh_lowering.slh_t list) Hf.t
+(** Internal function for the compiler, does not provide any security guaranty *)

--- a/compiler/src/slicing.ml
+++ b/compiler/src/slicing.ml
@@ -38,11 +38,11 @@ and inspect_instr_r k = function
   | Cfor (_, (_, e1, e2), s) -> inspect_stmt (inspect_es k [ e1; e2 ]) s
   | Ccall (_, xs, fn, es) -> with_fun (inspect_lvs (inspect_es k es) xs) fn
 
-let slice fs (gd, fds) =
+let slice fs (gd, fds as prog) =
   let funs =
     List.fold_left
       (fun s n ->
-        match List.find (fun fd -> String.equal n fd.f_name.fn_name) fds with
+        match get_fun_s prog n with
         | exception Not_found ->
             warning Always L.i_dummy "slicing: function “%s” not found" n;
             s

--- a/compiler/tests/sct-checker/accept.expected
+++ b/compiler/tests/sct-checker/accept.expected
@@ -1,190 +1,192 @@
 File annot.jazz:
-modmsf f : #transient ->
+modmsf f : #transient x ->
 #secret
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf id : #poly = { n = k, s = k} ->
+modmsf id : #poly = { n = k, s = k} arg ->
 #poly = { n = k, s = k}
 output corruption: #public
- constraints:
+constraints:
 k <= k, 
 
-nomodmsf id1 : #poly = { n = k, s = k} ->
+nomodmsf id1 : #poly = { n = k, s = k} arg ->
 #poly = { n = k, s = k}
 output corruption: #public
- constraints:
+constraints:
 
 
-nomodmsf id2 : #[ptr = { n = p, s = p}, val = { n = v, s = v}] ->
+nomodmsf id2 : #[ptr = { n = p, s = p}, val = { n = v, s = v}] arg ->
 #[ptr = { n = p, s = p}, val = { n = v, s = v}]
 output corruption: #public
- constraints:
+constraints:
 
 
-nomodmsf id3 : #public ->
+nomodmsf id3 : #public arg ->
 #public
 output corruption: #public
- constraints:
+constraints:
 
 
-nomodmsf id4 : #transient ->
+nomodmsf id4 : #transient arg ->
 #transient
 output corruption: #public
- constraints:
+constraints:
 
 
-nomodmsf id5 : #secret ->
+nomodmsf id5 : #secret arg ->
 #secret
 output corruption: #public
- constraints:
+constraints:
 
 
 File arrays.jazz:
-modmsf transient_read : #[ptr = transient, val = { n = d, s = secret}] *
-                        #transient ->
+modmsf transient_read : #[ptr = transient, val = { n = d, s = secret}] p *
+                        #transient i ->
 #poly = { n = d, s = secret}
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf safe_access : #public * #poly = { n = d, s = d} ->
+modmsf safe_access : #public c * #poly = { n = d, s = d} x ->
 #poly = { n = d, s = d}
 output corruption: #public
- constraints:
+constraints:
 
 
 File basic.jazz:
-modmsf nothing : #transient ->
+modmsf nothing : #transient a ->
 #public
 output corruption: #public
- constraints:
+constraints:
 
 
-nomodmsf secret : #secret ->
+nomodmsf secret : #secret a ->
 #secret
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf branch : #transient * #secret * #secret ->
+modmsf branch : #transient a * #secret b * #secret c ->
 #secret
 output corruption: #public
- constraints:
+constraints:
 
 
-nomodmsf branchless : #transient * #secret * #secret ->
+nomodmsf branchless : #transient a * #secret b * #secret c ->
 #secret
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf forloop : #transient ->
+modmsf forloop : #transient a ->
 #public
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf whileloop : #transient ->
+modmsf whileloop : #transient a ->
 #public
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf archetype : #transient ->
+modmsf archetype : #transient i ->
 #transient
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf load : #transient * #transient ->
+modmsf load : #transient p * #transient i ->
 #public
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf store : #transient * #transient * #transient * #secret ->
+modmsf store : #transient p * #transient i * #transient q * #secret v ->
 
 output corruption: #transient
- constraints:
+constraints:
 
 
 File local-stack-array.jazz:
-modmsf main : #transient ->
+modmsf main : #transient io ->
 #public
 output corruption: #public
- constraints:
+constraints:
 
 
 File paper.jazz:
-modmsf fig3a : #[ptr = transient, val = transient] *
-               #[ptr = transient, val = secret] * #transient ->
+modmsf fig3a : #[ptr = transient, val = transient] p *
+               #[ptr = transient, val = secret] w * #transient i ->
 #[ptr = public, val = secret]
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf fig3b : #[ptr = transient, val = transient] *
-               #[ptr = transient, val = { n = w, s = w}] *
-               #[ptr = transient, val = { n = s, s = s}] * #transient *
-               #secret ->
+modmsf fig3b : #[ptr = transient, val = transient] p *
+               #[ptr = transient, val = { n = w, s = w}] w *
+               #[ptr = transient, val = { n = s, s = s}] s * #transient i *
+               #secret secret ->
 #[ptr = public, val = { n = w, s = w}] *
 #[ptr = public, val = { n = s, s = s}]
 output corruption: #transient
- constraints:
+constraints:
 s <= s, w <= w, 
 
-modmsf fig4a : #[ptr = public, val = { n = d, s = d}] *
-               #[ptr = public, val = secret] ->
+modmsf fig4a : #[ptr = public, val = { n = d, s = d}] msg *
+               #[ptr = public, val = secret] key ->
 #[ptr = public, val = { n = d, s = d}]
 output corruption: #transient
- constraints:
+constraints:
 
 
-modmsf fig4b : #[ptr = transient, val = { n = d, s = d}] *
-               #[ptr = transient, val = secret] ->
+modmsf fig4b : #[ptr = transient, val = { n = d, s = d}] msg *
+               #[ptr = transient, val = secret] key ->
 #[ptr = public, val = { n = d, s = d}]
 output corruption: #transient
- constraints:
+constraints:
 d <= d, 
 
-modmsf fig4c : #[ptr = transient, val = { n = d, s = d}] *
-               #[ptr = transient, val = secret] ->
+modmsf fig4c : #[ptr = transient, val = { n = d, s = d}] msg *
+               #[ptr = transient, val = secret] key ->
 #[ptr = public, val = { n = d, s = d}]
 output corruption: #transient
- constraints:
+constraints:
 d <= d, 
 
-modmsf fig5a : #[ptr = public, val = { n = d, s = secret}] ->
+modmsf fig5a : #[ptr = public, val = { n = d, s = secret}] p ->
 #poly = { n = d, s = secret}
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf fig5b : #[ptr = transient, val = { n = d, s = d}] ->
+modmsf fig5b : #[ptr = transient, val = { n = d, s = d}] p ->
 #poly = { n = d, s = d}
 output corruption: #public
- constraints:
+constraints:
 d <= d, 
 
-modmsf fig5c : #[ptr = transient, val = { n = d, s = d}] ->
+modmsf fig5c : #[ptr = transient, val = { n = d, s = d}] p ->
 #poly = { n = d, s = d}
 output corruption: #public
- constraints:
+constraints:
 d <= d, 
 
-modmsf fig6a : #[ptr = transient, val = secret] *
-               #[ptr = transient, val = transient] * #transient * #transient ->
+modmsf fig6a : #[ptr = transient, val = secret] s *
+               #[ptr = transient, val = transient] p * #transient i *
+               #transient pub_v ->
 #public * #[ptr = public, val = secret]
 output corruption: #public
- constraints:
+constraints:
 
 
-modmsf fig6b : #[ptr = transient, val = secret] *
-               #[ptr = transient, val = transient] * #transient * #secret ->
+modmsf fig6b : #[ptr = transient, val = secret] s *
+               #[ptr = transient, val = transient] p * #transient cond *
+               #secret sec_v ->
 #public * #[ptr = public, val = secret]
 output corruption: #public
- constraints:
+constraints:
 
 

--- a/compiler/tests/sct-checker/accept.ml
+++ b/compiler/tests/sct-checker/accept.ml
@@ -1,17 +1,15 @@
 open Jasmin
 open Common
-open Sct_checker_forward
 
 let path = "success"
 
 let load_and_check name =
   Format.printf "File %s:@." name;
   let p = load_file (Filename.concat path name) in
-  match ty_prog p [] with
-  | exception Utils.HiError e ->
-      Format.eprintf "%a@." Utils.pp_hierror e;
-      exit 1
-  | r -> List.iter (Format.printf "%a@." pp_funty) r
+  try ty_prog p []
+  with Utils.HiError e ->
+    Format.eprintf "%a@." Utils.pp_hierror e;
+    exit 1
 
 let () =
   let cases = Sys.readdir path in

--- a/compiler/tests/sct-checker/common.ml
+++ b/compiler/tests/sct-checker/common.ml
@@ -22,3 +22,11 @@ let load_file name =
   | Syntax.ParseError (loc, None) ->
       Format.eprintf "Parse error: %a@." Location.pp_loc loc;
       assert false
+
+let ty_prog p fl =
+  let sigs, status = Sct_checker_forward.ty_prog ~infer:true p fl in
+  match status with
+  | None ->
+      List.iter (Format.printf "%a@." (Sct_checker_forward.pp_signature p)) sigs
+  | Some (loc, msg) ->
+      Utils.hierror ~loc:(Lone loc) ~kind:"SCT checker" "%t" msg

--- a/compiler/tests/sct-checker/common.mli
+++ b/compiler/tests/sct-checker/common.mli
@@ -13,3 +13,5 @@ val load_file :
       Arch.extra_op )
     Arch_extra.extended_op )
   Prog.prog
+
+val ty_prog : _ Prog.prog -> string list -> unit

--- a/compiler/tests/sct-checker/reject.expected
+++ b/compiler/tests/sct-checker/reject.expected
@@ -1,16 +1,16 @@
 File basic.jazz:
 Failed as expected missing_then: "fail/basic.jazz", line 37 (18-19):
-                                 speculative constant type checker: the variable m is not known to be a msf, only {
+                                 SCT checker: the variable m is not known to be a msf, only {
                                    } are
 Failed as expected missing_else: "fail/basic.jazz", line 23 (18-19):
-                                 speculative constant type checker: the variable m is not known to be a msf, only {
+                                 SCT checker: the variable m is not known to be a msf, only {
                                    } are
 Failed as expected after_branch: "fail/basic.jazz", line 10 (18-19):
-                                 speculative constant type checker: the variable m is not known to be a msf, only {
+                                 SCT checker: the variable m is not known to be a msf, only {
                                    } are
 Failed as expected leak_transient: "fail/basic.jazz", line 1 (42-50):
-                                   speculative constant type checker: x has type #transient but should be at most #public
+                                   SCT checker: x has type #transient but should be at most #public
 File functions.jazz:
 Failed as expected call_kills_msf: "fail/functions.jazz", line 9 (2-10):
-                                   speculative constant type checker: calls destroy msf variables, {
+                                   SCT checker: calls destroy msf variables, {
                                     m } are required

--- a/compiler/tests/sct-checker/reject.ml
+++ b/compiler/tests/sct-checker/reject.ml
@@ -1,6 +1,5 @@
 open Jasmin
 open Common
-open Sct_checker_forward
 
 let path = "fail"
 
@@ -11,12 +10,12 @@ let load_and_check name =
     (fun fd ->
       if fd.Prog.f_cc <> Internal then
         let f = fd.Prog.f_name.fn_name in
-        match ty_prog p [ f ] with
-        | exception Utils.HiError e ->
-            Format.printf "Failed as expected %s: %a@." f Utils.pp_hierror e
-        | _ ->
-            Format.eprintf "Did not fail: %s.@." f;
-            assert false)
+        try
+          ty_prog p [ f ];
+          Format.eprintf "Did not fail: %s.@." f;
+          assert false
+        with Utils.HiError e ->
+          Format.printf "Failed as expected %s: %a@." f Utils.pp_hierror e)
     fds
 
 let () =

--- a/compiler/tests/sct-checker/sct_errors.expected
+++ b/compiler/tests/sct-checker/sct_errors.expected
@@ -1,57 +1,57 @@
 Failed as expected assign_msf: "error_messages.jazz", line 3 (2-8):
-                               speculative constant type checker: assignment operation not permitted on a msf variable: x
+                               SCT checker: assignment operation not permitted on a msf variable: x
 Failed as expected syscall: "error_messages.jazz", line 11 (2-22):
-                            speculative constant type checker: syscalls destroy msf variables, {
+                            SCT checker: syscalls destroy msf variables, {
                              x } are required
 Failed as expected update_msf_not_trans: "error_messages.jazz", line 17 (25-26):
-                                         speculative constant type checker: MSF is not Trans
+                                         SCT checker: MSF is not Trans
 Failed as expected update_msf_wrong_expr: "error_messages.jazz", line 24 (27-28):
-                                          speculative constant type checker: the expression false need to be equal to
+                                          SCT checker: the expression false need to be equal to
                                           (x ==64u ((64u) 0))
 Failed as expected update_msf_not_msf: "error_messages.jazz", line 35 (28-29):
-                                       speculative constant type checker: the variable x is not known to be a msf, only {
+                                       SCT checker: the variable x is not known to be a msf, only {
                                          } are
 Failed as expected msf_trans: "error_messages.jazz", line 43 (20-21):
-                              speculative constant type checker: MSF is Trans
+                              SCT checker: MSF is Trans
                               (x ==64u ((64u) 0))
 Failed as expected not_known_as_msf: "error_messages.jazz", line 53 (15-16):
-                                     speculative constant type checker: the variable x is not known to be a msf, only {
+                                     SCT checker: the variable x is not known to be a msf, only {
                                        } are
-Annotation error in bad_poly_annot: "error_messages.jazz", line 56 (31-37) public not allowed as argument of poly
+Failed as expected bad_poly_annot: "error_messages.jazz", line 56 (31-37):
+                                   SCT checker: public not allowed as argument of poly
 Failed as expected msf_in_export: "error_messages.jazz", line 56 (51) to line 60 (1):
-                                  speculative constant type checker: {
-                                   p } need to be a msf, this is not allowed in export function
+                                  SCT checker: { p } need to be a msf, this is not allowed in export function
 Failed as expected must_not_be_a_msf: "error_messages.jazz", line 62 (38-39):
-                                      speculative constant type checker: p must not be a msf
+                                      SCT checker: p must not be a msf
 Failed as expected should_be_a_msf: "error_messages.jazz", line 68 (39-40):
-                                    speculative constant type checker: p should be a msf
+                                    SCT checker: p should be a msf
 Failed as expected at_least_transient: "error_messages.jazz", line 75 (45-46):
-                                       speculative constant type checker: security annotation for p should be at least transient
+                                       SCT checker: security annotation for p should be at least transient
 Failed as expected unbound_level: "error_messages.jazz", line 79 (0) to line 84 (1):
-                                  speculative constant type checker: unbound security level hello
+                                  SCT checker: unbound security level hello
 Failed as expected inconsistent_constraint: "error_messages.jazz", line 86 (0) to line 87 (38):
-                                            speculative constant type checker: cannot add constraint secret <= public, it is inconsistent
+                                            SCT checker: cannot add constraint secret <= public, it is inconsistent
 Failed as expected bad_modmsf: "error_messages.jazz", line 89 (0) to line 90 (25):
-                               speculative constant type checker: annotation modmsf should be nomodmsf
+                               SCT checker: annotation modmsf should be nomodmsf
 Failed as expected bad_nomodmsf: "error_messages.jazz", line 92 (0) to line 95 (1):
-                                 speculative constant type checker: annotation nomodmsf should be modmsf
+                                 SCT checker: annotation nomodmsf should be modmsf
 Failed as expected call_bad_nomodmsf: "error_messages.jazz", line 97 (0) to line 103 (1):
-                                      speculative constant type checker: annotation nomodmsf should be modmsf
+                                      SCT checker: annotation nomodmsf should be modmsf
 Failed as expected call_bad_nomodmsf2: "error_messages.jazz", line 111 (0) to line 119 (1):
-                                       speculative constant type checker: annotation nomodmsf should be modmsf
+                                       SCT checker: annotation nomodmsf should be modmsf
 Failed as expected call_bad_nomodmsf3: "error_messages.jazz", line 127 (0) to line 136 (1):
-                                       speculative constant type checker: annotation nomodmsf should be modmsf
+                                       SCT checker: annotation nomodmsf should be modmsf
 Failed as expected call_modmsf_destroys: "error_messages.jazz", line 153 (2-25):
-                                         speculative constant type checker: calls destroy msf variables, {
+                                         SCT checker: calls destroy msf variables, {
                                           msf } are required
 Failed as expected ret_high: "error_messages.jazz", line 160 (9-10):
-                             speculative constant type checker: return type for p is #secret it should be less than #public
+                             SCT checker: return type for p is #secret it should be less than #public
 Failed as expected ret_transient: "error_messages.jazz", line 164 (9-10):
-                                  speculative constant type checker: return type for p is #transient it should be less than #public
+                                  SCT checker: return type for p is #transient it should be less than #public
 Failed as expected ret_msf: "error_messages.jazz", line 170 (9-12):
-                            speculative constant type checker: return annotation for msf should be msf
+                            SCT checker: return annotation for msf should be msf
 Failed as expected public_arg: "error_messages.jazz", line 173 (37-38):
-                               speculative constant type checker: security annotation for x should be at least transient
-Failed as expected unknown function: speculative constant type checker: unknown function unknown function
+                               SCT checker: security annotation for x should be at least transient
+Failed as expected unknown function: SCT checker: unknown function unknown function
 Failed as expected need_declassify: "error_messages.jazz", line 180 (9-10):
-                                    speculative constant type checker: return type for x is #secret it should be less than #public
+                                    SCT checker: return type for x is #secret it should be less than #public

--- a/compiler/tests/sct-checker/sct_errors.ml
+++ b/compiler/tests/sct-checker/sct_errors.ml
@@ -4,7 +4,7 @@ open Common
 let () =
   let p = load_file "error_messages.jazz" in
   let check_fails f =
-    match Sct_checker_forward.ty_prog p [ f ] with
+    match ty_prog p [ f ] with
     | exception Annot.AnnotationError (loc, msg) ->
         Format.printf "Annotation error in %s: %a %t@." f Location.pp_loc loc
           msg


### PR DESCRIPTION
The main idea of this PR is do provide more flexibility in the usage of (S)CT checker.
What we want is to be able to add annotations in libjade allowing to say if (export) functions are CT of SCT.
By default, function export in libjade should be at least CT, but we want to be able replace step by step some CT implementations by SCT one (and this should be clearly expressed in the file). We also want to have the possibility to provide two implementations in particular in the case where the SCT version is much more costly.

For a longer term, I would like to be able to automatically print header file (for C for exemple), and I would like 
to be sure that the printed annotation are corrects (so we will need to check it before printing). 
To do that, it will be good to be able to add safety annotation directly in the jazz file. 
As well as functions documentation that can be also propagated to header file.





