### PR TITLE
Remove unneeded dependency on expr_facts

### DIFF
--- a/proofs/lang/psem_defs.v
+++ b/proofs/lang/psem_defs.v
@@ -3,7 +3,7 @@
 (* ** Imports and settings *)
 From mathcomp Require Import all_ssreflect all_algebra.
 Require Import Psatz xseq.
-Require Export array type expr gen_map low_memory warray_ sem_type sem_op_typed values varmap expr_facts low_memory syscall_sem.
+Require Export array type expr gen_map low_memory warray_ sem_type sem_op_typed values varmap low_memory syscall_sem.
 Require Export
   flag_combination
   sem_params.


### PR DESCRIPTION
The compiler does not need to depend on expr_facts.