### PR TITLE
Avoid explicitly using lstate records

### DIFF
--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -1746,8 +1746,7 @@ Proof.
   - move=> [xlr | ] r ok_i.
     + case heqlr: to_reg => [lr /= | //] [?]; subst aci.
       rewrite /linear_sem.eval_instr => /=; t_xrbindP => l hgetpc.
-      case ptr_eq: encode_label => [ ptr | ] //.
-      t_xrbindP => vm hset hjump.
+      t_xrbindP=> ptr /o2rP ptr_eq vm hset hjump.
       apply (match_state_step1 (ls' := ls') hnth) => /=.
       rewrite /return_address_from.
       have /= := assemble_get_label_after_pc hass ok_i _ heqf hip _ hgetpc.
@@ -1761,8 +1760,8 @@ Proof.
       by move=> /(lom_eqv_write_var MSB_CLEAR hloeq) -/(_ _ heqlr).
     move=> [?]; subst aci.
     rewrite /linear_sem.eval_instr => /=; t_xrbindP=> wsp vsp hsp htow_sp l hgetpc.
-    rewrite heqf; case ptr_eq: encode_label => [ ptr | ] //.
-    t_xrbindP => m1 hm1 /= => hjump.
+    rewrite heqf.
+    t_xrbindP=> ptr /o2rP ptr_eq m1 hm1 /= => hjump.
     apply (match_state_step1 (ls' := ls') hnth) => /=.
     rewrite /return_address_from.
     have /= := assemble_get_label_after_pc hass ok_i _ heqf hip _ hgetpc.
@@ -1781,8 +1780,7 @@ Proof.
     move=> /(lom_eqv_write_var MSB_CLEAR hloeq) -/(_ ad_rsp erefl).
     by case=> *; constructor => //.
   - move=> hok_i [?]; subst aci; rewrite /linear_sem.eval_instr /=.
-    t_xrbindP => wsp vsp hsp htow_sp ptr ok_ptr.
-    case ptr_eq: decode_label => [ r | // ] /= hjump.
+    t_xrbindP=> wsp vsp hsp htow_sp ptr ok_ptr r /o2rP ptr_eq hjump.
     apply (match_state_step1 (ls' := ls') hnth) => /=.
     rewrite /eval_POP truncate_word_u /=.
     rewrite to_var_rsp in hsp.
@@ -1816,11 +1814,11 @@ Proof.
     by apply (match_state_step1 (ls' := ls') hnth) => /=; apply: eval_jumpP; last by apply hi.
   - rewrite /linear_sem.eval_instr /=; t_xrbindP=> e hok_i ok_e.
     move => d ok_d ? ptr v ok_v /to_wordI[? [? [? /word_uincl_truncate hptr]]]; subst.
+    move=> r /o2rP ptr_eq.
     change reg_size with Uptr in ptr => hdec.
     apply (match_state_step1 (ls' := ls') hnth) => /=; move: hdec.
     have [v' -> /value_uinclE /= [? [? [-> /hptr /= ->]]]] := eval_assemble_word hloeq ok_e ok_d ok_v.
-    case ptr_eq: decode_label => [ r | // ] /=.
-    rewrite -assemble_prog_labels ptr_eq.
+    rewrite -assemble_prog_labels /= ptr_eq.
     by apply eval_jumpP.
   - move => x lbl hok_i.
     case ok_r_x': (of_var x) => [r|//]; have ok_r_x := of_varI ok_r_x'.
@@ -1828,10 +1826,8 @@ Proof.
     apply (match_state_step1 (ls' := ls') hnth) => /=.
     move: hev; rewrite /linear_sem.eval_instr /=.
     rewrite heqf -assemble_prog_labels.
-    case ptr_eq: encode_label => [ ptr | ] //.
-    t_xrbindP => vm ok_vm <-{ls'}.
+    t_xrbindP=> ptr /o2rP -> vm ok_vm <-{ls'}.
     eexists; first reflexivity.
-    rewrite /= -heqf.
     rewrite ok_fd /=; eexists; first by eauto.
     constructor => //=.
     + move: ok_r_x; change x with (v_var (VarI x dummy_var_info)).

--- a/proofs/arch/label.v
+++ b/proofs/arch/label.v
@@ -78,4 +78,12 @@ Proof.
   by case: encode_label.
 Qed.
 
+Definition rencode_label
+  (lbls : seq remote_label) (lbl : remote_label) : exec (word Uptr) :=
+  o2r ErrType (encode_label lbls lbl).
+
+Definition rdecode_label
+  (lbls : seq remote_label) (w : word Uptr) : exec remote_label :=
+  o2r ErrType (decode_label lbls w).
+
 End WITH_POINTER_DATA.

--- a/proofs/compiler/arm_stack_zeroization_proof.v
+++ b/proofs/compiler/arm_stack_zeroization_proof.v
@@ -13,6 +13,7 @@ Require Import
   psem
   psem_facts
   low_memory.
+Require stack_zeroization_proof.
 Require Import
   arch_decl
   arch_extra
@@ -28,24 +29,24 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
+(* FIXME: We should use the higher-level [eval_lsem] lemmas. *)
+Section FIXME.
+
+Context
+  {asm_op syscall_state : Type}
+  {ep : EstateParams syscall_state}
+  {sip : SemInstrParams asm_op syscall_state}.
+
+#[local]
+Lemma find_instr_skip p fn P Q :
+  is_linear_of p fn (P ++ Q) ->
+  forall scs m vm n,
+  find_instr p (Lstate scs m vm fn (size P + n)) = oseq.onth Q n.
+Proof. by eauto using find_instr_skip'. Qed.
+
+End FIXME.
+
 #[local] Existing Instance withsubword.
-
-(* TODO: cleaner proof & share with x86_stack_zeroization_proof *)
-Lemma read0 ws x :
-  @LE.wread8 ws 0 x = 0%R.
-Proof.
-  rewrite /LE.wread8 /LE.encode /split_vec.
-  case: (Nat.le_gt_cases (ws %/ U8 + ws %% U8) (Z.to_nat x)) => h0.
-  + rewrite nth_default; first done.
-    rewrite size_map size_iota.
-    by apply/leP.
-
-  rewrite (nth_map 0); first last.
-  + rewrite size_iota.
-    by apply/ltP.
-  rewrite /word.subword /= Z.shiftr_0_l Zmod_0_l.
-  by apply /(@eqP (word U8)).
-Qed.
 
 Section STACK_ZEROIZATION.
 
@@ -64,45 +65,24 @@ Let vzf := mk_var_i (to_var ZF).
 Let vflags := [seq mk_var_i (to_var f) | f <- rflags ].
 Let leflags := [seq LLvar f | f <- vflags ].
 
-Section STORE_ZERO.
-
-(* Linear state after executing a linear instruction [Lopn]. *)
-Notation next_ls ls m :=
-  {|
-    lscs := lscs ls;
-    lmem := m;
-    lvm := lvm ls;
-    lfn := lfn ls;
-    lpc := lpc ls + 1;
-  |}
-  (only parsing).
-
 Lemma store_zero_eval_instr lp ii ws e (ls:lstate) (w1 w2 : word Uptr) m' :
   (ws <= U32)%CMP ->
   get_var true (lvm ls) vzero = ok (@Vword Uptr 0) ->
   get_var true (lvm ls) rspi = ok (Vword w1) ->
   sem_fexpr (lvm ls) e >>= to_word Uptr = ok w2 ->
   write (lmem ls) (w1 + w2)%R (sz:=ws) 0 = ok m' ->
-  eval_instr lp (MkLI ii (store_zero rspi ws e)) ls = ok (next_ls ls m').
+  let i := MkLI ii (store_zero rspi ws e) in
+  eval_instr lp i ls = ok (lnext_pc (lset_mem ls m')).
 Proof.
   move=> ws_small hvzero hrsp he hm'.
-  rewrite /eval_instr /=.
-  rewrite /store_zero.
+  rewrite /eval_instr /= /store_zero.
   have [mn hstore]: exists mn, store_mn_of_wsize ws = Some mn.
   + by case: ws ws_small {hm'} => //= _; eexists; reflexivity.
-  rewrite hstore /=.
-  rewrite hvzero /=.
+  rewrite hstore /= hvzero /=.
   rewrite (store_mn_of_wsizeP (w:=0%R) hstore) /=;
     last by rewrite (truncate_word_le _ ws_small) zero_extend0.
-  rewrite hrsp /= (truncate_word_u w1) /=.
-  rewrite he /=.
-  rewrite truncate_word_u /=.
-  rewrite hm' /=.
-  rewrite /of_estate /=.
-  by rewrite -addn1; reflexivity.
+  by rewrite hrsp /= (truncate_word_u w1) /= he /= truncate_word_u /= hm' /=.
 Qed.
-
-End STORE_ZERO.
 
 Context (lp : lprog) (fn : funname).
 Context (ws_align : wsize) (ws : wsize) (stk_max : Z).
@@ -113,7 +93,8 @@ Context (ptr : pointer).
 Context (hstack : (stk_max <= wunsigned (align_word ws_align ptr))%Z).
 Let top := (align_word ws_align ptr - wrepr Uptr stk_max)%R.
 
-Local Lemma top_aligned : is_align top ws.
+#[local]
+Lemma top_aligned : is_align top ws.
 Proof.
   rewrite /top.
   apply is_align_add.
@@ -178,7 +159,7 @@ Context (hbody : is_linear_of lp fn (pre ++ sz_init rspi ws_align stk_max ++ pos
 Context (rsp_nin : ~ Sv.In rspi sz_init_vars).
 
 Lemma sz_initP (s1 : estate) :
-  (forall p, between top stk_max p U8 -> validw (emem s1) p U8) ->
+  valid_between (emem s1) top stk_max ->
   s1.(evm).[rspi] = Vword ptr ->
   exists s2,
     lsem lp (of_estate s1 fn (size pre)) (of_estate s2 fn (size pre + size (sz_init rspi ws_align stk_max))) /\
@@ -212,57 +193,59 @@ Proof.
       have /= := wunsigned_range (align_word ws_align ptr).
       by lia.
     have /= := [elaborate
-      arm_cmd_load_large_imm_lsem (with_vm s1 (evm s1).[vsaved_sp <- Vword ptr]) hbody' hmax].
+      let: s1 := with_vm s1 (evm s1).[vsaved_sp <- Vword ptr] in
+      let: ls1 := of_estate s1 _ _ in
+      arm_cmd_load_large_imm_lsem (ls := ls1) hbody' erefl erefl hmax
+    ].
     rewrite -/iload_off size_rcons -{1}addn1 => -[vm2 [hsem2 hvm2 hgetoff]].
     exists vm2; split=> //.
     + by rewrite size_cat /= -(addSnnS (size _) (size _)).
     by move/get_varP: hgetoff => [<- _ _].
 
   eexists (Estate _ _ _); split=> /=.
-  + apply: lsem_step.
-    + rewrite /lsem1 /step.
-      rewrite -{1}(addn0 (size _)).
-      rewrite (find_instr_skip hbody) /=.
-      apply arm_op_mov_eval_instr.
-      by rewrite /get_var hrsp /=; reflexivity.
-    rewrite /=.
-    apply: lsem_trans.
-    + exact: hsem2.
-    move: hbody'; rewrite -cat_rcons catA cat_rcons => hbody'.
-    apply: lsem_step.
-    + rewrite /lsem1 /step.
-      rewrite -{1}(addn0 (size _)).
-      rewrite (find_instr_skip hbody') /=.
-      apply arm_op_align_eval_instr.
-      rewrite /get_var /=.
-      rewrite hvm2;
-        last by move=> /Sv.singleton_spec /= /(@inj_to_var _ _ _ _ _ _).
-      by rewrite Vm.setP_eq /=; reflexivity.
-    apply: lsem_step.
-    + rewrite /lsem1 /step.
-      rewrite (find_instr_skip hbody') /=.
-      apply arm_op_mov_eval_instr.
-      rewrite get_var_eq /=; last by [].
-      by reflexivity.
-    rewrite /= -addnA addn1.
-    apply: lsem_step.
-    + rewrite /lsem1 /step.
-      rewrite (find_instr_skip hbody') /=.
-      apply arm_op_sub_eval_instr => /=.
-      + rewrite get_var_eq /=; last by [].
-        by reflexivity.
-      rewrite get_var_neq;
-        last by move=> h; apply /rsp_nin /sv_of_listP;
-        rewrite !in_cons /= -h eqxx /= ?orbT.
-      rewrite get_var_neq; last by move=> /(@inj_to_var _ _ _ _ _ _).
-      by rewrite /get_var hoff2 /=; reflexivity.
-    rewrite /= -addnA addn1.
-    apply: LSem_step.
-    rewrite /lsem1 /step.
-    rewrite (find_instr_skip hbody') /=.
-    rewrite !size_cat /= -addSn -(addn1 3) !addnA.
-    apply arm_op_movi_eval_instr.
-    by left.
+  move: hbody'; rewrite -cat_rcons catA cat_rcons => hbody'.
+  apply: (lsem_trans6 _ hsem2); apply: lsem_step1.
+
+  + apply: (eval_lsem1 hbody) => //.
+    rewrite addn1.
+    apply: arm_op_mov_eval_instr.
+    rewrite /get_var hrsp /=.
+    reflexivity.
+
+  + apply: (eval_lsem1 hbody') => //.
+    apply: arm_op_align_eval_instr.
+    rewrite /get_var /=.
+    rewrite hvm2;
+      last by move=> /Sv.singleton_spec /= /(@inj_to_var _ _ _ _ _ _).
+    rewrite Vm.setP_eq /=.
+    reflexivity.
+
+  + rewrite /lnext_pc /=.
+    rewrite -cat_rcons -cats1 in hbody'.
+    apply: (eval_lsem1 hbody') => //; first by rewrite !size_cat !addn1.
+    apply: arm_op_mov_eval_instr.
+    rewrite get_var_eq /=; last by [].
+    reflexivity.
+
+  + rewrite /lnext_pc /=.
+    rewrite -2!cat_rcons -2!cats1 in hbody'.
+    apply: (eval_lsem1 hbody') => //; first by rewrite !size_cat !addn1.
+    apply: arm_op_sub_eval_instr => /=.
+    * rewrite get_var_eq /=; last by []. reflexivity.
+    rewrite get_var_neq;
+      last by move=> h; apply /rsp_nin /sv_of_listP;
+      rewrite !in_cons /= -h eqxx /= ?orbT.
+    rewrite get_var_neq; last by move=> /(@inj_to_var _ _ _ _ _ _).
+    rewrite /get_var hoff2 /=.
+    reflexivity.
+
+  rewrite /lnext_pc /=.
+  rewrite -3!cat_rcons -3!cats1 in hbody'.
+  apply: (eval_lsem1 hbody') => //; first by rewrite !size_cat !addn1.
+  rewrite arm_op_movi_eval_instr; last by left.
+  rewrite !size_cat /= addn4 !addnS.
+  reflexivity.
+
   split=> /=.
   + do 4 (rewrite Vm.setP_neq;
       last by [
@@ -348,19 +331,13 @@ Proof.
     by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split=> /=.
-  + apply: lsem_step.
-    + rewrite /lsem1 /step.
-      rewrite (find_instr_skip hbody) /=.
-      rewrite /eval_instr /=.
-      rewrite /get_var hsr.(srl_off) /=.
-      rewrite /exec_sopn /= !truncate_word_u /=.
-      rewrite wsub_wnot1.
-      rewrite /of_estate /=.
-      by rewrite -addnS; reflexivity.
-    apply: LSem_step.
-    rewrite /lsem1 /step.
-    rewrite (find_instr_skip hbody) /=.
-    rewrite -(addn1 2) addnA.
+  apply: lsem_step2.
+  + rewrite
+      /lsem1 /step (find_instr_skip hbody) /= /eval_instr /=
+      /get_var hsr.(srl_off) /= /exec_sopn /= !truncate_word_u /= wsub_wnot1
+      /of_estate /= /lnext_pc /= -addnS.
+    reflexivity.
+  + rewrite /lsem1 /step (find_instr_skip hbody) /= -(addn1 2) addnA addn1.
     apply: store_zero_eval_instr => //=.
     + do 5 (rewrite (@get_var_neq _ _ _ vzero);
         last by [|move=> /(@inj_to_var _ _ _ _ _ _)]).
@@ -395,7 +372,7 @@ Proof.
   + move=> p hb.
     rewrite (write_read8 hm') subE /=.
     case: ifPn => [_|h].
-    + by rewrite read0.
+    + by rewrite LE.read0.
     apply hzero.
     move: h hb; rewrite /between /zbetween wsize8 !zify /top.
     change arm_reg_size with Uptr.
@@ -450,15 +427,10 @@ Proof.
   + subst k.
     move: hn; rewrite Z.mul_1_l => ?; subst n.
     exists s3; split.
-    + apply: (lsem_trans hsem3).
-      apply LSem_step.
-      rewrite /lsem1 /step.
-      rewrite (find_instr_skip hbody) /=.
-      rewrite /eval_instr /=.
-      rewrite /get_var /= hzf3 /=.
-      rewrite GRing.addrN /ZF_of_word /= eqxx /=.
-      rewrite /setpc /=.
-      by rewrite -addnS.
+    + apply: (lsem_step_end hsem3).
+      by rewrite /lsem1 /step (find_instr_skip hbody) /= /eval_instr /=
+         /get_var /= hzf3 /= GRing.addrN /ZF_of_word /= eqxx /= /setpc /=
+         /lnext_pc /= -addnS.
     by move: hsr3; rewrite Z.sub_diag.
   have hlt3: (0 < n - wsize_size ws)%Z by nia.
   have hn3: (n - wsize_size ws)%Z = (Z.of_nat k * wsize_size ws)%Z by lia.
@@ -498,13 +470,9 @@ Proof.
   move=> hsubset hsr hlt.
   have [s3 [hsem3 hsr3]] := loopP hsubset hsr hlt.
   exists s3; split=> //.
-  apply: lsem_trans hsem3.
-  apply LSem_step.
-  rewrite /lsem1 /step.
-  rewrite -{1}(addn0 (size _)).
-  rewrite (find_instr_skip hbody) /=.
-  rewrite /eval_instr /=.
-  by rewrite -addn1.
+  apply: (lsem_step _ hsem3).
+  apply: (eval_lsem1 hbody) => //.
+  by rewrite addn1.
 Qed.
 
 End LOOP.
@@ -530,11 +498,9 @@ Lemma restore_spP vars (s1 s2 : estate) :
 Proof.
   move=> hsr.
   eexists (Estate _ _ _); split=> /=.
-  + apply: LSem_step.
-    rewrite /lsem1 /step.
-    rewrite -{1}(addn0 (size _)).
-    rewrite (find_instr_skip hbody) /=.
-    apply arm_op_mov_eval_instr.
+  + apply: (eval_lsem_step1 hbody) => //.
+    rewrite addn1.
+    apply: arm_op_mov_eval_instr.
     by rewrite /get_var /= hsr.(sr_vsaved) /=; reflexivity.
   case: hsr => hscs hmem hvalid hdisj hzero hvm hsaved hrsp hvzero haligned hbound.
   split=> //=.
@@ -587,9 +553,8 @@ Local Opaque wsize_size Z.of_nat.
     by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split.
-  + apply: LSem_step.
-    rewrite /lsem1 /step.
-    rewrite (find_instr_skip hbody) /=.
+  + apply: lsem_step1.
+    rewrite /lsem1 /step (find_instr_skip hbody) /=.
     rewrite oseq.onth_cat !size_map size_rev size_ziota.
     have hlt'': n < Z.to_nat (stk_max / wsize_size ws) by apply /ltP; lia.
     rewrite hlt''.
@@ -607,7 +572,7 @@ Local Opaque wsize_size Z.of_nat.
       rewrite Z.mul_sub_distr_r.
       rewrite Z.mul_comm -(proj2 (Z.div_exact _ _ _)) //.
       by move: halign; rewrite /is_align WArray.p_to_zE => /eqP.
-    rewrite addnS -(addn1 (size _ + _)).
+    rewrite addnS.
     apply: store_zero_eval_instr => //=.
     + by rewrite /get_var hsr.(sr_vzero).
     + by rewrite /get_var hsr.(sr_rsp); reflexivity.
@@ -631,7 +596,7 @@ Local Opaque wsize_size Z.of_nat.
   + move=> p hb.
     rewrite (write_read8 hm') subE /=.
     case: ifPn => [_|h].
-    + by rewrite read0.
+    + by rewrite LE.read0.
     apply hzero.
     move: h hb; rewrite /between /zbetween wsize8 !zify /top.
     change arm_reg_size with Uptr.
@@ -703,7 +668,7 @@ Proof.
 Qed.
 
 Lemma stack_zero_loopP (s1 : estate) :
-  (forall p : word Uptr, between top stk_max p U8 -> validw (emem s1) p U8) ->
+  valid_between (emem s1) top stk_max ->
   (evm s1).[rspi] = Vword ptr ->
   exists s2,
     [/\ lsem lp (of_estate s1 fn (size pre))
@@ -761,7 +726,7 @@ Context (hbody : is_linear_of lp fn (pre ++ stack_zero_unrolled rspi ws_align ws
 Context (rsp_nin : ~ Sv.In rspi stack_zero_unrolled_vars).
 
 Lemma stack_zero_unrolledP (s1 : estate) :
-  (forall p : word Uptr, between top stk_max p U8 -> validw (emem s1) p U8) ->
+  valid_between (emem s1) top stk_max ->
   (evm s1).[rspi] = Vword ptr ->
   exists s2,
     [/\ lsem lp (of_estate s1 fn (size pre))
@@ -835,35 +800,15 @@ Qed.
 
 Lemma arm_stack_zero_cmdP szs rspn lbl ws_align ws stk_max cmd vars :
   stack_zeroization_cmd szs rspn lbl ws_align ws stk_max = ok (cmd, vars) ->
-  ~ Sv.In (vid rspn) vars ->
-  (0 < stk_max)%Z ->
-  is_align stk_max ws ->
-  (ws <= ws_align)%CMP ->
-  forall (lp : lprog) fn lfd lc,
-  ~ has (is_label lbl) lc ->
-  get_fundef lp.(lp_funcs) fn = Some lfd ->
-  lfd.(lfd_body) = lc ++ cmd ->
-  forall scs m vm ptr,
-  (stk_max <= wunsigned (align_word ws_align ptr))%Z ->
-  vm.[vid rspn] = Vword ptr ->
-  let top := (align_word ws_align ptr - wrepr Uptr stk_max)%R in
-  (forall p, between top stk_max p U8 -> validw m p U8) ->
-  exists m' vm', [/\
-    lsem lp (Lstate scs m vm fn (size lc))
-            (Lstate scs m' vm' fn (size lc+size cmd)),
-    vm =[\ vars ] vm',
-    validw m =2 validw m',
-    (forall p, between top stk_max p U8 -> read m' p U8 = ok 0%R) &
-    (forall p, disjoint_zrange top stk_max p (wsize_size U8) ->
-      read m p U8 = read m' p U8)].
+  stack_zeroization_proof.sz_cmd_spec rspn lbl ws_align ws stk_max cmd vars.
 Proof.
   move=> hcmd rsp_nin lt_0_stk_max halign le_ws_ws_align lp fn lfd lc
-    /negP hlabel hlfd hbody scs m vm ptr hstack hrsp top hvalid.
-  have [s2 [hsem hsr]]:
-    [elaborate
-      exists s2,
-        lsem lp (of_estate (Estate scs m vm) fn (size lc)) (of_estate s2 fn (size lc + size cmd)) /\
-        state_rel_unrolled rspn ws_align ws stk_max ptr vars (Estate scs m vm) s2 0 ptr].
+    /negP hlabel hlfd hbody ls ptr hfn hpc hstack hrsp top hvalid.
+  have [s2 [hsem hsr]]: [elaborate
+    exists s2,
+      lsem lp ls (of_estate s2 fn (size lc + size cmd))
+      /\ state_rel_unrolled
+          rspn ws_align ws stk_max ptr vars (to_estate ls) s2 0 ptr].
   + move: hcmd; rewrite /stack_zeroization_cmd.
     t_xrbindP=> ws_small.
     case: szs => //.
@@ -874,10 +819,11 @@ Proof.
           ++ stack_zero_loop (mk_var_i (vid rspn)) lbl ws_align ws stk_max
           ++ [::])].
       + by rewrite cats0; exists lfd.
-      exact:
-        (stack_zero_loopP
+        subst top.
+      have := stack_zero_loopP
           lt_0_stk_max halign le_ws_ws_align hstack ws_small hlinear rsp_nin
-          hlabel (s1:=Estate scs _ _) hvalid hrsp).
+          hlabel (s1 := to_estate _) hvalid hrsp.
+      by rewrite -{1}hfn -{1}hpc of_estate_to_estate.
     + move=> [??]; subst cmd vars.
       have hlinear: [elaborate
         is_linear_of lp fn
@@ -885,13 +831,13 @@ Proof.
           ++ stack_zero_unrolled (mk_var_i (vid rspn)) ws_align ws stk_max
           ++ [::])].
       + by rewrite cats0; exists lfd.
-      exact:
-        (stack_zero_unrolledP
+      have := stack_zero_unrolledP
           lt_0_stk_max halign le_ws_ws_align hstack ws_small hlinear rsp_nin
-          (s1:=Estate scs _ _) hvalid hrsp).
+          (s1 := to_estate _) hvalid hrsp.
+      by rewrite -{1}hfn -{1}hpc of_estate_to_estate.
 
   exists (emem s2), (evm s2); split=> //.
-  + by have /= {2}-> := hsr.(sr_scs).
+  + by rewrite -hfn /of_estate -hsr.(sr_scs) in hsem.
   + move=> x hin.
     case: (x =P vid rspn) => [->|hneq].
     + by rewrite hsr.(sr_rsp).

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -681,7 +681,7 @@ Proof.
   have! [|] := (lsem_run_tunnel_program ok_tp zp_exec).
   - by exists zfd.
   - move => tp_exec _.
-    rewrite /lfd_body size_tunnel_lcmd.
+    rewrite /ls_export_final size_tunnel_lcmd.
     exact: tp_exec.
   exact: ok_callee_saved.
 Qed.

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -230,7 +230,7 @@ Definition lstore
   (rd : var_i)      (* Base register. *)
   (ofs : Z)         (* Offset. *)
   (ws : wsize)      (* Size of the value to copy. *)
-  (r0 : var_i)       (* Source register. *)
+  (r0 : var_i)      (* Source register. *)
   : option linstr_r :=
   lassign (Store ws rd (fconst Uptr ofs)) ws (Rexpr (Fvar r0)).
 

--- a/proofs/compiler/tunneling_proof.v
+++ b/proofs/compiler/tunneling_proof.v
@@ -1095,22 +1095,23 @@ Section TunnelingSem.
     move => Huniq [ii i] s; case: i => [ | | | | | |[fn' l]|pe|lv l|pe l] //=.
     + move=> o r; rewrite /eval_instr /= label_in_lprog_tunnel_lprog_pc //.
       case: o.
-      + move=> lr. rewrite tunnel_get_label_after_pc.
+      * move=> lr.
+        rewrite tunnel_get_label_after_pc /rencode_label.
         apply bind_eq => // l.
-        case: encode_label => // wl; apply bind_eq => // m.
+        case: encode_label => //= wl; apply bind_eq => // m.
         by rewrite eval_jump_tunnel_lprog_pc.
-      rewrite tunnel_get_label_after_pc.
+      rewrite tunnel_get_label_after_pc /rencode_label.
       apply bind_eq => // u. apply bind_eq => // vm.
-      case: encode_label => // wl; apply bind_eq => // m.
+      case: encode_label => //= wl; apply bind_eq => // m.
       by rewrite eval_jump_tunnel_lprog_pc.
-    + rewrite /eval_instr /= label_in_lprog_tunnel_lprog_pc //.
+    + rewrite /eval_instr /= label_in_lprog_tunnel_lprog_pc /rdecode_label //.
       apply bind_eq => // ?; apply bind_eq => // ?.
-      case: decode_label => // ?;  by rewrite eval_jump_tunnel_lprog_pc.
+      case: decode_label => //= ?;  by rewrite eval_jump_tunnel_lprog_pc.
     + rewrite /eval_instr /= /tunnel_funcs_pc; case Hgfd: (get_fundef (lp_funcs p) fn) => [fd|//].
       rewrite get_fundef_setfunc -get_fundef_in Hgfd /=; case: ifP => // /eqP ?; subst fn'.
       by rewrite Hgfd /tunnel_lfundef_pc lfd_body_setfb /= find_label_tunnel_lcmd_pc.
-    + rewrite /eval_instr /= label_in_lprog_tunnel_lprog_pc //.
-      apply bind_eq => // u. case: (decode_label _ _) => // r.
+    + rewrite /eval_instr /= label_in_lprog_tunnel_lprog_pc /rdecode_label //.
+      apply bind_eq => // u. case: (decode_label _ _) => //= r.
       by rewrite eval_jump_tunnel_lprog_pc.
     + by rewrite /eval_instr /= label_in_lprog_tunnel_lprog_pc.
     rewrite /eval_instr /= /tunnel_funcs_pc; case Hgfd: (get_fundef (lp_funcs p) fn) => [fd|//].
@@ -1210,12 +1211,8 @@ Section TunnelingProof.
       rewrite Hgfd /=; case: pc Hpc HSpc => [//=|pc] Hpc HSpc; rewrite /= in Hpc.
       rewrite (@nth_label_find_label l (lfd_body fd) pc) //=.
       t_xrbindP => pc' Hfindlabel'; move => ?; subst s2.
-      case: s1 Hgfd Hwfb Hallg Hfindinstr Hv HSpc.
-      move => scs mem vm fn pc1; rewrite /setcpc; set c:= nth _ _ _ => //=.
-      set s1:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc1 |}.
-      set s2:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc.+1 |}.
-      move => Hgfd Hwfb Hallg Hfindinstr Hv HSpc; right; exists s2; split => //.
-      rewrite /find_instr Hgfd /s2 /= -/s2; case: (is_goto_nth_onth HSpc) => ii' ->.
+      right; eexists; split; first reflexivity.
+      rewrite /find_instr Hgfd; case: (is_goto_nth_onth HSpc) => ii' ->.
       by rewrite /eval_instr /= Hgfd /= Hfindlabel' /=.
     + move => Hgfd /eqP ? Hfindinstr; subst fn; rewrite Hfindinstr.
       have Hwfb:= (get_fundef_well_formed_funcs_body Hgfd Hwf).
@@ -1226,12 +1223,8 @@ Section TunnelingProof.
       rewrite Hgfd /=; case: pc Hpc HSpc => [//=|pc] Hpc HSpc; rewrite /= in Hpc.
       rewrite (@nth_label_find_label l (lfd_body fd) pc) //=.
       t_xrbindP => pc' Hfindlabel'; move => ?; subst s2.
-      case: s1 Hgfd Hwfb Hallg Hfindinstr HSpc.
-      move => scs mem vm fn pc1; rewrite /setcpc; set c:= nth _ _ _ => //=.
-      set s1:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc1 |}.
-      set s2:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc.+1 |}.
-      move => Hgfd Hwfb Hallg Hfindinstr HSpc; right; exists s2; split => //.
-      rewrite /find_instr Hgfd /s2 /= -/s2; case: (is_goto_nth_onth HSpc) => ii' ->.
+      right; eexists; split; first reflexivity.
+      rewrite /find_instr Hgfd; case: (is_goto_nth_onth HSpc) => ii' ->.
       by rewrite /eval_instr /= Hgfd /= Hfindlabel' /=.
     + move => Hgfd /eqP ? Hfindinstr; subst fn; rewrite Hfindinstr.
       have Hwfb:= (get_fundef_well_formed_funcs_body Hgfd Hwf).
@@ -1243,13 +1236,10 @@ Section TunnelingProof.
       rewrite Hgfd /=; case: pc Hpc HSpc => [//=|pc] Hpc HSpc; rewrite /= in Hpc.
       rewrite (@nth_label_find_label l (lfd_body fd) pc) //=.
       rewrite (@nth_label_find_label l' (lfd_body fd) pc.+1) //=.
-      move => [?]; subst s2; case: s1 Hgfd Hwfb Hallg Hfindinstr Hv HSpc.
-      move => scs mem vm fn pc1; rewrite /setcpc; set c:= nth _ _ _ => //=.
-      set s1:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc1 |}.
-      set s2:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc.+1 |}.
-      move => Hgfd Hwfb Hallg Hfindinstr Hv HSpc; right; exists s2; split => //.
-      rewrite /find_instr Hgfd /s2 /= -/s2; case: (is_label_nth_onth HSpc) => ii' [] ? ->.
-      by rewrite /eval_instr.
+      move => [?]; subst s2.
+      right; eexists; split; first reflexivity.
+      rewrite /find_instr Hgfd.
+      by case: (is_label_nth_onth HSpc) => ii' [] ? ->.
     move => Hgfd /eqP ? Hfindinstr; subst fn; rewrite Hfindinstr.
     have Hwfb:= (get_fundef_well_formed_funcs_body Hgfd Hwf).
     move: (Hwfb) => /andP [Huniql Hallg].
@@ -1259,13 +1249,10 @@ Section TunnelingProof.
     rewrite Hgfd /=; case: pc Hpc HSpc => [//=|pc] Hpc HSpc; rewrite /= in Hpc.
     rewrite (@nth_label_find_label l (lfd_body fd) pc) //=.
     rewrite (@nth_label_find_label l' (lfd_body fd) pc.+1) //=.
-    move => [?]; subst s2; case: s1 Hgfd Hwfb Hallg Hfindinstr HSpc.
-    move => scs mem vm fn pc1; rewrite /setcpc; set c:= nth _ _ _ => //=.
-    set s1:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc1 |}.
-    set s2:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc.+1 |}.
-    move => Hgfd Hwfb Hallg Hfindinstr HSpc; right; exists s2; split => //.
-    rewrite /find_instr Hgfd /s2 /= -/s2; case: (is_label_nth_onth HSpc) => ii' [] ? ->.
-    by rewrite /eval_instr.
+    move => [?]; subst s2.
+    right; eexists; split; first reflexivity.
+    rewrite /find_instr Hgfd.
+    by case: (is_label_nth_onth HSpc) => ii' [] ? ->.
   Qed.
 
   Lemma tunnel_lprog_pc_lsem p fn pc s1 s2 :
@@ -1303,23 +1290,18 @@ Section TunnelingProof.
       rewrite Hv /= Hb /=; case: ifP => [HisTb|]; last by left.
       rewrite Hgfd /=; case: pc Hpc HSpc => [//=|pc] Hpc HSpc; rewrite /= in Hpc.
       rewrite (@nth_label_find_label l (lfd_body fd) pc) //=.
-      move => [?]; subst s2; case : s1 Hgfd Hwfb Hallg Hfindinstr Hv HSpc.
-      move => scs mem vm fn pc1; rewrite /setcpc; set c:= nth _ _ _ => //=.
-      set s1:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc1 |}.
-      set s2:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc.+1 |}.
-      move => Hgfd Hwfb Hallg Hfindinstr Hv HSpc.
-      move: (@local_goto_find_label p s2 c fd l').
-      rewrite /s2 /= -/s2 => /(_ _ Hgfd Hwfb HSpc); case.
-      - rewrite /find_instr /s2 /= Hgfd; move: HSpc; rewrite /c.
+      move => [?]; subst s2.
+      have [] := local_goto_find_label (s := setpc s1 pc.+1) _ Hgfd Hwfb HSpc.
+      - rewrite /find_instr /= Hgfd; move: HSpc.
         set Spc:= pc.+1; elim: (lfd_body fd) Spc => [|[{ii Hfindinstr} ii i] lf IHlf] Spc.
         * by rewrite nth_nil.
         by case: Spc => [|Spc] //=; apply IHlf.
       move => pc' Hfindlabel'; rewrite Hfindlabel' /=.
-      set s3:= {| lmem := mem; lvm := vm; lfn := fn; lpc := pc'.+1 |}.
-      rewrite /find_instr /s2 /= -/s2 Hgfd /=.
-      rewrite /c in HSpc; move: (is_goto_nth_onth HSpc) => [ii'] ->.
+      rewrite /find_instr Hgfd /=.
+      move: (is_goto_nth_onth HSpc) => [ii'] ->.
       rewrite /eval_instr /= Hgfd /= Hfindlabel'.
-      by right; exists s3.
+      right; by eexists.
+
     + move => Hgfd /eqP ? Hfindinstr; subst fn; rewrite Hfindinstr.
       have Hwfb:= (get_fundef_well_formed_funcs_body Hgfd Hwf).
       move: (Hwfb) => /andP [Huniql Hallg].
@@ -1328,23 +1310,18 @@ Section TunnelingProof.
       rewrite {1 2 4}/eval_instr /= => Hpc HSpc.
       rewrite Hgfd /=; case: pc Hpc HSpc => [//=|pc] Hpc HSpc; rewrite /= in Hpc.
       rewrite (@nth_label_find_label l (lfd_body fd) pc) //=.
-      move => [?]; subst s2; case : s1 Hgfd Hwfb Hallg Hfindinstr HSpc.
-      move => scs mem vm fn pc1; rewrite /setcpc; set c:= nth _ _ _ => //=.
-      set s1:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc1 |}.
-      set s2:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc.+1 |}.
-      move => Hgfd Hwfb Hallg Hfindinstr HSpc.
-      move: (@local_goto_find_label p s2 c fd l').
-      rewrite /s2 /= -/s2 => /(_ _ Hgfd Hwfb HSpc); case.
-      - rewrite /find_instr /s2 /= Hgfd; move: HSpc; rewrite /c.
+      move => [?]; subst s2.
+      have [] := local_goto_find_label (s := setpc s1 pc.+1) _ Hgfd Hwfb HSpc.
+      - rewrite /find_instr /= Hgfd; move: HSpc.
         set Spc:= pc.+1; elim: (lfd_body fd) Spc => [|[{ii Hfindinstr} ii i] lf IHlf] Spc.
         * by rewrite nth_nil.
         by case: Spc => [|Spc] //=; apply IHlf.
       move => pc' Hfindlabel'; rewrite Hfindlabel' /=.
-      set s3:= {| lmem := mem; lvm := vm; lfn := fn; lpc := pc'.+1 |}.
-      rewrite /find_instr /s2 /= -/s2 Hgfd /=.
-      rewrite /c in HSpc; move: (is_goto_nth_onth HSpc) => [ii'] ->.
-      rewrite /eval_instr /= Hgfd /= Hfindlabel'.
-      by right; exists s3.
+      rewrite /find_instr Hgfd /=.
+      move: (is_goto_nth_onth HSpc) => [ii'] ->.
+      rewrite /eval_instr /= Hgfd /= Hfindlabel' /=.
+      right; by eexists.
+
     + move => Hgfd /eqP ? Hfindinstr; subst fn; rewrite Hfindinstr.
       have Hwfb:= (get_fundef_well_formed_funcs_body Hgfd Hwf).
       move: (Hwfb) => /andP [Huniql Hallg].
@@ -1354,14 +1331,12 @@ Section TunnelingProof.
       rewrite Hv /= Hb /=; case: ifP => [HisTb|]; last by left.
       rewrite Hgfd /=; case: pc Hpc HSpc => [//=|pc] Hpc HSpc; rewrite /= in Hpc.
       rewrite (@nth_label_find_label l (lfd_body fd) pc) //=.
-      move => [?]; subst s2; case : s1 Hgfd Hwfb Hallg Hfindinstr Hv HSpc.
-      move => scs mem vm fn pc1; rewrite /setcpc; set c:= nth _ _ _ => //=.
-      set s1:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc1 |}.
-      set s2:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc.+1 |}.
-      move => Hgfd Hwfb Hallg Hfindinstr Hv HSpc.
+      move => [?]; subst s2.
       rewrite (@nth_label_find_label l' (lfd_body fd) pc.+1) //=.
-      rewrite /find_instr /s2 /= Hgfd; case: (is_label_nth_onth HSpc) => ii' [] ? ->.
-      by rewrite /eval_instr /=; right; eexists; eauto.
+      rewrite /find_instr /= Hgfd.
+      case: (is_label_nth_onth HSpc) => ii' [] ? ->.
+      right; by eexists.
+
     move => Hgfd /eqP ? Hfindinstr; subst fn; rewrite Hfindinstr.
     have Hwfb:= (get_fundef_well_formed_funcs_body Hgfd Hwf).
     move: (Hwfb) => /andP [Huniql Hallg].
@@ -1370,14 +1345,11 @@ Section TunnelingProof.
     rewrite {1 2 4}/eval_instr /= => Hpc HSpc.
     rewrite Hgfd /=; case: pc Hpc HSpc => [//=|pc] Hpc HSpc; rewrite /= in Hpc.
     rewrite (@nth_label_find_label l (lfd_body fd) pc) //=.
-    move => [?]; subst s2; case : s1 Hgfd Hwfb Hallg Hfindinstr HSpc.
-    move => scs mem vm fn pc1; rewrite /setcpc; set c:= nth _ _ _ => //=.
-    set s1:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc1 |}.
-    set s2:= {| lscs := scs; lmem := mem; lvm := vm; lfn := fn; lpc := pc.+1 |}.
-    move => Hgfd Hwfb Hallg Hfindinstr HSpc.
+    move => [?]; subst s2.
     rewrite (@nth_label_find_label l' (lfd_body fd) pc.+1) //=.
-    rewrite /find_instr /s2 /= Hgfd; case: (is_label_nth_onth HSpc) => ii' [] ? ->.
-    by rewrite /eval_instr /=; right; eexists; eauto.
+    rewrite /find_instr /= Hgfd.
+    case: (is_label_nth_onth HSpc) => ii' [] ? ->.
+    right; by eexists.
   Qed.
 
   Lemma lsem_tunnel_lprog_pc p s1 s2 fn pc :

--- a/proofs/lang/linear_facts.v
+++ b/proofs/lang/linear_facts.v
@@ -1,16 +1,18 @@
-From mathcomp Require Import all_ssreflect all_algebra.
-Require Import Lia Relations.
+From Coq Require Import Relations.
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+
 Require Import
-  utils
-  psem
-  psem_facts
-  one_varmap
-  fexpr
+  fexpr_facts
   label
   linear
-  fexpr_sem
-  fexpr_facts
-  linear_sem.
+  linear_sem
+  one_varmap
+  psem
+  psem_facts
+  sem_one_varmap
+.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -18,53 +20,66 @@ Unset Printing Implicit Defensive.
 
 Section WITH_PARAMS.
 
+#[local] Existing Instance withsubword.
+
 Context
   {asm_op syscall_state : Type}
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  {ovm_i : one_varmap_info}.
+  {ovm_i : one_varmap_info}
+.
+
+Lemma setpc_id ls :
+  setpc ls (lpc ls) = ls.
+Proof. by case: ls. Qed.
+
+Lemma setpc_lset_estate ls pc scs m vm :
+  lset_estate (setpc ls pc) scs m vm
+  = setpc (lset_estate ls scs m vm) pc.
+Proof. done. Qed.
+
+Lemma lnext_pc_setpc ls n :
+  lnext_pc (setpc ls n) = setpc ls n.+1.
+Proof. done. Qed.
+
+Lemma setcpc_setpc ls fn n n' :
+  setcpc (setpc ls n') fn n = setcpc ls fn n.
+Proof. done. Qed.
+
+Lemma lfn_lset_estate ls scs m vm :
+  lfn (lset_estate ls scs m vm) = lfn ls.
+Proof. done. Qed.
+
+#[local]
+Lemma lsem_transn lp l : transn_spec (R := lsem lp) (Rstep := lsem lp) l.
+Proof. apply: transn_specP; by [| exact: rt_trans | exact: rt_refl ]. Qed.
+
+Definition lsem_trans3 lp := transn3 (lsem_transn lp).
+Definition lsem_trans4 lp := transn4 (lsem_transn lp).
+Definition lsem_trans5 lp := transn5 (lsem_transn lp).
+Definition lsem_trans6 lp := transn6 (lsem_transn lp).
+
+#[local]
+Lemma lsem1_transn lp l : transn_spec (R := lsem lp) (Rstep := lsem1 lp) l.
+Proof.
+  apply: transn_specP; by [ exact: rt_trans | exact: rt_step | exact: rt_refl ].
+Qed.
+
+Lemma lsem_step1 lp ls0 ls1 :
+  lsem1 lp ls0 ls1 ->
+  lsem lp ls0 ls1.
+Proof. exact: rt_step. Qed.
+
+Definition lsem_step2 lp := transn2 (lsem1_transn lp).
+Definition lsem_step3 lp := transn3 (lsem1_transn lp).
+Definition lsem_step4 lp := transn4 (lsem1_transn lp).
+Definition lsem_step5 lp := transn5 (lsem1_transn lp).
+Definition lsem_step6 lp := transn6 (lsem1_transn lp).
 
 Lemma label_in_lcmd_cat lc1 lc2 :
   label_in_lcmd (lc1 ++ lc2) = label_in_lcmd lc1 ++ label_in_lcmd lc2.
 Proof. by rewrite /label_in_lcmd pmap_cat. Qed.
-
-Definition is_linear_of (p : lprog) (fn : funname) (c : lcmd) : Prop :=
-  exists2 fd,
-    get_fundef (lp_funcs p) fn = Some fd
-    & lfd_body fd = c.
-
-Lemma label_in_lfundef p fn body (lbl: label) :
-  lbl \in label_in_lcmd body ->
-  is_linear_of p fn body ->
-  (fn, lbl) \in label_in_lprog p.
-Proof.
-  move=> hin [fd ok_fd ?]; subst body.
-  apply/flattenP => /=.
-  exists [seq (fn, lbl) | lbl <- label_in_lcmd (lfd_body fd) ];
-    last by apply/map_f: hin.
-  apply/in_map.
-  by exists (fn, fd); first exact: get_fundef_in'.
-Qed.
-
-Lemma find_instrE p fn body :
-  is_linear_of p fn body ->
-  forall scs m vm n,
-  find_instr p (Lstate scs m vm fn n) = oseq.onth body n.
-Proof. by rewrite /find_instr => - [] fd /= -> ->. Qed.
-
-Lemma find_instr_skip p fn P Q :
-  is_linear_of p fn (P ++ Q) ->
-  forall scs m vm n,
-  find_instr p (Lstate scs m vm fn (size P + n)) = oseq.onth Q n.
-Proof.
-  move => h scs m vm n; rewrite (find_instrE h).
-  rewrite !oseq.onth_nth map_cat nth_cat size_map.
-  rewrite ltnNge leq_addr /=;f_equal;rewrite -minusE -plusE; lia.
-Qed.
-
-Definition LSem_step p s1 s2 :
-  lsem1 p s1 s2 -> lsem p s1 s2 := rt_step _ _ s1 s2.
 
 Lemma find_labelE lbl c :
   find_label lbl c =
@@ -83,12 +98,95 @@ Qed.
 
 Lemma find_label_cat_hd lbl c1 c2:
   ~~ has (is_label lbl) c1 ->
-  find_label lbl (c1 ++ c2) =
-  (Let pc := find_label lbl c2 in ok (size c1 + pc)).
+  find_label lbl (c1 ++ c2)
+  = Let pc := find_label lbl c2 in ok (size c1 + pc).
 Proof.
   rewrite /find_label find_cat size_cat => /negbTE ->.
   by rewrite ltn_add2l;case:ifP.
 Qed.
+
+Definition is_linear_of (lp : lprog) (fn : funname) (lc : lcmd) : Prop :=
+  exists2 fd,
+    get_fundef (lp_funcs lp) fn = Some fd
+    & lfd_body fd = lc.
+
+Lemma label_in_lfundef p fn body (lbl: label) :
+  lbl \in label_in_lcmd body ->
+  is_linear_of p fn body ->
+  (fn, lbl) \in label_in_lprog p.
+Proof.
+  move=> hin [fd ok_fd ?]; subst body.
+  apply/flattenP => /=.
+  exists [seq (fn, lbl) | lbl <- label_in_lcmd (lfd_body fd) ];
+    last by apply/map_f: hin.
+  apply/in_map.
+  by exists (fn, fd); first exact: get_fundef_in'.
+Qed.
+
+Lemma find_instrE lp ls body :
+  is_linear_of lp (lfn ls) body ->
+  find_instr lp ls = oseq.onth body (lpc ls).
+Proof. by rewrite /find_instr => - [] fd /= -> ->. Qed.
+
+Lemma find_instr_skip' lp fn pre pos :
+  is_linear_of lp fn (pre ++ pos) ->
+  forall ls n,
+    lpc ls = size pre + n ->
+    lfn ls = fn ->
+    find_instr lp ls = oseq.onth pos n.
+Proof.
+  move=> h ls n hpc hfn.
+  rewrite -hfn in h.
+  rewrite (find_instrE h) !oseq.onth_nth map_cat nth_cat size_map.
+  by rewrite hpc lt_nm_n sub_nmn.
+Qed.
+
+Lemma find_instr_skip lp fn pre pos :
+  is_linear_of lp fn (pre ++ pos) ->
+  forall ls n,
+    lfn ls = fn ->
+    find_instr lp (setpc ls (size pre + n)) = oseq.onth pos n.
+Proof. by eauto using find_instr_skip'. Qed.
+
+Lemma find_instr_skip0 lp fn pre pos :
+  is_linear_of lp fn (pre ++ pos) ->
+  forall ls,
+    lpc ls = size pre ->
+    lfn ls = fn ->
+    find_instr lp ls = oseq.onth pos 0.
+Proof. rewrite -(addn0 (size pre)). by eauto using find_instr_skip'. Qed.
+
+Lemma eval_lsem1 lp ls ls' pre pos li fn :
+  is_linear_of lp fn (pre ++ li :: pos) ->
+  lpc ls = size pre ->
+  lfn ls = fn ->
+  eval_instr lp li ls = ok ls' ->
+  lsem1 lp ls ls'.
+Proof.
+  rewrite /lsem1 /step.
+  by move=> /find_instr_skip0 /[apply] /[apply] ->.
+Qed.
+
+Lemma eval_lsem_step1 lp ls ls' pre pos li fn :
+  is_linear_of lp fn (pre ++ li :: pos) ->
+  lpc ls = size pre ->
+  lfn ls = fn ->
+  eval_instr lp li ls = ok ls' ->
+  lsem lp ls ls'.
+Proof. by eauto using lsem_step1, eval_lsem1. Qed.
+
+Lemma eval_jumpE lp fn body :
+  is_linear_of lp fn body ->
+  forall lbl s,
+    eval_jump lp (fn, lbl) s
+    = Let pc := find_label lbl body in ok (setcpc s fn pc.+1).
+Proof. by case => ? /= -> ->. Qed.
+
+Lemma eval_jumpP lp fn lfd lbl lbl' :
+  get_fundef (lp_funcs lp) fn = Some lfd ->
+  find_label lbl (lfd_body lfd) = ok lbl' ->
+  eval_jump lp (fn, lbl) = fun ls => ok (setcpc ls fn lbl'.+1).
+Proof. by rewrite /eval_jump => -> /= ->. Qed.
 
 Section MEM_EQUIV.
 
@@ -112,34 +210,24 @@ Opaque eval_jump.
     split.
     + exact: write_lexprs_stack_stable hw.
     exact: write_lexprs_validw hw.
-  + t_xrbindP=> ?? _ [[??]?] /(@exec_syscallSs _ _ _ _ _ _ _ _ _ _) heq1.
+    + t_xrbindP=> ?? _ [[??]?] /(exec_syscallSs (rscs := _)) heq1.
     t_xrbindP=> ? hw <- /=.
     apply (mem_equiv_trans heq1).
     split.
     + exact: write_lvals_stack_stable hw.
     exact: write_lvals_validw hw.
   + move=> [p|].
-    + t_xrbindP=> ?? _.
-      case: encode_label => [w|//].
-      by t_xrbindP=> _ _ /eval_jump_mem_eq /= <-.
-    t_xrbindP=> ??? _ _ ? _.
-    case: encode_label => [w|//].
-    t_xrbindP=> ? hw /eval_jump_mem_eq /= <-.
+    + by t_xrbindP=> _ _ _ _ _ _ _ /eval_jump_mem_eq /= <-.
+    t_xrbindP=> ??? _ _ _ _ w _ ? hw /eval_jump_mem_eq /= <-.
     split.
     + exact: Memory.write_mem_stable hw.
     by move=> ??; rewrite (write_validw_eq hw).
-  + t_xrbindP=> ?? _ _ ? _.
-    case: decode_label => [r|//] /=.
-    by move=> /eval_jump_mem_eq /= <-.
+  + by t_xrbindP=> _ _ _ _ _ _ _ _ /eval_jump_mem_eq /= <-.
   + by move=> [<-] /=.
   + by move=> _ _ [<-] /=.
   + by move=> _ /eval_jump_mem_eq /= <-.
-  + t_xrbindP=> ??? _ _.
-    case: decode_label => [r|//] /=.
-    by move=> /eval_jump_mem_eq <-.
-  + move=> ??.
-    case: encode_label => [w|//].
-    by t_xrbindP=> _ _ <- /=.
+  + by t_xrbindP=> _ _ _ _ _ r _ /eval_jump_mem_eq <-.
+  + by t_xrbindP=> _ _ _ _ _ _ <- /=.
   t_xrbindP=> ?? b ? _ _.
   case: b.
   + by move=> /eval_jump_mem_eq <-.

--- a/proofs/lang/linear_sem.v
+++ b/proofs/lang/linear_sem.v
@@ -54,10 +54,28 @@ Definition of_estate (s:estate) fn pc := Lstate s.(escs) s.(emem) s.(evm) fn pc.
 Definition setpc (s:lstate) pc :=  Lstate s.(lscs) s.(lmem) s.(lvm) s.(lfn) pc.
 Definition setc (s:lstate) fn := Lstate s.(lscs) s.(lmem) s.(lvm) fn s.(lpc).
 Definition setcpc (s:lstate) fn pc := Lstate s.(lscs) s.(lmem) s.(lvm) fn pc.
- 
+Definition lset_estate' (ls : lstate) (s : estate) : lstate :=
+  Eval hnf in of_estate s ls.(lfn) ls.(lpc).
+Definition lset_estate
+  (ls : lstate) (scs : syscall_state) (m : mem) (vm : Vm.t) : lstate :=
+  Eval hnf in lset_estate' ls {| escs := scs; emem := m; evm := vm; |}.
+Definition lset_mem_vm (ls : lstate) (m : mem) (vm : Vm.t) : lstate :=
+  Eval hnf in lset_estate ls (lscs ls) m vm.
+Definition lset_mem (ls : lstate) (m : mem) : lstate :=
+  Eval hnf in lset_mem_vm ls m (lvm ls).
+Definition lset_vm (ls : lstate) (vm : Vm.t) : lstate :=
+  Eval hnf in lset_mem_vm ls (lmem ls) vm.
+Definition lnext_pc (ls : lstate) : lstate :=
+  Eval hnf in setpc ls (lpc ls).+1.
+
 Lemma to_estate_of_estate es fn pc:
   to_estate (of_estate es fn pc) = es.
 Proof. by case: es. Qed.
+
+Lemma of_estate_to_estate ls :
+  of_estate (to_estate ls) (lfn ls) (lpc ls) = ls.
+Proof. by case: ls. Qed.
+
 
 (* The [lsem] relation defines the semantics of a linear command
 as the reflexive transitive closure of the [lsem1] relation that
@@ -78,13 +96,11 @@ Definition eval_jump d s :=
   ok (setcpc s fn pc.+1).
 
 Definition find_instr (s:lstate) :=
-  if get_fundef (lp_funcs P) s.(lfn) is Some fd then
-    let body := lfd_body fd in
-    oseq.onth body s.(lpc)
-  else None.
+  let%opt fd := get_fundef (lp_funcs P) s.(lfn) in
+  oseq.onth (lfd_body fd) s.(lpc).
 
 Definition get_label_after_pc (s:lstate) :=
-  if find_instr (setpc s s.(lpc).+1) is Some i then
+  if find_instr (lnext_pc s) is Some i then
     if li_i i is Llabel ExternalLabel l then ok l
     else type_error
   else type_error.
@@ -95,76 +111,61 @@ Definition eval_instr (i : linstr) (s1: lstate) : exec lstate :=
     let s := to_estate s1 in
     Let args := sem_rexprs s es in
     Let res := exec_sopn o args in
-    Let s2 := write_lexprs xs res s in
-    ok (of_estate s2 s1.(lfn) s1.(lpc).+1)
+    Let s' := write_lexprs xs res s in
+    ok (lnext_pc (lset_estate' s1 s'))
   | Lsyscall o =>
-    Let ves := get_vars true s1.(lvm) (syscall_sig o).(scs_vin) in
-    Let: (scs, m, vs) := exec_syscall (semCallParams:= sCP_stack) s1.(lscs) s1.(lmem) o ves in 
-    Let s2 := write_lvals true [::] {| escs := scs; emem := m; evm := vm_after_syscall s1.(lvm) |}
-                (to_lvals (syscall_sig o).(scs_vout)) vs in
-    ok (of_estate s2 s1.(lfn) s1.(lpc).+1)
+    let sig := syscall_sig o in
+    Let ves := get_vars true s1.(lvm) sig.(scs_vin) in
+    Let: (scs, m, vs) :=
+      exec_syscall (semCallParams := sCP_stack) s1.(lscs) s1.(lmem) o ves
+    in
+    let s :=
+      {|
+        escs := scs;
+        emem := m;
+        evm := vm_after_syscall s1.(lvm);
+      |}
+    in
+    Let s' := write_lvals true [::] s (to_lvals sig.(scs_vout)) vs in
+    ok (lnext_pc (lset_estate' s1 s'))
   | Lcall None d =>
     let vrsp := v_var (vid (lp_rsp P)) in
     Let sp := get_var true s1.(lvm) vrsp >>= to_pointer in
     let nsp := (sp - wrepr Uptr (wsize_size Uptr))%R in
     Let vm := set_var true s1.(lvm) vrsp (Vword nsp) in
     Let lbl := get_label_after_pc s1 in
-    if encode_label labels (lfn s1, lbl) is Some p then
-      Let m :=  write s1.(lmem) nsp p in
-      let s1' :=
-        {| lscs := s1.(lscs);
-           lmem := m;
-           lvm  := vm;
-           lfn  := s1.(lfn);
-           lpc  := s1.(lpc) |} in
-      eval_jump d s1'
-    else type_error
+    Let p := rencode_label labels (lfn s1, lbl) in
+    Let m := write s1.(lmem) nsp p in
+    eval_jump d (lset_mem_vm s1 m vm)
   | Lcall (Some r) d =>
     Let lbl := get_label_after_pc s1 in
-    if encode_label labels (lfn s1, lbl) is Some p then
-      Let vm := set_var true s1.(lvm) r (Vword p) in
-      let s1' := 
-        {| lscs := s1.(lscs);
-           lmem := s1.(lmem);
-           lvm  := vm;
-           lfn  := s1.(lfn);
-           lpc  := s1.(lpc) |} in
-      eval_jump d s1'
-    else type_error
+    Let p := rencode_label labels (lfn s1, lbl) in
+    Let vm := set_var true s1.(lvm) r (Vword p) in
+    eval_jump d (lset_vm s1 vm)
   | Lret =>
     let vrsp := v_var (vid (lp_rsp P)) in
     Let sp := get_var true s1.(lvm) vrsp >>= to_pointer in
     let nsp := (sp + wrepr Uptr (wsize_size Uptr))%R in
     Let p  := read s1.(lmem) sp Uptr in
     Let vm := set_var true s1.(lvm) vrsp (Vword nsp) in
-    let s1' :=
-      {| lscs := s1.(lscs);
-         lmem := s1.(lmem);
-         lvm  := vm;
-         lfn  := s1.(lfn);
-         lpc  := s1.(lpc) |} in
-    if decode_label labels p is Some d then
-      eval_jump d s1'
-    else type_error
-  | Lalign   => ok (setpc s1 s1.(lpc).+1)
-  | Llabel _ _ => ok (setpc s1 s1.(lpc).+1)
+    Let d := rdecode_label labels p in
+    eval_jump d (lset_vm s1 vm)
+  | Lalign   => ok (lnext_pc s1)
+  | Llabel _ _ => ok (lnext_pc s1)
   | Lgoto d => eval_jump d s1
   | Ligoto e =>
     Let p := sem_rexpr s1.(lmem) s1.(lvm) e >>= to_pointer in
-    if decode_label labels p is Some d then
-      eval_jump d s1
-    else type_error
+    Let d := rdecode_label labels p in
+    eval_jump d s1
   | LstoreLabel x lbl =>
-    if encode_label labels (lfn s1, lbl) is Some p
-    then
-      Let vm := set_var true s1.(lvm) x (Vword p) in
-      ok {| lscs := s1.(lscs) ; lmem := s1.(lmem) ; lvm := vm ; lfn := s1.(lfn) ; lpc := s1.(lpc).+1 |}
-    else type_error
+    Let p := rencode_label labels (lfn s1, lbl) in
+    Let vm := set_var true s1.(lvm) x (Vword p) in
+    ok (lnext_pc (lset_vm s1 vm))
   | Lcond e lbl =>
     Let b := sem_fexpr s1.(lvm) e >>= to_bool in
     if b then
       eval_jump (s1.(lfn),lbl) s1
-    else ok (setpc s1 s1.(lpc).+1)
+    else ok (lnext_pc s1)
   end.
 
 Definition step (s: lstate) : exec lstate :=
@@ -193,28 +194,6 @@ Lemma lsem_step s2 s1 s3 :
   lsem s1 s3.
 Proof.
   by move=> H; apply: rt_trans; apply: rt_step.
-Qed.
-
-Lemma lsem_step2 ls0 ls1 ls2 :
-  lsem1 ls0 ls1
-  -> lsem1 ls1 ls2
-  -> lsem ls0 ls2.
-Proof.
-  move=> h0 h1.
-  apply: (lsem_step h0).
-  apply: (lsem_step h1).
-  exact: rt_refl.
-Qed.
-
-Lemma lsem_step3 ls0 ls1 ls2 ls3 :
-  lsem1 ls0 ls1
-  -> lsem1 ls1 ls2
-  -> lsem1 ls2 ls3
-  -> lsem ls0 ls3.
-Proof.
-  move=> h0 h1 h2.
-  apply: (lsem_step h0).
-  exact: (lsem_step2 h1 h2).
 Qed.
 
 Lemma lsem_step_end s2 s1 s3 :
@@ -301,13 +280,29 @@ Proof.
   by clear => s s' ? k _ _ /lsem_final_nostep /(_ k).
 Qed.
 
+Definition ls_export_initial scs m vm fn :=
+  {|
+    lscs := scs;
+    lmem := m;
+    lvm := vm;
+    lfn := fn;
+    lpc := 0;
+  |}.
+
+Definition ls_export_final scs m vm fn fd :=
+  {|
+    lscs := scs;
+    lmem := m;
+    lvm := vm;
+    lfn := fn;
+    lpc := size (lfd_body fd);
+  |}.
+
 Variant lsem_exportcall (scs:syscall_state_t) (m: mem) (fn: funname) (vm: Vm.t) (scs':syscall_state_t) (m': mem) (vm': Vm.t) : Prop :=
 | Lsem_exportcall (fd: lfundef) of
     get_fundef P.(lp_funcs) fn = Some fd
   & lfd_export fd
-  & lsem
-         {| lscs := scs; lmem := m ; lvm := vm ; lfn := fn ; lpc := 0 |}
-         {| lscs := scs'; lmem := m' ; lvm := vm' ; lfn := fn ; lpc := size (lfd_body fd) |}
+  & lsem (ls_export_initial scs m vm fn) (ls_export_final scs' m' vm' fn fd)
   & vm =[ callee_saved ] vm'
 .
 

--- a/proofs/lang/low_memory.v
+++ b/proofs/lang/low_memory.v
@@ -39,6 +39,19 @@ Lemma eq_mem_trans m2 m1 m3 :
   eq_mem m1 m3.
 Proof. move => p q x y; rewrite (p x y); exact: (q x y). Qed.
 
+Definition eq_mem_ex (m m' : mem) (top : word Uptr) (stk_max : Z) : Prop :=
+  forall p,
+    disjoint_zrange top stk_max p (wsize_size U8) ->
+    read m p U8 = read m' p U8.
+
+(* -------------------------------------------------------------- *)
+
+Definition valid_between (m : mem) (top : word Uptr) (stk_max : Z) : Prop :=
+  forall p, between top stk_max p U8 -> validw m p U8.
+
+Definition zero_between (m : mem) (top : word Uptr) (stk_max : Z) : Prop :=
+  forall p, between top stk_max p U8 -> read m p U8 = ok 0%R.
+
 (* -------------------------------------------------------------- *)
 #[ global ]
 Instance stack_stable_equiv : Equivalence stack_stable.

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -55,6 +55,21 @@ Module LE.
     by rewrite (nth_map 0%Z) ?size_ziota // nth_ziota // Z.add_0_l /wread8 Nat2Z.id.
   Qed.
 
+  Lemma read0 ws x :
+    wread8 (ws := ws) 0 x = 0%R.
+  Proof.
+    rewrite /LE.wread8 /LE.encode /split_vec.
+    case: (Nat.le_gt_cases (ws %/ U8 + ws %% U8) (Z.to_nat x)) => h0.
+    - rewrite nth_default; first done.
+      rewrite size_map size_iota.
+      by apply/leP.
+    rewrite (nth_map O); first last.
+    - rewrite size_iota.
+      by apply/ltP.
+    rewrite /word.subword /= Z.shiftr_0_l Zmod_0_l.
+    by apply/(@eqP (word U8)).
+  Qed.
+
 End LE.
 
 Section POINTER.

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -3,7 +3,7 @@
 (* ** Imports and settings *)
 From mathcomp Require Import all_ssreflect all_algebra.
 Require Import Psatz xseq.
-Require Export array type expr gen_map low_memory warray_ sem_type sem_op_typed values varmap expr_facts low_memory syscall_sem psem_defs.
+Require Export array type expr gen_map warray_ sem_type sem_op_typed values varmap expr_facts low_memory syscall_sem psem_defs.
 Require Export
   flag_combination
   sem_params.


### PR DESCRIPTION
Using explicit records for `lstate`s in lemmas makes changing that datatype very involved. I made some cosmetic changes to `eval_instr` in `linear_sem` to use `Let` instead of if-then-else, let me know if you think it's a bad idea.
Sorry for the string of boring refactoring PRs, hopefully I'm done.