### PR TITLE
OTBN: Make AK_mem more precise

### DIFF
--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -240,14 +240,23 @@ Definition implicit_arg_eqMixin := Equality.Mixin implicit_arg_eq_axiom.
 Canonical implicit_arg_eqType := EqType _ implicit_arg_eqMixin.
 
 (* -------------------------------------------------------------------- *)
-(* Address kinds.
- * An address argument may be used in two ways:
- * - To compute the effective address (such as in LEA in x86, or ADR in ARMv7).
- * - To load data from memory.
- *)
+(* Address kinds. *)
+
+(* Addresses may be relative to the IP or to a general purpose register.
+   Arguments may be restricted to only one of these, or use either. *)
+Variant memory_access_kind :=
+  | MAKrip
+  | MAKreg
+  | MAKeither
+.
+
+(* An address argument may be used in two ways:
+   - To compute the effective address (such as in LEA in x86, or ADR in ARMv7).
+   - To load data from memory. *)
 Variant addr_kind : Type :=
-| AK_compute (* Only compute the address. *)
-| AK_mem.    (* Compute the address and load from memory. *)
+  | AK_compute                   (* Only compute the address. *)
+  | AK_mem of memory_access_kind (* Compute the address and load from memory. *)
+.
 
 (* -------------------------------------------------------------------- *)
 (* Argument description.
@@ -262,9 +271,9 @@ Variant arg_desc :=
 
 Definition F  f   := ADImplicit (IArflag f).
 Definition R  r   := ADImplicit (IAreg   r).
-Definition E  n   := ADExplicit AK_mem n None.
+Definition E  n   := ADExplicit (AK_mem MAKeither) n None.
 Definition Ec n   := ADExplicit AK_compute n None.
-Definition Ef n r := ADExplicit AK_mem n (Some  r).
+Definition Ef n r := ADExplicit (AK_mem MAKeither) n (Some  r).
 
 Definition check_oreg or ai :=
   match or, ai with

--- a/proofs/arch/arch_sem.v
+++ b/proofs/arch/arch_sem.v
@@ -448,7 +448,7 @@ Definition eval_instr (i : asm_i) (s: asm_state) : exec asm_state :=
     else type_error
   | JMP lbl   => eval_JMP p lbl s
   | JMPI d =>
-    Let v := eval_asm_arg AK_mem s d (sword Uptr) >>= to_pointer in
+    Let v := eval_asm_arg (AK_mem MAKreg) s d (sword Uptr) >>= to_pointer in
     if decode_label labels v is Some lbl then
       eval_JMP p lbl s
     else type_error

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -1871,6 +1871,11 @@ Lemma isSomeP {A : Type} {oa : option A} :
   exists a, oa = Some a.
 Proof. case: oa; by [|eexists]. Qed.
 
+Lemma o2rP {eT A} {err : eT} {oa : option A} {a} :
+  o2r err oa = ok a ->
+  oa = Some a.
+Proof. by case: oa => //= ? [->]. Qed.
+
 Lemma cat_inj_head T (x y z : seq T) : x ++ y = x ++ z -> y = z.
 Proof. by elim: x y z => // > hrec >; rewrite !cat_cons => -[/hrec]. Qed.
 


### PR DESCRIPTION
In OTBN instructions can only use absolute memory addresses, except for the one instruction whose only purpose is to compute PC relative addresses. I think this way of making the distinction would lead to clearer errors, let me know if you think just checking at the end is better.