### PR TITLE
Fix #622

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@
 - Fix extraction to easycrypt on "for loop" that modifies the loop counter
   ([PR 616](https://github.com/jasmin-lang/jasmin/pull/616).
 
+- Fix instruction selection for stack-allocation on ARM
+  ([PR 623](https://github.com/jasmin-lang/jasmin/pull/623);
+  fixes [#622](https://github.com/jasmin-lang/jasmin/issues/622)).
+
 ## Other changes
 
 - Pretty-printing of Jasmin programs is more precise

--- a/compiler/tests/success/common/spill_pointer.jazz
+++ b/compiler/tests/success/common/spill_pointer.jazz
@@ -1,0 +1,15 @@
+u32[1] C = {1};
+
+export
+fn main() -> reg u32
+{
+  reg ptr u32[1] Cp;
+  stack ptr u32[1] Cps;
+  reg u32 c;
+
+  Cp = C;
+  Cps = Cp;
+  Cp = Cps;
+  c = Cp[0];
+  return c;
+}

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -2,6 +2,8 @@ From mathcomp Require Import
   all_ssreflect
   all_algebra.
 
+From mathcomp Require Import word_ssrZ.
+
 Require Import
   arch_params
   compiler_util
@@ -101,16 +103,29 @@ Definition arm_cmd_large_subi :=
 (* ------------------------------------------------------------------------ *)
 (* Stack alloc parameters. *)
 
+Definition is_load e :=
+  if e is Pload _ _ _ then true else false.
+
 Definition arm_mov_ofs
   (x : lval) (tag : assgn_tag) (vpk : vptr_kind) (y : pexpr) (ofs : Z) :
   option instr_r :=
-  let ofs := eword_of_int reg_size ofs in
-  let: (op, args) :=
-    match mk_mov vpk with
-    | MK_LEA => (ADR, [:: add y ofs ])
-    | MK_MOV => (ADD, [:: y; ofs ])
-    end in
-  Some (Copn [:: x ] tag (Oarm (ARM_op op default_opts)) args).
+  let mk oa :=
+    let: (op, args) := oa in
+     Some (Copn [:: x ] tag (Oarm (ARM_op op default_opts)) args) in
+  match mk_mov vpk with
+  | MK_LEA => mk (ADR, [:: if ofs == Z0 then y else add y (eword_of_int reg_size ofs) ])
+  | MK_MOV =>
+    match x with
+    | Lvar _ =>
+      if is_load y then
+        if ofs == Z0 then mk (LDR, [:: y]) else None
+      else
+        if ofs == Z0 then mk (MOV, [:: y]) else mk (ADD, [::y; eword_of_int reg_size ofs ])
+    | Lmem _ _ _ =>
+      if ofs == Z0 then mk (STR, [:: y]) else None
+    | _ => None
+    end
+  end.
 
 Definition arm_immediate (x: var_i) z :=
   Copn [:: Lvar x ] AT_none (Oarm (ARM_op MOV default_opts)) [:: cast_const z ].

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -70,9 +70,24 @@ Lemma arm_mov_ofsP {dc : DirectCall} (P': sprog) s1 e i x tag ofs w vpk s2 ins :
 Proof.
   rewrite /sap_mov_ofs /= /arm_mov_ofs => P'_globs.
   t_xrbindP => z ok_z ok_i.
-  case: (mk_mov vpk) => /Some_inj <-{ins} hx.
-  all: constructor.
-  all: by rewrite /sem_sopn /= P'_globs /exec_sopn /sem_sop2 /= ok_z /= ok_i /= truncate_word_u /= ?truncate_word_u /= hx.
+  case: (mk_mov vpk).
+  + move => /Some_inj <-{ins} hx; constructor.
+    rewrite /sem_sopn /= P'_globs /exec_sopn.
+    case: eqP hx.
+    - by move => -> {ofs}; rewrite wrepr0 GRing.addr0 ok_z /= ok_i /= => ->.
+    by move => _ hx; rewrite /= /sem_sop2 ok_z /= ok_i /= truncate_word_u /= ?truncate_word_u /= hx.
+  case: x => //.
+  + move=> x_; move: (Lvar x_) => x.
+    case: ifP; case: eqP => [-> | _ ] _ // /Some_inj <-{ins} hx; constructor.
+    + rewrite /sem_sopn /= P'_globs /exec_sopn ok_z /= ok_i /= zero_extend_u.
+      by move: hx; rewrite wrepr0 GRing.addr0 => ->.
+    + rewrite /sem_sopn /= P'_globs /exec_sopn ok_z /= ok_i /=.
+      by move: hx; rewrite wrepr0 GRing.addr0 => ->.
+    by rewrite /sem_sopn /= P'_globs /exec_sopn /sem_sop2 /= ok_z /= ok_i /= truncate_word_u /= ?truncate_word_u /= hx.
+  move=> ws_ x_ e_; move: (Lmem ws_ x_ e_) => {ws_ x_ e_} x.
+  case: eqP => [-> | _ ] // /Some_inj <-{ins} hx; constructor.
+  rewrite /sem_sopn /= P'_globs /exec_sopn ok_z /= ok_i /= zero_extend_u.
+  by move: hx; rewrite wrepr0 GRing.addr0 => ->.
 Qed.
 
 Lemma arm_immediateP {dc : DirectCall} (P': sprog) w s (x: var_i) z :


### PR DESCRIPTION
This patch as the advantage to fixes the current problem, but I think it is not the write way to do it. 
I think, the best will be to introduce speudo instruction in arm:
   x = #lea e 
   this one can be decomposed in a sequence of addition with shift.
   ie x = #lea (y + z << i + c) 
   ---->
      x = #ADD(y, z << i);
      x = #ADD(x, c);

   x = #lea (y + c) 
   ---->
   x = #ADD(y, c);   // if c is to large we can use x to compute it.

and 
   x = #GMOV e 
this 
   can become either a LDR or a STR or a MOV  depending of the source e and destination x.

The current patch poorly do that.



  
