### PR TITLE
Check branches of inline conditionals in the SCT checker

### DIFF
--- a/compiler/src/sct_checker_forward.ml
+++ b/compiler/src/sct_checker_forward.ml
@@ -141,7 +141,7 @@ let is_inline i =
 let rec modmsf_i fenv i =
   match i.i_desc with
   | Csyscall _ | Cwhile _ -> true
-  | Cif _ -> not (is_inline i)
+  | Cif(_, c0, c1) -> not (is_inline i) || modmsf_c fenv c0 || modmsf_c fenv c1
   | Cassgn _ -> false
   | Copn (_, _, o, _) ->
     begin match is_special o with

--- a/compiler/tests/sct-checker/fail/inline-if-modmsf.jazz
+++ b/compiler/tests/sct-checker/fail/inline-if-modmsf.jazz
@@ -1,0 +1,22 @@
+// This should kill the MSFs even if the outer if is inline.
+inline
+fn f(reg u64 a) -> reg u64 {
+    #inline
+    if (true) {
+        if (a == 0) {
+            a = 0;
+        }
+    }
+    return a;
+}
+
+export
+fn inline_if_modmsf(reg u64 a) {
+  reg u64 ms;
+  ms = #init_msf();
+
+  a = f(a);
+
+  a = #protect(a, ms);
+  [a] = a;
+}

--- a/compiler/tests/sct-checker/reject.expected
+++ b/compiler/tests/sct-checker/reject.expected
@@ -14,3 +14,7 @@ File functions.jazz:
 Failed as expected call_kills_msf: "fail/functions.jazz", line 9 (2-10):
                                    speculative constant type checker: calls destroy msf variables, {
                                     m } are required
+File inline-if-modmsf.jazz:
+Failed as expected inline_if_modmsf: "fail/inline-if-modmsf.jazz", line 18 (2-11):
+                                     speculative constant type checker: calls destroy msf variables, {
+                                      ms } are required


### PR DESCRIPTION
I think the example I added should fail, is it so?