### PR TITLE
Change Cassgn error message in linearization

### DIFF
--- a/compiler/tests/fail/x86-64/shift.jazz
+++ b/compiler/tests/fail/x86-64/shift.jazz
@@ -1,0 +1,7 @@
+export
+fn main() -> reg u64 {
+    reg u64 x;
+    x = 1;
+    x <<= x;
+    return x;
+}

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -51,6 +51,12 @@ Definition error (msg:string) :=
 Definition internal_error (msg:string) :=
   gen_error true None msg.
 
+Definition assign_remains (ii : instr_info) :=
+  let msg :=
+    "this assignment does not correspond to any known instruction"%string
+  in
+  ii_error ii (append msg ", try using the intrinsic").
+
 End E.
 
 
@@ -311,7 +317,7 @@ Definition stack_frame_allocation_size (e: stk_fun_extra) : Z :=
   Fixpoint check_i (i:instr) : cexec unit :=
     let (ii,ir) := i in
     match ir with
-    | Cassgn x tag ty e => Error (E.ii_error ii "assign remains")
+    | Cassgn _ _ _ _ => Error (E.assign_remains ii)
     | Copn xs tag o es =>
       allM (check_rexpr ii) es >> allM (check_lexpr ii) xs
     | Csyscall xs o es =>


### PR DESCRIPTION
In response to the last few questions on Zulip. I know that Lowering is not necessarily the culprit here, so the error message might be misleading (although I believe that the passes after Lowering no longer introduce assignments). But I think the worst case scenario is what currently happens: get confused, have to ask on Zulip.