### PR TITLE
SCT checker: accept compiler introduced assignments to MSF

### DIFF
--- a/compiler/tests/sct-checker/sct_errors.expected
+++ b/compiler/tests/sct-checker/sct_errors.expected
@@ -1,4 +1,4 @@
-Failed as expected assign_msf: speculative constant type checker: assignment operation not permitted on a msf variable: x
+Failed as expected assign_msf: speculative constant type checker: assignment to MSF variable x not allowed
 Failed as expected syscall: speculative constant type checker: syscalls destroy msf variables, {
                              x } are required
 Failed as expected update_msf_not_trans: speculative constant type checker: MSF is not Trans


### PR DESCRIPTION
This example
```
inline
fn f() -> #msf reg u64 {
    reg u64 msf;
    msf = #init_msf();
    return msf;
}

export
fn protect_leak(#transient reg u64 x) -> #public reg u64 {
    reg u64 msf;
    msf = f();
    x = #protect(x, msf);
    x = x;
    return x;
}
```
doesn't work with `-checkSCTafter inline`