### PR TITLE
Renaming: ensure that arguments are preserved

### DIFF
--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -829,8 +829,13 @@ let renaming (f: ('info, 'asm) func) : (unit, 'asm) func =
       f
   in
   let vars = normalize_variables vars eqc in
-  let a = reverse_varmap nv vars |> subst_of_allocation vars in
-  Subst.subst_func a f
+  let a = reverse_varmap nv vars in
+  (* The variable that is added last is the representative of its class.
+     This makes sure that each argument is the representative of its class,
+     meaning that it will be preserved. *)
+  List.iter (fun arg -> A.set (Hv.find vars arg) arg a) f.f_args;
+  let subst = subst_of_allocation vars a in
+  Subst.subst_func subst f
 
 let remove_phi_nodes (f: ('info, 'asm) func) : (unit, 'asm) func =
   Ssa.remove_phi_nodes f


### PR DESCRIPTION
Before this patch, an argument can be replaced by a local variable during renaming, meaning that its name changes (confusing for the user) and its kind can change (a `reg mut ptr` can become `reg constr ptr`, cf. `tests/success/x86-64/bug_190.jazz`).