### PR TITLE
eclib: use a project file + specify provers versions

### DIFF
--- a/eclib/easycrypt.project
+++ b/eclib/easycrypt.project
@@ -1,0 +1,4 @@
+[general]
+provers = Z3@4.8
+provers = Alt-Ergo@2.5
+rdirs = .

--- a/eclib/tests.config
+++ b/eclib/tests.config
@@ -1,5 +1,2 @@
-[default]
-args = -I .
-
 [test-jasmin]
 okdirs = .


### PR DESCRIPTION
Specifying the provers version numbers allows EasyCrypt to select the provers that best match the ones that were in use during the development.

Note that project files & specifying version numbers is not available in the last release of EasyCrypt. Hence, one test of the CI is expected to fail (eclib against EasyCrypt release). I don't know what is the Jasmin policy for that.