### PR TITLE
CI: update nixpkgs & nix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 - test
 - deploy
 
-image: nixos/nix:2.13.4
+image: nixos/nix:2.18.1
 
 variables:
   NIX_PATH: nixpkgs=channel:nixpkgs-unstable

--- a/scripts/nixpkgs.nix
+++ b/scripts/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/3a70dd92993182f8e514700ccf5b1ae9fc8a3b8d.tar.gz";
-  sha256 = "sha256:0npyj597wwrp7xyqwrkds537vs9i5gazhmaxv8wc8z0sjr1450fb";
+  url = "https://github.com/NixOS/nixpkgs/archive/933d7dc155096e7575d207be6fb7792bc9f34f6d.tar.gz";
+  sha256 = "sha256:1gcqpm7v42wfmq0wrl4dym9kg4y7n4f5wsgvisq52zr90vjvylwx";
 })


### PR DESCRIPTION
This gives access to latest versions of Coq (8.18) & math-comp (2.1)