### PR TITLE
Fix after https://github.com/coq/coq/pull/18374

### DIFF
--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -2042,7 +2042,7 @@ Qed.
 End PROG.
 
 Lemma lom_eqv_ext rip s xs vm :
-  (evm s) =1 vm ->
+  (evm s =1 vm)%vm ->
   lom_eqv rip s xs ->
   lom_eqv rip (with_vm s vm) xs.
 Proof.

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -272,9 +272,9 @@ Section ADD_INIT.
 
   Notation lift_vm sem s1 s2 :=
     (forall vm1,
-       evm s1 =1 vm1 ->
+       (evm s1 =1 vm1)%vm ->
        exists2 vm2,
-         evm s2 =1 vm2
+         (evm s2 =1 vm2)%vm
          & sem (with_vm s1 vm1) (with_vm s2 vm2))
     (only parsing).
 
@@ -474,7 +474,7 @@ Section ADD_INIT.
     apply aux.
     + constructor; econstructor;eauto.
     move=> vm1 heq1.
-    have heq1' : evm (with_mem s1 m2) =1 vm1 := heq1.
+    have heq1' : (evm (with_mem s1 m2) =1 vm1)%vm := heq1.
     have [vm2 heq2 hwr2 ]:= write_lvars_ext_eq (s1 := (with_scs (with_mem s1 m2) scs2)) heq1 Hxs.
     exists vm2 => //; constructor; econstructor; eauto.
     by rewrite -(sem_pexprs_ext_eq _ _ args).

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -2686,7 +2686,7 @@ Section PROOF.
     set o := Some ((fn, lbl), P', (size P + size before).+1).
     set s := (top_stack (emem s1) - wrepr Uptr sz)%R.
 
-    have vm2_b_upd : vm2_b =1 vm2.[vrsp <- Vword (top_stack (emem s1) -  wrepr Uptr sz_before)].
+    have vm2_b_upd : (vm2_b =1 vm2.[vrsp <- Vword (top_stack (emem s1) -  wrepr Uptr sz_before)])%vm.
     + move=> x; rewrite /vm2_b Vm.setP; case: (vrsp =P x) => [ | /eqP] *.
       + subst x; case: eqP => [-> | ?]; last by rewrite Vm.setP_eq.
         by rewrite wrepr0 GRing.subr0 vm_truncate_val_eq //.
@@ -2827,7 +2827,7 @@ Section PROOF.
       rewrite Vm.setP_eq /= cmp_le_refl => /get_word_uincl_eq -/(_ (subtype_refl _)).
       rewrite /rastack_after /ra.
       by case sf_return_address => //= *; rewrite wrepr0 GRing.addr0.
-    have vm2'_b_upd : vm2'_b =1 vm2'.[vrsp <- Vword ts].
+    have vm2'_b_upd : (vm2'_b =1 vm2'.[vrsp <- Vword ts])%vm.
     + move=> y; rewrite Vm.setP; case: eqP => [ | /eqP] heq;
         last by rewrite /vm2'_b; case: eqP => // _; rewrite Vm.setP_neq.
       subst y; rewrite /vm2'_b; case: eqP => heq; last by rewrite Vm.setP_eq.

--- a/proofs/compiler/makeReferenceArguments_proof.v
+++ b/proofs/compiler/makeReferenceArguments_proof.v
@@ -204,7 +204,7 @@ Context
     sem_pis ii s1 pis vs s2 ->
     exists s1' vm2,
       [/\ write_lvals true (p_globs p') s1 lvs vs = ok s1',
-          sem p' ev s1' c (with_vm s2 vm2) & evm s2 =1 vm2].
+          sem p' ev s1' c (with_vm s2 vm2) & (evm s2 =1 vm2)%vm].
   Proof.
     elim: pis lvs c vs s1 => /= [ | pi pis ih] lvs' c' vs s1.
     + case/ok_inj => <- <-{lvs' c'} /sem_pisE[] -> <- {vs s1}.
@@ -236,7 +236,7 @@ Context
     + move=> x hx; have /= <- := vrvsP hw3; last by SvD.fsetdec.
       rewrite -(vrvsP hws); last by SvD.fsetdec.
       by rewrite -(vrvP H3) //; SvD.fsetdec.
-    have [vmi [hsemi heqv]]: exists vmi, write_lval true (p_globs p') lv v' (with_vm s1' vm3) = ok (with_vm s1' vmi) /\ evm s1' =1 vmi.
+    have [vmi [hsemi heqv]]: exists vmi, write_lval true (p_globs p') lv v' (with_vm s1' vm3) = ok (with_vm s1' vmi) /\ (evm s1' =1 vmi)%vm.
     + move: H3; rewrite /write_lval.
       move /Sv.is_empty_spec: hwr; move /Sv.is_empty_spec: hrw.
       rewrite /read_I_rec /write_I_rec [X in (Sv.inter (vrvs _) X)]/= /read_gvar

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -1746,17 +1746,17 @@ Lemma sem_pexprs_wdb e : Q e.
 Proof. by case: sem_pexpr_wdb_and. Qed.
 
 Lemma sem_pexpr_ext_eq e vm :
-  evm s =1 vm ->
+  (evm s =1 vm)%vm ->
   sem_pexpr wdb gd s e = sem_pexpr wdb gd (with_vm s vm) e.
 Proof. by move=> heq; apply/read_e_eq_on_empty/vm_eq_eq_on. Qed.
 
 Lemma sem_pexprs_ext_eq es vm :
-  evm s =1 vm ->
+  (evm s =1 vm)%vm ->
   sem_pexprs wdb gd s es = sem_pexprs wdb gd (with_vm s vm) es.
 Proof. by move=> heq; apply/read_es_eq_on_empty/vm_eq_eq_on. Qed.
 
 Lemma write_lvar_ext_eq x v s1 s2 vm1 :
-  evm s1 =1 vm1 ->
+  (evm s1 =1 vm1)%vm ->
   write_lval wdb gd x v s1 = ok s2 ->
   exists2 vm2, evm s2 =1 vm2 & write_lval wdb gd x v (with_vm s1 vm1) = ok (with_vm s2 vm2).
 Proof.
@@ -1772,7 +1772,7 @@ Proof.
 Qed.
 
 Lemma write_lvars_ext_eq xs vs s1 s2 vm1 :
-  evm s1 =1 vm1 ->
+  (evm s1 =1 vm1)%vm ->
   write_lvals wdb gd s1 xs vs = ok s2 ->
   exists2 vm2, evm s2 =1 vm2 & write_lvals wdb gd (with_vm s1 vm1) xs vs = ok (with_vm s2 vm2).
 Proof.
@@ -1916,7 +1916,7 @@ Qed.
 
 Lemma sem_vm_eq s1 c s2 vm1:
   sem p ev s1 c s2 ->
-  evm s1 =1 vm1 ->
+  (evm s1 =1 vm1)%vm ->
   exists2 vm2, sem p ev (with_vm s1 vm1) c (with_vm s2 vm2) & evm s2 =1 vm2.
 Proof.
   move=> hsem heq1.

--- a/proofs/lang/psem_of_sem_proof.v
+++ b/proofs/lang/psem_of_sem_proof.v
@@ -30,7 +30,7 @@ Notation estate_s := (estate (wsw:= withsubword)).
 #[local]Open Scope vm_scope.
 
 Definition estate_sim (e: estate_n) (e': estate_s) : Prop :=
-  [/\ escs e = escs e', emem e = emem e' & evm e =1 evm e'].
+  [/\ escs e = escs e', emem e = emem e' & (evm e =1 evm e')%vm].
 
 Lemma estate_sim_scs e e' scs :
   estate_sim e e' ->
@@ -42,16 +42,16 @@ Lemma estate_sim_mem e e' m :
   estate_sim (with_mem e m) (with_mem e' m).
 Proof. by case => *; constructor. Qed.
 
-Lemma vmap0_sim : Vm.init (wsw:= nosubword) =1 Vm.init (wsw:= withsubword).
+Lemma vmap0_sim : (Vm.init (wsw:= nosubword) =1 Vm.init (wsw:= withsubword))%vm.
 Proof. by move=> x; rewrite !Vm.initP. Qed.
 
 Lemma get_var_sim (vm : vmap_n) (vm' : vmap_s) :
-  vm =1 vm' →
+  (vm =1 vm')%vm →
   ∀ x, get_var true vm x = get_var true vm' x.
 Proof. by move=> heq x; rewrite /get_var heq. Qed.
 
 Lemma get_gvar_sim gd (vm : vmap_n) (vm' : vmap_s) :
-  vm =1 vm' →
+  (vm =1 vm')%vm →
   ∀ x, get_gvar true gd vm x = get_gvar true gd vm' x.
 Proof.
 by move => h x; rewrite /get_gvar (get_var_sim h).
@@ -68,9 +68,9 @@ Proof.
 Qed.
 
 Lemma vmap_set_sim (vm : vmap_n) (vm' : vmap_s) x v:
-  vm =1 vm' →
+  (vm =1 vm')%vm →
   truncatable true (wsw:=nosubword) (vtype x) v →
-  vm.[x <- v] =1 vm'.[x <- v].
+  (vm.[x <- v] =1 vm'.[x <- v])%vm.
 Proof.
   move => hvm hv y; rewrite !Vm.setP.
   by rewrite vm_truncate_val_sim // hvm.
@@ -86,10 +86,10 @@ Proof.
 Qed.
 
 Lemma set_var_sim (vm1 : vmap_n) (vm1' : vmap_s) x v vm2 :
-  vm1 =1 vm1' →
+  (vm1 =1 vm1')%vm →
   set_var true vm1 x v = ok vm2 →
   ∃ vm2',
-    vm2 =1 vm2' ∧
+    (vm2 =1 vm2')%vm ∧
     set_var true vm1' x v = ok vm2'.
 Proof.
   move=> hsim /set_varP [hdb /dup []htr /truncatable_sim htr' ->].

--- a/proofs/lang/varmap.v
+++ b/proofs/lang/varmap.v
@@ -1008,11 +1008,11 @@ Section REL_EQUIV.
   Qed.
 
   Lemma eq_on_eq_vm vm1 vm2 vm1' vm2' d :
-    vm1  =1   vm2 →
+    (vm1  =1   vm2)%vm →
     vm1' =[d] vm2' →
     vm1  =[\d] vm1'→
     vm2  =[\d] vm2' →
-    vm1' =1   vm2'.
+    (vm1' =1   vm2')%vm.
   Proof.
     move => out on t1 t2 x.
     case: (Sv_memP x d); first exact: on.
@@ -1090,7 +1090,7 @@ Section REL_EQUIV.
   Proof. by move => h x _; exact: h. Qed.
 
   Lemma vm_eq_eq_on dom vm1 vm2 :
-    vm1 =1 vm2 →
+    (vm1 =1 vm2)%vm →
     vm1 =[dom] vm2.
   Proof. by move => h x _; exact: h. Qed.
 


### PR DESCRIPTION
Te PR https://github.com/coq/coq/pull/18374 moved the "_ =1 _" notation of ssreflect from function_scope to type_scope. This requires some disembiguation wit the "_ =1 _" of Jasmin in vm_scope.