### PR TITLE
Address a few kinds of warnings

### DIFF
--- a/compiler/tests/sct-checker/accept.expected
+++ b/compiler/tests/sct-checker/accept.expected
@@ -130,7 +130,7 @@ output corruption: #public
 
 
 File local-stack-array.jazz:
-modmsf main : #transient ->
+modmsf main :  ->
 #public
 output corruption: #public
  constraints:

--- a/compiler/tests/sct-checker/error_messages.jazz
+++ b/compiler/tests/sct-checker/error_messages.jazz
@@ -53,13 +53,13 @@ export fn not_known_as_msf() {
   x = #mov_msf(x);
 }
 
-export fn bad_poly_annot(#poly=public reg u64 x) {}
+export fn bad_poly_annot(#poly=public reg u64 x) { [x] = 0; }
 
 export fn msf_in_export(reg u64 p) {
   p = #protect(p, p);
 }
 
-fn must_not_be_a_msf_aux(#msf reg u64 p) {
+fn must_not_be_a_msf_aux(#msf reg u64 p) { p = p;
 }
 
 fn should_be_a_msf_aux(#public reg u64 p) {
@@ -167,7 +167,7 @@ export fn ret_msf() -> #public reg u64 {
   return msf;
 }
 
-export fn public_arg(#public reg u32 x) {}
+export fn public_arg(#public reg u32 x) { x = x; }
 
 export fn need_declassify(#transient reg u64 p) -> #public reg u64 {
   reg u64 x msf;

--- a/compiler/tests/sct-checker/success/local-stack-array.jazz
+++ b/compiler/tests/sct-checker/success/local-stack-array.jazz
@@ -1,5 +1,5 @@
 export
-fn main(#transient reg u64 io) -> #public reg u64 {
+fn main() -> #public reg u64 {
   _ = #init_msf();
   stack u64[1] local;
   local[0] = 42;

--- a/opam
+++ b/opam
@@ -28,7 +28,7 @@ depends: [
   "ocamlbuild" { build }
   "ocamlfind" { build }
   "coq" {>= "8.14.0" & < "8.19~"}
-  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.19~"}
+  "coq-mathcomp-ssreflect" {>= "1.17" & < "1.19~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-word" {>= "2.1" & < "3.0~"}
 ]

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -7,6 +7,7 @@
 -arg "-w +deprecated-hint-rewrite-without-locality"
 -arg "-w +deprecated-instance-without-locality"
 -arg "-w -hiding-delimiting-key"
+-arg "-w +deprecated-since-mathcomp-1.17.0"
 
 -R 3rdparty Jasmin
 -R arch Jasmin

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -272,10 +272,10 @@ Section ADD_INIT.
 
   Notation lift_vm sem s1 s2 :=
     (forall vm1,
-       (evm s1 =1 vm1)%vm ->
+       evm s1 =1 vm1 ->
        exists2 vm2,
-         (evm s2 =1 vm2)%vm
-         & sem (with_vm s1 vm1) (with_vm s2 vm2))
+         evm s2 =1 vm2
+         & sem (with_vm s1 vm1) (with_vm s2 vm2))%vm
     (only parsing).
 
   Definition lift_semI s1 i s2 :=

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -137,31 +137,38 @@ Section CAT.
 
   Let Pf (fd:sfundef) := True.
 
-  Let HmkI: forall i ii, Pr i -> Pi (MkI ii i).
+  #[ local ]
+  Lemma cat_mkI: forall i ii, Pr i -> Pi (MkI ii i).
   Proof. by []. Qed.
 
-  Let Hskip : Pc [::].
+  #[ local ]
+  Lemma cat_skip : Pc [::].
   Proof. by []. Qed.
 
-  Let Hseq : forall i c,  Pi i -> Pc c -> Pc (i::c).
+  #[ local ]
+  Lemma cat_seq : forall i c,  Pi i -> Pc c -> Pc (i::c).
   Proof.
     move=> i c Hi Hc fn lbl l /=.
     by rewrite Hc; case: linear_c => lbl1 lc1; rewrite Hi (Hi _ lbl1 lc1); case: linear_i => ??; rewrite catA.
   Qed.
 
-  Let Hassgn : forall x tg ty e, Pr (Cassgn x tg ty e).
+  #[ local ]
+  Lemma cat_assgn : forall x tg ty e, Pr (Cassgn x tg ty e).
   Proof. by move => x tg [] // sz e ii lbl c /=; case: assert. Qed.
 
-  Let Hopn : forall xs t o es, Pr (Copn xs t o es).
+  #[ local ]
+  Lemma cat_opn : forall xs t o es, Pr (Copn xs t o es).
   Proof.
     move => xs tg op es ii fn lbl tl /=.
     by do 2 (case: oseq.omap => // ?).
   Qed.
 
-  Let Hsyscall : forall xs o es, Pr (Csyscall xs o es).
+  #[ local ]
+  Lemma cat_syscall : forall xs o es, Pr (Csyscall xs o es).
   Proof. by []. Qed.
 
-  Let Hif   : forall e c1 c2,  Pc c1 -> Pc c2 -> Pr (Cif e c1 c2).
+  #[ local ]
+  Lemma cat_if   : forall e c1 c2,  Pc c1 -> Pc c2 -> Pr (Cif e c1 c2).
   Proof.
     move=> e c1 c2 Hc1 Hc2 ii fn lbl l /=.
     case Heq1: (c1)=> [|i1 l1].
@@ -174,10 +181,12 @@ Section CAT.
     by rewrite /= !cats1 /= -!cat_rcons catA.
   Qed.
 
-  Let Hfor : forall v dir lo hi c, Pc c -> Pr (Cfor v (dir, lo, hi) c).
+  #[ local ]
+  Lemma cat_for : forall v dir lo hi c, Pc c -> Pr (Cfor v (dir, lo, hi) c).
   Proof. by []. Qed.
 
-  Let Hwhile : forall a c e c', Pc c -> Pc c' -> Pr (Cwhile a c e c').
+  #[ local ]
+  Lemma cat_while : forall a c e c', Pc c -> Pc c' -> Pr (Cwhile a c e c').
   Proof.
     move=> a c e c' Hc Hc' ii fn lbl l /=.
     case: is_bool => [ [] | ].
@@ -193,7 +202,8 @@ Section CAT.
     by case: a; rewrite /= cats1 -catA /= cat_rcons.
   Qed.
 
-  Let Hcall : forall xs f es, Pr (Ccall xs f es).
+  #[ local ]
+  Lemma cat_call : forall xs f es, Pr (Ccall xs f es).
   Proof.
     move=> xs fn es ii fn' lbl tail /=.
     case: get_fundef => // fd; case: is_RAnoneP => //.
@@ -205,7 +215,7 @@ Section CAT.
      let: (lbl, lc) := linear_i fn i lbl [::] in (lbl, lc ++ tail).
   Proof.
     exact:
-      (instr_Rect HmkI Hskip Hseq Hassgn Hopn Hsyscall Hif Hfor Hwhile Hcall).
+      (instr_Rect cat_mkI cat_skip cat_seq cat_assgn cat_opn cat_syscall cat_if cat_for cat_while cat_call).
   Qed.
 
   Lemma linear_c_nil fn c lbl tail :
@@ -213,7 +223,7 @@ Section CAT.
      let: (lbl, lc) := linear_c (linear_i fn) c lbl [::] in (lbl, lc ++ tail).
   Proof.
     exact:
-      (cmd_rect HmkI Hskip Hseq Hassgn Hopn Hsyscall Hif Hfor Hwhile Hcall).
+      (cmd_rect cat_mkI cat_skip cat_seq cat_assgn cat_opn cat_syscall cat_if cat_for cat_while cat_call).
   Qed.
 
 End CAT.
@@ -508,17 +518,21 @@ Section VALIDITY.
          linear_c (linear_i liparams p fn) c lbl [::] in
       (lbl <= lblc)%positive ∧ valid fn lbl lblc lc.
 
-  Let HMkI i ii : Pr i → Pi (MkI ii i).
+  #[ local ]
+  Lemma valid_labels_MkI i ii : Pr i → Pi (MkI ii i).
   Proof. exact. Qed.
 
-  Let default fn lbl :
+  #[ local ]
+  Lemma default fn lbl :
     (lbl <= lbl)%positive ∧ valid fn lbl lbl [::].
   Proof. split; reflexivity. Qed.
 
-  Let Hnil : Pc [::].
+  #[ local ]
+  Lemma valid_labels_nil : Pc [::].
   Proof. exact: default. Qed.
 
-  Let Hcons (i : instr) (c : cmd) : Pi i → Pc c → Pc (i :: c).
+  #[ local ]
+  Lemma valid_labels_cons (i : instr) (c : cmd) : Pi i → Pc c → Pc (i :: c).
   Proof.
     move => hi hc fn lbl /=.
     case: linear_c (hc fn lbl) => lblc lc [Lc Vc]; rewrite linear_i_nil.
@@ -528,20 +542,24 @@ Section VALIDITY.
     apply: valid_le_max _ Vc; apply/Pos.leb_le; lia.
   Qed.
 
-  Let Hassign (x : lval) (tg : assgn_tag) (ty : stype) (e : pexpr) : Pr (Cassgn x tg ty e).
+  #[ local ]
+  Lemma valid_labels_assign (x : lval) (tg : assgn_tag) (ty : stype) (e : pexpr) : Pr (Cassgn x tg ty e).
   Proof. move => ???; exact: default. Qed.
 
-  Let Hopn (xs : lvals) (t : assgn_tag) (o : sopn) (es : pexprs) : Pr (Copn xs t o es).
+  #[ local ]
+  Lemma valid_labels_opn (xs : lvals) (t : assgn_tag) (o : sopn) (es : pexprs) : Pr (Copn xs t o es).
   Proof.
     move => ii fn lbl /=.
     case: oseq.omap => [ ls | ]; last exact: default.
     case: oseq.omap => [ rs | ] ; exact: default.
   Qed.
 
-  Let Hsyscall (xs : lvals) (o : syscall_t) (es : pexprs) : Pr (Csyscall xs o es).
+  #[ local ]
+  Lemma valid_labels_syscall (xs : lvals) (o : syscall_t) (es : pexprs) : Pr (Csyscall xs o es).
   Proof. move => ?; exact: default. Qed.
 
-  Let Hif (e : pexpr) (c1 c2 : cmd) : Pc c1 → Pc c2 → Pr (Cif e c1 c2).
+  #[ local ]
+  Lemma valid_labels_if (e : pexpr) (c1 c2 : cmd) : Pc c1 → Pc c2 → Pr (Cif e c1 c2).
   Proof.
     move => hc1 hc2 ii fn lbl /=.
     case: c1 hc1 => [ | i1 c1 ] hc1.
@@ -570,10 +588,12 @@ Section VALIDITY.
     all: apply/Pos.leb_le; lia.
   Qed.
 
-  Let Hfor (v : var_i) (d: dir) (lo hi : pexpr) (c : cmd) : Pc c → Pr (Cfor v (d, lo, hi) c).
+  #[ local ]
+  Lemma valid_labels_for (v : var_i) (d: dir) (lo hi : pexpr) (c : cmd) : Pc c → Pr (Cfor v (d, lo, hi) c).
   Proof. move => ? ?; exact: default. Qed.
 
-  Let Hwhile (a : expr.align) (c : cmd) (e : pexpr) (c' : cmd) : Pc c → Pc c' → Pr (Cwhile a c e c').
+  #[ local ]
+  Lemma valid_labels_while (a : expr.align) (c : cmd) (e : pexpr) (c' : cmd) : Pc c → Pc c' → Pr (Cwhile a c e c').
   Proof.
     move => hc hc' ii fn lbl /=.
     case: is_boolP => [ [] | {e} e ].
@@ -611,7 +631,8 @@ Section VALIDITY.
     valid fn lbl (lbl + 1)%positive (allocate_stack_frame liparams p b ii z rastack).
   Proof. by rewrite /allocate_stack_frame; case: eqP. Qed.
 
-  Let Hcall (xs : lvals) (f : funname) (es : pexprs) : Pr (Ccall xs f es).
+  #[ local ]
+  Lemma valid_labels_call (xs : lvals) (f : funname) (es : pexprs) : Pr (Ccall xs f es).
   Proof.
     move => ii fn lbl /=.
     case: get_fundef => [ fd | ]; last by split => //; lia.
@@ -624,10 +645,10 @@ Section VALIDITY.
   Qed.
 
   Definition linear_has_valid_labels : ∀ c, Pc c :=
-    cmd_rect HMkI Hnil Hcons Hassign Hopn Hsyscall Hif Hfor Hwhile Hcall.
+    cmd_rect valid_labels_MkI valid_labels_nil valid_labels_cons valid_labels_assign valid_labels_opn valid_labels_syscall valid_labels_if valid_labels_for valid_labels_while valid_labels_call.
 
   Definition linear_has_valid_labels_instr : ∀ i, Pi i :=
-    instr_Rect HMkI Hnil Hcons Hassign Hopn Hsyscall Hif Hfor Hwhile Hcall.
+    instr_Rect valid_labels_MkI valid_labels_nil valid_labels_cons valid_labels_assign valid_labels_opn valid_labels_syscall valid_labels_if valid_labels_for valid_labels_while valid_labels_call.
 
 End VALIDITY.
 
@@ -656,13 +677,16 @@ Section NUMBER_OF_LABELS.
          linear_c (linear_i liparams p fn) c lbl [::] in
       (Z.of_nat (size (label_in_lcmd lc)) + lbl <= lblc)%Z.
 
-  Let HMkI i ii : Pr i → Pi (MkI ii i).
+  #[ local ]
+  Lemma nb_labels_MkI i ii : Pr i → Pi (MkI ii i).
   Proof. exact. Qed.
 
-  Let Hnil : Pc [::].
+  #[ local ]
+  Lemma nb_labels_nil : Pc [::].
   Proof. by move => fn lbl; apply Z.le_refl. Qed.
 
-  Let Hcons (i : instr) (c : cmd) : Pi i → Pc c → Pc (i :: c).
+  #[ local ]
+  Lemma nb_labels_cons (i : instr) (c : cmd) : Pi i → Pc c → Pc (i :: c).
   Proof.
     move => hi hc fn lbl /=.
     case: linear_c (hc fn lbl) => lblc lc Lc; rewrite linear_i_nil.
@@ -678,10 +702,12 @@ Section NUMBER_OF_LABELS.
     by case: lip_lassign => [[[??]?]|].
   Qed.
 
-  Let Hassign (x : lval) (tg : assgn_tag) (ty : stype) (e : pexpr) : Pr (Cassgn x tg ty e).
+  #[ local ]
+  Lemma nb_labels_assign (x : lval) (tg : assgn_tag) (ty : stype) (e : pexpr) : Pr (Cassgn x tg ty e).
   Proof. move => ???; exact: Z.le_refl. Qed.
 
-  Let Hopn (xs : lvals) (t : assgn_tag) (o : sopn) (es : pexprs) : Pr (Copn xs t o es).
+  #[ local ]
+  Lemma nb_labels_opn (xs : lvals) (t : assgn_tag) (o : sopn) (es : pexprs) : Pr (Copn xs t o es).
   Proof.
     move=> ii fn lbl /=.
     case: oseq.omap => [ ? | /= ].
@@ -689,10 +715,12 @@ Section NUMBER_OF_LABELS.
     all: apply Z.le_refl.
   Qed.
 
-  Let Hsyscall (xs : lvals) (o : syscall_t) (es : pexprs) : Pr (Csyscall xs o es).
+  #[ local ]
+  Lemma nb_labels_syscall (xs : lvals) (o : syscall_t) (es : pexprs) : Pr (Csyscall xs o es).
   Proof. by move=> ii fn lbl /=; apply Z.le_refl. Qed.
 
-  Let Hif (e : pexpr) (c1 c2 : cmd) : Pc c1 → Pc c2 → Pr (Cif e c1 c2).
+  #[ local ]
+  Lemma nb_labels_if (e : pexpr) (c1 c2 : cmd) : Pc c1 → Pc c2 → Pr (Cif e c1 c2).
   Proof.
     move=> hc1 hc2 ii fn lbl /=.
     case: c1 hc1 => [ | i1 c1 ] hc1.
@@ -714,14 +742,16 @@ Section NUMBER_OF_LABELS.
     lia.
   Qed.
 
-  Let Hfor (v : var_i) (d: dir) (lo hi : pexpr) (c : cmd) : Pc c → Pr (Cfor v (d, lo, hi) c).
+  #[ local ]
+  Lemma nb_labels_for (v : var_i) (d: dir) (lo hi : pexpr) (c : cmd) : Pc c → Pr (Cfor v (d, lo, hi) c).
   Proof. by move=> hc ii fn lbl /=; apply Z.le_refl. Qed.
 
   Lemma label_in_lcmd_add_align ii al lc :
     label_in_lcmd (add_align ii al lc) = label_in_lcmd lc.
   Proof. by case: al. Qed.
 
-  Let Hwhile (a : expr.align) (c : cmd) (e : pexpr) (c' : cmd) : Pc c → Pc c' → Pr (Cwhile a c e c').
+  #[ local ]
+  Lemma nb_labels_while (a : expr.align) (c : cmd) (e : pexpr) (c' : cmd) : Pc c → Pc c' → Pr (Cwhile a c e c').
   Proof.
     move => hc hc' ii fn lbl /=.
     case: is_boolP => [ [] | {e} e ].
@@ -770,7 +800,8 @@ Section NUMBER_OF_LABELS.
     by rewrite /lload get_label_lassign /=.
   Qed.
 
-  Let Hcall (xs : lvals) (f : funname) (es : pexprs) : Pr (Ccall xs f es).
+  #[ local ]
+  Lemma nb_labels_call (xs : lvals) (f : funname) (es : pexprs) : Pr (Ccall xs f es).
   Proof.
     move => ii fn lbl /=.
     case: get_fundef => [ fd | ]; last by apply Z.le_refl.
@@ -782,10 +813,10 @@ Section NUMBER_OF_LABELS.
   Qed.
 
   Definition linear_c_nb_labels : ∀ c, Pc c :=
-    cmd_rect HMkI Hnil Hcons Hassign Hopn Hsyscall Hif Hfor Hwhile Hcall.
+    cmd_rect nb_labels_MkI nb_labels_nil nb_labels_cons nb_labels_assign nb_labels_opn nb_labels_syscall nb_labels_if nb_labels_for nb_labels_while nb_labels_call.
 
   Definition linear_i_nb_labels : ∀ i, Pi i :=
-    instr_Rect HMkI Hnil Hcons Hassign Hopn Hsyscall Hif Hfor Hwhile Hcall.
+    instr_Rect nb_labels_MkI nb_labels_nil nb_labels_cons nb_labels_assign nb_labels_opn nb_labels_syscall nb_labels_if nb_labels_for nb_labels_while nb_labels_call.
 
   Lemma linear_body_nb_labels fn e body :
     let: (lbl, lc) := linear_body liparams p fn e body in

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1163,45 +1163,45 @@ rewrite !mathcomp.word.word.msbE /= !subZE; set w := (_ sz);
   case: (lerP (modulus _) (val α)) => ha;
   case: (lerP (modulus _) (val β)) => hb;
   case: (lerP (modulus _) (val _)) => hab.
-+ rewrite ltr_add2r eq_sym eqb_id negbK opprB !addrA subrK.
++ rewrite ltrD2r eq_sym eqb_id negbK opprB !addrA subrK.
   rewrite [val (α - β)%R]subw_modE /urepr /= -/w.
   case: ltrP; first by rewrite addrK eqxx.
-  by rewrite addr0 lt_eqF // ltr_subl_addr ltr_addl modulus_gt0.
-+ rewrite ltr_add2r opprB !addrA subrK eq_sym eqbF_neg negbK.
+  by rewrite addr0 lt_eqF // ltrBlDr ltrDl modulus_gt0.
++ rewrite ltrD2r opprB !addrA subrK eq_sym eqbF_neg negbK.
   rewrite [val (α - β)%R]subw_modE /urepr -/w /=; case: ltrP.
-  + by rewrite mulr1n gt_eqF // ltr_addl modulus_gt0.
+  + by rewrite mulr1n gt_eqF // ltrDl modulus_gt0.
   + by rewrite addr0 eqxx.
-+ rewrite ltr_subl_addr (lt_le_trans (urepr_ltmod _)); last first.
-    by rewrite ler_addr urepr_ge0.
++ rewrite ltrBlDr (lt_le_trans (urepr_ltmod _)); last first.
+    by rewrite lerDr urepr_ge0.
   rewrite eq_sym eqb_id negbK; apply/esym.
   rewrite [val _]subw_modE /urepr -/w /= ltNge ltW /=.
   * by rewrite addr0 addrAC eqxx.
   * by rewrite (lt_le_trans hb).
-+ rewrite ltr_subl_addr (lt_le_trans (urepr_ltmod _)); last first.
-    by rewrite ler_addr urepr_ge0.
++ rewrite ltrBlDr (lt_le_trans (urepr_ltmod _)); last first.
+    by rewrite lerDr urepr_ge0.
   rewrite eq_sym eqbF_neg negbK [val _]subw_modE /urepr -/w /=.
   rewrite ltNge ltW ?addr0; last first.
     by rewrite (lt_le_trans hb).
-  by rewrite addrAC gt_eqF // ltr_subl_addr ltr_addl modulus_gt0.
-+ rewrite ltr_subr_addl ltNge ltW /=; last first.
-    by rewrite (lt_le_trans (urepr_ltmod _)) // ler_addl urepr_ge0.
+  by rewrite addrAC gt_eqF // ltrBlDr ltrDl modulus_gt0.
++ rewrite ltrBrDl ltNge ltW /=; last first.
+    by rewrite (lt_le_trans (urepr_ltmod _)) // lerDl urepr_ge0.
   apply/esym/negbTE; rewrite negbK; apply/eqP/esym.
   rewrite [val _]subw_modE /urepr /= -/w; have ->/=: (val α < val β)%R.
-    by have := ltr_le_add ha hb; rewrite addrC ltr_add2l.
+  by have := ltr_leD ha hb; rewrite addrC ltrD2l.
   rewrite mulr1n addrK opprD addrA lt_eqF //= opprK.
-  by rewrite ltr_addl modulus_gt0.
-+ rewrite ltr_subr_addl ltNge ltW /=; last first.
-    by rewrite (lt_le_trans (urepr_ltmod _)) // ler_addl urepr_ge0.
+  by rewrite ltrDl modulus_gt0.
++ rewrite ltrBrDl ltNge ltW /=; last first.
+    by rewrite (lt_le_trans (urepr_ltmod _)) // lerDl urepr_ge0.
   apply/esym/negbTE; rewrite negbK eq_sym eqbF_neg negbK.
   rewrite [val _]subw_modE /urepr -/w /= opprD addrA opprK.
   by have ->//: (val α < val β)%R; apply/(lt_le_trans ha).
 + rewrite [val (α - β)%R](subw_modE α β) -/w /urepr /=.
   rewrite eq_sym eqb_id negbK; case: ltrP.
   * by rewrite mulr1n addrK eqxx.
-  * by rewrite addr0 lt_eqF // ltr_subl_addr ltr_addl modulus_gt0.
+  * by rewrite addr0 lt_eqF // ltrBlDr ltrDl modulus_gt0.
 + rewrite [val (α - β)%R](subw_modE α β) -/w /urepr /=.
   rewrite eq_sym eqbF_neg negbK; case: ltrP.
-  * by rewrite mulr1n gt_eqF // ltr_addl modulus_gt0.
+  * by rewrite mulr1n gt_eqF // ltrDl modulus_gt0.
   * by rewrite addr0 eqxx.
 Qed.
 


### PR DESCRIPTION
  - Get rid of notations deprecated in math-comp 1.17
  - Use local lemmas instead of Let that trigger warnings with Coq 8.18
  - Ensure function arguments are used in the tests for the SCT checker.