### PR TITLE
Move arm utils to a module

### DIFF
--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -80,11 +80,11 @@ Notation vtmpi := (mk_var_i (to_var R12)).
 
 (* TODO_ARM: This assumes 0 <= sz < 4096. *)
 Definition arm_allocate_stack_frame (rspi : var_i) (sz : Z) :=
-  arm_op_subi rspi rspi sz.
+  ARMFopn.subi rspi rspi sz.
 
 (* TODO_ARM: This assumes 0 <= sz < 4096. *)
 Definition arm_free_stack_frame (rspi : var_i) (sz : Z) :=
-  arm_op_addi rspi rspi sz.
+  ARMFopn.addi rspi rspi sz.
 
 (* TODO_ARM: Review. This seems unnecessary. *)
 Definition arm_lassign
@@ -113,19 +113,19 @@ Definition arm_set_up_sp_register
   (r : var_i) :
   option (seq fopn_args) :=
   let%opt _ := oassert ((0 <=? sf_sz)%Z && (sf_sz <? wbase reg_size)%Z) in
-  let i0 := arm_op_mov r rspi in
-  let load_imm := arm_cmd_large_subi vtmpi rspi sf_sz in
-  let i1 := arm_op_align vtmpi vtmpi al in
-  let i2 := arm_op_mov rspi vtmpi in
+  let i0 := ARMFopn.mov r rspi in
+  let load_imm := ARMFopn.smart_subi vtmpi rspi sf_sz in
+  let i1 := ARMFopn.align vtmpi vtmpi al in
+  let i2 := ARMFopn.mov rspi vtmpi in
   Some (i0 :: load_imm ++ [:: i1; i2 ]).
 
 Definition arm_set_up_sp_stack
   (rspi : var_i) (sf_sz : Z) (al : wsize) (off : Z) : option (seq fopn_args) :=
   let%opt _ := oassert ((0 <=? sf_sz)%Z && (sf_sz <? wbase reg_size)%Z) in
-  let load_imm := arm_cmd_large_subi vtmpi rspi sf_sz in
-  let i0 := arm_op_align vtmpi vtmpi al in
-  let i1 := arm_op_str_off rspi vtmpi off in
-  let i2 := arm_op_mov rspi vtmpi in
+  let load_imm := ARMFopn.smart_subi vtmpi rspi sf_sz in
+  let i0 := ARMFopn.align vtmpi vtmpi al in
+  let i1 := ARMFopn.str rspi vtmpi off in
+  let i2 := ARMFopn.mov rspi vtmpi in
   Some (load_imm ++ [:: i0; i1; i2 ]).
 
 Definition arm_tmp : Ident.ident := vname (v_var vtmpi).

--- a/proofs/compiler/arm_params_common_proof.v
+++ b/proofs/compiler/arm_params_common_proof.v
@@ -29,7 +29,9 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Section Section.
+Module ARMFopnP.
+
+Section WITH_PARAMS.
 
 Context
   {atoI  : arch_toIdent}
@@ -71,25 +73,25 @@ Ltac t_arm_op :=
   rewrite ?zero_extend_u;
   t_simpl_rewrites.
 
-Lemma arm_op_addi_eval_instr {lp ls ii y imm wy} :
+Lemma addi_eval_instr {lp ls ii y imm wy} :
   get_var true (lvm ls) (v_var y) = ok (Vword wy)
-  -> let: li := li_of_fopn_args ii (arm_op_addi x y imm) in
+  -> let: li := li_of_fopn_args ii (ARMFopn.addi x y imm) in
      let: wx' := Vword (wy + wrepr reg_size imm)in
      let: vm' := (lvm ls).[v_var x <- wx'] in
      eval_instr lp li ls = ok (next_vm_ls ls vm').
 Proof. move=> ?. by t_arm_op. Qed.
 
-Lemma arm_op_subi_eval_instr {lp ls ii y imm wy} :
+Lemma subi_eval_instr {lp ls ii y imm wy} :
   get_var true (lvm ls) (v_var y) = ok (Vword wy)
-  -> let: li := li_of_fopn_args ii (arm_op_subi x y imm) in
+  -> let: li := li_of_fopn_args ii (ARMFopn.subi x y imm) in
      let: wx' := Vword (wy - wrepr reg_size imm)in
      let: vm' := (lvm ls).[v_var x <- wx'] in
      eval_instr lp li ls = ok (next_vm_ls ls vm').
 Proof. move=> ?. t_arm_op. by rewrite wsub_wnot1. Qed.
 
-Lemma arm_op_align_eval_instr {lp ls ii y al} {wy : word Uptr} :
+Lemma align_eval_instr {lp ls ii y al} {wy : word Uptr} :
   get_var true (lvm ls) (v_var y) = ok (Vword wy)
-  -> let: li := li_of_fopn_args ii (arm_op_align x y al) in
+  -> let: li := li_of_fopn_args ii (ARMFopn.align x y al) in
      let: wx' := Vword (align_word al wy) in
      let: vm' := (lvm ls).[v_var x <- wx'] in
      eval_instr lp li ls = ok (next_vm_ls ls vm').
@@ -101,36 +103,36 @@ Proof.
   by rewrite wrepr_wnot ZlnotE Z.sub_1_r Z.add_1_r Z.succ_pred.
 Qed.
 
-Lemma arm_op_sub_eval_instr lp ls ii y (wy : word Uptr) z (wz : word Uptr) :
+Lemma sub_eval_instr lp ls ii y (wy : word Uptr) z (wz : word Uptr) :
   get_var true (lvm ls) (v_var y) = ok (Vword wy)
   -> get_var true (lvm ls) (v_var z) = ok (Vword wz)
-  -> let: li := li_of_fopn_args ii (arm_op_sub x y z) in
+  -> let: li := li_of_fopn_args ii (ARMFopn.sub x y z) in
      let: wx' := Vword (wy - wz)in
      let: vm' := (lvm ls).[v_var x <- wx'] in
      eval_instr lp li ls = ok (next_vm_ls ls vm').
 Proof. move=> ??. t_arm_op. by rewrite wsub_wnot1. Qed.
 
-Lemma arm_op_mov_eval_instr {lp ls ii y} {wy : word Uptr} :
+Lemma mov_eval_instr {lp ls ii y} {wy : word Uptr} :
   get_var true (lvm ls) (v_var y) = ok (Vword wy)
-  -> let: li := li_of_fopn_args ii (arm_op_mov x y) in
+  -> let: li := li_of_fopn_args ii (ARMFopn.mov x y) in
      let: vm' := (lvm ls).[v_var x <- Vword wy] in
      eval_instr lp li ls = ok (next_vm_ls ls vm').
 Proof. move=> hgety. by t_arm_op. Qed.
 
-Lemma arm_op_movi_eval_instr {lp ls ii imm} :
+Lemma movi_eval_instr {lp ls ii imm} :
   (is_expandable imm \/ is_w16_encoding imm) ->
-  let: li := li_of_fopn_args ii (arm_op_movi x imm) in
+  let: li := li_of_fopn_args ii (ARMFopn.movi x imm) in
   let: vm' := (lvm ls).[v_var x <- Vword (wrepr U32 imm)] in
   eval_instr lp li ls = ok (next_vm_ls ls vm').
 Proof. move=> _. by t_arm_op. Qed.
 
-Lemma arm_op_str_off_eval_instr {lp ls m' ii y off wx} {wy : word reg_size} :
+Lemma str_eval_instr {lp ls m' ii y off wx} {wy : word reg_size} :
   get_var true (lvm ls) (v_var x) = ok (Vword wx)
   -> get_var true (lvm ls) (v_var y) = ok (Vword wy)
   -> write (lmem ls) (wx + wrepr Uptr off)%R wy = ok m'
-  -> let: li := li_of_fopn_args ii (arm_op_str_off y x off) in
+  -> let: li := li_of_fopn_args ii (ARMFopn.str y x off) in
      eval_instr lp li ls = ok (next_mem_ls ls m').
-Proof. move=> hgety hgetx hwrite. by t_arm_op. Qed.
+Proof. move=> ???. by t_arm_op. Qed.
 
 End ARM_OP.
 
@@ -269,10 +271,10 @@ Proof.
   by apply: ltnSE.
 Qed.
 
-Lemma arm_cmd_load_large_imm_lsem lp fn ls ii P Q xname imm :
+Lemma li_lsem lp fn ls ii P Q xname imm :
   let: x := {| vname := xname; vtype := sword reg_size; |} in
   let: xi := mk_var_i x in
-  let: lcmd := map (li_of_fopn_args ii) (arm_cmd_load_large_imm xi imm) in
+  let: lcmd := map (li_of_fopn_args ii) (ARMFopn.li xi imm) in
   is_linear_of lp fn (P ++ lcmd ++ Q)
   -> lpc ls = size P
   -> lfn ls = fn
@@ -285,14 +287,14 @@ Lemma arm_cmd_load_large_imm_lsem lp fn ls ii P Q xname imm :
        ].
 Proof.
   set x := {| vname := _; |}.
-  rewrite /arm_cmd_load_large_imm /=.
+  rewrite /ARMFopn.li /=.
 
   case: orP => [himm | _].
   - move=> hbody hpc hfn _.
     eexists; split.
     + apply: (eval_lsem_step1 hbody) => //.
       rewrite addn1 -hpc.
-      exact: arm_op_movi_eval_instr.
+      exact: movi_eval_instr.
     + move=> v /Sv.singleton_spec ?. by t_vm_get.
     by t_get_var.
 
@@ -301,7 +303,7 @@ Proof.
   move=> hbody hpc hfn himm.
   eexists; split.
   - apply: lsem_step2.
-    + apply: (eval_lsem1 hbody _ _ (arm_op_movi_eval_instr _)) => //.
+    + apply: (eval_lsem1 hbody _ _ (movi_eval_instr _)) => //.
       right.
       apply/ZltP.
       have := Z_div_mod imm (wbase U16) erefl.
@@ -322,10 +324,10 @@ Proof.
   by t_get_var.
 Qed.
 
-Lemma arm_cmd_large_subi_lsem lp fn ls ii P Q xname y imm wy :
+Lemma smart_subi_lsem lp fn ls ii P Q xname y imm wy :
   let: x := {| vname := xname; vtype := sword Uptr; |} in
   let: xi := mk_var_i x in
-  let: lcmd := map (li_of_fopn_args ii) (arm_cmd_large_subi xi y imm) in
+  let: lcmd := map (li_of_fopn_args ii) (ARMFopn.smart_subi xi y imm) in
   is_linear_of lp fn (P ++ lcmd ++ Q)
   -> lpc ls = size P
   -> lfn ls = fn
@@ -342,7 +344,7 @@ Proof.
   set x := {| vname := _; |}.
   move=> hbody hpc hfn hxy hgety himm.
   move: hbody.
-  rewrite /arm_cmd_large_subi /arm_cmd_large_arith_imm /=.
+  rewrite /ARMFopn.smart_subi /=.
 
   case: ZeqbP => [? | _].
   - subst imm.
@@ -350,26 +352,24 @@ Proof.
     eexists; split.
     + apply: (eval_lsem_step1 hbody) => //.
       rewrite -hpc addn1.
-      exact: (arm_op_mov_eval_instr hgety).
+      exact: (mov_eval_instr hgety).
     + move=> v /Sv.singleton_spec ?. by t_vm_get.
     rewrite wrepr0 GRing.subr0 /=.
     by t_get_var.
 
-  case hexp: is_expandable.
+  case: ifP => _.
   - move=> hbody.
     eexists; split.
     + apply: (eval_lsem_step1 hbody) => //.
       rewrite -hpc addn1.
-      exact: (arm_op_subi_eval_instr hgety).
+      exact: (subi_eval_instr hgety).
     + move=> v /Sv.singleton_spec ?. by t_vm_get.
     by t_get_var.
 
-  clear hexp.
-  rewrite map_cat.
-  rewrite -(catA _ _ Q).
+  rewrite -cats1 map_cat -(catA _ _ Q).
   move=> hbody.
 
-  have [vm' [hsem hvm hgetx]] := arm_cmd_load_large_imm_lsem hbody hpc hfn himm.
+  have [vm' [hsem hvm hgetx]] := li_lsem hbody hpc hfn himm.
   eexists; split.
   - apply: (lsem_step_end hsem).
     rewrite catA in hbody.
@@ -396,6 +396,21 @@ Proof.
   by t_get_var.
 Qed.
 
+End WITH_PARAMS.
+
+End ARMFopnP.
+
+Section WITH_PARAMS.
+
+Context
+  {atoI  : arch_toIdent}
+  {syscall_state : Type}
+  {sc_sem : syscall_sem syscall_state}
+  {call_conv : calling_convention}
+.
+
+#[local] Existing Instance withsubword.
+
 Lemma store_mn_of_wsizeP ws ws' mn (w : word ws) (w' : word ws') :
   store_mn_of_wsize ws = Some mn
   -> truncate_word ws w' = ok w
@@ -408,4 +423,4 @@ Proof.
   all: by rewrite zero_extend_u.
 Qed.
 
-End Section.
+End WITH_PARAMS.

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -118,7 +118,7 @@ Lemma arm_spec_lip_allocate_stack_frame :
   allocate_stack_frame_correct arm_liparams.
 Proof.
   move=> *.
-  apply: arm_op_subi_eval_instr.
+  apply: ARMFopnP.subi_eval_instr.
   rewrite /get_var.
   by t_simpl_rewrites.
 Qed.
@@ -127,7 +127,7 @@ Lemma arm_spec_lip_free_stack_frame :
   free_stack_frame_correct arm_liparams.
 Proof.
   move=> *.
-  apply: arm_op_addi_eval_instr.
+  apply: ARMFopnP.addi_eval_instr.
   rewrite /get_var.
   by t_simpl_rewrites.
 Qed.
@@ -157,10 +157,10 @@ Proof.
   rewrite /set_up_sp_register /= /arm_set_up_sp_register hset_up /= -/vtmpi.
   rewrite map_cat.
   rewrite -catA /=.
-  set cmd_large_subi := _ _ (arm_cmd_large_subi _ _ _).
-  set i_mov_r := _ _ (arm_op_mov _ _).
-  set i_align_tmp := _ _ (arm_op_align _ _ _).
-  set i_mov_rsp := _ _ (arm_op_mov _ _).
+  set cmd_large_subi := _ _ (ARMFopn.smart_subi _ _ _).
+  set i_mov_r := _ _ (ARMFopn.mov _ _).
+  set i_align_tmp := _ _ (ARMFopn.align _ _ _).
+  set i_mov_rsp := _ _ (ARMFopn.mov _ _).
   rewrite -[i_mov_r :: _]/([:: i_mov_r ] ++ _).
   rewrite catA.
   move=> hbody.
@@ -178,7 +178,7 @@ Proof.
 
   set ls0 := lnext_pc (lset_vm ls vm0).
   have [|vm1 [hsem hvm1 hgettmp1]] :=
-    arm_cmd_large_subi_lsem (ls := ls0) hbody _ erefl hneq_tmp_rsp hgetrsp0 hsz.
+    ARMFopnP.smart_subi_lsem (ls := ls0) hbody _ erefl hneq_tmp_rsp hgetrsp0 hsz.
   - by rewrite size_cat addn1 -hpc.
 
   set vm2 := vm1.[vtmp <- Vword ts'].
@@ -191,7 +191,7 @@ Proof.
     (* R[r] := R[rsp]; *)
     + rewrite -catA in hbody.
       apply: (eval_lsem1 hbody) => //.
-      exact: (arm_op_mov_eval_instr (y := vrspi) hgetrsp).
+      exact: (ARMFopnP.mov_eval_instr (y := vrspi) hgetrsp).
 
     (* R[tmp] := R[rsp] - off; *)
     apply: (lsem_trans hsem).
@@ -203,7 +203,7 @@ Proof.
       apply: (eval_lsem1 hbody) => //;
         first by rewrite !size_cat.
       set ls1 := setpc (lset_vm _ _) _.
-      exact: (arm_op_align_eval_instr (ls := ls1) (y := vtmpi) hgettmp1).
+      exact: (ARMFopnP.align_eval_instr (ls := ls1) (y := vtmpi) hgettmp1).
 
     (* R[rsp] := R[tmp]; *)
     + rewrite -(cat1s i_align_tmp) 2!catA in hbody.
@@ -215,7 +215,7 @@ Proof.
       * by rewrite get_var_eq.
 
       set ls2 := lnext_pc (lset_vm _ _).
-      rewrite (arm_op_mov_eval_instr (ls := ls2) (y := vtmpi) hgettmp2).
+      rewrite (ARMFopnP.mov_eval_instr (ls := ls2) (y := vtmpi) hgettmp2).
       rewrite /lnext_pc /setpc /= !size_cat /= !size_map /addn /addn_rec.
       repeat f_equal.
       lia.
@@ -266,10 +266,10 @@ Proof.
   set vrspi := mk_var_i vrsp.
   rewrite /set_up_sp_stack /= /arm_set_up_sp_stack hset_up /= -/vtmpi.
   rewrite map_cat /=.
-  set cmd_large_subi := map _ (arm_cmd_large_subi _ _ _).
-  set i_align_tmp := li_of_fopn_args _ (arm_op_align _ _ _).
-  set i_str_rsp := li_of_fopn_args _ (arm_op_str_off _ _ _).
-  set i_mov_rsp := li_of_fopn_args _ (arm_op_mov _ _).
+  set cmd_large_subi := map _ (ARMFopn.smart_subi _ _ _).
+  set i_align_tmp := li_of_fopn_args _ (ARMFopn.align _ _ _).
+  set i_str_rsp := li_of_fopn_args _ (ARMFopn.str _ _ _).
+  set i_mov_rsp := li_of_fopn_args _ (ARMFopn.mov _ _).
   rewrite -catA.
   move=> hbody.
 
@@ -279,7 +279,7 @@ Proof.
 
   (* We need [vm0] before [eexists]. *)
   have [vm0 [hsem hvm0 hgettmp0]] :=
-    arm_cmd_large_subi_lsem hbody hpc erefl hneq_tmp_rsp hgetrsp hsz.
+    ARMFopnP.smart_subi_lsem hbody hpc erefl hneq_tmp_rsp hgetrsp hsz.
   set vm1 := vm0.[vtmp <- Vword ts'].
   set vm2 := vm1.[vrsp <- Vword ts'].
 
@@ -304,7 +304,7 @@ Proof.
       apply: (eval_lsem1 hbody) => //;
         first by rewrite size_cat.
       set ls0 := setpc (lset_vm _ _) _.
-      exact: (arm_op_align_eval_instr (ls := ls0) (y := vtmpi) hgettmp0).
+      exact: (ARMFopnP.align_eval_instr (ls := ls0) (y := vtmpi) hgettmp0).
 
     (* M[R[rsp]] := R[tmp]; *)
     + rewrite -(cat1s i_align_tmp) -!catA 2!catA in hbody.
@@ -312,7 +312,7 @@ Proof.
         first by rewrite !size_cat /= addn1.
       set ls1 := lnext_pc (lset_vm _ _).
       apply:
-        (arm_op_str_off_eval_instr (ls := ls1) (y := vrspi) hgettmp1 hgetrsp1).
+        (ARMFopnP.str_eval_instr (ls := ls1) (y := vrspi) hgettmp1 hgetrsp1).
       exact: hwrite.
 
     (* R[rsp] := R[tmp]; *)
@@ -320,7 +320,7 @@ Proof.
       apply: (eval_lsem1 hbody) => //;
         first by rewrite !size_cat /= !addn1.
       set ls2 := lnext_pc (lset_mem _ _).
-      rewrite (arm_op_mov_eval_instr (ls := ls2) (y := vtmpi) hgettmp1).
+      rewrite (ARMFopnP.mov_eval_instr (ls := ls2) (y := vtmpi) hgettmp1).
       rewrite /ls2 !size_cat /= !addnS addn0.
       reflexivity.
 

--- a/proofs/compiler/arm_stack_zeroization.v
+++ b/proofs/compiler/arm_stack_zeroization.v
@@ -58,12 +58,12 @@ Notation rconst := (fun ws imm => Rexpr (fconst ws imm)) (only parsing).
 *)
 Definition sz_init : lcmd :=
   let args :=
-    arm_op_mov vsaved_sp vrsp
-    :: arm_cmd_load_large_imm voff stk_max
-    ++ arm_op_align vzero vsaved_sp alignment
-    :: arm_op_mov vrsp vzero
-    :: arm_op_sub vrsp vrsp voff
-    :: [:: arm_op_movi vzero 0 ]
+    ARMFopn.mov vsaved_sp vrsp
+    :: ARMFopn.li voff stk_max
+    ++ ARMFopn.align vzero vsaved_sp alignment
+    :: ARMFopn.mov vrsp vzero
+    :: ARMFopn.sub vrsp vrsp voff
+    :: [:: ARMFopn.movi vzero 0 ]
   in
   map (li_of_fopn_args dummy_instr_info) args.
 
@@ -100,7 +100,7 @@ Definition sz_loop : lcmd :=
   map (MkLI dummy_instr_info) irs.
 
 Definition restore_sp :=
-  [:: li_of_fopn_args dummy_instr_info (arm_op_mov vrsp vsaved_sp) ].
+  [:: li_of_fopn_args dummy_instr_info (ARMFopn.mov vrsp vsaved_sp) ].
 
 Definition stack_zero_loop : lcmd := sz_init ++ sz_loop ++ restore_sp.
 

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -915,3 +915,23 @@ Definition instr_of_copn_args
   (args : copn_args)
   : instr_r :=
   Copn args.1.1 tg args.1.2 args.2.
+
+
+(* ------------------------------------------------------------------- *)
+
+Module Type OpnArgs.
+  Parameter lval rval : Type.
+  Parameter lvar : var_i -> lval.
+  Parameter lmem : forall {_ : PointerData}, wsize -> var_i -> Z -> lval.
+  Parameter rvar : var_i -> rval.
+  Parameter rconst : wsize -> Z -> rval.
+End OpnArgs.
+
+Module CopnArgs.
+  Definition lval := lval.
+  Definition rval := pexpr.
+  Definition lvar := Lvar.
+  Definition lmem {_ : PointerData} ws x z := Lmem ws x (cast_const z).
+  Definition rvar x := Pvar (mk_lvar x).
+  Definition rconst ws z := cast_w ws (Pconst z).
+End CopnArgs.

--- a/proofs/lang/fexpr.v
+++ b/proofs/lang/fexpr.v
@@ -80,3 +80,15 @@ Definition free_vars_r (r:rexpr) : Sv.t :=
   | Load _ x e => free_vars_rec (Sv.singleton x) e
   | Rexpr e    => free_vars e
   end.
+
+Definition rvar (x : var_i) : rexpr := Rexpr (Fvar x).
+Definition rconst (ws : wsize) (z : Z) : rexpr := Rexpr (fconst ws z).
+
+Module FopnArgs.
+  Definition lval := lexpr.
+  Definition rval := rexpr.
+  Definition lvar := LLvar.
+  Definition lmem {_ : PointerData} ws x z := Store ws x (fconst Uptr z).
+  Definition rvar := rvar.
+  Definition rconst := rconst.
+End FopnArgs.


### PR DESCRIPTION
I parameterized the common operations defined in arm params so that we can use them for `Copn` and `Lopn`. I don't think we can easily abstract the proofs, but if you let me know how I would like to.