### PR TITLE
Less algebra

### DIFF
--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -104,6 +104,7 @@ compiler/x86_params_proof.v
 compiler/x86_stack_zeroization.v
 compiler/x86_stack_zeroization_proof.v
 compiler/x86.v
+lang/algebra.v
 lang/array.v
 lang/expr.v
 lang/expr_facts.v

--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -1,5 +1,6 @@
 (* -------------------------------------------------------------------- *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 From Coq Require Import
   Relation_Operators

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -1,5 +1,6 @@
 (* -------------------------------------------------------------------- *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import xseq strings utils var type values sopn expr fexpr arch_decl.
 Require Import compiler_util.
 

--- a/proofs/arch/arch_sem.v
+++ b/proofs/arch/arch_sem.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require oseq.
 Require Import ZArith
@@ -189,7 +190,8 @@ Definition eval_Jcc lbl ct (s : asm_state) : asm_result_state :=
     ok (st_write_ip s.(asm_ip).+1 s).
 
 (* -------------------------------------------------------------------- *)
-Definition word_of_scale (n:nat) : pointer := wrepr Uptr (2%Z^n)%R.
+(* FIXME: is this correct? *)
+Definition word_of_scale (n:nat) : pointer := wrepr Uptr (2 ^ Z.of_nat n)%Z.
 
 (* -------------------------------------------------------------------- *)
 Definition decode_reg_addr (s : asmmem) (a : reg_address) : pointer := nosimpl (

--- a/proofs/arch/arch_utils.v
+++ b/proofs/arch/arch_utils.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import
   type

--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import
   oseq
   compiler_util

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From Coq Require Import Relation_Operators.
 Require Import
   oseq

--- a/proofs/arch/label.v
+++ b/proofs/arch/label.v
@@ -1,5 +1,6 @@
 (* -------------------------------------------------------------------- *)
-From mathcomp Require Import all_ssreflect all_algebra. 
+From mathcomp Require Import all_ssreflect .
+Require Import algebra. 
 Require Import global Utf8.
 
 Set   Implicit Arguments.

--- a/proofs/arch/sem_params_of_arch_extra.v
+++ b/proofs/arch/sem_params_of_arch_extra.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import
   sem_params

--- a/proofs/arch/spp_arch_extra.v
+++ b/proofs/arch/spp_arch_extra.v
@@ -1,5 +1,6 @@
 (* -------------------------------------------------------------------- *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import syscall sem_pexpr_params arch_decl arch_extra.
 
 Set   Implicit Arguments.

--- a/proofs/compiler/allocation.v
+++ b/proofs/compiler/allocation.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import expr compiler_util ZArith.
 Import Utf8.

--- a/proofs/compiler/allocation_proof.v
+++ b/proofs/compiler/allocation_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import psem compiler_util.
 Require Export allocation.
 

--- a/proofs/compiler/arch_params.v
+++ b/proofs/compiler/arch_params.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import
   compiler_util
   expr.

--- a/proofs/compiler/arch_params_proof.v
+++ b/proofs/compiler/arch_params_proof.v
@@ -1,5 +1,6 @@
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import
   compiler_util
   expr

--- a/proofs/compiler/arm.v
+++ b/proofs/compiler/arm.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import utils.
 Require Import arch_decl.

--- a/proofs/compiler/arm_decl.v
+++ b/proofs/compiler/arm_decl.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 
 Require Import
@@ -351,8 +352,8 @@ Definition z_to_bytes (n : Z) : Z * Z * Z * Z :=
 Definition is_ei_pattern (n : Z) : bool :=
   let '(b3, b2, b1, b0) := z_to_bytes n in
   [|| [&& b3 == b0, b2 == b0 & b1 == b0 ]
-    , [&& b3 == 0, b2 == b0 & b1 == 0 ]
-    | [&& b3 == b1, b2 == 0 & b0 == 0 ]
+    , [&& b3 == 0%Z, b2 == b0 & b1 == 0%Z ]
+    | [&& b3 == b1, b2 == 0%Z & b0 == 0%Z ]
   ].
 
 (* An immediate of the shift kind has the shape [0...01xxxxxxx0...0] where the
@@ -363,7 +364,7 @@ Definition is_ei_shift (n : Z) : bool :=
   (* Find where the first set bit and move 7 bits further. *)
   let byte_end := (Z.log2 n - 7)%Z in
   (* Check if any bit after the byte is one. *)
-  Z.rem n (Z.pow 2 byte_end) == 0.
+  Z.rem n (Z.pow 2 byte_end) == 0%Z.
 
 Definition ei_kind (n : Z) : expand_immediate_kind :=
   if [&& 0 <=? n & n <? 256 ]%Z then EI_byte

--- a/proofs/compiler/arm_extra.v
+++ b/proofs/compiler/arm_extra.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import
   compiler_util

--- a/proofs/compiler/arm_facts.v
+++ b/proofs/compiler/arm_facts.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 From Coq Require Import ZArith.
 
 Require Import

--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -5,7 +5,8 @@
 
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 
 Require Import

--- a/proofs/compiler/arm_instr_decl_lemmas.v
+++ b/proofs/compiler/arm_instr_decl_lemmas.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 
 Require Import

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 
 Require Import

--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 Import
   Order.POrderTheory
   Order.TotalTheory.

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 From mathcomp Require Import word_ssrZ.
 

--- a/proofs/compiler/arm_params_common.v
+++ b/proofs/compiler/arm_params_common.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 From mathcomp Require Import word_ssrZ.
 

--- a/proofs/compiler/arm_params_common_proof.v
+++ b/proofs/compiler/arm_params_common_proof.v
@@ -1,7 +1,8 @@
 From Coq Require Import Lia.
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 From mathcomp Require Import word_ssrZ.
 
@@ -250,7 +251,7 @@ Lemma wbit_n_add ws n lbs hbs (i : nat) :
   -> (0 <= lbs < n2)%Z
   -> (0 <= hbs < n2)%Z
   -> let b :=
-       if (i <? n)%Z
+       if (Z.of_nat i <? n)%Z
        then wbit_n (wrepr ws lbs) i
        else wbit_n (wrepr ws hbs) (i - Z.to_nat n)
      in
@@ -258,7 +259,7 @@ Lemma wbit_n_add ws n lbs hbs (i : nat) :
 Proof.
   move=> hn hlbs hhbs.
 
-  have h0i : (0 <= i)%Z.
+  have h0i : (0 <= Z.of_nat i)%Z.
   - exact: Zle_0_nat.
 
   have h0n : (0 <= n)%Z.
@@ -276,7 +277,7 @@ Proof.
   all: rewrite wbit_nE.
   all: rewrite (wunsigned_repr_small hrange).
 
-  - rewrite -(Zplus_minus i n).
+  - rewrite -(Zplus_minus (Z.of_nat i) n).
     rewrite Z.pow_add_r; last lia; last done.
     rewrite Z.add_comm -Z.mul_assoc Z.mul_comm.
     rewrite Z_div_plus; first last.
@@ -290,7 +291,7 @@ Proof.
     rewrite wunsigned_repr_small; first done.
     lia.
 
-  rewrite -(Zplus_minus n i).
+  rewrite -(Zplus_minus n (Z.of_nat i)).
   rewrite (Z.pow_add_r _ _ _ h0n); last lia.
   rewrite -Z.div_div; last lia; last lia.
   rewrite Z.add_comm Z.mul_comm.
@@ -305,7 +306,6 @@ Proof.
     apply: (Z.lt_le_trans _ (2 ^ n)); first lia.
     apply: Z.pow_le_mono_r; lia.
 
-  rewrite int_of_Z_PoszE.
   rewrite Nat2Z.n2zB; first by rewrite Z2Nat.id.
   apply/ZNleP.
   rewrite (Z2Nat.id _ h0n).

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -1,6 +1,7 @@
 From Coq Require Import Relations.
 From Coq Require Import Psatz.
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 
 Require Import oseq.

--- a/proofs/compiler/arm_stack_zeroization.v
+++ b/proofs/compiler/arm_stack_zeroization.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 
 Require Import
   expr

--- a/proofs/compiler/arm_stack_zeroization_proof.v
+++ b/proofs/compiler/arm_stack_zeroization_proof.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import Lia.
 

--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import array_copy psem.
 Require Import compiler_util ZArith.

--- a/proofs/compiler/array_expansion.v
+++ b/proofs/compiler/array_expansion.v
@@ -1,6 +1,7 @@
 (* ** Imports and settings *)
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import expr.
 Require Import compiler_util ZArith.

--- a/proofs/compiler/array_expansion_proof.v
+++ b/proofs/compiler/array_expansion_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import psem array_expansion compiler_util ZArith.
 Import Utf8.
@@ -788,9 +789,9 @@ Proof.
   case heq : WArray.get => [w | /=]; last first.
   + by rewrite /undef_v (undef_x_vundef (_ _)).
   have []:= WArray.get_bound heq; rewrite /mk_scale => ???.
-  have h : ((0 <= 0%N)%Z ∧ (0%N < wsize_size (ai_ty ai)))%Z.
+  have h : ((0 <= 0 < wsize_size (ai_ty ai)))%Z.
   + by move=> /=; have := wsize_size_pos (ai_ty ai); Psatz.lia.
-  have [_ /(_ 0 h)] := read_read8 heq.
+  have [_ /(_ 0%Z h)] := read_read8 heq.
   by rewrite WArray.get0 //= WArray.addE; have := wsize_size_pos (ai_ty ai); Psatz.lia.
 Qed.
 

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import psem compiler_util.
 Require Export array_init.
 Import Utf8.

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import ZArith.
 Require Import Utf8.
 

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 
 Require Import
   arch_params_proof

--- a/proofs/compiler/compiler_util.v
+++ b/proofs/compiler/compiler_util.v
@@ -1,5 +1,6 @@
 Require Import ZArith Setoid Morphisms.
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import expr fexpr.
 
 Set Implicit Arguments.

--- a/proofs/compiler/constant_prop.v
+++ b/proofs/compiler/constant_prop.v
@@ -1,7 +1,8 @@
 (* ** Imports and settings *)
 From mathcomp Require Import word_ssrZ.
 Require Import expr ZArith sem_op_typed compiler_util.
-Import all_ssreflect all_algebra.
+Import all_ssreflect .
+Require Import algebra.
 Import Utf8.
 Import oseq.
 Require Import flag_combination.

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import psem compiler_util.
 Require Export constant_prop.
 

--- a/proofs/compiler/dead_code_proof.v
+++ b/proofs/compiler/dead_code_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import psem compiler_util.
 Require Export dead_code.
 Import Utf8.

--- a/proofs/compiler/direct_call_proof.v
+++ b/proofs/compiler/direct_call_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import varmap psem.
 
 Import Utf8.

--- a/proofs/compiler/inline_proof.v
+++ b/proofs/compiler/inline_proof.v
@@ -1,6 +1,7 @@
 (* ** Imports and settings *)
 Require Import ZArith.
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import psem allocation_proof compiler_util.
 Require Export inline.
 

--- a/proofs/compiler/lea.v
+++ b/proofs/compiler/lea.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import Utf8.
 Require Import expr.

--- a/proofs/compiler/lea_proof.v
+++ b/proofs/compiler/lea_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import oseq.
 Require Import psem compiler_util.
 Require Import fexpr fexpr_sem fexpr_facts.

--- a/proofs/compiler/linear_util.v
+++ b/proofs/compiler/linear_util.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import expr label linear.
 Require Import seq_extra compiler_util.
 

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -2,7 +2,8 @@
 
 (* ** Imports and settings *)
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import ZArith.
 Require Import Utf8.
 Import Relations.
@@ -493,8 +494,8 @@ Definition check_fd (fn: funname) (fd:sfundef) :=
     | SavedStackNone =>
         [&& sf_to_save e == [::]
           , sf_align e == U8
-          , sf_stk_sz e == 0
-          & sf_stk_extra_sz e == 0
+          , sf_stk_sz e == 0%Z
+          & sf_stk_extra_sz e == 0%Z
         ]
 
     | SavedStackReg x =>

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -2,7 +2,8 @@
 From Coq
 Require Import Setoid Morphisms Lia.
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import ZArith Utf8.
         Import Relations.
 

--- a/proofs/compiler/lowering.v
+++ b/proofs/compiler/lowering.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import compiler_util expr.
 

--- a/proofs/compiler/makeReferenceArguments_proof.v
+++ b/proofs/compiler/makeReferenceArguments_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import psem compiler_util.
 Require Export makeReferenceArguments.
 Import Utf8.

--- a/proofs/compiler/merge_varmaps_proof.v
+++ b/proofs/compiler/merge_varmaps_proof.v
@@ -3,7 +3,8 @@
 Require Import sem_one_varmap sem_one_varmap_facts merge_varmaps psem_facts.
 Require Import seq_extra.
 Import Utf8.
-Import all_ssreflect all_algebra.
+Import all_ssreflect .
+Require Import algebra.
 Import word_ssrZ.
 Import psem.
 Import merge_varmaps.

--- a/proofs/compiler/propagate_inline_proof.v
+++ b/proofs/compiler/propagate_inline_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import psem psem_facts constant_prop constant_prop_proof.
 Require Export propagate_inline.
 

--- a/proofs/compiler/remove_globals.v
+++ b/proofs/compiler/remove_globals.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import xseq.
 Require Import expr compiler_util ZArith.

--- a/proofs/compiler/remove_globals_proof.v
+++ b/proofs/compiler/remove_globals_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import xseq.
 Require Import compiler_util ZArith expr psem remove_globals low_memory.

--- a/proofs/compiler/slh_lowering.v
+++ b/proofs/compiler/slh_lowering.v
@@ -18,7 +18,8 @@
 
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import expr.
 Require constant_prop flag_combination.

--- a/proofs/compiler/slh_lowering_proof.v
+++ b/proofs/compiler/slh_lowering_proof.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import
   expr

--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import strings word utils type var expr.
 Require Import compiler_util byteset.

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import psem psem_facts compiler_util low_memory.
 Require Export stack_alloc.

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -3,7 +3,8 @@
 *)
 
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import psem psem_facts compiler_util.
 Require Export stack_alloc stack_alloc_proof.
@@ -2235,7 +2236,9 @@ Proof.
   rewrite /wbit_n.
   case: ltP.
   + move=> /ltP hlt.
-    by rewrite word.subwordE word.wbit_t2wE (nth_map 0%R) ?size_enum_ord // nth_enum_ord.
+    (* FIXME: ord0 to avoid depending on Zmodp, but 0%R is clearly better *)
+    (* this lemma should not be here anyway *)
+    by rewrite word.subwordE word.wbit_t2wE (nth_map ord0) ?size_enum_ord // nth_enum_ord.
   rewrite /nat_of_wsize => hle.
   rewrite word.wbit_word_ovf //.
   by apply /ltP; lia.

--- a/proofs/compiler/stack_zeroization.v
+++ b/proofs/compiler/stack_zeroization.v
@@ -14,7 +14,8 @@ writes. *)
 
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import ZArith.
 

--- a/proofs/compiler/stack_zeroization_proof.v
+++ b/proofs/compiler/stack_zeroization_proof.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import ZArith.
 

--- a/proofs/compiler/tunneling_proof.v
+++ b/proofs/compiler/tunneling_proof.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import ZArith.
 Require Import Utf8.
 

--- a/proofs/compiler/x86.v
+++ b/proofs/compiler/x86.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import sem_type arch_decl x86_decl x86_instr_decl.
 
 Set   Implicit Arguments.

--- a/proofs/compiler/x86_decl.v
+++ b/proofs/compiler/x86_decl.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require oseq.
 Require Import ZArith

--- a/proofs/compiler/x86_extra.v
+++ b/proofs/compiler/x86_extra.v
@@ -1,5 +1,6 @@
 (* -------------------------------------------------------------------- *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import Utf8.
 Require Import compiler_util.

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import utils strings word waes sem_type global oseq sopn.
 Import Utf8 Relation_Operators ZArith.
@@ -712,7 +713,7 @@ Definition x86_MOVD sz (v: word sz) : ex_tpl (w_ty U128) :=
 (* How many elements of size ve in a vector of size ws *)
 Definition vector_size (ve: velem) (ws: wsize) : option Z :=
   let: (q, r) := Z.div_eucl (wsize_size ws) (wsize_size ve) in
-  if r == 0 then Some q else None.
+  if r == 0%Z then Some q else None.
 
 Definition same_vector_length ve sz ve' sz' :=
   match vector_size ve sz, vector_size ve' sz' with
@@ -776,7 +777,7 @@ Definition x86_VPMULHRS sz v1 v2 :=
 
 (* ---------------------------------------------------------------- *)
 Definition x86_nelem_mask (sze szc:wsize) : u8 :=
-  wrepr U8 (2 ^ (wsize_log2 szc - wsize_log2 sze) - 1).
+  wrepr U8 (2 ^ Z.of_nat (wsize_log2 szc - wsize_log2 sze) - 1).
 
 Definition x86_VPEXTR (ve: wsize) (v: u128) (i: u8) : ex_tpl (w_ty ve) :=
   Let _ := check_size_8_64 ve in
@@ -917,9 +918,11 @@ Definition x86_VMOVSLDUP sz (v: word sz) : ex_tpl (w_ty sz) :=
   Let _ := check_size_128_256 sz in
   ok (wdup_lo VE32 v).
 
+(* FIXME: check coercions. Should nat_of_wsize be a coercion ? *)
+(* wsize_of_velem just local ? *)
 (* ---------------------------------------------------------------- *)
 Definition x86_VEXTRACTI128 (v: u256) (i: u8) : ex_tpl (w_ty U128) :=
-  let r := if lsb i then wshr v U128 else v in
+  let r := if lsb i then wshr v 128 else v in
   ok (zero_extend U128 r).
 
 Definition x86_VINSERTI128 (v1: u256) (v2: u128) (m: u8) : ex_tpl (w_ty U256) :=

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import Utf8.
 Require Import

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -2,7 +2,8 @@
 (* * Correctness proof of the lowering pass *)
 
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import ZArith psem compiler_util lea_proof x86_instr_decl x86_extra.
 Require Import

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 
 Require Import
@@ -95,7 +96,7 @@ Definition x86_set_up_sp_register
   (rspi : var_i) (sf_sz : Z) (al : wsize) (r : var_i) : seq fopn_args :=
   let i0 := x86_lassign (LLvar r) Uptr (Rexpr (Fvar rspi)) in
   let i2 := x86_op_align rspi Uptr al in
-  i0 :: rcons (if sf_sz != 0 then x86_allocate_stack_frame rspi None sf_sz else [::]) i2.
+  i0 :: rcons (if sf_sz != 0%Z then x86_allocate_stack_frame rspi None sf_sz else [::]) i2.
 
 Definition x86_set_up_sp_stack
   (rspi : var_i) (sf_sz : Z) (al : wsize) (off : Z) : seq fopn_args :=

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 
 Require Import
@@ -212,8 +213,8 @@ Proof.
 
   set vm0 := (lvm ls).[v_var r <- Vword ts].
   set ls0 := lnext_pc (lset_vm ls vm0).
-  set vm2 := if sz != 0 then vm0.[vrsp <- Vword (ts - wrepr Uptr sz)] else vm0.
-  set ls2 := setpc (lset_vm ls0 vm2) (size P + Nat.b2n (sz != 0)).+1.
+  set vm2 := if sz != 0%Z then vm0.[vrsp <- Vword (ts - wrepr Uptr sz)] else vm0.
+  set ls2 := setpc (lset_vm ls0 vm2) (size P + Nat.b2n (sz != 0%Z)).+1.
   set vm3 := vm_op_align vm2 vrsp ts'.
 
   exists vm3; split.
@@ -231,7 +232,7 @@ Proof.
 
     (* R[rsp] := R[rsp] - sz; *)
     + subst ls2; rewrite /vm2.
-      case: (sz =P 0) hbody => [? | /eqP hneq] /= hbody.
+      case: (sz =P 0%Z) hbody => [? | /eqP hneq] /= hbody.
       * subst sz. rewrite addn0 -hpc. by constructor.
       rewrite -cat1s catA in hbody.
       apply: (eval_lsem_step1 hbody) => //;
@@ -245,9 +246,9 @@ Proof.
     (* R[rsp] := R[rsp] & alignment; *)
     rewrite map_rcons -cat1s catA cat_rcons catA in hbody.
     apply: (eval_lsem_step1 hbody) => //.
-    + rewrite !size_cat /=. case: (sz != 0); by rewrite ?addn0 ?addn1.
+    + rewrite !size_cat /=. case: (sz != 0%Z); by rewrite ?addn0 ?addn1.
     rewrite (x86_op_align_eval_instr (w := ts - wrepr Uptr sz) (cmp_le_refl _)).
-    + rewrite /ls2. case: (sz != 0); by rewrite ?addn0 ?addn1 ?addn2 ?addn3.
+    + rewrite /ls2. case: (sz != 0%Z); by rewrite ?addn0 ?addn1 ?addn2 ?addn3.
     rewrite /get_var /= /vm2; case: eqP => ?; last first.
     + by rewrite Vm.setP_eq vm_truncate_val_eq.
     rewrite Vm.setP_neq; last exact/eqP.

--- a/proofs/compiler/x86_stack_zeroization.v
+++ b/proofs/compiler/x86_stack_zeroization.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 
 Require Import
   expr

--- a/proofs/compiler/x86_stack_zeroization_proof.v
+++ b/proofs/compiler/x86_stack_zeroization_proof.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import Lia.
 

--- a/proofs/lang/algebra.v
+++ b/proofs/lang/algebra.v
@@ -1,0 +1,2 @@
+From mathcomp Require Export ssralg ssrnum.
+(* do we need ring except a few files? *)

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import oseq.
 Require Export ZArith Setoid Morphisms.
 From mathcomp Require Import word_ssrZ.

--- a/proofs/lang/expr_facts.v
+++ b/proofs/lang/expr_facts.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import Utf8.
 Require Export expr.
 

--- a/proofs/lang/fexpr_sem.v
+++ b/proofs/lang/fexpr_sem.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import fexpr.
 Require Import psem.
 

--- a/proofs/lang/flag_combination.v
+++ b/proofs/lang/flag_combination.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import expr.
 

--- a/proofs/lang/gen_map.v
+++ b/proofs/lang/gen_map.v
@@ -1,6 +1,7 @@
 (* ** Imports and settings *)
 Require Import FMaps FMapAVL FSetAVL.
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import utils.
 
 Set Implicit Arguments.

--- a/proofs/lang/global.v
+++ b/proofs/lang/global.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import xseq.
 Require Export xseq ZArith strings word utils var type warray_.

--- a/proofs/lang/ident.v
+++ b/proofs/lang/ident.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import Sint63 strings utils gen_map tagged wsize.
 Require Import Utf8.
 

--- a/proofs/lang/linear.v
+++ b/proofs/lang/linear.v
@@ -1,6 +1,7 @@
 (* * Syntax of the linear language *)
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import expr fexpr label sopn.
 
 Set Implicit Arguments.

--- a/proofs/lang/linear_facts.v
+++ b/proofs/lang/linear_facts.v
@@ -1,7 +1,8 @@
 From Coq Require Import Relations.
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import
   fexpr_facts

--- a/proofs/lang/linear_sem.v
+++ b/proofs/lang/linear_sem.v
@@ -2,7 +2,8 @@
 
 (* ** Imports and settings *)
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import ZArith Utf8.
         Import Relations.
 Require oseq.

--- a/proofs/lang/low_memory.v
+++ b/proofs/lang/low_memory.v
@@ -3,7 +3,8 @@
 From Coq Require Import RelationClasses.
 Require memory_example.
 
-Import all_ssreflect all_algebra.
+Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import Lia.
 Import Utf8 ZArith.

--- a/proofs/lang/lowering_lemmas.v
+++ b/proofs/lang/lowering_lemmas.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import
   expr

--- a/proofs/lang/memory_example.v
+++ b/proofs/lang/memory_example.v
@@ -24,7 +24,8 @@ We additionally maintain two invariants:
 Require memory_model array type.
 
 Import Utf8.
-Import all_ssreflect all_algebra.
+Import all_ssreflect .
+Require Import algebra.
 Import ZArith.
 Import word_ssrZ.
 Import type word utils gen_map.

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -1,6 +1,7 @@
 (* ** Imports and settings *)
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import strings word utils.
 Import Utf8 ZArith.
@@ -219,7 +220,7 @@ Section CoreMem.
     elim: iota m => /=; first by move=> ?; constructor; eauto.
     move=> k l hrec m.
     apply (iffP andP).
-    + move=> [] /valid8P -/(_ (LE.wread8 v k)) [m'] hset hall.
+    + move=> [] /valid8P -/(_ (LE.wread8 v (Z.of_nat k))) [m'] hset hall.
       by rewrite hset;apply/hrec; apply: sub_all hall => i; rewrite (valid8_set _ hset).
     move=> [m'];t_xrbindP => m'' hset hf; split.
     + by apply/valid8P; eexists; eauto.

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -1,7 +1,8 @@
 (* * Jasmin semantics with “partial values”. *)
 
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import Psatz xseq.
 Require Export array type expr gen_map warray_ sem_type sem_op_typed values varmap expr_facts low_memory syscall_sem psem_defs.
 Require Export

--- a/proofs/lang/psem_defs.v
+++ b/proofs/lang/psem_defs.v
@@ -1,7 +1,8 @@
 (* * Jasmin semantics with “partial values”. *)
 
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import Psatz xseq.
 Require Export array type expr gen_map low_memory warray_ sem_type sem_op_typed values varmap low_memory syscall_sem.
 Require Export

--- a/proofs/lang/psem_facts.v
+++ b/proofs/lang/psem_facts.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import psem.
 Import Utf8.
 Import Memory low_memory.

--- a/proofs/lang/psem_of_sem_proof.v
+++ b/proofs/lang/psem_of_sem_proof.v
@@ -1,6 +1,7 @@
 Require Import psem psem_facts.
 Import Utf8.
-Import all_ssreflect all_algebra.
+Import all_ssreflect .
+Require Import algebra.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/proofs/lang/pseudo_operator.v
+++ b/proofs/lang/pseudo_operator.v
@@ -1,7 +1,8 @@
 From Coq Require Import ZArith.
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import
   strings

--- a/proofs/lang/sem_op_typed.v
+++ b/proofs/lang/sem_op_typed.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Export type expr sem_type.
 Require Export flag_combination.

--- a/proofs/lang/sem_type.v
+++ b/proofs/lang/sem_type.v
@@ -1,7 +1,8 @@
 (* * Syntax and semantics of the Jasmin source language *)
 
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import Psatz xseq.
 Require Export strings warray_.

--- a/proofs/lang/slh_ops.v
+++ b/proofs/lang/slh_ops.v
@@ -1,6 +1,7 @@
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 
 Require Import
   sem_type

--- a/proofs/lang/sopn.v
+++ b/proofs/lang/sopn.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 
 Require Import
   pseudo_operator

--- a/proofs/lang/stack_zero_strategy.v
+++ b/proofs/lang/stack_zero_strategy.v
@@ -12,7 +12,8 @@ circular dependency. *)
 
 From mathcomp Require Import
   all_ssreflect
-  all_algebra.
+  .
+Require Import algebra.
 Require Import utils.
 
 Set Implicit Arguments.

--- a/proofs/lang/syscall.v
+++ b/proofs/lang/syscall.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From Coq Require Import PArith ZArith.
 Require Import
   word

--- a/proofs/lang/syscall_sem.v
+++ b/proofs/lang/syscall_sem.v
@@ -1,7 +1,8 @@
 (* * Jasmin semantics with “partial values”. *)
 
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import ZArith Psatz.
 Require Export utils syscall wsize word type low_memory sem_type values.
 Import Utf8.

--- a/proofs/lang/type.v
+++ b/proofs/lang/type.v
@@ -1,5 +1,6 @@
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import ZArith gen_map utils strings.
 Require Export wsize.
 Import Utf8.

--- a/proofs/lang/values.v
+++ b/proofs/lang/values.v
@@ -1,7 +1,8 @@
 (* * Syntax and semantics of the Jasmin source language *)
 
 (* ** Imports and settings *)
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import Psatz xseq.
 Require Export warray_ word sem_type.

--- a/proofs/lang/var.v
+++ b/proofs/lang/var.v
@@ -1,6 +1,7 @@
 (* ** Imports and settings *)
 Require Import Setoid Morphisms.
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import strings utils gen_map type ident tagged.
 Require Import Utf8.
 

--- a/proofs/lang/varmap.v
+++ b/proofs/lang/varmap.v
@@ -1,4 +1,5 @@
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import ZArith Setoid Morphisms.
 Require Export var type values.
 Import Utf8 ssrbool.

--- a/proofs/lang/waes.v
+++ b/proofs/lang/waes.v
@@ -3,7 +3,8 @@
 
 (* ** Imports and settings *)
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ word.
 Require Import word.
 Require Import Psatz ZArith utils.

--- a/proofs/lang/warray_.v
+++ b/proofs/lang/warray_.v
@@ -2,7 +2,8 @@
 
 (* ** Imports and settings *)
 Require Export ZArith Setoid Morphisms.
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ.
 Require Import Psatz xseq.
 Require Export utils array gen_map type word memory_model.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -2,7 +2,8 @@
 
 (* ** Imports and settings *)
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 From mathcomp Require Import word_ssrZ word.
 Require Import ssrring.
 Require Zquot.
@@ -102,7 +103,7 @@ Definition wbase (s: wsize) : Z :=
   modulus (wsize_size_minus_1 s).+1.
 
 Lemma wbaseE ws :
-  wbase ws = (2 ^ (wsize_size_minus_1 ws).+1)%Z.
+  wbase ws = (2 ^ Z.of_nat (wsize_size_minus_1 ws).+1)%Z.
 Proof. rewrite /wbase /word.modulus. by rewrite two_power_nat_equiv. Qed.
 
 Lemma wbase_pos ws :
@@ -399,7 +400,7 @@ Definition wmulhs sz (x y: word sz) : word sz :=
   high_bits sz (wsigned x * wsigned y).
 
 Definition wmulhrs sz (x y: word sz) : word sz :=
-  let: p := Z.shiftr (wsigned x * wsigned y) (wsize_size_minus_1 sz).-1 + 1 in
+  let: p := Z.shiftr (wsigned x * wsigned y) (Z.of_nat (wsize_size_minus_1 sz).-1) + 1 in
   wrepr sz (Z.shiftr p 1).
 
 Definition wmax_unsigned sz := wbase sz - 1.
@@ -434,7 +435,7 @@ Definition wbit_n sz (w:word sz) (n:nat) : bool :=
    wbit (wunsigned w) n.
 
 Lemma wbit_nE ws (w : word ws) i :
-  wbit_n w i = Z.odd (wunsigned w / 2 ^ i)%Z.
+  wbit_n w i = Z.odd (wunsigned w / 2 ^ Z.of_nat i)%Z.
 Proof.
   have [hlo _] := wunsigned_range w.
   rewrite /wbit_n.
@@ -459,16 +460,16 @@ Proof. apply/eq_from_wbit. Qed.
 Lemma wbit_higher_bits_0 x n ws (i : nat) :
   (0 <= n)%Z
   -> (0 <= x < 2 ^ n)%Z
-  -> (n <= i < (wsize_size_minus_1 ws).+1)%Z
+  -> (n <= Z.of_nat i < Z.of_nat (wsize_size_minus_1 ws).+1)%Z
   -> wbit_n (wrepr ws x) i = false.
 Proof.
-  set m : Z := (wsize_size_minus_1 ws).+1.
+  set m : Z := Z.of_nat (wsize_size_minus_1 ws).+1.
   move=> h0n [h0x hxn] [hni him].
 
   rewrite wbit_nE.
   rewrite Zdiv_small; first done.
 
-  have hxi : (x < 2 ^ i)%Z.
+  have hxi : (x < 2 ^ Z.of_nat i)%Z.
   - apply: (Z.lt_le_trans _ _ _ hxn). apply: Z.pow_le_mono_r; lia.
 
   have hnm : (x < 2 ^ m)%Z.
@@ -479,14 +480,14 @@ Proof.
 Qed.
 
 Lemma wbit_lower_bits_0 x n ws (i : nat) :
-  (0 <= i < n)%Z
+  (0 <= Z.of_nat i < n)%Z
   -> (0 <= 2 ^ n * x < wbase ws)%Z
   -> wbit_n (wrepr ws (2 ^ n * x)) i = false.
 Proof.
   move=> [h0i hin] hw.
   rewrite wbit_nE.
   rewrite (wunsigned_repr_small hw).
-  rewrite -(Zplus_minus i n).
+  rewrite -(Zplus_minus (Z.of_nat i) n).
   rewrite Z.pow_add_r; last lia; last lia.
   rewrite -Z.mul_assoc Z.mul_comm.
   rewrite Z_div_mult; last lia.
@@ -1361,7 +1362,7 @@ Definition wbswap sz (w: word sz) : word sz :=
 
 (* -------------------------------------------------------------------*)
 Definition popcnt sz (w: word sz) :=
- wrepr sz (count id (w2t w)).
+ wrepr sz (Z.of_nat (count id (w2t w))).
 
 (* -------------------------------------------------------------------*)
 Definition pextr sz (w1 w2: word sz) :=
@@ -1383,7 +1384,7 @@ Definition pdep sz (w1 w2: word sz) :=
 (* -------------------------------------------------------------------*)
 
 Fixpoint leading_zero_aux (n : Z) (res sz : nat) : nat :=
-  if (n <? 2 ^ (sz - res))%Z
+  if (n <? 2 ^ Z.of_nat (sz - res))%Z
   then res
   else
     match res with
@@ -1392,7 +1393,7 @@ Fixpoint leading_zero_aux (n : Z) (res sz : nat) : nat :=
     end.
 
 Definition leading_zero (sz : wsize) (w : word sz) : word sz :=
-  wrepr sz (leading_zero_aux (wunsigned w) sz sz).
+  wrepr sz (Z.of_nat (leading_zero_aux (wunsigned w) sz sz)).
 
 (* -------------------------------------------------------------------*)
 Definition halve_list A : seq A → seq A :=
@@ -2122,7 +2123,7 @@ Qed.
 Notation pointer := (word Uptr) (only parsing).
 
 Lemma subword_make_vec_bits_low (n m : nat) x y :
-  (n < m)%Z ->
+  (Z.of_nat n < Z.of_nat m)%Z ->
   word.subword 0 n (word.mkword m (wcat_r [:: x; y ])) = x.
 Proof.
   move=> h.

--- a/proofs/lang/wsize.v
+++ b/proofs/lang/wsize.v
@@ -2,7 +2,8 @@
 
 (* ** Imports and settings *)
 
-From mathcomp Require Import all_ssreflect all_algebra.
+From mathcomp Require Import all_ssreflect .
+Require Import algebra.
 Require Import strings ZArith utils.
 Import Utf8.
 Import word_ssrZ.


### PR DESCRIPTION
This is an experiment to check on how much we depend on mathcomp.algebra.

It seems that we really depend only on `ssralg` and `ssrnum`.

We also depend on:
- `ssrint`: it seems that we only use the coercion `nat >-> Z`, I introduced `Z.of_nat` where appropriate, but we could also declare `Z.of_nat` as a coercion.
- `zmodp`: to manipulate ordinals used by `nth` (one occurrence only)

Note that we still indirectly rely on all algebra because of coqword.

Context: mathcomp 2 slows the compilation down; maybe if we use less of mathcomp, the impact is smaller.