### PR TITLE
 eval_cond also take registers as argument.

### DIFF
--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -663,7 +663,7 @@ Canonical rflagv_eqType := EqType _ rflagv_eqMixin.
 Class asm (reg regx xreg rflag cond asm_op: Type) :=
   { _arch_decl   : arch_decl reg regx xreg rflag cond
   ; _asm_op_decl : asm_op_decl asm_op
-  ; eval_cond   : (rflag_t -> exec bool) -> cond_t -> exec bool
+  ; eval_cond   : (reg_t -> word reg_size) -> (rflag_t -> exec bool) -> cond_t -> exec bool
   }.
 
 #[global]

--- a/proofs/arch/arch_sem.v
+++ b/proofs/arch/arch_sem.v
@@ -136,7 +136,7 @@ Definition st_get_rflag (s : asmmem) (rf : rflag_t) :=
 (* -------------------------------------------------------------------- *)
 
 Definition eval_cond_mem (s : asmmem) (c : cond_t) :=
-  eval_cond (st_get_rflag s) c.
+  eval_cond s.(asm_reg) (st_get_rflag s) c.
 
 (* -------------------------------------------------------------------- *)
 Definition st_write_ip (ip : nat) (s : asm_state) :=

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -348,12 +348,13 @@ Proof.
 Qed.
 
 Definition assemble_cond_spec :=
-  forall ii m rf e c v,
+  forall ii m rr rf e c v,
+    (∀ r, value_uincl (evm m).[to_var r] (Vword (rr r))) ->
     eqflags m rf
     -> agp_assemble_cond agparams ii e = ok c
     -> sem_fexpr m.(evm) e = ok v
     -> exists2 v',
-         value_of_bool (eval_cond (get_rf rf) c) = ok v' & value_uincl v v'.
+         value_of_bool (eval_cond rr (get_rf rf) c) = ok v' & value_uincl v v'.
 
 Context
   (eval_assemble_cond : assemble_cond_spec).
@@ -375,8 +376,8 @@ Proof.
   + case: e; first by [].
     t_xrbindP => e _ <- c hac <-.
     rewrite /compat_imm orbF => /eqP <- -> /= b hb.
-    case: eqm => ??????? eqf.
-    have [v'] := eval_assemble_cond eqf hac hb.
+    case: eqm => ???? eqr ?? eqf.
+    have [v'] := eval_assemble_cond eqr eqf hac hb.
     rewrite /eval_cond_mem; case: eval_cond => /=;
       last by case=> // [[<-]] /[swap] /to_boolI ->.
     move=> b' [<-] {hb}; case: v => // [b1 | [] //] -> ?.
@@ -1838,7 +1839,7 @@ Proof.
   - rewrite /linear_sem.eval_instr => /=.
     t_xrbindP => cnd lbl hok_i cndt ok_c ? b v ok_v ok_b; subst aci.
     case: hloeq => eqscs eqm hrip hd eqr eqrx eqx eqf.
-    have [v' ok_v' hvv'] := hagp_eval_assemble_cond hagparams eqf ok_c ok_v.
+    have [v' ok_v' hvv'] := hagp_eval_assemble_cond hagparams eqr eqf ok_c ok_v.
     case: v ok_v ok_b hvv' => // [ b' | [] // ] ok_b [?]; subst b'.
     rewrite ok_fd /=; case: v' ok_v' => // b1 ok_v' ? h; subst b1.
     apply (match_state_step1 (ls' := ls') hnth) => /=; move: h.

--- a/proofs/compiler/arm.v
+++ b/proofs/compiler/arm.v
@@ -12,7 +12,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Definition eval_cond (get: rflag -> result error bool) (c: condt) :
+Definition arm_eval_cond (get: rflag -> result error bool) (c: condt) :
   result error bool :=
   match c with
   | EQ_ct =>
@@ -62,6 +62,6 @@ Definition eval_cond (get: rflag -> result error bool) (c: condt) :
 #[ export ]
 Instance arm : asm register register_ext xregister rflag condt arm_op :=
   {
-    eval_cond := eval_cond;
+    eval_cond := fun _ => arm_eval_cond;
   }.
 

--- a/proofs/compiler/x86.v
+++ b/proofs/compiler/x86.v
@@ -47,4 +47,4 @@ Definition x86_eval_cond (get : rflag -> result error bool) (c : condt) :=
 
 #[global]
 Instance x86 : asm register register_ext xmm_register rflag condt x86_op :=
-  {| eval_cond := x86_eval_cond |}.
+  {| eval_cond := fun _ => x86_eval_cond |}.

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -33,6 +33,7 @@ Require Import
   x86_decl
   x86_extra
   x86_instr_decl
+  x86
   x86_lowering
   x86_lowering_proof
   x86_stack_zeroization_proof.
@@ -359,7 +360,7 @@ Defined.
 Import arch_sem.
 
 Lemma not_condtP (c : cond_t) rf b :
-  eval_cond rf c = ok b -> eval_cond rf (not_condt c) = ok (negb b).
+  x86_eval_cond rf c = ok b -> x86_eval_cond rf (not_condt c) = ok (negb b).
 Proof.
   case: c => /=.
   1,3,5,9,11: by case: (rf _) => //= ? [->].
@@ -374,9 +375,9 @@ Qed.
 
 Lemma or_condtP ii e c1 c2 c rf b1 b2:
   or_condt ii e c1 c2 = ok c ->
-  eval_cond rf c1 = ok b1 ->
-  eval_cond rf c2 = ok b2 ->
-  eval_cond rf c  = ok (b1 || b2).
+  x86_eval_cond rf c1 = ok b1 ->
+  x86_eval_cond rf c2 = ok b2 ->
+  x86_eval_cond rf c  = ok (b1 || b2).
 Proof.
   case: c1 => //; case: c2 => //= -[<-] /=.
   + by case: (rf _) => // ? [->]; case: (rf _) => // ? [->].
@@ -387,9 +388,9 @@ Qed.
 
 Lemma and_condtP ii e c1 c2 c rf b1 b2:
   and_condt ii e c1 c2 = ok c ->
-  eval_cond rf c1 = ok b1 ->
-  eval_cond rf c2 = ok b2 ->
-  eval_cond rf c  = ok (b1 && b2).
+  x86_eval_cond rf c1 = ok b1 ->
+  x86_eval_cond rf c2 = ok b2 ->
+  x86_eval_cond rf c  = ok (b1 && b2).
 Proof.
   case: c1 => //; case: c2 => //= -[<-] /=.
   + by case: (rf _) => // ? [<-]; case: (rf _) => // ? [<-].
@@ -405,8 +406,8 @@ Proof. by rewrite /of_var_e_bool /of_var_e; case: of_var. Qed.
 
 Lemma eval_assemble_cond : assemble_cond_spec x86_agparams.
 Proof.
-  move=> ii m rf e c v; rewrite /x86_agparams /eval_cond /get_rf /=.
-  move=> eqv; elim: e c v => //.
+  move=> ii m rr rf e c v; rewrite /x86_agparams /x86_eval_cond /get_rf /=.
+  move=> eqr eqv; elim: e c v => //.
   + move=> x c v /=; t_xrbindP=> r /of_var_e_boolP ok_r ok_ct ok_v.
     have := xgetflag_ex eqv ok_r ok_v.
     case: {ok_r ok_v} r ok_ct => // -[<-] {c} /= h;


### PR DESCRIPTION
Adapt x86 and arm proofs to handle the additional argument. Renames specific arm Definition of eval_cond to arm_eval_cond. Use generic eval_assemble_cond definition for arm_eval_assemble_cond.