### PR TITLE
CT checker requires public input for div and mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## New features
 
+- The type system for constant time now ensures that division and modulo
+  operators may only be used with public arguments.
+  ([PR #722](https://github.com/jasmin-lang/jasmin/pull/722)).
+
 - Add spill/unspill primitives allowing to spill/unspill reg and reg ptr
   to/from the stack without need to declare the corresponding stack variable.
   If the annotation #spill_to_mmx is used at the variable declaration the variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 
 ## New features
 
-- The type system for constant time now ensures that division and modulo
-  operators may only be used with public arguments.
+- The type systems for constant time and speculative constant time now ensure
+  that division and modulo operators may only be used with public arguments.
+  This ensures that problems like KyberSlash (https://kyberslash.cr.yp.to/) do
+  not occur.
   ([PR #722](https://github.com/jasmin-lang/jasmin/pull/722)).
 
 - Add spill/unspill primitives allowing to spill/unspill reg and reg ptr

--- a/compiler/CCT/fail/div_secret.jazz
+++ b/compiler/CCT/fail/div_secret.jazz
@@ -1,0 +1,8 @@
+export fn div(#secret reg u32 x) -> #secret reg u32 {
+  reg u32 d q;
+  x = x;
+  d = 3;
+  q = x / d;
+  q = q;
+  return q;
+}

--- a/compiler/CCT/fail/mod_secret.jazz
+++ b/compiler/CCT/fail/mod_secret.jazz
@@ -1,0 +1,8 @@
+export fn mod(#secret reg u32 x) -> #secret reg u32 {
+  reg u32 d q;
+  x = x;
+  d = 3;
+  q = x % d;
+  q = q;
+  return q;
+}

--- a/compiler/CCT/success/div.jazz
+++ b/compiler/CCT/success/div.jazz
@@ -1,0 +1,12 @@
+export fn add_div_mod(#public reg u32 x) -> #public reg u32 {
+  reg u32 x1 x2 d q q1 r r1;
+  x1 = x; x2 = x;
+  d = 3;
+  q = x1 / d;
+  q1 = q;
+  r = x2 % d;
+  r = r1;
+  r = r + q1;
+  r = r;
+  return r;
+}

--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -5,7 +5,7 @@ open Prog
 
 type 'a callstyle =
   | StackDirect           (* call instruction push the return address on top of the stack *)
-  | ByReg of 'a option    (* call instruction store the return address on a register, 
+  | ByReg of 'a option    (* call instruction store the return address on a register,
                                (Some r) neams that the register is forced to be r *)
 
 (* TODO: check that we cannot use sth already defined on the Coq side *)
@@ -33,6 +33,9 @@ module type Core_arch = sig
   val callstyle : reg callstyle
 
   val known_implicits : (Name.t * string) list
+
+  val is_ct_asm_op : asm_op -> bool
+  val is_ct_asm_extra : extra_op -> bool
 
 end
 
@@ -67,6 +70,8 @@ module type Arch = sig
   val callstyle : var callstyle
 
   val arch_info : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Pretyping.arch_info
+
+  val is_ct_sopn : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op -> bool
 end
 
 module Arch_from_Core_arch (A : Core_arch) :
@@ -80,7 +85,7 @@ module Arch_from_Core_arch (A : Core_arch) :
      and type extra_op = A.extra_op = struct
   include A
 
-  let arch_decl = A.asm_e._asm._arch_decl 
+  let arch_decl = A.asm_e._asm._arch_decl
   let reg_size = arch_decl.reg_size
   let xreg_size = arch_decl.xreg_size
   let pointer_data = arch_pd A.asm_e._asm._arch_decl
@@ -111,30 +116,30 @@ module Arch_from_Core_arch (A : Core_arch) :
 
   let callee_save = call_conv.callee_saved
 
-  (* Remark the order is very important this register allocation use this list to 
-     allocate register. The lasts in the list are taken only when needed. 
+  (* Remark the order is very important this register allocation use this list to
+     allocate register. The lasts in the list are taken only when needed.
      So it is better to have callee_saved at the end *)
-  
+
   let callee_save_reg  = List.filter_map (Arch_decl.get_ARReg arch_decl) callee_save
   let callee_save_regx = List.filter_map (Arch_decl.get_ARegX arch_decl) callee_save
   let callee_save_xreg = List.filter_map (Arch_decl.get_AXReg arch_decl) callee_save
 
   let rsp = arch_decl.ad_rsp
 
-  let mk_allocatable regs callee_save = 
+  let mk_allocatable regs callee_save =
      List.filter (fun r -> not (List.mem r callee_save)) regs
      @
      callee_save
 
-  let allocatable = 
+  let allocatable =
     let good_order = mk_allocatable (Arch_decl.registers arch_decl) callee_save_reg in
     (* be sure that rsp is not used *)
-    List.filter (fun r -> r <> rsp) good_order  
+    List.filter (fun r -> r <> rsp) good_order
 
-  let extra_allocatable = 
+  let extra_allocatable =
     mk_allocatable (Arch_decl.registerxs arch_decl) callee_save_regx
 
-  let xmm_allocatable = 
+  let xmm_allocatable =
     mk_allocatable (Arch_decl.xregisters arch_decl) callee_save_xreg
 
   let arguments = call_conv.call_reg_args
@@ -168,7 +173,7 @@ module Arch_from_Core_arch (A : Core_arch) :
     List.map var_of_xreg xmm_allocatable
 
   let callee_save_vars =
-    let var_of_typed = function 
+    let var_of_typed = function
       | ARReg r -> var_of_reg  r
       | ARegX r -> var_of_regx r
       | AXReg r -> var_of_xreg r
@@ -181,7 +186,7 @@ module Arch_from_Core_arch (A : Core_arch) :
 
   let syscall_kill = Sv.diff (Sv.of_list all_registers) (Sv.of_list callee_save_vars)
 
-  let callstyle = 
+  let callstyle =
     match A.callstyle with
     | StackDirect -> StackDirect
     | ByReg o -> ByReg (Option.map var_of_reg o)
@@ -192,5 +197,10 @@ module Arch_from_Core_arch (A : Core_arch) :
       known_implicits = known_implicits;
       flagnames = List.map fst known_implicits;
     }
+
+  let is_ct_sopn (o : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op) =
+   match o with
+   | BaseOp (_, o) -> is_ct_asm_op o
+   | ExtOp o -> is_ct_asm_extra o
 
 end

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -35,6 +35,9 @@ module type Core_arch = sig
 
   val known_implicits : (Name.t * string) list
 
+  val is_ct_asm_op : asm_op -> bool
+  val is_ct_asm_extra : extra_op -> bool
+
 end
 
 module type Arch = sig
@@ -68,6 +71,8 @@ module type Arch = sig
   val callstyle : var callstyle 
   
   val arch_info : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Pretyping.arch_info
+
+  val is_ct_sopn : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op -> bool
 end
 
 module Arch_from_Core_arch (A : Core_arch) : Arch

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -28,6 +28,14 @@ module Arm_core = struct
   let alloc_stack_need_extra sz =
     not (Arm_params_core.is_arith_small (Conv.cz_of_z sz))
 
+  let is_ct_asm_op (o : asm_op) =
+    match o with
+    | ARM_op( (SDIV  | UDIV), _) -> false
+    | _ -> true
+
+
+  let is_ct_asm_extra (o : extra_op) = true
+
 end
 
 module Arm (Lowering_params : Arm_input) : Arch_full.Core_arch = struct

--- a/compiler/src/ct_checker_forward.ml
+++ b/compiler/src/ct_checker_forward.ml
@@ -352,7 +352,22 @@ let instanciate_fty fty lvls  =
   tyout
 
 (* -----------------------------------------------------------*)
+let is_ct_op1 (o: Expr.sop1) = true
 
+let is_ct_op2 (o: Expr.sop2) =
+  match o with
+  | Omod (Cmp_w _) | Odiv (Cmp_w _) -> false
+  | _ -> true
+
+let is_ct_opN (o : Expr.opN) = true
+
+let is_ct_sopn is_ct_asm (o : 'a Sopn.sopn) =
+  match o with
+  | Opseudo_op _ -> true
+  | Oslh _ -> true
+  | Oasm asm -> is_ct_asm asm
+
+(* -----------------------------------------------------------*)
 (* [ty_expr ~public env e] return [env', lvl] such that [env' |- e : lvl]
    and [env' <= env] i.e for all x, [env'(x) <= env(x)].
    Furthermore [public => lvl = Public.
@@ -375,9 +390,15 @@ let rec ty_expr ~(public:bool) env (e:expr) =
     let env, _ = ty_expr ~public:true env i in
     env, Secret
 
-  | Papp1(_, e)        -> ty_expr ~public env e
-  | Papp2(_, e1, e2)   -> ty_exprs_max ~public env [e1; e2]
-  | PappN(_, es)       -> ty_exprs_max ~public env es
+  | Papp1(o, e)        ->
+    let public = public || not (is_ct_op1 o) in
+    ty_expr ~public env e
+  | Papp2(o, e1, e2)   ->
+    let public = public || not (is_ct_op2 o) in
+    ty_exprs_max ~public env [e1; e2]
+  | PappN(o, es)       ->
+    let public = public || not (is_ct_opN o) in
+    ty_exprs_max ~public env es
   | Pif(_, e1, e2, e3) -> ty_exprs_max ~public env [e1; e2; e3]
 
 and ty_exprs ~public env es =
@@ -507,15 +528,16 @@ let declassify_lvls annot lvls =
 
 (* [ty_instr env i] return env' such that env |- i : env' *)
 
-let rec ty_instr fenv env i =
+let rec ty_instr is_ct_asm fenv env i =
   let env1 =
   match i.i_desc with
   | Cassgn(x, _, _, e) ->
     let env, lvl = ty_expr ~public:false env e in
     ty_lval env x (declassify_lvl i.i_annot lvl)
 
-  | Copn(xs, _, _, es) ->
-    let env, lvl = ty_exprs_max ~public:false env es in
+  | Copn(xs, _, o, es) ->
+    let public = not (is_ct_sopn is_ct_asm o) in
+    let env, lvl = ty_exprs_max ~public env es in
     ty_lvals1 env xs (declassify_lvl i.i_annot lvl)
 
   | Csyscall(xs, RandomBytes _, es) ->
@@ -524,15 +546,15 @@ let rec ty_instr fenv env i =
 
   | Cif(e, c1, c2) ->
     let env, _ = ty_expr ~public:true env e in
-    let env1 = ty_cmd fenv env c1 in
-    let env2 = ty_cmd fenv env c2 in
+    let env1 = ty_cmd is_ct_asm fenv env c1 in
+    let env2 = ty_cmd is_ct_asm fenv env c2 in
     Env.max env1 env2
 
   | Cfor(x, (_, e1, e2), c) ->
     let env, _ = ty_exprs ~public:true env [e1; e2] in
     let rec loop env =
       let env1 = Env.set env x Public in
-      let env1 = ty_cmd fenv env1 c in (*  env |- x = p; c : env1 <= env  *)
+      let env1 = ty_cmd is_ct_asm fenv env1 c in (*  env |- x = p; c : env1 <= env  *)
       if Env.le env1 env then env      (* G <= G'  G' |- c : G''   G |- c : G'' *)
       else loop (Env.max env1 env) in  (* le env/env1 (max env1 env) Check *)
     loop env
@@ -545,15 +567,15 @@ let rec ty_instr fenv env i =
      *)
 
     let rec loop env =
-      let env1 = ty_cmd fenv env c1 in   (* env |- c1 : env1 *)
+      let env1 = ty_cmd is_ct_asm fenv env c1 in   (* env |- c1 : env1 *)
       let env1,_ = ty_expr ~public:true env1 e in
-      let env2 = ty_cmd fenv env1 c2 in  (* env1 |- c2 : env2 *)
+      let env2 = ty_cmd is_ct_asm fenv env1 c2 in  (* env1 |- c2 : env2 *)
       if Env.le env2 env then env1
       else loop (Env.max env2 env) in
     loop env
 
   | Ccall (xs, f, es) ->
-    let fty = get_fun fenv f in
+    let fty = get_fun is_ct_asm fenv f in
     (* Check the arguments *)
     let do_e env e (_,lvl) = ty_expr ~public:(lvl=Public) env e in
     let env, elvls = List.map_fold2 do_e env es fty.tyin in
@@ -564,23 +586,23 @@ let rec ty_instr fenv env i =
     Format.eprintf "%a: @[<v>before %a@ after %a@]@." L.pp_loc (i.i_loc.base_loc) Env.pp env Env.pp env1;
   env1
 
-and ty_cmd fenv env c =
-  List.fold_left (fun env i -> ty_instr fenv env i) env c
+and ty_cmd is_ct_asm fenv env c =
+  List.fold_left (fun env i -> ty_instr is_ct_asm fenv env i) env c
 
-and get_fun fenv f =
+and get_fun is_ct_asm fenv f =
   try Hf.find fenv.env_ty f
   with Not_found ->
-    let fty = ty_fun fenv f in
+    let fty = ty_fun is_ct_asm fenv f in
     Hf.add fenv.env_ty f fty;
     fty
 
-and ty_fun fenv fn =
+and ty_fun is_ct_asm fenv fn =
   (* TODO: we should have this defined *)
   let f = List.find (fun f -> F.equal f.f_name fn) fenv.env_def in
   let tyin, aout, ldecls = get_annot fenv.ensure_annot f in
   let env = List.fold_left2 Env.add Env.empty f.f_args tyin in
   let env = List.fold_left (fun env (x,lvl) -> Env.add env x (Strict, lvl)) env ldecls in
-  let env = ty_cmd fenv env f.f_body in
+  let env = ty_cmd is_ct_asm fenv env f.f_body in
   (* First ensure that all return that are required to be public are publics *)
   let set_pub env x aout =
     if aout = Some Public then
@@ -608,7 +630,7 @@ and ty_fun fenv fn =
   let tyin = List.map (fun (k, lvl) -> k, Env.norm_lvl env lvl) tyin in
   { tyin ; tyout }
 
-let ty_prog ~infer (prog: ('info, 'asm) prog) fl =
+let ty_prog (is_ct_asm: 'asm -> bool)  ~infer (prog: ('info, 'asm) prog) fl =
   let prog = snd prog in
   let fenv =
     { ensure_annot = not infer
@@ -623,7 +645,7 @@ let ty_prog ~infer (prog: ('info, 'asm) prog) fl =
         with Not_found -> hierror ~loc:Lnone ~kind:"constant type checker" "unknown function %s" fn in
       List.map get fl in
   let status =
-    match List.iter (fun fn -> ignore (get_fun fenv fn : signature)) fl with
+    match List.iter (fun fn -> ignore (get_fun is_ct_asm fenv fn : signature)) fl with
     | () -> None
     | exception Annot.AnnotationError (loc, msg)
     | exception CtTypeError (loc, msg)

--- a/compiler/src/ct_checker_forward.mli
+++ b/compiler/src/ct_checker_forward.mli
@@ -7,8 +7,9 @@ val pp_signature : _ prog -> Format.formatter -> funname * signature -> unit
 (** Human-readable form of a signature *)
 
 val ty_prog :
+  ('asm -> bool) ->
   infer:bool ->
-  _ prog ->
+  (_, 'asm) prog ->
   Name.t list ->
   (funname * signature) list * (L.t * (Format.formatter -> unit)) option
 (** Type-check (for constant-time) a list of functions in the given program

--- a/compiler/src/ct_checker_forward.mli
+++ b/compiler/src/ct_checker_forward.mli
@@ -1,5 +1,11 @@
 open Prog
 
+val is_ct_op1 : Expr.sop1 -> bool
+val is_ct_op2 : Expr.sop2 -> bool
+val is_ct_opN : Expr.opN -> bool
+val is_ct_sopn : ('asm -> bool) -> 'asm Sopn.sopn -> bool
+
+
 type signature
 (** Security type of a function *)
 

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -60,8 +60,8 @@ let check_safety_p pd asmOp analyze s (p : (_, 'asm) Prog.prog) source_p =
   ()
 
 (* -------------------------------------------------------------------- *)
-let check_sct _s p _source_p =
-  Sct_checker_forward.ty_prog p (oget !sct_list)
+let check_sct is_ct_asm _s p _source_p =
+  Sct_checker_forward.ty_prog is_ct_asm p (oget !sct_list)
 
 (* -------------------------------------------------------------------- *)
 module type ArchCoreWithAnalyze = sig
@@ -179,7 +179,7 @@ let main () =
           source_prog
         |> donotcompile
       else if s = !Glob_options.sct_comp_pass && !sct_list <> None then
-        check_sct s p source_prog
+        check_sct Arch.is_ct_sopn s p source_prog
         |> List.iter (Format.printf "%a@." Sct_checker_forward.pp_funty)
         |> donotcompile
       else

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -215,7 +215,7 @@ let main () =
     end;
 
     if !ct_list <> None then begin
-        let sigs, status = Ct_checker_forward.ty_prog ~infer:!infer source_prog (oget !ct_list) in
+        let sigs, status = Ct_checker_forward.ty_prog Arch.is_ct_sopn ~infer:!infer source_prog (oget !ct_list) in
            Format.printf "/* Security types:\n@[<v>%a@]*/@."
               (pp_list "@ " (Ct_checker_forward.pp_signature source_prog)) sigs;
            let on_err (loc, msg) =

--- a/compiler/src/sct_checker_forward.mli
+++ b/compiler/src/sct_checker_forward.mli
@@ -3,7 +3,7 @@ open Prog
 type ty_fun
 
 val pp_funty : Format.formatter -> Name.t * ty_fun -> unit
-val ty_prog : ('info, 'asm) prog -> Name.t list -> (Name.t * ty_fun) list
+val ty_prog : ('asm -> bool) -> ('info, 'asm) prog -> Name.t list -> (Name.t * ty_fun) list
 
 val compile_infer_msf :
   ('info, 'asm) prog -> (Slh_lowering.slh_t list * Slh_lowering.slh_t list) Hf.t

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -2,11 +2,11 @@ open Arch_decl
 open X86_decl
 
 module type X86_input = sig
-  
- val call_conv : (register, register_ext, xmm_register, rflag, condt) calling_convention 
+
+ val call_conv : (register, register_ext, xmm_register, rflag, condt) calling_convention
  val lowering_opt : X86_lowering.lowering_options
 
-end 
+end
 
 let atoI decl =
   let open Prog in
@@ -41,6 +41,15 @@ module X86_core = struct
   let known_implicits = ["OF","_of_"; "CF", "_cf_"; "SF", "_sf_"; "ZF", "_zf_"]
 
   let alloc_stack_need_extra _ = false
+
+  let is_ct_asm_op (o : asm_op) =
+    match o with
+    | DIV _ | IDIV _ -> false
+    | _ -> true
+
+  let is_ct_asm_extra (o : extra_op) = true
+
+
 end
 
 

--- a/compiler/tests/sct-checker/accept.ml
+++ b/compiler/tests/sct-checker/accept.ml
@@ -7,7 +7,7 @@ let path = "success"
 let load_and_check name =
   Format.printf "File %s:@." name;
   let p = load_file (Filename.concat path name) in
-  match ty_prog p [] with
+  match ty_prog Arch.is_ct_sopn p [] with
   | exception Utils.HiError e ->
       Format.eprintf "%a@." Utils.pp_hierror e;
       exit 1

--- a/compiler/tests/sct-checker/reject.ml
+++ b/compiler/tests/sct-checker/reject.ml
@@ -11,7 +11,7 @@ let load_and_check name =
     (fun fd ->
       if fd.Prog.f_cc <> Internal then
         let f = fd.Prog.f_name.fn_name in
-        match ty_prog p [ f ] with
+        match ty_prog Arch.is_ct_sopn p [ f ] with
         | exception Utils.HiError e ->
             Format.printf "Failed as expected %s: %a@." f Utils.pp_hierror e
         | _ ->

--- a/compiler/tests/sct-checker/sct_errors.ml
+++ b/compiler/tests/sct-checker/sct_errors.ml
@@ -4,7 +4,7 @@ open Common
 let () =
   let p = load_file "error_messages.jazz" in
   let check_fails f =
-    match Sct_checker_forward.ty_prog p [ f ] with
+    match Sct_checker_forward.ty_prog Arch.is_ct_sopn p [ f ] with
     | exception Annot.AnnotationError (loc, msg) ->
         Format.printf "Annotation error in %s: %t@." f msg
     | exception Utils.HiError e ->


### PR DESCRIPTION
The constant time checker ensures that if the division or modulo operator can only be used on public value