### PR TITLE
opam: ez-conf-lib is broken

### DIFF
--- a/compiler/jasmin.opam
+++ b/compiler/jasmin.opam
@@ -32,3 +32,6 @@ depends: [
   "yojson" {>= "1.6.0"}
   "ocamlfind" { build }
 ]
+conflicts: [
+  "ez-conf-lib"
+]


### PR DESCRIPTION
This fixes the `opam-compiler` CI job.