### PR TITLE
Pretyping: accept all calls to export functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,11 @@
   ([PR #710](https://github.com/jasmin-lang/jasmin/pull/710);
    fixes [#709](https://github.com/jasmin-lang/jasmin/issues/709)).
 
+- Type-checking warns about calls to export functions that are not explicitly
+  inlined; export functions called from Jasmin code are inlined at call sites
+  ([PR #731](https://github.com/jasmin-lang/jasmin/pull/731);
+  fixes [#729](https://github.com/jasmin-lang/jasmin/issues/729)).
+
 ## Other changes
 
 - Pretty-printing of Jasmin programs is more precise

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1563,8 +1563,7 @@ let mk_call loc inline lvs f es =
   | Internal -> ()
   | Export ->
     if not inline then
-      let err = string_error "call to export function needs to be inlined" in
-      rs_tyerror ~loc err
+      warning Always (L.i_loc0 loc) "export function will be inlined"
   | Subroutine _ when not inline ->
     let check_lval = function
       | Lnone _ | Lvar _ | Lasub _ -> ()
@@ -1630,7 +1629,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       let es  = tt_exprs_cast arch_info.pd env (L.loc pi) args tes in
       let is_inline = P.is_inline annot f.P.f_cc in
       let annot =
-        if is_inline
+        if is_inline || f.P.f_cc = FInfo.Export
         then Annotations.add_symbol ~loc:el "inline" annot
         else annot
       in

--- a/compiler/tests/success/common/bug_729.jazz
+++ b/compiler/tests/success/common/bug_729.jazz
@@ -1,0 +1,7 @@
+export fn id(reg u32 x) -> reg u32 { x = x; return x; }
+
+export
+fn whynot(reg u32 a) -> reg u32 {
+  a = id(a);
+  return a;
+}


### PR DESCRIPTION
Just emit a warning if said call is not annotated as inline

Fixes #729