### PR TITLE
Let's DOIT: Add support for DOIT-instruction list in (S)CT checkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
   returned first and in the same order in the list of results.
   ([PR #707](https://github.com/jasmin-lang/jasmin/pull/707)).
 
+- The (speculative) constant-time checker (`jazzct`) can optionally
+  (when the `-doit` flag is used) check that secrets are only used with
+  guaranteed constant time instructions (DOIT for Intel, DIT for ARM). This option
+  only makes sense when done after the lowering compiler pass, which can be ensured
+  with the new `-after` option.
+  ([PR #736](https://github.com/jasmin-lang/jasmin/pull/736)).
+
 - Add spill/unspill primitives allowing to spill/unspill reg and reg ptr
   to/from the stack without need to declare the corresponding stack variable.
   If the annotation #spill_to_mmx is used at the variable declaration the variable

--- a/compiler/CCT/fail/H_L_L.jazz
+++ b/compiler/CCT/fail/H_L_L.jazz
@@ -1,8 +1,9 @@
-fn add_H_L_L(#secret reg u64 x, #public reg u64 ya) -> #public reg u64 {
+export fn add_H_L_L(#secret reg u64 x, #public reg u64 ya) -> #public reg u64 {
 
  reg u64 t;
 
  t = x + ya;
+ t = t;
 
  return t;
 }

--- a/compiler/CCT/fail/doit/rol.jazz
+++ b/compiler/CCT/fail/doit/rol.jazz
@@ -1,0 +1,5 @@
+// This is CT in the ordinary sense, but not DOIT as ROL is not DOIT.
+export fn rol(#secret reg u32 x) -> #secret reg u32 {
+  _, _, x = #ROL_32(x, 5);
+  return x;
+}

--- a/compiler/CCT/fail/doit/xchg.jazz
+++ b/compiler/CCT/fail/doit/xchg.jazz
@@ -1,0 +1,5 @@
+// This is CT in the ordinary sense, but not DOIT as XCHG is not DOIT.
+export fn xchange(#secret reg u32 a, #secret reg u32 b) -> #secret reg u32, #secret reg u32 {
+    a, b = #XCHG_32(a, b);
+    return a, b;
+}

--- a/compiler/CCT/fail/flex_on_ret.jazz
+++ b/compiler/CCT/fail/flex_on_ret.jazz
@@ -1,4 +1,4 @@
-fn foo(#public reg u64 r) -> #flex reg u64 {
+export fn foo(#public reg u64 r) -> #flex reg u64 {
    return r;
 }
 

--- a/compiler/CCT/fail/load_on_poly.jazz
+++ b/compiler/CCT/fail/load_on_poly.jazz
@@ -1,4 +1,4 @@
-fn load(#poly=l1 reg u64 x) -> reg u64 {
+export fn load(#poly=l1 reg u64 x) -> reg u64 {
 
  reg u64 t;
   

--- a/compiler/CCT/fail/load_on_secret.jazz
+++ b/compiler/CCT/fail/load_on_secret.jazz
@@ -1,4 +1,4 @@
-fn mem3(#secret reg u64 p, reg u64 x) {
+export fn mem3(#secret reg u64 p, reg u64 x) {
   reg u64 r;
    
   [p] = x;

--- a/compiler/CCT/fail/strict.jazz
+++ b/compiler/CCT/fail/strict.jazz
@@ -1,4 +1,4 @@
-fn add(#public reg u64 p, #secret reg u64 s) -> reg u64 {
+export fn add(#public reg u64 p, #secret reg u64 s) -> reg u64 {
    p += s;
    return p;
 }

--- a/compiler/CCT/fail/strict_local.jazz
+++ b/compiler/CCT/fail/strict_local.jazz
@@ -1,4 +1,4 @@
-fn add(#public reg u64 p, #secret reg u64 s) -> reg u64 {
+export fn add(#public reg u64 p, #secret reg u64 s) -> reg u64 {
    #public reg u64 p1; 
    p1 = p + s;
    return p1;

--- a/compiler/CCT/fail/strict_on_ret.jazz
+++ b/compiler/CCT/fail/strict_on_ret.jazz
@@ -1,4 +1,4 @@
-fn foo(#public reg u64 r) -> #strict reg u64 {
+export fn foo(#public reg u64 r) -> #strict reg u64 {
    return r;
 }
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -8,6 +8,7 @@ CHECK     += config/tests.config
 CHECKCATS ?= \
 	safety \
 	CCT \
+	CCT-DOIT \
 	x86-64-ATT \
 	x86-64-Intel \
 	x86-64-print \

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -14,6 +14,13 @@ kodirs = !safety/fail
 bin    = ./scripts/check-cct
 okdirs = !CCT/success
 kodirs = !CCT/fail
+exclude = !CCT/fail/doit
+
+[test-CCT-DOIT]
+bin    = ./scripts/check-cct
+args   = --doit --after=propagate
+okdirs = !CCT/success
+kodirs = !CCT/fail !CCT/fail/doit
 
 [test-SCT]
 bin    = ./scripts/check-cct

--- a/compiler/scripts/extract_doit.py
+++ b/compiler/scripts/extract_doit.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+#
+# This script extracts the guaranteed constant-time (if a register is set) instructions from the Intel/ARM pages.
+# It required the following non-stdlib packages:
+#   requests, beautifulsoup4, tqdm
+# It also assumes it is run inside of the compiler/scripts directory and that a "../jasminc" binary exists.
+#
+
+import sys
+import subprocess
+import json
+import re
+import requests
+
+from enum import Enum
+from base64 import b64decode
+from pathlib import Path
+from operator import itemgetter
+from typing import List, Tuple, Set, Mapping, Optional
+from tqdm import tqdm
+from bs4 import BeautifulSoup
+
+
+class wsize(Enum):
+    U8 = "b"
+    U16 = "w"
+    U32 = "l"
+    U64 = "q"
+
+
+class velem(Enum):
+    VE8 = "b"
+    VE16 = "w"
+    VE32 = "d"
+    VE64 = "q"
+
+
+class velem_long(Enum):
+    VE8 = "bw"
+    VE16 = "wd"
+    VE32 = "dq"
+    VE64 = "qdq"
+
+
+class condt(Enum):
+    O = "o"
+    NO = "no"
+    B = "b"
+    NB = "nb"
+    E = "e"
+    NE = "ne"
+    BE = "be"
+    NBE = "nbe"
+    S = "s"
+    NS = "ns"
+    P = "p"
+    NP = "np"
+    L = "l"
+    NL = "nl"
+    LE = "le"
+    NLE = "nle"
+
+
+def x86_extract_doitm() -> List[Tuple[str, int]]:
+    """Extract a list of instruction + opcode pairs from the Intel website."""
+    req = requests.get("https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/resources/data-operand-independent-timing-instructions.html")
+    soup = BeautifulSoup(req.content, "lxml")
+    table = soup.find("div", class_="articlepara").find("table")
+    results = []
+    for tr in table.find_all("tr")[2:]:
+        instr_td, opcode_td = tr.find_all("td")
+        instruction = str(instr_td.text).strip()
+        opcode = int(str(opcode_td.text).strip(), 16)
+        results.append((instruction, opcode))
+    return results
+
+
+def x86_extract_opcodes(link: str, instruction: str) -> Set[str]:
+    """Given a link to an instruction page and the mnemonic, extract all of the opcode fields."""
+    pattern = re.compile(fr"\b{instruction}\b")
+    req = requests.get(link)
+    req.raise_for_status()
+    soup = BeautifulSoup(req.content, "lxml")
+    opcodes = set()
+    for table in soup.find_all("table"):
+        head_tr = table.find("tr")
+        if "Instruction" not in head_tr.text:
+            continue
+        for tr in table.find_all("tr")[1:]:
+            tds = tr.find_all("td")[:2]
+            s0, s1 = str(tds[0].text).upper(), str(tds[1].text).upper()
+            if pattern.search(s0) or pattern.search(s1):
+                opcodes.add(s0.strip())
+    return opcodes
+
+
+def x86_extract_mnemonic_links() -> Mapping[str, str]:
+    """Extract a mapping of instruction mnemonics to links."""
+    req = requests.get("https://www.felixcloutier.com/x86/")
+    req.raise_for_status()
+    soup = BeautifulSoup(req.content, "lxml")
+    instruction_table = soup.find("table")
+    links = {}
+    for tr in instruction_table.find_all("tr")[1:]:
+        td = tr.find("td")
+        a = td.find("a")
+        mnemonic = str(td.text).strip()
+        href = "https://www.felixcloutier.com" + a["href"]
+        links[mnemonic.upper()] = href
+    return links
+
+
+def x86_resolve_instruction_link(instruction: str, links: Mapping[str, str]) -> Optional[str]:
+    """Resolve an instruction to its link, special casing some cases."""
+    # Oh lord save us, don't look at this fudge.
+    cc_instructions = {"SET", "CMOV"}
+    substring_instructions = ["PMOVSX", "PMOVZX", "VPBROADCASTM", "VPBROADCASTI", "VBROADCAST"]
+    explicit_map = {
+        "VMOVSD": "movsd",
+        "VBROADCASTI128": "vpbroadcast",
+        "VBROADCASTI32X2": "vpbroadcast",
+        "VBROADCASTI32X4": "vpbroadcast",
+        "VBROADCASTI32X8": "vpbroadcast",
+        "VBROADCASTI64X2": "vpbroadcast",
+        "VBROADCASTI64X4": "vpbroadcast",
+    }
+    if instruction in explicit_map:
+        return f"https://www.felixcloutier.com/x86/{explicit_map[instruction]}"
+    if instruction not in links:
+        if instruction.startswith("V"):
+            if instruction[1:] in links:
+                return links[instruction[1:]]
+            elif instruction[:-1] in links:
+                return links[instruction[:-1]]
+            elif instruction[1:-1] in links:
+                return links[instruction[1:-1]]
+        for cc_intruction in cc_instructions:
+            if instruction.startswith(cc_intruction):
+                return links[cc_intruction + "CC"]
+        for sub_instruction in substring_instructions:
+            if sub_instruction in instruction:
+                return links[sub_instruction]
+    else:
+        return links[instruction]
+    return None
+
+def x86_validate_coverage(doitm_map):
+    """
+    Verify that the opcodes in the DOITM map fully cover all instruction encodings for the instructions.
+
+    This is important, as Jasmin outputs assembly and has no direct control over the instruction encodings
+    (and thus opcodes) the assembler picks. This validation function prints "BAD" in case some instruction's
+    opcodes are not fully in the DOIT list.
+
+    As of this comment (March 2024), only MOV, POP, PUSH opcodes involving some segment registers are not on
+    the DOIT list. These will not be issued by Jasmin.
+    """
+    links = x86_extract_mnemonic_links()
+    for instruction, opcodes in tqdm(doitm_map.items()):
+        link = x86_resolve_instruction_link(instruction, links)
+        if link is None:
+            print(f"Ignoring {instruction}", file=sys.stderr)
+            continue
+        hex_opcodes = set(map(lambda x: f"{x:02X}", opcodes))
+        extracted_opcodes = x86_extract_opcodes(link, instruction)
+        covered_opcodes = set()
+        for extracted in extracted_opcodes:
+            for opcode in hex_opcodes:
+                if opcode in extracted:
+                    covered_opcodes.add(extracted)
+                    break
+        if covered_opcodes != extracted_opcodes:
+            not_covered = extracted_opcodes.difference(covered_opcodes)
+            print("BAD", instruction, link, hex_opcodes, not_covered, file=sys.stderr)
+
+def x86():
+    # Only do this once and store.
+    doitm_json = Path("doitm.json")
+    if doitm_json.exists() and doitm_json.is_file():
+        print("doitm.json exists, will use and not validate again.", file=sys.stderr)
+        with doitm_json.open("r") as f:
+            doitm_list = json.load(f)
+    else:
+        print("Extracting... (will write into doitm.json for later use)", file=sys.stderr)
+        doitm_instructions = x86_extract_doitm()
+        doitm_map = {}
+        for instruction, opcode in doitm_instructions:
+            doitm_map.setdefault(instruction, set())
+            doitm_map[instruction].add(opcode)
+        x86_validate_coverage(doitm_map)
+        doitm_list = list(doitm_map)
+        with doitm_json.open("w") as f:
+            json.dump(doitm_list, f)
+    # Now compare with Jasmin supported instructions
+    intrinsics_lines = subprocess.run(["../jasminc", "-help-instructions", "-arch", "x86-64"], capture_output=True, encoding="ascii").stdout.split("\n")
+    name2instr = {}
+    instr2name = {}
+    for line in intrinsics_lines:
+        if not line:
+            continue
+        name, instruction = line.strip().split(":")
+        name2instr.setdefault(name, set())
+        name2instr[name].add(instruction)
+        instr2name.setdefault(instruction, set())
+        instr2name[instruction].add(name)
+    doit2instr = {}
+    unused_doits = set()
+    for instruction in doitm_list:
+        if instruction == "MULX":
+            instruction = "MULX_lo_hi"
+        if instruction in name2instr:
+            doit2instr[instruction] = name2instr[instruction]
+        names = instr2name.get(instruction)
+        if not names:
+            unused_doits.add(instruction)
+            continue
+        for name in names:
+            doit2instr.setdefault(name, set())
+            doit2instr[name].add(instruction)
+    names = set(doit2instr).union(name2instr).union(unused_doits)
+    for name in sorted(names):
+        instructions = doit2instr.get(name, set())
+        jazz_instructions = name2instr.get(name, set())
+        if not jazz_instructions:
+            print(f"Not JAZZ          {name}", file=sys.stderr)
+        elif not instructions:
+            print(f"Not DOIT          {name} JAZZ:{jazz_instructions}", file=sys.stderr)
+        elif jazz_instructions == instructions:
+            print(f"Fully covered     {name} {instructions}", file=sys.stderr)
+        else:
+            print(f"Not fully covered {name} DOIT:{instructions} JAZZ:{jazz_instructions} DOIT-JAZZ:{instructions.difference(jazz_instructions)} JAZZ-DOIT:{jazz_instructions.difference(instructions)}", file=sys.stderr)
+    print("  let is_doit_asm_op (o : asm_op) =")
+    print("    match o with")
+    for name in sorted(names):
+        instructions = doit2instr.get(name, set())
+        jazz_instructions = name2instr.get(name, set())
+        if not jazz_instructions:
+            print(f"    (* Not in Jasmin {name} *)")
+        elif not instructions:
+            if len(jazz_instructions) > 1:
+                print(f"    | {name} _ -> false (* Not DOIT *)")
+            else:
+                print(f"    | {name} -> false (* Not DOIT *)")
+        elif jazz_instructions == instructions:
+            if len(instructions) > 1:
+                print(f"    | {name} _ -> true")
+            else:
+                print(f"    | {name} -> true")
+        else:
+            print(f"    (* Partial, investigate! {name} {instructions} *)")
+
+
+def arm():
+    req = requests.get("https://documentation-service.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/DIT--Data-Independent-Timing")
+    req.raise_for_status()
+    data = req.json()
+    content = b64decode(data["content"])
+    soup = BeautifulSoup(content, "lxml")
+    title_ps = soup.find_all("p", string=re.compile("These instructions are"))
+    instructions = set()
+    for p in title_ps:
+        ul = p.find_next_sibling("ul")
+        li = ul.find("li")
+        for span in li.find_all("span"):
+            instructions.add(str(span.text).strip())
+    # Now compare with Jasmin supported instructions
+    intrinsics_lines = subprocess.run(["../jasminc", "-help-instructions", "-arch", "arm-m4"], capture_output=True, encoding="ascii").stdout.split("\n")
+    name2instr = {}
+    instr2name = {}
+    for line in intrinsics_lines:
+        if not line:
+            continue
+        name, instruction = line.strip().split(":")
+        name2instr.setdefault(name, set())
+        name2instr[name].add(instruction)
+        instr2name.setdefault(instruction, set())
+        instr2name[instruction].add(name)
+    names = instructions.union(name2instr)
+    print("  let is_doit_asm_op (o : asm_op) =")
+    print("    match o with")
+    for name in sorted(names):
+        if name in name2instr and name in instructions:
+            print(f"    | ARM_op({name}, _) -> true")
+        elif name in name2instr:
+            print(f"    | ARM_op({name}, _) -> false (* Not DIT *)")
+        elif name in instructions:
+            print(f"    (* Not in Jasmin {name} *)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} x86|arm", file=sys.stderr)
+        exit(2)
+    match sys.argv[1]:
+        case "x86":
+            x86()
+        case "arm":
+            arm()

--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -35,7 +35,9 @@ module type Core_arch = sig
   val known_implicits : (Name.t * string) list
 
   val is_ct_asm_op : asm_op -> bool
+  val is_doit_asm_op : asm_op -> bool
   val is_ct_asm_extra : extra_op -> bool
+  val is_doit_asm_extra : extra_op -> bool
 
 end
 
@@ -71,7 +73,7 @@ module type Arch = sig
 
   val arch_info : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Pretyping.arch_info
 
-  val is_ct_sopn : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op -> bool
+  val is_ct_sopn : ?doit:bool -> (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op -> bool
 end
 
 module Arch_from_Core_arch (A : Core_arch) :
@@ -198,9 +200,9 @@ module Arch_from_Core_arch (A : Core_arch) :
       flagnames = List.map fst known_implicits;
     }
 
-  let is_ct_sopn (o : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op) =
+  let is_ct_sopn ?(doit = false) (o : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op) =
    match o with
-   | BaseOp (_, o) -> is_ct_asm_op o
-   | ExtOp o -> is_ct_asm_extra o
+   | BaseOp (_, o) -> (if doit then is_doit_asm_op else is_ct_asm_op) o
+   | ExtOp o -> (if doit then is_doit_asm_extra else is_ct_asm_extra) o
 
 end

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -36,7 +36,9 @@ module type Core_arch = sig
   val known_implicits : (Name.t * string) list
 
   val is_ct_asm_op : asm_op -> bool
+  val is_doit_asm_op : asm_op -> bool
   val is_ct_asm_extra : extra_op -> bool
+  val is_doit_asm_extra : extra_op -> bool
 
 end
 
@@ -72,7 +74,7 @@ module type Arch = sig
   
   val arch_info : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Pretyping.arch_info
 
-  val is_ct_sopn : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op -> bool
+  val is_ct_sopn : ?doit:bool -> (reg, regx, xreg, rflag, cond, asm_op, extra_op) Arch_extra.extended_op -> bool
 end
 
 module Arch_from_Core_arch (A : Core_arch) : Arch

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -33,8 +33,70 @@ module Arm_core = struct
     | ARM_op( (SDIV  | UDIV), _) -> false
     | _ -> true
 
+  let is_doit_asm_op (o : asm_op) =
+    match o with
+    | ARM_op(ADC, _) -> true
+    | ARM_op(ADD, _) -> true
+    | ARM_op(ADR, _) -> false (* Not DIT *)
+    | ARM_op(AND, _) -> true
+    | ARM_op(ASR, _) -> true
+    | ARM_op(BFC, _) -> true
+    | ARM_op(BFI, _) -> true
+    | ARM_op(BIC, _) -> true
+    | ARM_op(CLZ, _) -> true
+    | ARM_op(CMN, _) -> true
+    | ARM_op(CMP, _) -> true
+    | ARM_op(EOR, _) -> true
+    | ARM_op(LDR, _) -> false (* Not DIT *)
+    | ARM_op(LDRB, _) -> false (* Not DIT *)
+    | ARM_op(LDRH, _) -> false (* Not DIT *)
+    | ARM_op(LDRSB, _) -> false (* Not DIT *)
+    | ARM_op(LDRSH, _) -> false (* Not DIT *)
+    | ARM_op(LSL, _) -> true
+    | ARM_op(LSR, _) -> true
+    | ARM_op(MLA, _) -> true
+    | ARM_op(MLS, _) -> true
+    | ARM_op(MOV, _) -> true
+    | ARM_op(MOVT, _) -> false (* Not DIT *)
+    | ARM_op(MUL, _) -> true
+    | ARM_op(MVN, _) -> true
+    | ARM_op(ORR, _) -> true
+    | ARM_op(REV, _) -> true
+    | ARM_op(REV16, _) -> true
+    | ARM_op(REVSH, _) -> false (* Not DIT *)
+    | ARM_op(ROR, _) -> true
+    | ARM_op(RSB, _) -> false (* Not DIT *)
+    | ARM_op(SBFX, _) -> true
+    | ARM_op(SDIV, _) -> false (* Not DIT *)
+    | ARM_op(SMLA_hw _, _) -> false (* Not DIT *)
+    | ARM_op(SMLAL, _) -> true
+    | ARM_op(SMMUL, _) -> false (* Not DIT *)
+    | ARM_op(SMMULR, _) -> false (* Not DIT *)
+    | ARM_op(SMUL_hw _, _) -> false (* Not DIT *)
+    | ARM_op(SMULL, _) -> true
+    | ARM_op(SMULW_hw _, _) -> false (* Not DIT *)
+    | ARM_op(STR, _) -> false (* Not DIT *)
+    | ARM_op(STRB, _) -> false (* Not DIT *)
+    | ARM_op(STRH, _) -> false (* Not DIT *)
+    | ARM_op(SUB, _) -> true
+    | ARM_op(TST, _) -> true
+    | ARM_op(UBFX, _) -> true
+    | ARM_op(UDIV, _) -> false (* Not DIT *)
+    | ARM_op(UMAAL, _) -> false (* Not DIT *)
+    | ARM_op(UMLAL, _) -> true
+    | ARM_op(UMULL, _) -> true
+    | ARM_op(UXTB, _) -> true
+    | ARM_op(UXTH, _) -> true
 
-  let is_ct_asm_extra (_ : extra_op) = true
+
+  (* All of the extra ops compile into CT instructions (no DIV). *)
+  let is_ct_asm_extra (o : extra_op) = true
+
+  (* All of the extra ops compile into DIT instructions only, but this needs to be checked manually. *)
+  let is_doit_asm_extra (o : extra_op) =
+    match o with
+    | Oarm_swap _ -> true
+    | Oarm_add_large_imm -> true
 
 end
 

--- a/compiler/src/ct_checker_forward.ml
+++ b/compiler/src/ct_checker_forward.ml
@@ -172,7 +172,7 @@ let pp_kind fmt k =
   if k = Flexible then Format.fprintf fmt "#%s " (string_of_lvl_kind k)
 
 let pp_arg fmt (x, (k, lvl)) =
-  Format.fprintf fmt "%a%a %a" pp_kind k  Lvl.pp lvl (Printer.pp_var ~debug:false) x
+  Format.fprintf fmt "%a%a %a" pp_kind k  Lvl.pp lvl (Printer.pp_var ~debug:!Glob_options.debug) x
 
 let pp_signature prog fmt (fn, { tyin ; tyout }) =
   Format.fprintf fmt "@[<h>@[%s(@[%a@]) ->@ @[%a@]@]@]@."
@@ -264,7 +264,7 @@ end = struct
       if not (Lvl.equal lvl lvlx) then
         error ~loc:(L.loc x)
              "%a has type #%s %a it cannot receive a value of type %a"
-             (Printer.pp_var ~debug:false) (L.unloc x)
+             (Printer.pp_var ~debug:!Glob_options.debug) (L.unloc x)
              Lvl.sstrict Lvl.pp lvlx
              Lvl.pp lvl
       else env
@@ -282,7 +282,7 @@ end = struct
       | Secret ->
         error ~loc
           "%a has type secret it needs to be public"
-             (Printer.pp_var ~debug:false) (L.unloc x)
+             (Printer.pp_var ~debug:!Glob_options.debug) (L.unloc x)
       | Public -> env, Public
       | Poly s ->
         let poly = Svl.filter Vl.is_poly s in
@@ -290,7 +290,7 @@ end = struct
         else
           error ~loc
                "variable %a has type %a, it should be public. Replace the polymorphic variable(s) %a by public"
-               (Printer.pp_var ~debug:false) (L.unloc x)
+               (Printer.pp_var ~debug:!Glob_options.debug) (L.unloc x)
                Lvl.pp lvl
                (pp_list ",@ " Vl.pp) (Svl.elements poly)
     else env, lvl
@@ -301,7 +301,7 @@ end = struct
 
   let pp fmt env =
     let pp_ty fmt (x, (k, lvl)) =
-      Format.fprintf fmt "@[%a : %s %a@]" (Printer.pp_var ~debug:false) x
+      Format.fprintf fmt "@[%a : %s %a@]" (Printer.pp_var ~debug:!Glob_options.debug) x
         (string_of_lvl_kind k) Lvl.pp lvl in
     Format.fprintf fmt "@[<v>type = @[%a@]@ vlevel= @[%a@]@]"
        (pp_list ";@ " pp_ty) (Mv.bindings env.env_v)
@@ -508,7 +508,7 @@ let get_annot ensure_annot f =
       begin
         warning Always (L.i_loc0 x.v_dloc)
           "%s annotation will be ignored for local variable %a"
-          Lvl.sflexible (Printer.pp_var ~debug:false) x;
+          Lvl.sflexible (Printer.pp_var ~debug:!Glob_options.debug) x;
         decls
       end
     else
@@ -647,7 +647,7 @@ and ty_fun is_ct_asm fenv fn =
         else
           error ~loc:(L.loc x)
             "the variable %a has type %a instead of %a"
-              (Printer.pp_var ~debug:false) (L.unloc x)
+              (Printer.pp_var ~debug:!Glob_options.debug) (L.unloc x)
               Lvl.pp lvl Lvl.pp alvl in
     lvl in
   let tyout = List.map2 (do_r env) f.f_ret aout in

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -22,6 +22,7 @@ let trust_aligned = ref false
 
 let help_version = ref false
 let help_intrinsics = ref false
+let help_instructions = ref false
 type color = | Auto | Always | Never
 let color = ref Auto
 
@@ -204,9 +205,10 @@ let options = [
     "-wduplicatevar", Arg.Unit (add_warning DuplicateVar), " Print warning when two variables share the same name";
     "-wunusedvar", Arg.Unit (add_warning UnusedVar), " Print warning when a variable is not used";
     "-noinsertarraycopy", Arg.Clear introduce_array_copy, " Do not automatically insert array copy";
-    "-nowarning", Arg.Unit (nowarning), " Do no print warnings";
+    "-nowarning", Arg.Unit (nowarning), " Do not print warnings";
     "-color", Arg.Symbol (["auto"; "always"; "never"], set_color), " Print messages with color";
     "-help-intrinsics", Arg.Set help_intrinsics, " List the set of intrinsic operators (and exit)";
+    "-help-instructions", Arg.Set help_instructions, " List the set of instructions and their variants (and exit)";
     "-print-stack-alloc", Arg.Set print_stack_alloc, " Print the results of the stack allocation OCaml oracle";
     "-lazy-regalloc", Arg.Set lazy_regalloc, " Allocate variables to registers in program order";
     "-pall"    , Arg.Unit set_all_print, " Print program after each compilation steps";

--- a/compiler/src/help.ml
+++ b/compiler/src/help.ml
@@ -1,10 +1,129 @@
-open Pretyping
+open Arch_decl
+
+let rec product'' l =
+  (* We need to do the cross product of our current list and all the others
+   * so we define a helper function for that *)
+  let rec aux ~acc l1 l2 = match l1, l2 with
+  | [], _ | _, [] -> acc
+  | h1::t1, h2::t2 ->
+      let acc = (h1::h2)::acc in
+      let acc = (aux ~acc t1 l2) in
+      aux ~acc [h1] t2
+  (* now we can do the actual computation *)
+  in match l with
+  | [] -> []
+  | [l1] -> List.map (fun x -> [x]) l1
+  | l1::tl ->
+      let tail_product = product'' tl in
+      aux ~acc:[] l1 tail_product
+
+let x86_condts =
+  [ X86_decl.O_ct; NO_ct; B_ct; NB_ct; E_ct; NE_ct; BE_ct; NBE_ct; S_ct; NS_ct; P_ct;
+    NP_ct; L_ct; NL_ct; LE_ct; NLE_ct ]
+
+let x86_arg_of_arg_kind = function
+  | CAcond -> List.map (fun c -> Condt c) x86_condts
+  | CAreg -> [ Reg X86_decl.RSP ]
+  | CAregx -> [ Regx X86_decl.MM0 ]
+  | CAxmm -> [ XReg X86_decl.XMM0 ]
+  | CAmem _ ->
+      let addr =
+        {
+          ad_disp = Word0.wrepr U64 (Conv.cz_of_int 0);
+          ad_base = None;
+          ad_scale = Conv.nat_of_int 0;
+          ad_offset = None;
+        }
+      in
+      [ Addr (Areg addr) ]
+  | CAimm _ -> [ Imm(U32, Word0.wrepr U32 (Conv.cz_of_int 0)) ]
+
+let x86_args_of_arg_kinds aks = List.concat_map x86_arg_of_arg_kind aks
+
+
+let x86_args_of_args_kinds as_ks =
+  List.map x86_args_of_arg_kinds as_ks |> product''
+
+let x86_args_of_i_args_kinds i_as_ks = List.concat_map x86_args_of_args_kinds i_as_ks
+
+let pp_suff_x86 name preop suff : string list =
+  match preop suff with
+  | None -> failwith "ERROR: invalid suffix"
+  | Some op ->
+      let id =
+        instr_desc X86_decl.x86_decl X86_instr_decl.x86_op_decl (None, op)
+      in
+      let i_as_ks = id_args_kinds X86_decl.x86_decl id in
+      let all_args = x86_args_of_i_args_kinds i_as_ks in
+      let doit args = id.id_pp_asm args |> Ppasm.pp_name_ext in
+      let mapped = List.map doit all_args in
+      List.map (fun f -> name ^ ":" ^ String.uppercase_ascii f) mapped
+
+let pp_x86 name pc : string list =
+  match pc with
+  | Sopn.PrimX86 (suffs, preop) ->
+    if suffs = [] then
+      [name ^ ":" ^ name]
+    else
+      List.concat_map (pp_suff_x86 name preop) suffs
+  | Sopn.PrimARM _ -> failwith "Bad type!"
+
+let x86_supp_instr =
+  List.concat_map (fun (name, pc) -> pp_x86 (Conv.string_of_cstring name) pc) X86_instr_decl.x86_prim_string
+  |> List.sort_uniq String.compare
+
+let arm_condts =
+  [ Arm_decl.EQ_ct; NE_ct; CS_ct; CC_ct; MI_ct; PL_ct; VS_ct; VC_ct; HI_ct; LS_ct; GE_ct; LT_ct; GT_ct; LE_ct  ]
+
+let arm_arg_of_arg_kind = function
+  | CAcond -> List.map (fun c -> Condt c) arm_condts
+  | CAreg -> [ Reg Arm_decl.R00 ]
+  | CAregx -> []
+  | CAxmm -> []
+  | CAmem _ ->
+      let addr =
+        {
+          ad_disp = Word0.wrepr U64 (Conv.cz_of_int 0);
+          ad_base = None;
+          ad_scale = Conv.nat_of_int 0;
+          ad_offset = None;
+        }
+      in
+      [ Addr (Areg addr) ]
+  | CAimm _ -> [ Imm(U32, Word0.wrepr U32 (Conv.cz_of_int 0)) ]
+
+let arm_args_of_arg_kinds aks = List.concat_map arm_arg_of_arg_kind aks
+
+let arm_args_of_args_kinds as_ks =
+  List.map arm_args_of_arg_kinds as_ks |> product''
+
+let arm_args_of_i_args_kinds i_as_ks = List.concat_map arm_args_of_args_kinds i_as_ks
+
+let pp_suff_arm name f a b : string list =
+  let op = f a b in
+  let id = instr_desc Arm_decl.arm_decl Arm_instr_decl.arm_op_decl (None, op) in
+  let i_as_ks = id_args_kinds Arm_decl.arm_decl id in
+  let all_args = arm_args_of_i_args_kinds i_as_ks in
+  let doit args = id.id_pp_asm args in
+  let mapped = List.map doit all_args in
+  (* TODO: actually use this and print the expanded instructions. *)
+  List.map (fun f -> name ^ ":" ^ name) mapped
+
+let pp_arm name pc : string list =
+  match pc with
+  | Sopn.PrimX86 _ -> failwith "Bad type!"
+  | Sopn.PrimARM (f) -> pp_suff_arm name f true false
+
+
+let arm_supp_instr =
+  List.concat_map (fun (name, pc) -> pp_arm (Conv.string_of_cstring name) pc) Arm_instr_decl.arm_prim_string
+  |> List.sort_uniq String.compare
+
 
 let show_intrinsics asmOp fmt =
   let index =
-    let open Sopn in
     function
-    | PrimX86 (sfx, _) ->
+    | Sopn.PrimX86 (sfx, _) ->
       begin match sfx with
       | [] -> 0
       | PVp _ :: _ -> 1
@@ -26,7 +145,7 @@ let show_intrinsics asmOp fmt =
   List.iter (fun (n, i) ->
       let j = index i in
       intrinsics.(j) <- n :: intrinsics.(j))
-    (prim_string asmOp);
+    (Pretyping.prim_string asmOp);
   Array.iter2 (fun h m ->
       Format.fprintf fmt "Intrinsics accepting %s:@." h;
       m |>
@@ -35,5 +154,14 @@ let show_intrinsics asmOp fmt =
       Format.fprintf fmt "@."
     ) headers intrinsics
 
+
 let show_intrinsics asmOp () =
   show_intrinsics asmOp Format.std_formatter
+
+
+let show_instructions () =
+  let instr_list = match !Glob_options.target_arch with
+  | X86_64 -> x86_supp_instr
+  | ARM_M4 -> arm_supp_instr
+  in
+  List.iter print_endline instr_list

--- a/compiler/src/help.mli
+++ b/compiler/src/help.mli
@@ -1,1 +1,3 @@
 val show_intrinsics : 'asm Sopn.asmOp -> unit -> unit
+
+val show_instructions : unit -> unit

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -25,7 +25,7 @@ let parse () =
   if c then enable_colors ();
   match !infiles with
   | [] ->
-    if !help_intrinsics || !safety_makeconfigdoc <> None || !help_version
+    if !help_intrinsics || !help_instructions || !safety_makeconfigdoc <> None || !help_version
     then ""
     else error()
   | [ infile ] ->
@@ -97,6 +97,10 @@ let main () =
       SafetyConfig.mk_config_doc dir;
       exit 0);
 
+
+    if !help_instructions
+    then (Help.show_instructions (); exit 0);
+
     if !help_intrinsics
     then (Help.show_intrinsics Arch.asmOp_sopn (); exit 0);
 
@@ -123,12 +127,12 @@ let main () =
     in
 
     if !print_dependencies then begin
-      Format.printf "%a" 
+      Format.printf "%a"
         (pp_list " " (fun fmt p -> Format.fprintf fmt "%s" (BatPathGen.OfString.to_string p)))
         (List.tl (List.rev (Pretyping.Env.dependencies env)));
       exit 0
     end;
- 
+
     if !latexfile <> "" then begin
       let out = open_out !latexfile in
       let fmt = Format.formatter_of_out_channel out in
@@ -136,7 +140,7 @@ let main () =
       close_out out;
       if !debug then Format.eprintf "Pretty printed to LATEX@."
     end;
-  
+
     eprint Compiler.Typing (Printer.pp_pprog Arch.reg_size Arch.asmOp) pprog;
 
     let prog =

--- a/compiler/src/ppasm.ml
+++ b/compiler/src/ppasm.ml
@@ -495,6 +495,11 @@ end
 module PATT = Printer(ATT)
 module PIntel = Printer(Intel)
 
+let pp_name_ext pp_op =
+  match !Glob_options.assembly_style with
+  | `ATT -> PATT.pp_name_ext pp_op
+  | `Intel -> PIntel.pp_name_ext pp_op
+
 let pp_instr name fmt i =
     match !Glob_options.assembly_style with
     | `ATT -> PATT.pp_instr name fmt i

--- a/compiler/src/ppasm.mli
+++ b/compiler/src/ppasm.mli
@@ -1,4 +1,5 @@
 open Wsize
+open Arch_decl
 (* -------------------------------------------------------------------- *)
 exception InvalidRegSize of wsize
 
@@ -6,6 +7,9 @@ exception InvalidRegSize of wsize
 val mangle : string -> string
 
 (* -------------------------------------------------------------------- *)
+val pp_name_ext :
+  (X86_decl.register, X86_decl.register_ext, X86_decl.xmm_register, X86_decl.rflag, X86_decl.condt) pp_asm_op -> string
+
 val pp_instr :
   string -> Format.formatter ->
   (X86_decl.register, X86_decl.register_ext, X86_decl.xmm_register, X86_decl.rflag, X86_decl.condt, X86_instr_decl.x86_op) Arch_decl.asm_i ->

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -1,5 +1,6 @@
 open Arch_decl
 open X86_decl
+open Wsize
 
 module type X86_input = sig
 
@@ -47,8 +48,156 @@ module X86_core = struct
     | DIV _ | IDIV _ -> false
     | _ -> true
 
-  let is_ct_asm_extra (_ : extra_op) = true
+  let is_doit_asm_op (o : asm_op) =
+    match o with
+    | ADC _ -> true
+    | ADCX _ -> true
+    | ADD _ -> true
+    | ADOX _ -> true
+    | AESDEC -> true
+    | AESDECLAST -> true
+    | AESENC -> true
+    | AESENCLAST -> true
+    | AESIMC -> true
+    | AESKEYGENASSIST -> true
+    | AND _ -> true
+    | ANDN _ -> true
+    | BSWAP _ -> false (* Not DOIT *)
+    | BT _ -> true
+    | CLC -> false (* Not DOIT *)
+    | CLFLUSH -> false (* Not DOIT *)
+    | CMOVcc _ -> true
+    | CMP _ -> true
+    | CQO _ -> false (* Not DOIT *)
+    | DEC _ -> true
+    | DIV _ -> false (* Not DOIT *)
+    | IDIV _ -> false (* Not DOIT *)
+    | IMUL _ -> true
+    | IMULr _ -> false (* Not DOIT *)
+    | IMULri _ -> false (* Not DOIT *)
+    | INC _ -> true
+    | LEA _ -> true
+    | LFENCE -> false (* Not DOIT *)
+    | LZCNT _ -> false (* Not DOIT *)
+    | MFENCE -> false (* Not DOIT *)
+    | MOV _ -> true
+    | MOVD _ -> true
+    | MOVSX _ -> true
+    | MOVV _ -> true
+    | MOVX _ -> true
+    | MOVZX _ -> true
+    | MUL _ -> true
+    | MULX_lo_hi _ -> true
+    | NEG _ -> true
+    | NOT _ -> true
+    | OR _ -> true
+    | PCLMULQDQ -> true
+    | PDEP _ -> false (* Not DOIT *)
+    | PEXT _ -> false (* Not DOIT *)
+    | POPCNT _ -> false (* Not DOIT *)
+    | RCL _ -> false (* Not DOIT *)
+    | RCR _ -> false (* Not DOIT *)
+    | RDTSC _ -> false (* Not DOIT *)
+    | RDTSCP _ -> false (* Not DOIT *)
+    | ROL _ -> false (* Not DOIT *)
+    | ROR _ -> false (* Not DOIT *)
+    | SAL _ -> false (* Not DOIT *)
+    | SAR _ -> true
+    | SBB _ -> true
+    | SETcc -> true
+    | SFENCE -> false (* Not DOIT *)
+    | SHL _ -> true
+    | SHLD _ -> false (* Not DOIT *)
+    | SHR _ -> true
+    | SHRD _ -> false (* Not DOIT *)
+    | STC -> false (* Not DOIT *)
+    | SUB _ -> true
+    | TEST _ -> true
+    | VAESDEC -> true
+    | VAESDECLAST -> true
+    | VAESENC -> true
+    | VAESENCLAST -> true
+    | VAESIMC -> true
+    | VAESKEYGENASSIST -> true
+    | VBROADCASTI128 -> true
+    | VEXTRACTI128 -> true
+    | VINSERTI128 -> true
+    | VMOV _ -> true
+    | VMOVDQA _ -> true
+    | VMOVDQU _ -> true
+    | VMOVHPD -> false (* Not DOIT *)
+    | VMOVLPD -> false (* Not DOIT *)
+    | VMOVSHDUP _ -> true
+    | VMOVSLDUP _ -> true
+    | VPACKSS _ -> true
+    | VPACKUS _ -> true
+    | VPADD _ -> true
+    | VPALIGNR _ -> true
+    | VPAND _ -> true
+    | VPANDN _ -> true
+    | VPAVG _ -> true
+    | VPBLEND _ -> true
+    | VPBLENDVB _ -> true
+    | VPBROADCAST _ -> true
+    | VPCLMULQDQ _ -> true
+    | VPCMPEQ _ -> true
+    | VPCMPGT _ -> true
+    | VPERM2I128 -> true
+    | VPERMD -> true
+    | VPERMQ -> true
+    | VPEXTR _ -> true
+    | VPINSR _ -> true
+    | VPMADDUBSW _ -> true
+    | VPMADDWD _ -> true
+    | VPMAXS (ve, _) -> ve = VE8 || ve = VE16
+    | VPMAXU _ -> true
+    | VPMINS (ve, _) -> ve = VE8 || ve = VE16
+    | VPMINU _ -> true
+    | VPMOVMSKB _ -> true
+    | VPMOVSX _ -> true
+    | VPMOVZX _ -> true
+    | VPMUL _ -> true
+    | VPMULH _ -> true
+    | VPMULHRS _ -> true
+    | VPMULHU _ -> true
+    | VPMULL _ -> true
+    | VPMULU _ -> true
+    | VPOR _ -> true
+    | VPSHUFB _ -> true
+    | VPSHUFD _ -> true
+    | VPSHUFHW _ -> true
+    | VPSHUFLW _ -> true
+    | VPSLL _ -> true
+    | VPSLLDQ _ -> true
+    | VPSLLV _ -> true
+    | VPSRA _ -> true
+    | VPSRL _ -> true
+    | VPSRLDQ _ -> true
+    | VPSRLV _ -> true
+    | VPSUB _ -> true
+    | VPTEST _ -> true
+    | VPUNPCKH _ -> true
+    | VPUNPCKL _ -> true
+    | VPXOR _ -> true
+    | VSHUFPS _ -> false (* Not DOIT *)
+    | XCHG _ -> false (* Not DOIT *)
+    | XOR _ -> true
 
+  (* All of the extra ops compile into CT instructions (no DIV). *)
+  let is_ct_asm_extra (o : extra_op) = true
+
+  (* All of the extra ops compile into DOIT instructions only, but this needs to be checked manually. *)
+  let is_doit_asm_extra (o : extra_op) =
+    match o with
+    | Oset0 _           -> true
+    | Oconcat128        -> true
+    | Ox86MOVZX32       -> true
+    | Ox86MULX ws       -> true
+    | Ox86MULX_hi _     -> true
+    | Ox86SLHinit       -> true
+    | Ox86SLHupdate     -> true
+    | Ox86SLHmove       -> true
+    | Ox86SLHprotect _  -> true
 
 end
 


### PR DESCRIPTION
This PR will add support for ensuring that secret values only go into guaranteed constant-time instructions (Intel DOITM, ARM DIT).

Currently it does the following:
 - Adds a script for semi-automated extraction of the [Intel DOIT](https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/resources/data-operand-independent-timing-instructions.html)/[ARM DIT](https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/DIT--Data-Independent-Timing?lang=en) lists. This script checks, in the Intel case, whether the opcodes on the list cover all the instruction encodings of the mnemonic on the list.
 - Adds a CLI option `-help-instructions` to the compiler that is similar to the `-help-instrinsics` one but prints all of the instructions for the given architecture that Jasmin understands along with their expanded variants. This is necessary for the automated extraction of the DIT/DOIT instructions that Jasmin supports. Example of output:
>    VPSUB:VPSUBB
>    VPSUB:VPSUBD
>    VPSUB:VPSUBQ
>    VPSUB:VPSUBW

 - Adds a CLI option `-doit` to the `jazzct` tool that **switches** the CT checker list of constant-time instructions from "*all but DIV/MOD*" to "*only those in the DOIT/DIT*" lists. This CLI option also checks that the compiler pass selected is during or after lowering, because the mode otherwise does not make sense.

### Which compiler pass to run with
It needs to be done at least after lowering, to have the instructions.

When run right after lowering, the CT checker can have false positives in case of lines like:
`if (_LT(of, cf, sf, zf)) {`
because it will consider all of the flags, even though the _LT operator only actually considers some.
If run after inline variable propagation this problem disappears, because the expression will be replaced with one that contains only the used flags.