### PR TITLE
writeP_neq: remove redundant lemma

### DIFF
--- a/proofs/compiler/arm_stack_zeroization_proof.v
+++ b/proofs/compiler/arm_stack_zeroization_proof.v
@@ -361,6 +361,7 @@ Proof.
     by apply hvalid.
   + move=> p hp.
     rewrite (writeP_neq hm'); first by apply hdisj.
+    apply: disjoint_range_alt.
     apply: disjoint_zrange_incl_l hp.
     rewrite /top /zbetween !zify -wrepr_sub.
     assert (h := wunsigned_range (align_word ws_align ptr)).
@@ -585,6 +586,7 @@ Local Opaque wsize_size Z.of_nat.
     by apply hvalid.
   + move=> p hp.
     rewrite (writeP_neq hm'); first by apply hdisj.
+    apply: disjoint_range_alt.
     apply: disjoint_zrange_incl_l hp.
     rewrite /top /zbetween !zify.
     assert (h := wunsigned_range (align_word ws_align ptr)).

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -2893,6 +2893,7 @@ Section PROOF.
   Proof.
     move=> ok_m1' ok_m2' hioff a ha _.
     symmetry; apply (writeP_neq ok_m2').
+    apply: disjoint_range_alt.
     have A := alloc_stackP ok_m1'.
     have: pointer_range (top_stack m1) (stack_root m1) a.
     + rewrite /pointer_range !zify; lia.
@@ -2937,6 +2938,7 @@ Section PROOF.
     move=> hb1 hb2 ok_m2.
     move=> pr' hnv hnpr.
     symmetry; apply (writeP_neq ok_m2).
+    apply: disjoint_range_alt.
     apply (disjoint_zrange_incl_l hb2).
     apply (disjoint_zrange_incl_l hb1).
     apply (not_between_U8_disjoint_zrange no_overflow_max0).
@@ -3437,7 +3439,8 @@ Section PROOF.
       have n_pos := wsize_size_pos ws.
       have n_pos' := wsize_size_pos ws'.
       have [top_lo _] := wunsigned_range top.
-      rewrite (writeP_neq ok_m1) //; split.
+      rewrite (writeP_neq ok_m1) //.
+      apply: disjoint_range_alt; split.
       1-2: rewrite !zify !wunsigned_add; lia.
       rewrite !wunsigned_add; lia.
     move => y ofs_y; rewrite inE; case: eqP.

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -1695,8 +1695,8 @@ Proof.
     + by apply (Memory.write_mem_stable hmem2).
     + by move=> ??; apply (write_validw_eq hmem2).
     + move=> p ws''.
-      rewrite -sub_region_addr_offset hty.
-      by apply: (writeP_neq hmem2).
+      rewrite -sub_region_addr_offset hty => /disjoint_range_alt.
+      apply: (writeP_neq hmem2).
     rewrite {2}hty htrw; split => //.
     move=> off hmem ? hget; rewrite {1}hty /= in hofs.
     have /= hoff := get_val_byte_bound hget.
@@ -1727,7 +1727,7 @@ Proof.
     + case: (hwfr) => hwfsr hval hptr; split=> //.
       + move=> y sry bytes vy hgvalid hgy.
         assert (hwfy := check_gvalid_wf hwfsr hgvalid).
-        have hreadeq := writeP_neq hmem2.
+        have hreadeq := writeP_neq hmem2 (disjoint_range_alt _).
         apply: (eq_sub_region_val_disjoint_zrange hreadeq _ (hval _ _ _ _ hgvalid hgy)).
         apply disjoint_zrange_sym.
         apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwfy)).
@@ -1736,6 +1736,7 @@ Proof.
       have [pk [hgpk hvpk]] := hptr _ _ hgy; exists pk; split => //.
       case: pk hgpk hvpk => //= s ofs ws' z f hgpk hread /hread <-.
       apply: (writeP_neq hmem2).
+      apply: disjoint_range_alt.
       assert (hwf' := sub_region_stkptr_wf (wf_locals hgpk)).
       apply disjoint_zrange_sym.
       apply: (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf')).
@@ -1780,6 +1781,7 @@ Proof.
   + by apply (Memory.write_mem_stable hmem2).
   + move=> p ws' hdisj.
     apply (writeP_neq hmem2).
+    apply: disjoint_range_alt.
     apply: disjoint_zrange_incl_l hdisj.
     by apply: (zbetween_sub_region_at_ofs_option hwf _ (mk_ofsiP he1)).
   have /vm_truncate_valE [_ ->]:= htr.
@@ -2518,7 +2520,7 @@ Proof.
       exists vm2, mem2; split => //.
       + by apply (Memory.write_mem_stable hmem2).
       + by move=> ??; apply (write_validw_eq hmem2).
-      + by move=> ??; apply (writeP_neq hmem2).
+      + by move=> ?? /disjoint_range_alt; apply (writeP_neq hmem2).
       rewrite (writeP_eq hmem2).
       by rewrite wrepr_add GRing.addrA -haddr -sub_region_addr_offset.
 

--- a/proofs/compiler/x86_stack_zeroization_proof.v
+++ b/proofs/compiler/x86_stack_zeroization_proof.v
@@ -215,6 +215,7 @@ Proof.
     by apply hvalid.
   + move=> p hp.
     rewrite (writeP_neq hm'); first by apply hdisj.
+    apply: disjoint_range_alt.
     apply: disjoint_zrange_incl_l hp.
     rewrite /top /zbetween !zify -wrepr_sub.
     assert (h := wunsigned_range (align_word ws_align ptr)).
@@ -523,6 +524,7 @@ Proof.
     by apply hvalid.
   + move=> p hp.
     rewrite (writeP_neq hm'); first by apply hdisj.
+    apply: disjoint_range_alt.
     apply: disjoint_zrange_incl_l hp.
     rewrite /top /zbetween !zify -wrepr_sub.
     assert (h := wunsigned_range (align_word ws_align ptr)).
@@ -888,6 +890,7 @@ Local Opaque wsize_size Z.of_nat.
     by apply hvalid.
   + move=> p hp.
     rewrite (writeP_neq hm'); first by apply hdisj.
+    apply: disjoint_range_alt.
     apply: disjoint_zrange_incl_l hp.
     rewrite /top /zbetween !zify.
     assert (h := wunsigned_range (align_word ws_align ptr)).
@@ -1141,6 +1144,7 @@ Local Opaque wsize_size Z.of_nat.
     by apply hvalid.
   + move=> p hp.
     rewrite (writeP_neq hm'); first by apply hdisj.
+    apply: disjoint_range_alt.
     apply: disjoint_zrange_incl_l hp.
     rewrite /top /zbetween !zify.
     assert (h := wunsigned_range (align_word ws_align ptr)).

--- a/proofs/lang/low_memory.v
+++ b/proofs/lang/low_memory.v
@@ -75,40 +75,6 @@ Proof.
   move => hw; apply /writeV; exists m'; exact hw.
 Qed.
 
-(* An alternate form of [CoreMem.writeP_neq] that should be easier to use. *)
-Lemma writeP_neq mem1 mem2 p ws (v : word ws) p2 ws2 :
-  write mem1 p v = ok mem2 ->
-  disjoint_range p ws p2 ws2 ->
-  read mem2 p2 ws2 = read mem1 p2 ws2.
-Proof.
-  move=> hmem2 hdisj.
-  apply (writeP_neq hmem2).
-  by apply disjoint_range_alt.
-Qed.
-
-Lemma disjoint_range_valid_not_valid_U8 m p1 ws1 p2 :
-  validw m p1 ws1 ->
-  ~ validw m p2 U8 ->
-  disjoint_range p1 ws1 p2 U8.
-Proof.
-  move=> /validwP [hal1 hval1] hnval.
-  split.
-  + by apply is_align_no_overflow.
-  + by apply is_align_no_overflow; apply is_align8.
-  rewrite wsize8.
-  case: (Z_le_gt_dec (wunsigned p1 + wsize_size ws1) (wunsigned p2)); first by left.
-  case: (Z_le_gt_dec (wunsigned p2 + 1) (wunsigned p1)); first by right.
-  move=> hgt1 hgt2.
-  case: hnval.
-  apply /validwP; split.
-  + by apply is_align8.
-  move=> k; rewrite wsize8 => hk; have ->: k = 0%Z by Lia.lia.
-  rewrite add_0.
-  have ->: p2 = (p1 + wrepr _ (wunsigned p2 - wunsigned p1))%R.
-  + by rewrite wrepr_sub !wrepr_unsigned; ssring.
-  by apply hval1; Lia.lia.
-Qed.
-
 Lemma alloc_stack_top_stack m ws sz ioff sz' m' :
   alloc_stack m ws sz ioff sz' = ok m' →
   top_stack m' = top_stack_after_alloc (top_stack m) ws (sz + sz').

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -306,6 +306,22 @@ Section CoreMem.
     elim: (hd (sub (add p' k) p) k) => //; by rewrite add_sub.
   Qed.
 
+  Lemma disjoint_range_valid_not_valid_U8 m p1 ws1 p2 :
+    validw m p1 ws1 ->
+    ~ validw m p2 U8 ->
+    disjoint_range p1 ws1 p2 U8.
+  Proof.
+    move=> /validwP [hal1 hval1] hnval.
+    red; rewrite wsize8 => i i' i_range ?.
+    have ? : i' = 0 by Lia.lia.
+    subst; rewrite add_0.
+    move => ?; subst; apply: hnval; apply/validwP; split.
+    + by apply is_align8.
+    move=> k; rewrite wsize8 => hk; have ->: k = 0%Z by Lia.lia.
+    rewrite add_0.
+    exact: hval1.
+  Qed.
+
   Lemma read_write_any_mem m1 m1' pr pw szw (vw:word szw) m2 m2':
     read m1 pr U8 = read m1' pr U8 ->
     write m1 pw vw = ok m2 ->


### PR DESCRIPTION
The removed lemma has too strong hypotheses (that may not hold when memory accesses are not aligned…).