### PR TITLE
Slicing: turn export functions into inline ones unless there are explicitly asked to be kept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,11 @@
 - The compiler no longer throws an exception when a required file does not exist
   ([PR #733](https://github.com/jasmin-lang/jasmin/pull/733)).
 
+- When slicing, export functions that are called from kept functions are no
+  longer spuriously kept
+  ([PR #751](https://github.com/jasmin-lang/jasmin/pull/751);
+  fixes [#750](https://github.com/jasmin-lang/jasmin/issues/750)).
+
 ## Other changes
 
 - Pretty-printing of Jasmin programs is more precise

--- a/compiler/src/fInfo.ml
+++ b/compiler/src/fInfo.ml
@@ -35,5 +35,9 @@ let is_subroutine = function
   | Subroutine _ -> true
   | _            -> false
 
+let is_export = function
+  | Export -> true
+  | _ -> false
+
 type t =
   Location.t * f_annot * call_conv * Annotations.annotations list

--- a/compiler/src/slicing.ml
+++ b/compiler/src/slicing.ml
@@ -55,5 +55,17 @@ let slice fs (gd, fds) =
         if Sf.mem fd.f_name k.funs then inspect_stmt k fd.f_body else k)
       { vars = Sv.empty; funs } fds
   in
-  ( List.filter (fun (x, _) -> Sv.mem x k.vars) gd,
-    List.filter (fun fd -> Sf.mem fd.f_name k.funs) fds )
+  (* Keep only global variables that are referenced *)
+  let gd = List.filter (fun (x, _) -> Sv.mem x k.vars) gd in
+  (* Keep only functions that are referenced *)
+  let fds = List.filter (fun fd -> Sf.mem fd.f_name k.funs) fds in
+  (* Turn export functions that are not in the fs list into inline functions *)
+  let fds =
+    List.map
+      (fun fd ->
+        if List.mem fd.f_name.fn_name fs || not (FInfo.is_export fd.f_cc) then
+          fd
+        else { fd with f_cc = Internal })
+      fds
+  in
+  (gd, fds)


### PR DESCRIPTION
Fixes #750.