### PR TITLE
Riscv compiler skeleton

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -17,7 +17,8 @@ CHECKCATS ?= \
 	x86-64-stack-zero-loop \
 	x86-64-stack-zero-unrolled \
 	arm-m4-stack-zero-loop \
-	arm-m4-stack-zero-unrolled
+	arm-m4-stack-zero-unrolled \
+	risc-v
 
 # --------------------------------------------------------------------
 DESTDIR  ?=

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -80,3 +80,8 @@ args    = -stack-zero=unrolled
 okdirs  = examples/**/arm-m4 tests/success/**/arm-m4
 kodirs  = tests/fail/**/arm-m4
 exclude = !tests/success/arm-m4/large_stack
+
+[test-risc-v]
+bin = ./scripts/check-risc-v
+okdirs = examples/**/risc-v tests/success/**/risc-v tests/success/**/common
+kodirs = tests/fail/**/risc-v

--- a/compiler/scripts/check-risc-v
+++ b/compiler/scripts/check-risc-v
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+DIR=$(mktemp -d jasminXXXXXX)
+ASM=${DIR}/jasmin.s
+OBJ=${DIR}/jasmin.o
+
+trap "rm -r ${DIR}" EXIT
+
+set -x
+
+$(dirname $0)/../jasminc -g -arch risc-v -o ${ASM} "$@"
+
+llvm-mc --triple=riscv32 --mcpu=generic-rv32 --filetype=obj -o ${OBJ} ${ASM}

--- a/compiler/src/CLI_errors.ml
+++ b/compiler/src/CLI_errors.ml
@@ -54,6 +54,10 @@ let check_options () =
     then warning Experimental Location.i_dummy
       "support of the ARMv7 architecture is experimental";
 
+  if !target_arch = RISCV
+    then warning Experimental Location.i_dummy
+      "support of the RISC-V architecture is really experimental";
+
   if !latexfile <> ""
   then warning Deprecated Location.i_dummy
          "the [-latex] option has been deprecated since March 2023; use [jazz2tex] instead";

--- a/compiler/src/coreArchFactory.ml
+++ b/compiler/src/coreArchFactory.ml
@@ -6,6 +6,10 @@ module Core_arch_ARM : Arch_full.Core_arch = Arm_arch_full.Arm (struct
   let call_conv = Arm_decl.arm_linux_call_conv
 end)
 
+module Core_arch_RISCV : Arch_full.Core_arch = Riscv_arch_full.Riscv (struct
+  let call_conv = Riscv_decl.riscv_linux_call_conv
+end)
+
 let core_arch_x86 ~use_lea ~use_set0 call_conv :
     (module Arch_full.Core_arch
        with type reg = register

--- a/compiler/src/coreArchFactory.mli
+++ b/compiler/src/coreArchFactory.mli
@@ -1,4 +1,5 @@
 module Core_arch_ARM : Arch_full.Core_arch
+module Core_arch_RISCV : Arch_full.Core_arch
 open X86_decl
 
 val core_arch_x86 :

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -54,6 +54,7 @@ let set_stack_zero_size s = stack_zero_size := Some (Annot.ws_of_string s)
 type architecture =
   | X86_64
   | ARM_M4
+  | RISCV
 let target_arch = ref X86_64
 
 let set_target_arch a =
@@ -61,6 +62,7 @@ let set_target_arch a =
     match a with
     | "x86-64" -> X86_64
     | "arm-m4" -> ARM_M4
+    | "risc-v" -> RISCV
     | _ -> assert false
   in target_arch := a'
 
@@ -247,7 +249,7 @@ let options = [
     "-intel", Arg.Unit (set_syntax `Intel), "use intel syntax (default is AT&T)"; 
     "-ATT", Arg.Unit (set_syntax `ATT), "use AT&T syntax (default is AT&T)"; 
     "-call-conv", Arg.Symbol (["windows"; "linux"], set_cc), ": select calling convention (default depend on host architecture)";
-    "-arch", Arg.Symbol (["x86-64"; "arm-m4"], set_target_arch), ": select target arch (default is x86-64)";
+    "-arch", Arg.Symbol (["x86-64"; "arm-m4"; "risc-v"], set_target_arch), ": select target arch (default is x86-64)";
     "-stack-zero",
       Arg.Symbol (List.map fst stack_zero_strategies, set_stack_zero_strategy),
       ": select stack zeroization strategy for export functions";

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -92,6 +92,11 @@ let main () =
             module C = CoreArchFactory.Core_arch_ARM
             let analyze _ _ _ _ _ = failwith "TODO_ARM: analyze"
           end)
+      | RISCV ->
+         (module struct
+            module C = CoreArchFactory.Core_arch_RISCV
+            let analyze _ _ _ _ _ = failwith "TODO_RISCV: analyze"
+          end)
     in
     let module Arch = Arch_full.Arch_from_Core_arch (P.C) in
 

--- a/compiler/src/pp_riscv.ml
+++ b/compiler/src/pp_riscv.ml
@@ -1,0 +1,258 @@
+(* Assembly printer for RISC-V.
+*)
+
+open Arch_decl
+open Utils
+open Prog
+open Var0
+open Riscv_decl
+open Riscv_instr_decl
+
+let arch = riscv_decl
+
+let imm_pre = ""
+
+(* We support the following RISCVv7-M memory accesses.
+   Offset addressing:
+     - A base register and an immediate offset (displacement):
+       [<reg>, #+/-<imm>] (where + can be omitted).
+     - A base register and a register offset: [<reg>, <reg>].
+     - A base register and a scaled register offset: [<reg>, <reg>, LSL #<imm>].
+*)
+let pp_reg_address_aux base disp off scal =
+  match (disp, off, scal) with
+  | None, None, None ->
+      Printf.sprintf "[%s]" base
+  | Some disp, None, None ->
+      Printf.sprintf "[%s, %s%s]" base imm_pre disp
+  | None, Some off, None ->
+      Printf.sprintf "[%s, %s]" base off
+  | None, Some off, Some scal ->
+      Printf.sprintf "[%s, %s, lsl %s%s]" base off imm_pre scal
+  | _, _, _ ->
+      failwith "TODO_RISCV: pp_reg_address_aux"
+
+let global_datas = "glob_data"
+
+let pp_rip_address (p : Ssralg.GRing.ComRing.sort) : string =
+  Format.asprintf "%s+%a" global_datas Z.pp_print (Conv.z_of_int32 p)
+
+(* -------------------------------------------------------------------- *)
+(* TODO_RISCV: This is architecture-independent. *)
+(* Assembly code lines. *)
+
+type asm_line =
+  | LLabel of string
+  | LInstr of string * string list
+  | LByte of string
+
+let iwidth = 4
+
+let print_asm_line fmt ln =
+  match ln with
+  | LLabel lbl ->
+      Format.fprintf fmt "%s:" lbl
+  | LInstr (s, []) ->
+      Format.fprintf fmt "\t%-*s" iwidth s
+  | LInstr (s, args) ->
+      Format.fprintf fmt "\t%-*s\t%s" iwidth s (String.concat ", " args)
+  | LByte n -> Format.fprintf fmt "\t.byte\t%s" n
+
+let print_asm_lines fmt lns =
+  List.iter (Format.fprintf fmt "%a\n%!" print_asm_line) lns
+
+(* -------------------------------------------------------------------- *)
+(* TODO_RISCV: This is architecture-independent. *)
+
+let string_of_label name p = Printf.sprintf "L%s$%d" name (Conv.int_of_pos p)
+
+let pp_label n lbl = string_of_label n lbl
+
+let pp_remote_label (fn, lbl) =
+  string_of_label fn.fn_name lbl
+
+let hash_to_string_core (to_string : 'a -> string) =
+  let tbl = Hashtbl.create 17 in
+  fun r ->
+     try Hashtbl.find tbl r
+     with Not_found ->
+       let s = to_string r in
+       Hashtbl.add tbl r s;
+       s
+
+let hash_to_string (to_string : 'a -> char list) =
+  hash_to_string_core (fun x -> Conv.string_of_cstring (to_string x))
+
+let pp_register = hash_to_string arch.toS_r.to_string
+
+let pp_register_ext = hash_to_string arch.toS_rx.to_string
+
+let pp_xregister = hash_to_string arch.toS_x.to_string
+
+let pp_condition_kind  (ck : Riscv_decl.condition_kind) =
+  match ck with
+  | EQ -> "beq"          
+  | NE -> "bne"          
+  | LT Signed -> "blt"
+  | LT Unsigned -> "bltu"
+  | GE Signed -> "bge"
+  | GE Unsigned -> "bgeu"
+
+let pp_condt (ct: Riscv_decl.condt) =
+  pp_condition_kind ct.cond_kind
+
+let pp_imm imm = Printf.sprintf "%s%s" imm_pre (Z.to_string imm)
+
+let pp_reg_address addr =
+  match addr.ad_base with
+  | None ->
+      failwith "TODO_RISCV: pp_reg_address"
+  | Some r ->
+      let base = pp_register r in
+      let disp = Conv.z_of_word (arch_pd arch) addr.ad_disp in
+      let disp =
+        if Z.equal disp Z.zero then None else Some (Z.to_string disp)
+      in
+      let off = Option.map pp_register addr.ad_offset in
+      let scal = Conv.z_of_nat addr.ad_scale in
+      let scal =
+        if Z.equal scal Z.zero then None else Some (Z.to_string scal)
+      in
+      pp_reg_address_aux base disp off scal
+
+let pp_address addr =
+  match addr with
+  | Areg ra -> pp_reg_address ra
+  | Arip r -> pp_rip_address r
+
+let pp_asm_arg arg =
+  match arg with
+  | Condt _ -> None
+  | Imm (ws, w) -> Some (pp_imm (Conv.z_unsigned_of_word ws w))
+  | Reg r -> Some (pp_register r)
+  | Regx r -> Some (pp_register_ext r)
+  | Addr addr -> Some (pp_address addr)
+  | XReg r -> Some (pp_xregister r)
+
+(* -------------------------------------------------------------------- *)
+
+(* TODO_RISCV: Review. *)
+let headers = [  ]
+
+(* -------------------------------------------------------------------- *)
+
+  let pp_iname_ext _ = ""
+  let pp_iname2_ext ext _ _ = Conv.string_of_cstring ext
+
+let pp_ext = function
+ | PP_error             -> assert false
+ | PP_name              -> ""
+ | PP_iname ws          -> pp_iname_ext ws
+ | PP_iname2(s,ws1,ws2) -> pp_iname2_ext s ws1 ws2
+ | PP_viname(ve,long)   -> assert false
+ | PP_viname2(ve1, ve2) -> assert false
+ | PP_ct ct            -> pp_condt (match ct with Condt ct -> ct | _ -> assert false)
+
+let pp_name_ext pp_op =
+  Printf.sprintf "%s%s" (Conv.string_of_cstring pp_op.pp_aop_name) (pp_ext pp_op.pp_aop_ext)
+
+let pp_syscall (o : _ Syscall_t.syscall_t) =
+  match o with
+  | Syscall_t.RandomBytes _ -> "__jasmin_syscall_randombytes__"
+
+let pp_instr fn i =
+  match i with
+  | ALIGN ->
+      failwith "TODO_RISCV: pp_instr align"
+
+  | LABEL (_, lbl) ->
+      [ LLabel (pp_label fn lbl) ]
+
+  | STORELABEL (dst, lbl) ->
+      [ LInstr ("adr", [ pp_register dst; string_of_label fn lbl ]) ]
+
+  | JMP lbl ->
+      [ LInstr ("b", [ pp_remote_label lbl ]) ]
+
+  | JMPI arg ->
+      (* TODO_RISCV: Review. *)
+      let lbl =
+        match arg with
+        | Reg r -> pp_register r
+        | _ -> failwith "TODO_RISCV: pp_instr jmpi"
+      in
+      [ LInstr ("bx", [ lbl ]) ]
+
+  | Jcc (lbl, ct) ->
+      let iname = Printf.sprintf "b%s" (pp_condt ct) in
+      [ LInstr (iname, [ pp_label fn lbl ]) ]
+
+  | JAL (X1, lbl) ->
+      [ LInstr ("bl", [ pp_remote_label lbl ]) ]
+
+  | CALL _
+  | JAL _ -> assert false
+
+  | POPPC ->
+      [ LInstr ("pop", [ "{pc}" ]) ]
+
+  | SysCall op ->
+      [LInstr ("bl", [ pp_syscall op ])]
+
+  | AsmOp (op, args) ->
+      let id = instr_desc riscv_decl riscv_op_decl (None, op) in
+      let pp = id.id_pp_asm args in
+      let name = pp_name_ext pp in
+      let args = List.filter_map (fun (_, a) -> pp_asm_arg a) pp.pp_aop_args in
+      [ LInstr (name, args) ]
+
+
+(* -------------------------------------------------------------------- *)
+
+let pp_body fn =
+  let open List in
+  concat_map @@ fun { asmi_i = i ; asmi_ii = (ii, _) } ->
+  let i = 
+    try pp_instr fn i 
+    with HiError err -> raise (HiError (Utils.add_iloc err ii)) in
+  append
+    (map (fun i -> LInstr (i, [])) (DebugInfo.source_positions ii.base_loc))
+    i
+
+(* -------------------------------------------------------------------- *)
+(* TODO_RISCV: This is architecture-independent. *)
+
+let mangle x = Printf.sprintf "_%s" x
+
+let pp_brace s = Format.sprintf "{%s}" s
+
+let pp_fun (fn, fd) =
+  let fn = fn.fn_name in
+  let head =
+    if fd.asm_fd_export then
+      [ LInstr (".global", [ mangle fn ]); LInstr (".global", [ fn ]) ]
+    else []
+  in
+  let pre =
+    if fd.asm_fd_export then [ LLabel (mangle fn); LLabel fn; LInstr ("push", [pp_brace (pp_register X5)]) ] else []
+  in
+  let body = pp_body fn fd.asm_fd_body in
+  (* TODO_RISCV: Review. *)
+  let pos = if fd.asm_fd_export then pp_instr fn POPPC else [] in
+  head @ pre @ body @ pos
+
+let pp_funcs funs = List.concat_map pp_fun funs
+
+let pp_data globs =
+  if not (List.is_empty globs) then
+    LInstr (".p2align", ["5"]) ::
+    LLabel global_datas :: List.map (fun b -> LByte (Z.to_string (Conv.z_of_int8 b))) globs
+  else []
+
+let pp_prog p =
+  let code = pp_funcs p.asm_funcs in
+  let data = pp_data p.asm_globs in
+  headers @ code @ data
+
+let print_instr s fmt i = print_asm_lines fmt (pp_instr s i)
+let print_prog fmt p = print_asm_lines fmt (pp_prog p)

--- a/compiler/src/pp_riscv.mli
+++ b/compiler/src/pp_riscv.mli
@@ -1,0 +1,16 @@
+val mangle : string -> string
+
+val print_instr :
+  string (* Current function name. *)
+  -> Format.formatter
+  -> ( Riscv_decl.register
+     , Riscv_decl.__
+     , Riscv_decl.__
+     , Riscv_decl.__
+     , Riscv_decl.condt
+     , Riscv_instr_decl.riscv_op )
+     Arch_decl.asm_i_r
+  -> unit
+
+val print_prog :
+  Format.formatter -> Riscv_instr_decl.riscv_prog -> unit

--- a/compiler/src/riscv_arch_full.ml
+++ b/compiler/src/riscv_arch_full.ml
@@ -15,7 +15,7 @@ module Riscv_core = struct
   type cond = condt
   type asm_op = Riscv_instr_decl.riscv_op
   type extra_op = Riscv_decl.__
-  type lowering_options = Riscv_params.lowering_options
+  type lowering_options = Riscv_lowering.lowering_options
 
   let atoI = X86_arch_full.atoI riscv_decl
 
@@ -24,7 +24,7 @@ module Riscv_core = struct
   let known_implicits = []
 
   let alloc_stack_need_extra sz =
-    failwith "TODO RISCV : alloc_stack_need_extra"
+    not (Riscv_params.is_arith_small (Conv.cz_of_z sz))
 
 end
 

--- a/compiler/src/riscv_arch_full.ml
+++ b/compiler/src/riscv_arch_full.ml
@@ -24,7 +24,7 @@ module Riscv_core = struct
   let known_implicits = []
 
   let alloc_stack_need_extra sz =
-    not (Riscv_params.is_arith_small (Conv.cz_of_z sz))
+    not (Riscv_params_core.is_arith_small (Conv.cz_of_z sz))
 
 end
 

--- a/compiler/src/riscv_arch_full.ml
+++ b/compiler/src/riscv_arch_full.ml
@@ -1,0 +1,42 @@
+open Arch_decl
+open Prog
+open Riscv_decl
+
+module type Riscv_input = sig
+  val call_conv : (register, Riscv_decl.__, Riscv_decl.__, Riscv_decl.__, condt) calling_convention
+
+end
+
+module Riscv_core = struct
+  type reg = register
+  type regx = Riscv_decl.__
+  type xreg = Riscv_decl.__
+  type rflag =  Riscv_decl.__
+  type cond = condt
+  type asm_op = Riscv_instr_decl.riscv_op
+  type extra_op = Riscv_decl.__
+  type lowering_options = Riscv_params.lowering_options
+
+  let atoI = X86_arch_full.atoI riscv_decl
+
+  let asm_e =  Riscv_extra.riscv_extra atoI
+  let aparams = Riscv_params.riscv_params atoI
+  let known_implicits = []
+
+  let alloc_stack_need_extra sz =
+    failwith "TODO RISCV : alloc_stack_need_extra"
+
+end
+
+module Riscv (Lowering_params : Riscv_input) : Arch_full.Core_arch = struct
+  include Riscv_core
+  include Lowering_params
+
+  let lowering_opt = ()
+
+  let not_saved_stack = []
+
+  let pp_asm = Pp_riscv.print_prog
+
+  let callstyle = Arch_full.ByReg (Some Riscv_decl.X1)
+end

--- a/compiler/src/sct_checker_forward.ml
+++ b/compiler/src/sct_checker_forward.ml
@@ -715,7 +715,9 @@ let expr_equal a b =
     let open Glob_options in
     match !target_arch with
     | X86_64 -> X86_decl.x86_fcp
-    | ARM_M4 -> Arm_decl.arm_fcp in
+    | ARM_M4 -> Arm_decl.arm_fcp 
+    | RISCV  -> Riscv_decl.riscv_fcp
+  in 
   let normalize e =
     e |> Conv.cexpr_of_expr |> Constant_prop.(const_prop_e fcp None empty_cpm) in
   Expr.eq_expr (normalize a) (normalize b)

--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -1464,12 +1464,15 @@ let jmodel () =
   match !target_arch with
   | X86_64 -> "JModel_x86"
   | ARM_M4 -> "JModel_m4"
+  | RISCV -> failwith "TODO_RISCV: jmodel"
 
 let require_lib_slh () =
   let s =
     match !Glob_options.target_arch with
     | X86_64 -> "SLH64"
     | ARM_M4 -> "SLH32"
+    | RISCV -> failwith "TODO_RISCV: slh"
+
   in
   Format.sprintf "import %s." s
 

--- a/compiler/tests/fail/risc-v/basics.jazz
+++ b/compiler/tests/fail/risc-v/basics.jazz
@@ -1,0 +1,8 @@
+// Should be implemented in the long run, fails for now
+
+export
+fn copy_cast_lowering(reg u32 r) -> reg u32, reg u16 { 
+    reg u16 c;    
+    c = r;
+    return r, c; 
+}

--- a/compiler/tests/success/risc-v/basics.jazz
+++ b/compiler/tests/success/risc-v/basics.jazz
@@ -5,7 +5,7 @@ export
 fn pass(reg u32 r) -> reg u32 { return r; }
 
 export
-fn copy(reg u32 r) -> reg u32, reg u32 { 
+fn copy(reg u32 r) -> reg u32, reg u32 {
     reg u32 c;    
     c = #MV(r);
     return r, c; 
@@ -13,7 +13,14 @@ fn copy(reg u32 r) -> reg u32, reg u32 {
 
 export
 fn copy_lowering(reg u32 r) -> reg u32, reg u32 { 
-    reg u32 c;    
+    reg u32 c;
     c = r;
-    return r, c; 
+    return r, c;
+}
+
+export
+fn add_lowering(reg u32 a, reg u32 b) -> reg u32 {
+    reg u32 c;
+    c = a + b;
+    return c;
 }

--- a/compiler/tests/success/risc-v/basics.jazz
+++ b/compiler/tests/success/risc-v/basics.jazz
@@ -10,3 +10,10 @@ fn copy(reg u32 r) -> reg u32, reg u32 {
     c = #MV(r);
     return r, c; 
 }
+
+export
+fn copy_lowering(reg u32 r) -> reg u32, reg u32 { 
+    reg u32 c;    
+    c = r;
+    return r, c; 
+}

--- a/compiler/tests/success/risc-v/basics.jazz
+++ b/compiler/tests/success/risc-v/basics.jazz
@@ -1,0 +1,12 @@
+export
+fn void() {  }
+
+export
+fn pass(reg u32 r) -> reg u32 { return r; }
+
+export
+fn copy(reg u32 r) -> reg u32, reg u32 { 
+    reg u32 c;    
+    c = #MV(r);
+    return r, c; 
+}

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -85,6 +85,7 @@ compiler/riscv.v
 compiler/riscv_decl.v
 compiler/riscv_instr_decl.v
 compiler/riscv_extra.v
+compiler/riscv_lowering.v
 compiler/riscv_params.v
 compiler/remove_globals.v
 compiler/remove_globals_proof.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -87,6 +87,8 @@ compiler/riscv_instr_decl.v
 compiler/riscv_extra.v
 compiler/riscv_lowering.v
 compiler/riscv_params.v
+compiler/riscv_params_core.v
+compiler/riscv_params_common.v
 compiler/remove_globals.v
 compiler/remove_globals_proof.v
 compiler/slh_lowering.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -84,6 +84,8 @@ compiler/propagate_inline_proof.v
 compiler/riscv.v
 compiler/riscv_decl.v
 compiler/riscv_instr_decl.v
+compiler/riscv_extra.v
+compiler/riscv_params.v
 compiler/remove_globals.v
 compiler/remove_globals_proof.v
 compiler/slh_lowering.v

--- a/proofs/compiler/jasmin_compiler.v
+++ b/proofs/compiler/jasmin_compiler.v
@@ -3,4 +3,5 @@ Require compiler.
 Require psem_defs.
 Require arm_params.
 Require x86_params.
+Require riscv_params.
 Require sem_params_of_arch_extra.

--- a/proofs/compiler/riscv_decl.v
+++ b/proofs/compiler/riscv_decl.v
@@ -27,8 +27,8 @@ Definition riscv_xreg_size := U64. (* Unused *)
 (* -------------------------------------------------------------------- *)
 (* Registers. *)
 Variant register : Type :=
-| X01 | X02 | X03 | X04 | X05 | X06 | X07 | X08 (* General-purpose registers. *)
-| X09 | X10 | X11 | X12 | X13 | X14 | X15 | X16 (* General-purpose registers. *)
+| X1  | X2  | X3  | X4  | X5  | X6  | X7  | X8  (* General-purpose registers. *)
+| X9  | X10 | X11 | X12 | X13 | X14 | X15 | X16 (* General-purpose registers. *)
 | X17 | X18 | X19 | X20 | X21 | X22 | X23 | X24 (* General-purpose registers. *)
 | X25 | X26 | X27 | X28 | X29 | X30 | X31.      (* General-purpose registers. *)
 
@@ -46,8 +46,8 @@ Instance eqTC_register : eqTypeC register :=
 Canonical arm_register_eqType := @ceqT_eqType _ eqTC_register.
 
 Definition registers :=
-  [:: X01; X02; X03; X04; X05; X06; X07; X08;
-      X09; X10; X11; X12; X13; X14; X15; X16;
+  [::  X1;  X2;  X3;  X4;  X5;  X6;  X7;  X8;
+       X9; X10; X11; X12; X13; X14; X15; X16;
       X17; X18; X19; X20; X21; X22; X23; X24;
       X25; X26; X27; X28; X29; X30; X31
   ].
@@ -66,15 +66,15 @@ Canonical register_finType := @cfinT_finType _ finTC_register.
 
 Definition register_to_string (r : register) : string :=
   match r with
-  | X01 => "x1"
-  | X02 => "x2"
-  | X03 => "x3"
-  | X04 => "x4"
-  | X05 => "x5"
-  | X06 => "x6"
-  | X07 => "x7"
-  | X08 => "x8"
-  | X09 => "x9"
+  | X1  => "x1"
+  | X2  => "x2"
+  | X3  => "x3"
+  | X4  => "x4"
+  | X5  => "x5"
+  | X6  => "x6"
+  | X7  => "x7"
+  | X8  => "x8"
+  | X9  => "x9"
   | X10 => "x10"
   | X11 => "x11"
   | X12 => "x12"
@@ -165,6 +165,17 @@ Instance riscv_decl : arch_decl register register_ext xregister rflag condt :=
   ; toS_x     := empty_toS sword64
   ; toS_f     := empty_toS sbool
   ; reg_size_neq_xreg_size := refl_equal
-  ; ad_rsp := X02
+  ; ad_rsp := X2
   ; ad_fcp := riscv_fcp
   }.
+
+  Definition riscv_linux_call_conv : calling_convention :=
+  {| callee_saved :=
+      map ARReg [:: X2; X8; X9; X18; X19; X20; X21; X22; X23; X24; X25; X26; X27 ]
+   ; callee_saved_not_bool := erefl true
+   ; call_reg_args  := [:: X10; X11; X12; X13; X14; X15; X16; X17 ]
+   ; call_xreg_args := [::]
+   ; call_reg_ret   := [:: X10; X11]
+   ; call_xreg_ret  := [::]
+   ; call_reg_ret_uniq := erefl true;
+  |}.

--- a/proofs/compiler/riscv_extra.v
+++ b/proofs/compiler/riscv_extra.v
@@ -1,0 +1,76 @@
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+
+Require Import
+  compiler_util
+  expr
+  fexpr
+  sopn
+  utils.
+Require Export
+  arch_decl
+  arch_extra.
+Require Import
+  riscv_decl
+  riscv_instr_decl
+  riscv.
+
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Variant riscv_extra_op : Type := .
+
+Scheme Equality for riscv_extra_op.
+
+Lemma riscv_extra_op_eq_axiom : Equality.axiom riscv_extra_op_beq.
+Proof.
+  exact:
+    (eq_axiom_of_scheme
+       internal_riscv_extra_op_dec_bl
+       internal_riscv_extra_op_dec_lb).
+Qed.
+
+Definition riscv_extra_op_eqMixin :=
+  Equality.Mixin riscv_extra_op_eq_axiom.
+Canonical riscv_extra_op_eqType :=
+  Eval hnf in EqType riscv_extra_op riscv_extra_op_eqMixin.
+
+#[ export ]
+Instance eqTC_riscv_extra_op : eqTypeC riscv_extra_op :=
+  { ceqP := riscv_extra_op_eq_axiom }.
+
+Definition get_instr_desc (o: riscv_extra_op) : instruction_desc :=
+  match o with end.
+  
+(* Without priority 1, this instance is selected when looking for an [asmOp],
+ * meaning that extra ops are the only possible ops. With that priority,
+ * [arch_extra.asm_opI] is selected first and we have both base and extra ops.
+*)
+#[ export ]
+Instance riscv_extra_op_decl : asmOp riscv_extra_op | 1 :=
+  {
+    asm_op_instr := get_instr_desc;
+    prim_string := [::];
+  }.
+
+Definition assemble_extra
+           (ii: instr_info)
+           (o: riscv_extra_op)
+           (outx: lexprs)
+           (inx: rexprs)
+           : cexec (seq (asm_op_msb_t * lexprs * rexprs)) :=
+  match o with end.
+
+#[ export ]
+Instance riscv_extra {atoI : arch_toIdent} :
+  asm_extra register register_ext xregister rflag condt riscv_op riscv_extra_op :=
+  { to_asm := assemble_extra }.
+
+(* This concise name is convenient in OCaml code. *)
+Definition riscv_extended_op {atoI : arch_toIdent} :=
+  @extended_op _ _ _ _ _ _ _ riscv_extra.
+
+Definition Oriscv {atoI : arch_toIdent} o : @sopn riscv_extended_op _ := Oasm (BaseOp (None, o)).

--- a/proofs/compiler/riscv_instr_decl.v
+++ b/proofs/compiler/riscv_instr_decl.v
@@ -42,6 +42,7 @@ Variant riscv_op : Type :=
 | XOR                            (* Bitwise XOR *)
 
 (* Other data processing instructions *)
+| LA                             (* Load address *)
 | MV                             (* Copy operand to destination *)
 
 (* Loads *)
@@ -170,6 +171,31 @@ Definition riscv_AND_instr : instr_desc_t :=
 Definition prim_AND := ("AND"%string, primM AND).
 
 
+Definition riscv_OR_semi (wn wm : ty_r) : exec ty_r :=
+  ok (wor wn wm).
+
+Definition riscv_OR_instr : instr_desc_t :=
+  {|
+      id_msb_flag := MSB_MERGE;
+      id_tin := [:: sreg; sreg ];
+      id_in := [:: E 1; E 2 ];
+      id_tout := [:: sreg];
+      id_out := [:: E 0 ];
+      id_semi := riscv_OR_semi;
+      id_nargs := 3;
+      id_args_kinds := ak_reg_reg_reg ++ ak_reg_reg_imm;
+      id_eq_size := refl_equal;
+      id_tin_narr := refl_equal;
+      id_tout_narr := refl_equal;
+      id_check_dest := refl_equal;
+      id_str_jas := pp_s "OR";
+      id_safe := [::];
+      id_pp_asm := pp_name "or";
+    |}.
+
+Definition prim_OR := ("OR"%string, primM OR).
+
+
 Definition riscv_MV_semi (wn : ty_r) : exec ty_r :=
   ok wn.
 
@@ -195,29 +221,29 @@ Definition riscv_MV_instr : instr_desc_t :=
 Definition prim_MV := ("MV"%string, primM MV).
 
 
-Definition riscv_OR_semi (wn wm : ty_r): exec ty_r :=
-  ok (wor wn wm).
+Definition riscv_LA_semi (wn : ty_r) : exec ty_r :=
+  ok wn.
 
-Definition riscv_OR_instr : instr_desc_t :=
-  {|
+Definition riscv_LA_instr : instr_desc_t :=
+    {|
       id_msb_flag := MSB_MERGE;
-      id_tin := [:: sreg; sreg ];
-      id_in := [:: E 1; E 2 ];
-      id_tout := [:: sreg];
+      id_tin := [:: sreg ];
+      id_in := [:: Ec 1 ];
+      id_tout := [:: sreg ];
       id_out := [:: E 0 ];
-      id_semi := riscv_OR_semi;
-      id_nargs := 3;
-      id_args_kinds := ak_reg_reg_reg ++ ak_reg_reg_imm;
+      id_semi := riscv_LA_semi;
+      id_nargs := 2;
+      id_args_kinds := ak_reg_addr;
       id_eq_size := refl_equal;
       id_tin_narr := refl_equal;
       id_tout_narr := refl_equal;
       id_check_dest := refl_equal;
-      id_str_jas := pp_s "OR";
+      id_str_jas := pp_s "LA";
       id_safe := [::];
-      id_pp_asm := pp_name "or";
+      id_pp_asm := pp_name "la";
     |}.
 
-Definition prim_OR := ("OR"%string, primM OR).
+Definition prim_LA := ("LA"%string, primM LA).
 
 
 Definition riscv_XOR_semi (wn wm : ty_r): exec ty_r :=
@@ -325,6 +351,7 @@ Definition riscv_instr_desc (mn : riscv_op) : instr_desc_t :=
   | AND => riscv_AND_instr
   | OR => riscv_OR_instr
   | XOR => riscv_XOR_instr
+  | LA => riscv_LA_instr
   | MV => riscv_MV_instr
   | LOAD s ws => riscv_LOAD_instr s ws
   | STORE ws => riscv_STORE_instr ws
@@ -336,6 +363,7 @@ Definition riscv_prim_string : seq (string * prim_constructor riscv_op) := [::
   prim_AND;
   prim_OR;
   prim_XOR;
+  prim_LA;
   prim_MV;
   prim_LOAD;
   prim_STORE

--- a/proofs/compiler/riscv_instr_decl.v
+++ b/proofs/compiler/riscv_instr_decl.v
@@ -41,9 +41,10 @@ Variant riscv_op : Type :=
 | OR                             (* Bitwise OR *)
 | XOR                            (* Bitwise XOR *)
 
-(* Other data processing instructions *)
+(* Pseudo instruction : Other data processing instructions *)
 | LA                             (* Load address *)
 | MV                             (* Copy operand to destination *)
+| LI                             (* Load immediate up to 32 bits *)
 
 (* Loads *)
 | LOAD of signedness & wsize     (* Load 8 / 16 or 32-bit & signed / unsigned *)
@@ -271,6 +272,31 @@ Definition riscv_XOR_instr : instr_desc_t :=
 Definition prim_XOR := ("XOR"%string, primM XOR).
 
 
+Definition riscv_LI_semi (wn : ty_r) : exec ty_r :=
+  ok wn.
+
+Definition riscv_LI_instr : instr_desc_t :=
+    {|
+      id_msb_flag := MSB_MERGE;
+      id_tin := [:: sreg ];
+      id_in := [:: E 1 ];
+      id_tout := [:: sreg ];
+      id_out := [:: E 0 ];
+      id_semi := riscv_LI_semi;
+      id_nargs := 2;
+      id_args_kinds := ak_reg_imm;
+      id_eq_size := refl_equal;
+      id_tin_narr := refl_equal;
+      id_tout_narr := refl_equal;
+      id_check_dest := refl_equal;
+      id_str_jas := pp_s "LI";
+      id_safe := [::];
+      id_pp_asm := pp_name "li";
+    |}.
+
+Definition prim_LI := ("LI"%string, primM LI).
+
+
 Definition string_of_sign s : string :=
   match s with
   | Signed => ""
@@ -301,7 +327,7 @@ Definition riscv_LOAD_instr s ws : instr_desc_t :=
       id_out := [:: E 0 ];
       id_semi := @riscv_extend_semi s reg_size ws;
       id_nargs := 2;
-      id_args_kinds := ak_reg_reg ++ ak_reg_addr; (* TODO: are globs allowed? *)
+      id_args_kinds := ak_reg_addr; (* TODO: are globs allowed? *)
       id_eq_size := refl_equal;
       id_tin_narr := refl_equal;
       id_tout_narr := refl_equal;
@@ -323,12 +349,12 @@ Definition riscv_STORE_instr ws : instr_desc_t :=
     {|
       id_msb_flag := MSB_MERGE; (* ? *)
       id_tin := [:: sreg ];
-      id_in := [:: E 1 ];
+      id_in := [:: E 0 ];
       id_tout := [:: sword ws ];
-      id_out := [:: E 0 ];
+      id_out := [:: E 1 ];
       id_semi := @riscv_extend_semi Unsigned ws reg_size;
       id_nargs := 2;
-      id_args_kinds := ak_reg_reg ++ ak_reg_addr; (* TODO: are globs allowed? *)
+      id_args_kinds := ak_reg_addr; (* TODO: are globs allowed? *)
       id_eq_size := refl_equal;
       id_tin_narr := refl_equal;
       id_tout_narr := refl_equal;
@@ -352,6 +378,7 @@ Definition riscv_instr_desc (mn : riscv_op) : instr_desc_t :=
   | OR => riscv_OR_instr
   | XOR => riscv_XOR_instr
   | LA => riscv_LA_instr
+  | LI => riscv_LI_instr
   | MV => riscv_MV_instr
   | LOAD s ws => riscv_LOAD_instr s ws
   | STORE ws => riscv_STORE_instr ws
@@ -364,6 +391,7 @@ Definition riscv_prim_string : seq (string * prim_constructor riscv_op) := [::
   prim_OR;
   prim_XOR;
   prim_LA;
+  prim_LI;
   prim_MV;
   prim_LOAD;
   prim_STORE

--- a/proofs/compiler/riscv_lowering.v
+++ b/proofs/compiler/riscv_lowering.v
@@ -28,6 +28,21 @@ Context {atoI : arch_toIdent}.
 Definition chk_ws_reg (ws : wsize) : option unit :=
   oassert (ws == reg_size)%CMP.
 
+Definition lower_Papp1 (ws : wsize) (op : sop1) (e : pexpr) : option(riscv_op * pexprs) :=
+  let%opt _ := chk_ws_reg ws in
+  match op with
+  | Oword_of_int _ =>
+    if is_const e is Some _
+      then  Some(LI, [:: Papp1 (Oword_of_int U32) e])
+    else None
+(*  | Olnot U32 =>
+      Some (arg_shift MVN U32 [:: e ])
+  | Oneg (Op_w U32) =>
+      Some (ARM_op RSB default_opts, [:: e; wconst (wrepr U32 0) ]) *)
+  | _ =>
+      None
+  end.
+
 Definition lower_Papp2
   (ws : wsize) (op : sop2) (e0 e1 : pexpr) :
   option (riscv_op * pexprs) :=
@@ -92,6 +107,7 @@ Definition lower_cassgn
     | Pvar v => lower_Pvar ws v
     | Pget _ _ _ _
     | Pload _ _ _=> lower_load ws e
+    | Papp1 op e => lower_Papp1 ws op e
     | Papp2 op a b => lower_Papp2 ws op a b
     | _ => None    
     end

--- a/proofs/compiler/riscv_lowering.v
+++ b/proofs/compiler/riscv_lowering.v
@@ -1,0 +1,158 @@
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  compiler_util
+  expr
+  lowering
+  pseudo_operator
+  shift_kind.
+Require Import
+  arch_decl
+  arch_extra.
+Require Import
+  riscv_decl
+  riscv_instr_decl
+  riscv_extra.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Section Section.
+Context {atoI : arch_toIdent}.
+
+(* TODO : Review *)
+Definition chk_ws_reg (ws : wsize) : option unit :=
+  oassert (ws == reg_size)%CMP.
+
+Definition lower_Papp2
+  (ws : wsize) (op : sop2) (e0 e1 : pexpr) :
+  option (riscv_op * pexprs) :=
+  let%opt _ := chk_ws_reg ws in
+  match op with
+  | Oadd (Op_w _) =>
+      Some (ADD, [:: e0; e1 ])
+  | Osub (Op_w _) =>
+        Some (SUB, [:: e0; e1 ])
+  | Oland _ =>
+      Some (AND, [:: e0; e1 ])
+  | Olor _ =>
+      Some (OR, [:: e0; e1 ])
+(*  | Olxor _ =>
+      Some (EOR, e0, [:: e1 ])
+  | Olsr U32 =>
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else Some (LSR, e0, [:: e1 ])
+  | Olsl (Op_w U32) =>
+      Some (LSL, e0, [:: e1 ])
+  | Oasr (Op_w U32) =>
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else Some (ASR, e0, [:: e1 ])
+  | Oror U32 =>
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else Some (ROR, e0, [:: e1 ])
+  | Orol U32 =>
+      let%opt c := is_wconst U8 e1 in
+      if c == 0%R then Some (MOV, e0, [::])
+      else Some (ROR, e0, [:: wconst (32 - c) ]) *)
+  | _ =>
+      None
+  end.
+
+
+(* Lower an expression of the form [(ws)[v + e]] or [tab[ws e]]. *)
+Definition lower_load (ws: wsize) (e: pexpr) : option(riscv_op * pexprs) :=
+  let%opt _ := chk_ws_reg ws in
+  Some (LOAD Signed U32, [:: e ]).
+
+(* Lower an expression of the form [v].
+   Precondition:
+   - [v] is a one of the following:
+     + a register.
+     + a stack variable. *)
+Definition lower_Pvar (ws : wsize) (v : gvar) : option(riscv_op * pexprs) :=
+    (* For now, only 32 bits can be read from memory or upon move, signed / unsigned has no effect on load or move *)
+    if ws != U32 
+        then None 
+    else
+        let op := if is_var_in_memory (gv v) then LOAD Signed U32 else MV in
+        Some (op, [:: Pvar v ]).
+
+(* Convert an assignment into an architecture-specific operation. *)
+Definition lower_cassgn
+  (lv : lval) (ws : wsize) (e : pexpr) : option (copn_args) :=
+  if is_lval_in_memory lv 
+    then Some ([:: lv], Oriscv (STORE ws), [:: e])
+  else
+  let%opt (op, e) :=
+    match e with
+    | Pvar v => lower_Pvar ws v
+    | Pget _ _ _ _
+    | Pload _ _ _=> lower_load ws e
+    | Papp2 op a b => lower_Papp2 ws op a b
+    | _ => None    
+    end
+    in Some ([:: lv], Oriscv op, e).
+
+
+Definition lower_copn
+  (lvs : seq lval) (op : sopn) (es : seq pexpr) : option copn_args :=
+  match op with
+  | Opseudo_op pop => None
+  | _ => None
+  end.
+
+(* -------------------------------------------------------------------- *)
+
+Definition lowering_options := unit.
+
+(* Applied to every jasmin lines, cmd is a list of instructions *)
+Fixpoint lower_i (i : instr) : cmd :=
+(* ii : instruction info, ir : instruction itself *)
+  let '(MkI ii ir) := i in
+  match ir with
+  (* ty is the type of the assign, lv and e *)
+  | Cassgn lv tag ty e =>
+      let oirs :=
+        match ty with
+        | sword ws =>
+            let%opt (lvs, op, es) := lower_cassgn lv ws e in
+            Some ([:: Copn lvs tag op es ])
+        | _ => None
+        end
+      in
+      let irs := if oirs is Some irs then irs else [:: ir ] in
+      (* Reintroduce information instruction *)
+      map (MkI ii) irs
+
+ (* Copn : "assembly" instruction pattern matching, required for pseudo instructions or extra instructions *)
+  | Copn lvs tag op es =>
+      let ir' :=
+        if lower_copn lvs op es is Some (lvs', op', es')
+        then Copn lvs' tag op' es'
+        else ir
+      in
+      [:: MkI ii ir' ]
+
+  | Cif e c1 c2  =>
+      let c1' := conc_map lower_i c1 in
+      let c2' := conc_map lower_i c2 in
+        [:: MkI ii (Cif e c1' c2')]
+
+  | Cfor v r c =>
+      let c' := conc_map lower_i c in
+      [:: MkI ii (Cfor v r c') ]
+
+  | Cwhile a c0 e c1 =>
+      let c0' := conc_map lower_i c0 in
+      let c1' := conc_map lower_i c1 in
+      [:: MkI ii (Cwhile a c0' e c1')]
+
+  | _ =>
+      [:: i ]
+  end.
+
+End Section.

--- a/proofs/compiler/riscv_params.v
+++ b/proofs/compiler/riscv_params.v
@@ -1,0 +1,141 @@
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  arch_params
+  compiler_util
+  expr
+  fexpr.
+Require Import
+  linearization
+  lowering
+  stack_alloc
+  stack_zeroization
+  slh_lowering.
+Require Import
+  arch_decl
+  arch_extra
+  asm_gen.
+Require Import
+  riscv_decl
+  riscv_extra
+  riscv_instr_decl.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Section Section.
+Context {atoI : arch_toIdent}.
+
+(* ------------------------------------------------------------------------ *)
+(* Stack alloc parameters. *)
+
+Definition is_load e :=
+  if e is Pload _ _ _ then true else false.
+
+Definition riscv_mov_ofs
+  (x : lval) (tag : assgn_tag) (vpk : vptr_kind) (y : pexpr) (ofs : Z) :
+  option instr_r := None.
+
+Definition riscv_immediate (x: var_i) z :=
+  Copn [:: Lvar x ] AT_none (Oriscv MV) [:: cast_const z ].
+
+(* Nonesense *)
+Definition dummy_instr_r :=
+  Cassgn (Lnone dummy_var_info sbool) AT_none sbool (Pbool true).
+
+Definition riscv_swap (t : assgn_tag) (x y z w : var_i) := dummy_instr_r.
+
+Definition riscv_saparams : stack_alloc_params :=
+  {|
+    sap_mov_ofs := riscv_mov_ofs;
+    sap_immediate := riscv_immediate;
+    sap_swap := riscv_swap;
+  |}.
+
+
+(* ------------------------------------------------------------------------ *)
+(* Linearization parameters. *)
+
+Section LINEARIZATION.
+
+Notation vtmpi := (mk_var_i (to_var X28)).
+
+Definition riscv_tmp : Ident.ident := vname (v_var vtmpi).
+
+Definition riscv_liparams : linearization_params :=
+  {|
+    lip_tmp := riscv_tmp;
+    lip_not_saved_stack := [:: riscv_tmp ];
+    lip_allocate_stack_frame := fun _ _ _ => [::];
+    lip_free_stack_frame := fun _ _ _ => [::];
+    lip_set_up_sp_register := fun _ _ _ _=> None;
+    lip_set_up_sp_stack := fun _ _ _ _ => None;
+    lip_lassign := fun _ _ _ => None;
+  |}.
+
+End LINEARIZATION.
+
+
+(* ------------------------------------------------------------------------ *)
+(* Lowering parameters. *)
+Definition lowering_options := unit.
+
+Definition riscv_loparams : lowering_params lowering_options :=
+  {|
+    lop_lower_i := fun _ _ _ i => [:: i];
+    lop_fvars_correct := fun _ _ _ => true;
+  |}.
+
+
+(* ------------------------------------------------------------------------ *)
+(* Speculative execution operator lowering parameters. *)
+
+Definition riscv_shparams : sh_params :=
+  {|
+    shp_lower := fun _ _ _ => None;
+  |}.
+
+(* ------------------------------------------------------------------------ *)
+(* Assembly generation parameters. *)
+
+Definition riscv_agparams : asm_gen_params :=
+  {|
+    agp_assemble_cond := fun ii e => Error (E.berror ii e"not implemented");
+  |}.
+
+(* ------------------------------------------------------------------------ *)
+(* Stack zeroization parameters. *)
+
+Definition riscv_szparams : stack_zeroization_params :=
+  {|
+    szp_cmd := fun _ _ _ _ _ _ => Error (stack_zeroization.E.error ( compiler_util.pp_s "not implemented"));
+  |}.
+
+(* ------------------------------------------------------------------------ *)
+(* Shared parameters. *)
+
+Definition riscv_is_move_op (o : asm_op_t) : bool :=
+  match o with
+  | BaseOp (None, MV) =>
+     true
+  | _ =>
+      false
+  end.
+
+Definition riscv_params : architecture_params lowering_options :=
+  {|
+    ap_sap := riscv_saparams;
+    ap_lip := riscv_liparams;
+    ap_lop := riscv_loparams;
+    ap_agp := riscv_agparams;
+    ap_szp := riscv_szparams;
+    ap_shp := riscv_shparams;
+    ap_is_move_op := riscv_is_move_op;
+  |}.
+
+End Section.

--- a/proofs/compiler/riscv_params_common.v
+++ b/proofs/compiler/riscv_params_common.v
@@ -1,0 +1,93 @@
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  arch_params
+  compiler_util
+  expr
+  fexpr
+  linear.
+Require Import
+  arch_decl
+  arch_extra.
+Require Import
+  riscv_decl
+  riscv_extra
+  riscv_instr_decl
+  riscv_params_core.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Module RISCVOpn (Args : OpnArgs).
+
+  Import Args.
+
+  Module Core := RISCVOpn_core(Args).
+
+  #[local]
+  Open Scope Z.
+
+  Section WITH_PARAMS.
+
+  Context {atoI : arch_toIdent}.
+
+  Notation opn_args := (seq lval * sopn * seq rval)%type.
+
+  Let op_gen mn x res : opn_args :=
+    ([:: lvar x ], Oriscv mn, res).
+  Let op_un_reg mn x y := op_gen mn x [:: rvar y ].
+  Let op_un_imm mn x imm := op_gen mn x [:: rconst reg_size imm ].
+  Let op_bin_reg mn x y z := op_gen mn x [:: rvar y; rvar z ].
+  Let op_bin_imm mn x y imm := op_gen mn x [:: rvar y; rconst reg_size imm ].
+
+  Definition to_opn '(d, o, e) : opn_args := (d, Oriscv o, e).
+
+  Definition mov x y   := to_opn (Core.mov x y).
+  Definition add x y z := to_opn (Core.add x y z).
+  Definition sub x y z := to_opn (Core.sub x y z).
+
+  (* Load an immediate to a register. *)
+  Definition li x   imm := to_opn (Core.li x imm).
+
+  Definition addi x y imm := to_opn (Core.addi x y imm).
+  Definition subi x y imm := to_opn (Core.subi x y imm).
+
+  Definition andi := op_bin_imm AND.
+
+(* To remove *)
+  Definition str x y off :=
+    let lv := lmem reg_size y off in
+    ([:: lv ], Oriscv (STORE U32) , [:: rvar x ]).
+
+  Definition align x y al := andi x y (wsize_size al - 1).
+
+  Definition smart_mov x y := map to_opn (Core.smart_mov x y).
+
+  (* Compute [R[x] := R[y] + imm % 2^32
+     Precondition: if [imm] is large, [x <> y]. *)
+  Definition smart_addi x y imm := map to_opn (Core.smart_addi x y imm).
+
+  (* Compute [R[x] := R[y] - imm % 2^32
+     Precondition: if [imm] is large, [x <> y]. *)
+  Definition smart_subi x y imm := map to_opn (Core.smart_subi x y imm).
+
+  (* Compute [R[x] := R[x] + imm % 2^32].
+     Precondition: if [imm] is large, [x <> tmp]. *)
+  Definition smart_addi_tmp x tmp imm := map to_opn (Core.smart_addi_tmp x tmp imm).
+
+  (* Compute [R[x] := R[x] - imm % 2^32].
+     Precondition: if [imm] is large, [x <> tmp]. *)
+  Definition smart_subi_tmp x tmp imm := map to_opn (Core.smart_subi_tmp x tmp imm).
+
+
+  End WITH_PARAMS.
+
+End RISCVOpn.
+
+Module RISCVCopn := RISCVOpn(CopnArgs).
+Module RISCVFopn := RISCVOpn(FopnArgs).

--- a/proofs/compiler/riscv_params_core.v
+++ b/proofs/compiler/riscv_params_core.v
@@ -1,0 +1,99 @@
+From mathcomp Require Import
+  all_ssreflect
+  all_algebra.
+
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  arch_params
+  compiler_util
+  expr
+  fexpr
+  linear.
+Require Import
+  arch_decl.
+Require Import
+  riscv_decl
+  riscv_instr_decl.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Definition is_arith_small (imm : Z) : bool := (imm <? Z.pow 2 12)%Z.
+
+Module RISCVOpn_core (Args : OpnArgs).
+
+  Import Args.
+
+  #[local]
+  Open Scope Z.
+
+  Section WITH_PARAMS.
+
+  Definition opn_args := (seq lval * riscv_op * seq rval)%type.
+
+  Let op_gen mn x res : opn_args :=
+    ([:: lvar x ], mn, res).
+  Let op_un_reg mn x y := op_gen mn x [:: rvar y ].
+  Let op_un_imm mn x imm := op_gen mn x [:: rconst reg_size imm ].
+  Let op_bin_reg mn x y z := op_gen mn x [:: rvar y; rvar z ].
+  Let op_bin_imm mn x y imm := op_gen mn x [:: rvar y; rconst reg_size imm ].
+
+  Definition mov := op_un_reg MV.
+  Definition add := op_bin_reg ADD.
+  Definition sub := op_bin_reg SUB.
+
+  Definition li := op_un_imm LI.
+  Definition addi := op_bin_imm ADD.
+  Definition subi := op_bin_imm SUB.
+
+  Definition smart_mov x y :=
+    if v_var x == v_var y then [::] else [:: mov x y ].
+
+  (* Compute [R[x] := R[y] <o> imm % 2^32].
+     Precondition: if [imm] is large, [y <> tmp]. *)
+  Definition gen_smart_opi
+    (on_reg : var_i -> var_i -> var_i -> opn_args)
+    (on_imm : var_i -> var_i -> Z -> opn_args)
+    (is_small : Z -> bool)
+    (neutral : option Z)
+    (tmp x y : var_i)
+    (imm : Z) :
+    seq opn_args :=
+    let is_mov := if neutral is Some n then (imm =? n)%Z else false in
+    if is_mov
+    then smart_mov x y
+    else
+      if is_small imm
+      then [:: on_imm x y imm ]
+    else [:: li tmp imm; on_reg x y tmp].
+
+  (* Compute [R[x] := R[y] + imm % 2^32
+     Precondition: if [imm] is large, [x <> y]. *)
+  Definition smart_addi x y :=
+    gen_smart_opi add addi is_arith_small (Some 0%Z) x x y.
+
+  (* Compute [R[x] := R[y] - imm % 2^32
+     Precondition: if [imm] is large, [x <> y]. *)
+  Definition smart_subi x y :=
+    gen_smart_opi sub subi is_arith_small (Some 0%Z) x x y.
+
+  (* Compute [R[x] := R[x] <o> imm % 2^32].
+     Precondition: if [imm] is large, [x <> tmp]. *)
+  Definition gen_smart_opi_tmp on_reg on_imm x tmp imm :=
+    gen_smart_opi on_reg on_imm is_arith_small (Some 0%Z) tmp x x (imm mod (wbase U32)).
+
+  (* Compute [R[x] := R[x] + imm % 2^32].
+     Precondition: if [imm] is large, [x <> tmp]. *)
+  Definition smart_addi_tmp := gen_smart_opi_tmp add addi.
+
+  (* Compute [R[x] := R[x] - imm % 2^32].
+     Precondition: if [imm] is large, [x <> tmp]. *)
+  Definition smart_subi_tmp := gen_smart_opi_tmp sub subi.
+
+  End WITH_PARAMS.
+
+End RISCVOpn_core.
+
+Module RISCVFopn_core := RISCVOpn_core(FopnArgs).

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -78,6 +78,10 @@ Separate Extraction
   arm_instr_decl
   arm_extra
   arm_params
+  riscv_decl
+  riscv_instr_decl
+  riscv_extra
+  riscv_params
   compiler.
 
 Cd  "../..".


### PR DESCRIPTION
Provides slightly more than the minimum bits to compile a void function.

Many success/common  tests pass.
success/risc-v/basics.jazz pass.