### PR TITLE
feat: allow nix-build from repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ Makefile.coq.conf
 /jasmin.tar.gz
 /compiler/config/checker_config_default.json
 /compiler/config/checker_config_doc.json
+
+# nix build output
+result

--- a/default.nix
+++ b/default.nix
@@ -43,7 +43,7 @@ let ecDeps = ecRef != ""; in
 
 stdenv.mkDerivation {
   name = "jasmin-0";
-  src = ./.;
+  src = nix-gitignore.gitignoreSource [] ./.;
   buildInputs = []
     ++ optionals coqDeps [ coqPackages.coq mathcomp-word ]
     ++ optionals testDeps ([ curl.bin oP.apron.out libllvm ] ++ (with python3Packages; [ python pyyaml ]))
@@ -57,16 +57,9 @@ stdenv.mkDerivation {
     ++ optionals opamDeps [ rsync git pkg-config perl ppl mpfr opam ]
     ;
 
-  buildPhase = ''
-    make -C compiler CIL
-    make -C compiler
-  '';
+  enableParallelBuilding = true;
 
   installPhase = ''
-    mkdir -p $out/bin
-    for p in jasminc jazz2tex
-    do
-      cp compiler/_build/default/entry/$p.exe $out/bin/$p
-    done
+    make -C compiler install PREFIX=$out
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -43,7 +43,7 @@ let ecDeps = ecRef != ""; in
 
 stdenv.mkDerivation {
   name = "jasmin-0";
-  src = null;
+  src = ./.;
   buildInputs = []
     ++ optionals coqDeps [ coqPackages.coq mathcomp-word ]
     ++ optionals testDeps ([ curl.bin oP.apron.out libllvm ] ++ (with python3Packages; [ python pyyaml ]))
@@ -56,4 +56,17 @@ stdenv.mkDerivation {
     ++ optionals ecDeps [ easycrypt alt-ergo z3.out ]
     ++ optionals opamDeps [ rsync git pkg-config perl ppl mpfr opam ]
     ;
+
+  buildPhase = ''
+    make -C compiler CIL
+    make -C compiler
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    for p in jasminc jazz2tex
+    do
+      cp compiler/_build/default/entry/$p.exe $out/bin/$p
+    done
+  '';
 }


### PR DESCRIPTION
This change makes it possible to call nix-build from the repository root. It also allows to pin specific versions of the jasmin compiler in a nix shell. For example like this:

```
{ pkgs ? import <nixpkgs> {} }:
with pkgs;
jasmin-src = pkgs.fetchFromGitHub {
    owner  = "Rixxc";
    repo   = "jasmin";
    rev    = "c523a9e20bae85e028c6cb9b0b55bfc3f8f3734b";
    hash   = "sha256-6cDmfj55mYwTQE0Fka7s3/EuBts9hj+65xgWQ7OTez8=";
  };

  jasmin = pkgs.callPackage "${jasmin-src}/default.nix" { inherit pkgs; };
in
pkgs.mkShell {
   nativeBuildInputs = [
     jasmin
   ];
}