### PR TITLE
Remove deprecated legacy interface to the CT checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
   We now support operators SLH operators as in [Typing High-Speed Cryptography
   against Spectre v1](https://ia.cr/2022/1270).
   The compilation of these is proven to preserve functional semantics.
-  We also provide a speculative CCT checker, via the compiler flag `-checkSCT`.
+  We also provide a speculative CCT checker, via the `jazzct` flag `--sct`.
   ([PR #447](https://github.com/jasmin-lang/jasmin/pull/447),
    [PR #723](https://github.com/jasmin-lang/jasmin/pull/723)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@
   ([PR #531](https://github.com/jasmin-lang/jasmin/pull/531);
   fixes [#525](https://github.com/jasmin-lang/jasmin/issues/525)).
 
+- The deprecated legacy interface to the CT checker has been removed
+  ([PR #769](https://github.com/jasmin-lang/jasmin/pull/769)).
+
 # Jasmin 2023.06.3 — 2024-04-10
 
 ## New features

--- a/compiler/src/CLI_errors.ml
+++ b/compiler/src/CLI_errors.ml
@@ -58,8 +58,4 @@ let check_options () =
   then warning Deprecated Location.i_dummy
          "the [-latex] option has been deprecated since March 2023; use [jazz2tex] instead";
 
-  if Option.is_some !ct_list || !infer
-  then warning Deprecated Location.i_dummy
-         "the command-line options for constant-time have been deprecated since March 2024; use [jazzct] instead";
-
   List.iter chk_out_file [ outfile; latexfile; ecfile ]

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -25,11 +25,6 @@ let help_intrinsics = ref false
 type color = | Auto | Always | Never
 let color = ref Auto
 
-let ct_list = ref None
-let infer   = ref false
-
-let sct_list = ref None
-
 let lea = ref false
 let set0 = ref false
 let model = ref Normal
@@ -105,26 +100,6 @@ let set_color c =
   in
   color := assoc c
 
-let set_ct () =  
-  if !ct_list = None then ct_list := Some []
-
-let set_ct_on s = 
-  ct_list := 
-    Some (match !ct_list with
-          | None -> [s]
-          | Some l -> s::l)
-
-let set_sct () =
-  if !sct_list = None then sct_list := Some []
-
-let set_sct_on s =
-  sct_list :=
-    Some (match !sct_list with
-          | None -> [s]
-          | Some l -> s::l)
-
-let sct_comp_pass = ref Compiler.ParamsExpansion
-
 let parse_jasmin_path s =
   s |> String.split_on_char ':' |> List.map (String.split ~by:"=")
 
@@ -185,9 +160,6 @@ let symbol2pass =
   List.iter (fun s -> Hashtbl.add tbl (fst (print_strings s)) s) Compiler.compiler_step_list;
   fun s -> Hashtbl.find tbl s
 
-let set_sct_comp_pass s =
- sct_comp_pass := symbol2pass s
-
 let print_option p =
   let s, msg = print_strings p in
   ("-p"^s, Arg.Unit (set_printing p), " Print program after "^msg)
@@ -212,12 +184,6 @@ let options = [
     "-oec"     ,  Arg.Set_string ecfile , "[filename] Use filename as output destination for easycrypt extraction";
     "-oecarray" , Arg.String set_ec_array_path, "[dir] Output easycrypt array theories to the given path";
     "-CT" , Arg.Unit set_constTime      , " Generate model for constant time verification";
-    "-checkCT", Arg.Unit set_ct         , " Check that the full program is constant time (using a type system) (deprecated)";
-    "-checkCTon", Arg.String set_ct_on  , "[f] Check that the function [f] is constant time (using a type system) (deprecated)";
-    "-infer"    , Arg.Set infer         , " Infer security level annotations of the constant time type system (deprecated)";
-    "-checkSCT", Arg.Unit set_sct       , " Check that the full program is speculative constant time (using a type system)";
-    "-checkSCTon", Arg.String set_sct_on, "[f] Check that the function [f] is speculative constant time (using a type system)";
-    "-checkSCTafter", Arg.Symbol(compiler_step_symbol, set_sct_comp_pass), " Run SCT checker after the given pass";
     "-slice"    , Arg.String set_slice  , "[f] Keep function [f] and everything it needs";
     "-safety", Arg.Unit set_safety      , " Generate model for safety verification";
     "-checksafety", Arg.Unit set_checksafety, " Automatically check for safety";

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -60,10 +60,6 @@ let check_safety_p pd asmOp analyze s (p : (_, 'asm) Prog.prog) source_p =
   ()
 
 (* -------------------------------------------------------------------- *)
-let check_sct is_ct_asm _s p _source_p =
-  Sct_checker_forward.ty_prog is_ct_asm p (oget !sct_list)
-
-(* -------------------------------------------------------------------- *)
 module type ArchCoreWithAnalyze = sig
   module C : Arch_full.Core_arch
   val analyze :
@@ -178,10 +174,6 @@ let main () =
           p
           source_prog
         |> donotcompile
-      else if s = !Glob_options.sct_comp_pass && !sct_list <> None then
-        check_sct Arch.is_ct_sopn s p source_prog
-        |> List.iter (Format.printf "%a@." Sct_checker_forward.pp_funty)
-        |> donotcompile
       else
       (
         if s == Unrolling then CheckAnnot.check_no_for_loop p;
@@ -212,17 +204,6 @@ let main () =
           (fun () -> if !ecfile <> "" then Unix.unlink !ecfile) ();
         raise e end;
       donotcompile()
-    end;
-
-    if !ct_list <> None then begin
-        let sigs, status = Ct_checker_forward.ty_prog Arch.is_ct_sopn ~infer:!infer source_prog (oget !ct_list) in
-           Format.printf "/* Security types:\n@[<v>%a@]*/@."
-              (pp_list "@ " (Ct_checker_forward.pp_signature source_prog)) sigs;
-           let on_err (loc, msg) =
-             hierror ~loc:(Lone loc) ~kind:"constant type checker" "%t" msg
-           in
-           Stdlib.Option.iter on_err status;
-        donotcompile()
     end;
 
     if !do_compile then begin


### PR DESCRIPTION
Let’s make some room for a better interface.