### PR TITLE
SCT-checker: accept “sct” annotation for functions

### DIFF
--- a/compiler/default.nix
+++ b/compiler/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "jasmin-0";
   src = ./.;
   buildInputs = [ mpfr ppl ]
-  ++ (with ocamlPackages; [ ocaml findlib dune_3 apron batteries camlidl cmdliner menhir menhirLib zarith yojson])
+  ++ (with ocamlPackages; [ ocaml findlib dune_3 apron angstrom batteries camlidl cmdliner menhir menhirLib zarith yojson])
   ;
 
   installPhase = ''

--- a/compiler/jasmin.opam
+++ b/compiler/jasmin.opam
@@ -31,6 +31,7 @@ depends: [
   "apron" {>= "v0.9.12"}
   "conf-ppl"
   "yojson" {>= "1.6.0"}
+  "angstrom"
   "ocamlfind" { build }
 ]
 conflicts: [

--- a/compiler/src/annotations.ml
+++ b/compiler/src/annotations.ml
@@ -29,6 +29,13 @@ and annotation = pident * attribute option
 
 and annotations = annotation list
 
+let get (s: string) (annot: annotations) =
+  match
+    List.find_opt (fun (k, _) -> String.equal (Location.unloc k) s) annot
+  with
+  | Some (_, a) -> Some a
+  | None -> None
+
 let has_symbol s annot =
   List.exists (fun (k, _) -> String.equal (Location.unloc k) s) annot
 

--- a/compiler/src/dune
+++ b/compiler/src/dune
@@ -12,7 +12,7 @@
  (public_name jasmin.jasmin)
  (flags -rectypes)
  (modules :standard \ main_compiler x86_safety uint63_63 uint63_31)
- (libraries batteries.unthreaded zarith menhirLib))
+ (libraries angstrom batteries.unthreaded zarith menhirLib))
 
 (library
  (name jasminc)

--- a/compiler/src/securityAnnotations.ml
+++ b/compiler/src/securityAnnotations.ml
@@ -119,3 +119,8 @@ module Parse = struct
           rule s;
         None
 end
+
+let get_sct_signature a =
+  Option.bind (Annotations.get "sct" a) (function
+    | Some { pl_desc = Astring s; _ } -> Parse.string s
+    | _ -> None)

--- a/compiler/src/securityAnnotations.ml
+++ b/compiler/src/securityAnnotations.ml
@@ -1,0 +1,119 @@
+open Utils
+open Prog
+
+(* Abstract syntax for security annotations *)
+type simple_level = Public | Secret | Named of Name.t
+
+let named n = Named n
+
+type level = { normal : simple_level; speculative : simple_level }
+
+let diag d = { normal = d; speculative = d }
+let transient = { normal = Public; speculative = Secret }
+
+type typ = Msf | Direct of level | Indirect of { ptr : level; value : level }
+
+let direct d = Direct d
+
+type typs = typ list
+type signature = { arguments : typs; results : typs }
+
+let get_nth_argument n { arguments; _ } = List.nth_opt arguments n
+let get_nth_result n { results; _ } = List.nth_opt results n
+
+(** Pretty-printing *)
+module PP = struct
+  open Format
+
+  let simple_level fmt = function
+    | Public -> fprintf fmt "public"
+    | Secret -> fprintf fmt "secret"
+    | Named n -> fprintf fmt "%s" n
+
+  let level fmt = function
+    | { normal = Public; speculative = Secret } -> fprintf fmt "transient"
+    | { normal = n; speculative = s } ->
+        if n = s then simple_level fmt n
+        else
+          fprintf fmt "{ normal: %a, speculative: %a }" simple_level n
+            simple_level s
+
+  let typ fmt = function
+    | Msf -> fprintf fmt "msf"
+    | Direct t -> level fmt t
+    | Indirect { ptr; value } ->
+        fprintf fmt "{ ptr: %a, val: %a }" level ptr level value
+
+  let typs fmt = function
+    | [] -> fprintf fmt "()"
+    | ts -> fprintf fmt "@[<h>%a@]" (pp_list "@ ×@ " typ) ts
+
+  let signature fmt { arguments; results } =
+    fprintf fmt "%a → %a" typs arguments typs results
+end
+
+(** Parsing *)
+module Parse = struct
+  open Angstrom
+
+  let ws =
+    skip_while (function
+      | '\x20' | '\x0a' | '\x0d' | '\x09' -> true
+      | _ -> false)
+
+  let ident =
+    take_while1 (function 'a' .. 'z' | '_' | 'A' .. 'Z' -> true | _ -> false)
+    >>= fun hd ->
+    take_while (function
+      | 'a' .. 'z' | '_' | 'A' .. 'Z' | '0' .. '9' -> true
+      | _ -> false)
+    >>= fun tl -> return (hd ^ tl)
+
+  let arrow = (string "->" <|> string "→") *> ws
+  let times = char '*' *> ws <|> string "×" *> ws
+
+  let simple_level =
+    string "public" *> ws *> return Public
+    <|> string "secret" *> ws *> return Secret
+    <|> lift named (ident <* ws)
+
+  (** Accepts a “key: value” pair where the key can be abbreviated by its first character. *)
+  let labelled ~(key : string) value =
+    char key.[0]
+    *> option "" (string String.(sub key 1 (length key - 1)))
+    *> ws *> char ':' *> ws *> value
+    <* ws
+
+  let level =
+    char '{' *> ws
+    *> ( labelled ~key:"normal" simple_level >>= fun normal ->
+         char ',' *> ws *> labelled ~key:"speculative" simple_level <* ws
+         >>= fun speculative -> return { normal; speculative } )
+    <* char '}' <* ws
+    <|> string "transient" *> ws *> return transient
+    <|> lift diag simple_level
+
+  let typ =
+    char '{' *> ws
+    *> ( labelled ~key:"ptr" level >>= fun ptr ->
+         char ',' *> ws *> labelled ~key:"val" level >>= fun value ->
+         return (Indirect { ptr; value }) )
+    <* char '}' <* ws
+    <|> string "msf" *> ws *> return Msf
+    <|> lift direct level
+
+  let typs =
+    char '(' *> ws *> sep_by times typ <* char ')' <|> sep_by1 times typ
+
+  let signature =
+    ws *> typs >>= fun arguments ->
+    ws *> arrow *> typs >>= fun results -> return { arguments; results }
+
+  let string s =
+    match parse_string ~consume:All signature s with
+    | Ok v -> Some v
+    | Error rule ->
+        warning Always Location.i_dummy "ill-formed security signature (%s): %s"
+          rule s;
+        None
+end

--- a/compiler/src/securityAnnotations.ml
+++ b/compiler/src/securityAnnotations.ml
@@ -9,7 +9,9 @@ let named n = Named n
 type level = { normal : simple_level; speculative : simple_level }
 
 let diag d = { normal = d; speculative = d }
+let public = diag Public
 let transient = { normal = Public; speculative = Secret }
+let secret = diag Secret
 
 type typ = Msf | Direct of level | Indirect of { ptr : level; value : level }
 

--- a/compiler/src/securityAnnotations.mli
+++ b/compiler/src/securityAnnotations.mli
@@ -1,0 +1,15 @@
+type simple_level = Public | Secret | Named of Prog.Name.t
+type level = { normal : simple_level; speculative : simple_level }
+type typ = Msf | Direct of level | Indirect of { ptr : level; value : level }
+type signature
+
+val get_nth_argument : int -> signature -> typ option
+val get_nth_result : int -> signature -> typ option
+
+module PP : sig
+  val signature : Format.formatter -> signature -> unit
+end
+
+module Parse : sig
+  val string : string -> signature option
+end

--- a/compiler/src/securityAnnotations.mli
+++ b/compiler/src/securityAnnotations.mli
@@ -8,6 +8,7 @@ val transient : level
 val secret : level
 val get_nth_argument : int -> signature -> typ option
 val get_nth_result : int -> signature -> typ option
+val get_sct_signature : Annotations.annotations -> signature option
 
 module PP : sig
   val simple_level : simple_level Utils.pp

--- a/compiler/src/securityAnnotations.mli
+++ b/compiler/src/securityAnnotations.mli
@@ -1,15 +1,25 @@
 type simple_level = Public | Secret | Named of Prog.Name.t
 type level = { normal : simple_level; speculative : simple_level }
 type typ = Msf | Direct of level | Indirect of { ptr : level; value : level }
-type signature
+type signature = { arguments : typ list; results : typ list }
 
+val public : level
+val transient : level
+val secret : level
 val get_nth_argument : int -> signature -> typ option
 val get_nth_result : int -> signature -> typ option
 
 module PP : sig
-  val signature : Format.formatter -> signature -> unit
+  val simple_level : simple_level Utils.pp
+  val level : level Utils.pp
+  val typ : typ Utils.pp
+  val signature : signature Utils.pp
 end
 
 module Parse : sig
+  val simple_level : simple_level Angstrom.t
+  val level : level Angstrom.t
+  val typ : typ Angstrom.t
+  val signature : signature Angstrom.t
   val string : string -> signature option
 end

--- a/compiler/tests/sct-checker/dune
+++ b/compiler/tests/sct-checker/dune
@@ -23,3 +23,10 @@
   (modules accept reject)
   (names
     accept reject))
+
+(tests
+  (libraries jasmin.jasmin angstrom)
+  (flags (:standard -rectypes))
+  (modules sct_annot)
+  (names
+    sct_annot))

--- a/compiler/tests/sct-checker/sct_annot.ml
+++ b/compiler/tests/sct-checker/sct_annot.ml
@@ -1,0 +1,64 @@
+open Jasmin
+open Utils
+open SecurityAnnotations
+
+let roundtrip (pp : 'a pp) (read : 'a Angstrom.t) (x : 'a) =
+  let s = Format.asprintf "%a" pp x in
+  match Angstrom.parse_string ~consume:All read s with
+  | Ok c ->
+      let r = Format.asprintf "%a" pp c in
+      assert (r = s);
+      assert (c = x)
+  | Error rule -> failwith (Format.asprintf "%s failed at %s" s rule)
+
+let simple_level () =
+  List.iter
+    (roundtrip PP.simple_level Parse.simple_level)
+    [ Public; Secret; Named "a"; Named "bcd1_2e" ]
+
+let level () =
+  List.iter
+    (roundtrip PP.level Parse.level)
+    [
+      (let helo = Named "helo" in
+       { normal = helo; speculative = helo });
+      { normal = Named "low"; speculative = Named "high" };
+      transient;
+    ]
+
+let typ () =
+  List.iter
+    (roundtrip PP.typ Parse.typ)
+    [
+      Msf;
+      Direct public;
+      Indirect
+        { ptr = secret; value = { normal = Secret; speculative = Named "n" } };
+    ]
+
+let signature () =
+  List.iter
+    (roundtrip PP.signature Parse.signature)
+    [
+      { arguments = []; results = [] };
+      { arguments = [ Direct public ]; results = [] };
+      { arguments = []; results = [ Direct secret ] };
+      {
+        arguments =
+          [
+            Direct secret;
+            Indirect
+              {
+                ptr = { normal = Named "n"; speculative = Secret };
+                value = secret;
+              };
+          ];
+        results = [ Direct public; Direct public ];
+      };
+    ]
+
+let () =
+  simple_level ();
+  level ();
+  typ ();
+  signature ()

--- a/compiler/tests/sct-checker/success/arrays.jazz
+++ b/compiler/tests/sct-checker/success/arrays.jazz
@@ -1,10 +1,10 @@
 param int N = 2;
 
-#[constraints="t <= transient"]
+#[sct="{ ptr: transient, val: { n: d, s:secret } } × transient → { n: d, s: secret }"]
 fn transient_read(
-  #[poly = t, poly = d] reg ptr u64[N] p,
-  #[poly = t] reg u64 i
-) -> #[poly = d] reg u64 {
+  reg ptr u64[N] p,
+  reg u64 i
+) -> reg u64 {
   reg u64 x;
   x = #init_msf();
   x = i if i < N;
@@ -12,10 +12,8 @@ fn transient_read(
   return x;
 }
 
-fn safe_access(
-  #public reg u64 c,
-  #[poly = d] reg u64 x
-) -> #[poly = d] reg u64 {
+#[sct="public * d -> d"]
+fn safe_access(reg u64 c x) -> reg u64 {
   stack u64[1] s;
   if c != 0 {
     s[0] = x;
@@ -24,10 +22,11 @@ fn safe_access(
   return x;
 }
 
+#[sct="public × d → d"]
 fn safe_direct_access(
-  #public reg u64 c,
-  #[poly = d] reg u8 x
-) -> #[poly = d] reg u8 {
+  reg u64 c,
+  reg u8 x
+) -> reg u8 {
   stack u64[1] s;
   if c != 0 {
     s.[u8 3] = x;

--- a/compiler/tests/sct-checker/success/basic.jazz
+++ b/compiler/tests/sct-checker/success/basic.jazz
@@ -92,13 +92,13 @@ export fn store(#transient reg u64 p i q, #secret reg u64 v) {
   }
 }
 
-#[constraints="p <= public, t <= transient, secret <= s"]
+#[sct="public * { ptr: public, val: transient } * { ptr: public, val: secret } -> { ptr: public, val: secret }"]
 fn xof_init(
-  #public reg u64 j,
-  #[poly = p, poly = t] reg ptr u64[25] state,
-  #[poly = p, poly = s] reg ptr u8[32] rho)
+  reg u64 j,
+  reg ptr u64[25] state,
+  reg ptr u8[32] rho)
   ->
-  #[poly = p, poly = s] reg ptr u64[25]
+  reg ptr u64[25]
 {
   reg u64 t;
   t = rho[u64 j];

--- a/compiler/tests/sct-checker/success/corruption.jazz
+++ b/compiler/tests/sct-checker/success/corruption.jazz
@@ -1,51 +1,60 @@
 /* This tests that stores that are not speculatively safe corrupt the whole (memory) state */
-#[constraints="p <= public, transient <= t, t <= transient, secret <= s"]
+#[sct="
+  public × secret × { ptr: public, val: any } × { ptr: public, val: public } →
+    { ptr: public, val: secret } × { ptr: public, val: transient }
+"]
 fn corrupts_memory(
-  #public reg u64 i,
-  #secret reg u64 s,
+  reg u64 i,
+  reg u64 s,
   reg ptr u64[1] x,
-  #[poly = p, poly = p] reg ptr u64[1] y
+  reg ptr u64[1] y
 ) ->
- #[poly = p, poly = s] reg ptr u64[1],
- #[poly = p, poly = t] reg ptr u64[1] {
+ reg ptr u64[1],
+ reg ptr u64[1] {
   x[i] = s;
   return x, y;
 }
 
-#[constraints="p <= public, secret <= s"]
+#[sct="
+  secret × { ptr: public, val: any } × { ptr: public, val: public } →
+    { ptr: public, val: secret } × { ptr: public, val: public }
+"]
 fn does_not_corrupt_memory(
-  #secret reg u64 s,
+  reg u64 s,
   reg ptr u64[1] x,
-  #[poly = p, poly = p] reg ptr u64[1] y
+  reg ptr u64[1] y
 ) ->
- #[poly = p, poly = s] reg ptr u64[1],
- #[poly = p, poly = p] reg ptr u64[1] {
+ reg ptr u64[1],
+ reg ptr u64[1] {
   x[0] = s;
   return x, y;
 }
 
-#[constraints="p <= public, transient <= t, t <= transient, secret <= s"]
+#[sct="
+  secret × { ptr: public, val: any } × { ptr: public, val: public } →
+    { ptr: public, val: secret } × { ptr: public, val: transient }
+"]
 fn does_corrupt_memory(
-  #secret reg u64 s,
+  reg u64 s,
   reg ptr u64[1] x,
-  #[poly = p, poly = p] reg ptr u64[1] y
+  reg ptr u64[1] y
 ) ->
- #[poly = p, poly = s] reg ptr u64[1],
- #[poly = p, poly = t] reg ptr u64[1] {
+ reg ptr u64[1],
+ reg ptr u64[1] {
   if false {
     x[1] = s;
   }
   return x, y;
 }
 
-#[constraints="p <= public, secret <= s"]
+#[sct="public * secret * { ptr: public, val: any } -> { ptr: public, val: secret } * public"]
 fn does_not_corrupt_registers(
-  #public reg u64 i,
-  #secret reg u64 s,
+  reg u64 i,
+  reg u64 s,
   reg ptr u64[1] x
 ) ->
- #[poly = p, poly = s] reg ptr u64[1],
- #public reg u64 {
+ reg ptr u64[1],
+ reg u64 {
   x[i] = s;
   return x, i;
 }

--- a/compiler/tests/sct-checker/success/for_loop.jazz
+++ b/compiler/tests/sct-checker/success/for_loop.jazz
@@ -1,4 +1,5 @@
-fn for_inference_bug1(reg u64 msf) -> #msf reg u64 {
+#[sct="msf → msf"]
+fn for_inference_bug1(reg u64 msf) -> reg u64 {
     inline int i;
     for i = 0 to 1 {
         msf = #init_msf();

--- a/compiler/tests/sct-checker/success/paper.jazz
+++ b/compiler/tests/sct-checker/success/paper.jazz
@@ -3,37 +3,43 @@
 */
 param int N = 20;
 
-// TODO: this is a workaround, parsing of annotations being certainly buggy
-#[constraints="p <= public, t <= transient, secret <= s"]
+#[sct =
+  "{ ptr: transient, val: transient } * { ptr: transient, val: secret } * transient -> { ptr: public, val: secret }"
+]
+// ct = "public * secret * public -> secret"
 fn fig3a(
-  #[poly = t, poly = t] reg const ptr u64[N] p,
-  #[poly = t, poly = s] reg mut ptr u64[N] w,
-  #transient reg u64 i)
-  ->  #[poly = p, poly = s] reg mut ptr u64[N] {
+  reg const ptr u64[N] p,
+  reg mut ptr u64[N] w,
+  reg u64 i)
+  ->  reg mut ptr u64[N] {
   reg u64 ms x;
   reg bool b;
   ms = #init_msf();
   b = i < N;
   if b {
     ms = #update_msf(b, ms);
-    x = p[(int) i];
+    x = p[i];
     x = #protect(x, ms);
   } else {
     ms = #update_msf(! b, ms);
   }
-  w[(int) x] = 0;
+  w[x] = 0;
   return w;
 }
 
-#[constraints="p <= public, t <= transient, secret <= s"]
+#[sct = "
+{ ptr: transient, val: transient } * { ptr: transient, val: { n: w, s: secret } } * { ptr: transient, val: secret } * transient * secret
+-> { ptr: public, val: { n: w, s: secret } } * { ptr: public, val: secret }
+"]
+// ct = "public * w * secret * public * secret → w * secret"
 fn fig3b(
-  #[poly = t, poly = t] reg const ptr u64[N] p,
-  #[poly = t, poly = w] reg mut ptr u64[N] w,
-  #[poly = t, poly = i] reg mut ptr u64[N] s,
-  #transient reg u64 i,
-  #secret reg u64 secret)
-  -> #[poly = p, poly = w] reg mut ptr u64[N]
-    , #[poly = p, poly = s] reg mut ptr u64[N] {
+  reg const ptr u64[N] p,
+  reg mut ptr u64[N] w,
+  reg mut ptr u64[N] s,
+  reg u64 i,
+  reg u64 secret)
+  -> reg mut ptr u64[N]
+  ,  reg mut ptr u64[N] {
   reg u64 ms x;
   reg bool b;
   ms = #init_msf();
@@ -50,11 +56,13 @@ fn fig3b(
   return w, s;
 }
 
-#[constraints="p <= public, secret <= s"]
+#[ sct = "
+  { ptr: public, val: secret } * { ptr: public, val: secret } -> { ptr: public, val: secret }
+"]
 fn fig4a(
-  #[poly = p, poly = d] reg mut ptr u64[N] msg,
-  #[poly = p, poly = s] reg const ptr u64[N] key
-) -> #[poly = p, poly = d] reg mut ptr u64[N] {
+  reg mut ptr u64[N] msg,
+  reg const ptr u64[N] key
+) -> reg mut ptr u64[N] {
   reg u64 i t1 t2;
   i = 0;
   while (i < N) {
@@ -67,11 +75,13 @@ fn fig4a(
   return msg;
 }
 
-#[constraints="p <= public, t <= transient, secret <= s"]
+#[sct = "
+  { ptr: transient, val: secret } * { ptr: transient, val: secret } -> { ptr: public, val: secret }
+"]
 fn fig4b(
-  #[poly = t, poly = d] reg mut ptr u64[N] msg,
-  #[poly = t, poly = s] reg const ptr u64[N] key
-) -> #[poly = p, poly = d] reg mut ptr u64[N] {
+  reg mut ptr u64[N] msg,
+  reg const ptr u64[N] key
+) -> reg mut ptr u64[N] {
   reg u64 ms i t1 t2;
   ms = #init_msf();
   i = 0;
@@ -89,11 +99,13 @@ fn fig4b(
   return msg;
 }
 
-#[constraints="p <= public, t <= transient, secret <= s"]
+#[sct = "
+  { ptr: transient, val: secret } * { ptr: transient, val: secret } -> { ptr: public, val: secret }
+"]
 fn fig4c(
-  #[poly = t, poly = d] reg mut ptr u64[N] msg,
-  #[poly = t, poly = s] reg const ptr u64[N] key
-) -> #[poly = p, poly = d] reg mut ptr u64[N] {
+  reg mut ptr u64[N] msg,
+  reg const ptr u64[N] key
+) -> reg mut ptr u64[N] {
   reg u64 ms i t1 t2;
   ms = #init_msf();
   i = 0;
@@ -109,26 +121,27 @@ fn fig4c(
   return msg;
 }
 
-// FIXME: It should be explicit that “d” is secret on speculative executions
-#[constraints="t <= transient"]
+#[sct = "
+  { ptr: public, val: { normal: d, speculative: secret } } -> { normal: d, speculative: d }
+"]
 fn fig5a(
-  #[poly = t, poly = d] reg const ptr u64[N] p
-) -> #[poly = d] reg u64 {
+  reg const ptr u64[N] p
+) -> reg u64 {
   reg u64 i s t;
   s = 0;
   i = 0;
   while (i < N) {
-    t = p[(int) i];
+    t = p[i];
     s += t;
     i += 1;
   }
   return s;
 }
 
-#[constraints="t <= transient"]
-fn fig5b(
-  #[poly = t, poly = d] reg const ptr u64[N] p
-) -> #[poly = d] reg u64 {
+#[sct = "
+  { ptr: transient, val: d } -> d
+"]
+fn fig5b(reg const ptr u64[N] p) -> reg u64 {
   reg u64 ms i s t;
   ms = #init_msf();
   s = 0;
@@ -144,10 +157,10 @@ fn fig5b(
   return s;
 }
 
-#[constraints="t <= transient"]
-fn fig5c(
-  #[poly = t, poly = d] reg const ptr u64[N] p
-) -> #[poly = d] reg u64 {
+#[sct = "
+  { ptr: transient, val: d } -> d
+"]
+fn fig5c(reg const ptr u64[N] p) -> reg u64 {
   reg u64 ms i s t;
   ms = #init_msf();
   s = 0;
@@ -182,12 +195,14 @@ fn fig5d(
 }
 */
 
-#[constraints="p <= public, t <= transient, secret <= s"]
+#[sct = "
+  { ptr: transient, val: secret } * { ptr: transient, val: transient } * transient -> public * { ptr: public, val: secret }
+"]
 fn fig6a(
-  #[poly = t, poly = s] reg mut ptr u64[N] s,
-  #[poly = t, poly = t] reg const ptr u64[N] p,
-  #transient reg u64 i pub_v
-) -> #public reg u64, #[poly = p, poly = s] reg mut ptr u64[N] {
+  reg mut ptr u64[N] s,
+  reg const ptr u64[N] p,
+  reg u64 i pub_v
+) -> reg u64, reg mut ptr u64[N] {
   reg u64 ms x;
   reg bool b;
   ms = #init_msf();
@@ -202,13 +217,15 @@ fn fig6a(
   return x, s;
 }
 
-#[constraints="p <= public, t <= transient, secret <= s"]
+#[sct = "
+  { ptr: transient, val: secret } * { ptr: transient, val: transient } * transient * secret -> public * { ptr: public, val: secret }
+"]
 fn fig6b(
-  #[poly = t, poly = s] reg mut ptr u64[N] s,
-  #[poly = t, poly = t] reg const ptr u64[N] p,
-  #transient reg u64 cond,
-  #secret reg u64 sec_v
-) -> #public reg u64, #[poly = p, poly = s] reg mut ptr u64[N] {
+  reg mut ptr u64[N] s,
+  reg const ptr u64[N] p,
+  reg u64 cond,
+  reg u64 sec_v
+) -> reg u64, reg mut ptr u64[N] {
   reg u64 ms x;
   reg bool b;
   ms = #init_msf();

--- a/compiler/tests/success/slh/x86-64/function_calls.jazz
+++ b/compiler/tests/success/slh/x86-64/function_calls.jazz
@@ -50,7 +50,8 @@ fn main_move(reg u64 x) {
     [x] = 0;
 }
 
-fn dup_msf(reg u64 msf) -> #msf reg u64, #msf reg u64 {
+#[sct="msf -> msf * msf"]
+fn dup_msf(reg u64 msf) -> reg u64, reg u64 {
     reg u64 msf1 msf2;
     msf1 = #mov_msf(msf);
     msf2 = #mov_msf(msf);

--- a/compiler/tests/success/slh/x86-64/function_kills_msf_2.jazz
+++ b/compiler/tests/success/slh/x86-64/function_kills_msf_2.jazz
@@ -2,10 +2,11 @@ fn f(reg u64 x) {
     [x] = x;
 }
 
-export fn main(reg u64 x) -> reg u64 {
-    reg u64 ms r;
+export fn main(reg u64 x r) -> reg u64 {
+    reg u64 ms;
     ms = #init_msf();
     f(x);
     r = #protect(r, ms);
+    r = r;
     return r;
 }

--- a/default.nix
+++ b/default.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation {
     ++ optionals ocamlDeps ([ mpfr ppl ] ++ (with oP; [
          ocaml findlib dune_3
          cmdliner
+         angstrom
          batteries
          menhir (oP.menhirLib or null) zarith camlidl apron yojson ]))
     ++ optionals devTools (with oP; [ merlin ocaml-lsp ])

--- a/opam
+++ b/opam
@@ -25,6 +25,7 @@ depends: [
   "apron" {>= "v0.9.12"}
   "conf-ppl"
   "yojson" {>= "1.6.0"}
+  "angstrom"
   "ocamlfind" { build }
   "coq" {>= "8.14.0" & < "8.19~"}
   "coq-mathcomp-ssreflect" {>= "1.17" & < "1.20~"}


### PR DESCRIPTION
The value of this annotation is a security signature for the function. Said signature gives the security type  of each argument and returned value.

A security level is a pair (first component for normal, correctly speculated executions, second component for mis-speculated executions) made of:

  - “public”
  - “secret”
  - an arbitrary identifier

There are a few notational shortcuts:

  - “transient” denotes the pair (public, secret)
  - a lone component x denotes the pair (x, x)

A type for non-ptr variables is just a level. A type for a ptr variable is made of two levels: one for the value (i.e., the array), the other one for the reference (aka the pointer) which may become transient when unspilled from memory.