### PR TITLE
CT checker: accept S-CT annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@
   when the `-g` command-line flag is given (off by default).
   ([PR #684](https://github.com/jasmin-lang/jasmin/pull/684)).
 
+- The Constant-Time security checker also accepts annotations for the
+  *Speculative*-Constant-Time checker (`transient` and `msf` are interpreted as
+  `public`; information relative to pointers or to mis-speculated executions is
+  ignored)
+  ([PR #773](https://github.com/jasmin-lang/jasmin/pull/773)).
+
 ## Bug fixes
 
 - Type-checking rejects invalid variants of primitive operators

--- a/compiler/CCT/success/sct.jazz
+++ b/compiler/CCT/success/sct.jazz
@@ -1,0 +1,21 @@
+#[sct="{ ptr: transient, val : { n: d, s: secret } } -> d"]
+export
+fn load(reg ptr u32[1] a) -> reg u32 {
+  _ = #init_msf();
+  reg u32 r;
+  r = a[0];
+  return r;
+}
+
+#[sct="{n: a, s: secret} × {n: b, s: secret} → c"
+, constraints="a <= c, b <= c"]
+export fn sum(
+  #poly=x reg u32 x,
+  #poly=y reg u32 y)
+-> #poly={x, y} reg u32 {
+  _ = #init_msf();
+  reg u32 r;
+  r = x;
+  r += y;
+  return r;
+}

--- a/compiler/src/ct_checker_forward.ml
+++ b/compiler/src/ct_checker_forward.ml
@@ -448,9 +448,7 @@ let get_annot ensure_annot f =
     let lvl =
       match Lvl.parse ~single:true ~kind_allowed:true x.v_annot, Option.bind sig_annot (SecurityAnnotations.get_nth_argument i) with
       | lvl, None -> lvl
-      | (_, Some _), Some _ ->
-         error ~loc:(x.v_dloc)
-           "security annotations for argument %a redundant with security signature" (Printer.pp_var ~debug:false) x
+      | (_, Some _) as lvl, _ -> lvl
       | _, Some t -> Some Flexible, Some (lvl_of_typ t)
     in
     x.v_name, lvl
@@ -458,9 +456,7 @@ let get_annot ensure_annot f =
   let process_result i a =
     match Lvl.parse ~single:false ~kind_allowed:false a, Option.bind sig_annot (SecurityAnnotations.get_nth_result i) with
     | (_, lvl), None -> lvl
-    | (_, Some _), Some _ ->
-       error ~loc:L._dummy
-         "security annotations for result at position %d redundant with security signature" i
+    | (_, (Some _ as lvl)), _ -> lvl
     | _, Some t -> Some (lvl_of_typ t)
   in
   let ain  = List.mapi process_argument f.f_args in

--- a/compiler/src/sct_checker_forward.ml
+++ b/compiler/src/sct_checker_forward.ml
@@ -1129,32 +1129,11 @@ let parse_var_annot ~(kind_allowed:bool) ~(msf:bool) (annot: annotations) : ulev
         sstrict,   (fun a -> check_allowed a; A.none a; Strict)] in
     A.ensure_uniq filters annot in
 
-  let poly arg =
-    let poly_error loc =
-      A.error ~loc
-        "= ident or = { ident } is expected after “%s”" spoly in
-
-    let mk_poly loc _nid id =
-      if id = stransient || id = spublic || id = ssecret then
-        A.error ~loc
-          "%s not allowed as argument of %s" id spoly;
-      Poly (L.mk_loc loc id) in
-
-    let on_struct loc _nid (s:annotations) =
-      List.iter A.none s;
-      if List.length s <> 1 then poly_error loc;
-      let (s, _) = List.hd s in
-      mk_poly (L.loc s) _nid (L.unloc s) in
-
-    let on_id loc _nid id = mk_poly loc _nid id in
-
-    A.on_attribute ~on_id ~on_struct poly_error arg in
-
   let filters =
     [spublic, (fun a -> A.none a; Public);
      ssecret, (fun a -> A.none a; Secret);
-     stransient, (fun a -> A.none a; Transient);
-     spoly, poly] in
+     stransient, (fun a -> A.none a; Transient)
+     ] in
 
   let filters =
     if msf then (smsf, (fun a -> A.none a; Msf)) :: filters else filters in

--- a/compiler/tests/sct-checker/error_messages.jazz
+++ b/compiler/tests/sct-checker/error_messages.jazz
@@ -53,8 +53,6 @@ export fn not_known_as_msf() {
   x = #mov_msf(x);
 }
 
-export fn bad_poly_annot(#poly=public reg u64 x) { [x] = 0; }
-
 export fn msf_in_export(reg u64 p) {
   p = #protect(p, p);
 }

--- a/compiler/tests/sct-checker/fail/basic.jazz
+++ b/compiler/tests/sct-checker/fail/basic.jazz
@@ -37,13 +37,13 @@ fn missing_then(#transient reg u64 a){
   a = #protect(a, m);
 }
 
-#[constraints="p <= public, t <= transient, secret <= s"]
+#[sct="public × { ptr: public, val: transient } × { ptr: public, val: secret } → { ptr: public, val: transient }"]
 fn xof_init(
-  #public reg u64 j,
-  #[poly = p, poly = t] reg ptr u64[25] state,
-  #[poly = p, poly = s] reg ptr u8[32] rho)
+  reg u64 j,
+  reg ptr u64[25] state,
+  reg ptr u8[32] rho)
   ->
-  #[poly = p, poly = t] reg ptr u64[25]
+  reg ptr u64[25]
 {
   reg u64 t;
   t = rho[u64 j];

--- a/compiler/tests/sct-checker/reject.expected
+++ b/compiler/tests/sct-checker/reject.expected
@@ -1,6 +1,6 @@
 File basic.jazz:
 Failed as expected xof_init: "fail/basic.jazz", line 51 (9-14):
-                             speculative constant type checker: return type for state is #[ptr = public, val = secret] it should be less than #[ptr = public, val = { n = public, s = t}]
+                             speculative constant type checker: return type for state is #[ptr = public, val = secret] it should be less than #[ptr = public, val = transient]
 Failed as expected missing_then: "fail/basic.jazz", line 37 (18-19):
                                  speculative constant type checker: the variable m is not known to be a msf, only {
                                    } are

--- a/compiler/tests/sct-checker/sct_errors.expected
+++ b/compiler/tests/sct-checker/sct_errors.expected
@@ -10,7 +10,6 @@ Failed as expected msf_trans: speculative constant type checker: MSF is Trans
                               (x ==64u ((64u) 0))
 Failed as expected not_known_as_msf: speculative constant type checker: 
                                      the variables { x } need to be MSFs.
-Annotation error in bad_poly_annot: public not allowed as argument of poly
 Failed as expected msf_in_export: speculative constant type checker: 
                                   the arguments { p } need to be MSFs, this is not allowed for export functions.
 Failed as expected should_be_a_msf: speculative constant type checker: p should be an MSF
@@ -25,7 +24,7 @@ Failed as expected call_bad_nomodmsf3: speculative constant type checker: annota
 Failed as expected call_modmsf_destroys: speculative constant type checker: 
                                          this function call destroys MSFs and { msf } are required.
                                          Trace:
-                                           the function modmsf_destroys destroys MSFs at "error_messages.jazz", line 142 (2) to line 144 (3)
+                                           the function modmsf_destroys destroys MSFs at "error_messages.jazz", line 140 (2) to line 142 (3)
 Failed as expected ret_high: speculative constant type checker: return type for p is #secret it should be less than #public
 Failed as expected ret_transient: speculative constant type checker: return type for p is #transient it should be less than #public
 Failed as expected ret_msf: speculative constant type checker: return annotation for msf should be msf

--- a/compiler/tests/sct-checker/sct_errors.ml
+++ b/compiler/tests/sct-checker/sct_errors.ml
@@ -21,7 +21,6 @@ let () =
       "update_msf_not_msf";
       "msf_trans";
       "not_known_as_msf";
-      "bad_poly_annot";
       "msf_in_export";
       "should_be_a_msf";
       "at_least_transient";

--- a/compiler/tests/sct-checker/success/annot.jazz
+++ b/compiler/tests/sct-checker/success/annot.jazz
@@ -8,12 +8,14 @@ fn f(#transient reg u64 x) -> #secret reg u64 {
    return r;
 }
 
-fn id(#poly = k reg u64 arg) -> #poly = { k } reg u64 {
+#[sct="k → k"]
+fn id(reg u64 arg) -> reg u64 {
   _ = #init_msf();
   return arg;
 }
 
-fn id1(#poly = k reg u64 arg) -> #poly = { k } reg u64 {
+#[sct="k → k"]
+fn id1(reg u64 arg) -> reg u64 {
   return arg;
 }
 

--- a/compiler/tests/sct-checker/success/annot.jazz
+++ b/compiler/tests/sct-checker/success/annot.jazz
@@ -17,7 +17,8 @@ fn id1(#poly = k reg u64 arg) -> #poly = { k } reg u64 {
   return arg;
 }
 
-fn id2(#[poly = p, poly = v] reg ptr u64[2] arg) -> #[poly = p, poly = v] reg ptr u64[2] {
+#[sct="{ p: p, v: v } -> { p: p, v: v }"]
+fn id2(reg ptr u64[2] arg) -> reg ptr u64[2] {
   return arg;
 }
 


### PR DESCRIPTION
Security annotations for the speculative-ct checker are translated (weakened) when handled by the (non-speculative) CT checker.