### PR TITLE
CI: update nixpkgs

### DIFF
--- a/scripts/nixpkgs.nix
+++ b/scripts/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/53fbe41cf76b6a685004194e38e889bc8857e8c2.tar.gz";
-  sha256 = "sha256:1fyc4kbhv7rrfzya74yprvd70prlcsv56b7n0fv47kn7rznvvr2b";
+  url = "https://github.com/NixOS/nixpkgs/archive/219951b495fc2eac67b1456824cc1ec1fd2ee659.tar.gz";
+  sha256 = "sha256:065jy7qivlbdqmbvd7r9h97b23f21axmc4r7sqmq2h0j82rmymxv";
 })


### PR DESCRIPTION
This brings OCaml 4.14.2 & alt-ergo 2.5.3