### PR TITLE
Regalloc: clearer printing of live variables at call sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,8 @@
   ([PR #766](https://github.com/jasmin-lang/jasmin/pull/766)).
 
 - Register allocation can print liveness information (enable with `-pliveness`)
-  ([PR #749](https://github.com/jasmin-lang/jasmin/pull/749)).
+  ([PR #749](https://github.com/jasmin-lang/jasmin/pull/749),
+  [PR #776](https://github.com/jasmin-lang/jasmin/pull/776)).
 
 - Relaxed alignment constraints for memory and array accesses
   ([PR #748](https://github.com/jasmin-lang/jasmin/pull/748)).

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -915,7 +915,7 @@ let subroutine_ra_by_stack f =
         | None -> dfl
         | Some k -> dfl || k = OnStack
 
-let pp_liveness vars get_liveness liveness_table conflicts a =
+let pp_liveness vars liveness_per_callsite liveness_table conflicts a =
   (* Prints the program with forced registers, equivalence classes, and liveness information *)
   let open Format in
   let open PrintCommon in
@@ -987,44 +987,30 @@ let pp_liveness vars get_liveness liveness_table conflicts a =
     fprintf fmt "@[<v>/* Live-out:@ %a */@]@ " pp_liveset o
   in
 
-  (** Partition the set s according to conflicts: conflicting variables are in the same component. *)
-  let components s =
-    let r, o = Sv.fold (fun x (r, o) ->
-          match Hv.find vars x with
-          | exception Not_found -> r, Sv.add x o
-          | i -> IntMap.add i x r, o
-        ) s (IntMap.empty, Sv.empty) in
-    let mark = ref IntSet.empty in
-    IntMap.fold (fun i x acc ->
-        if IntSet.mem i !mark then acc else (
-          let k = IntSet.filter (fun j -> IntMap.mem j r) (get_conflicts i conflicts) in
-          mark := IntSet.union (IntSet.add i k) !mark;
-          IntSet.fold (fun j -> Sv.add (IntMap.find j r)) k (Sv.singleton x) :: acc
-        )
-      ) r [o]
+  let pp_callsites fmt fn =
+    let s = Hf.find_default liveness_per_callsite fn [] in
+    let pp_callsite fmt (loc, s) =
+      fprintf fmt "@[<hov 2>at %a: %a@]" (pp_list "@ " L.pp_iloc) loc pp_liveset s in
+    if s <> [] then
+      fprintf fmt "/* @[<v>Live when calling %s:@ %a@ */@]@." fn.fn_name (pp_list "@ " pp_callsite) s
   in
 
   let pp_recap fmt fn =
     let pp fmt (k, n) =
       fprintf fmt  "%d %s%s" n (string_of_k k) (if n > 1 then "s" else "")
     in
-    let s = get_liveness fn in
-    let pp_s fmt s =
-      if not (Sv.is_empty s) then
-        let c = components s in
-        fprintf fmt "@[<v>Live at call sites:@ %a@]@ " (pp_list "@ " pp_liveset) c in
-    fprintf fmt "/* @[<v>Maximum register usage for %s:@ %a@ @]%a*/@.@."
+    fprintf fmt "/* @[<v>Maximal register usage for %s:@ %a@ @]*/@.@."
       fn.fn_name
       (pp_list "@ " pp)
       (List.filter (fun (_, n) -> n > 0)
          [ Word, !m_word; Extra, !m_extra; Vector, !m_vector; Flag, !m_flag])
-      pp_s s
   in
 
   printf "/* Ready to allocate variables to registers: */@.";
   liveness_table |> Hf.iter (fun fn fd ->
     reset_max();
     printf "%a@." (pp_fun ~pp_locals ~pp_info (pp_opn Arch.reg_size Arch.asmOp) pp_var) fd;
+    printf "%a" pp_callsites fn;
     pp_recap Format.std_formatter fn)
 
 let global_allocation translate_var get_internal_size (funcs: ('info, 'asm) func list) :
@@ -1095,16 +1081,16 @@ let global_allocation translate_var get_internal_size (funcs: ('info, 'asm) func
     Format.printf "Before REGALLOC:@.%a@."
       Printer.(pp_list "@ @ " (pp_func ~debug:true Arch.reg_size Arch.asmOp)) (List.rev funcs);
   (* Live variables at the end of each function, in addition to returned local variables *)
-  let get_liveness, slive =
-    let live : Sv.t Hf.t = Hf.create 17 in
+  let get_liveness, slive, liveness_per_callsite =
+    let live : (L.i_loc list * Sv.t) list Hf.t = Hf.create 17 in
     let slive : (BinNums.positive Syscall_t.syscall_t, Sv.t) Hashtbl.t = Hashtbl.create 17 in
     List.iter (fun f ->
         let f_with_liveness = Hf.find liveness_table f.f_name in
-        let live_when_calling_f = Hf.find_default live f.f_name Sv.empty in
-        let cbf _loc fn xs (_, s) =
-          let s = Sv.union live_when_calling_f s in
+        let live_when_calling_f = Hf.find_default live f.f_name [[], Sv.empty] in
+        let cbf loc fn xs (_, s) =
           let s = Liveness.dep_lvs s xs in
-          Hf.modify_def Sv.empty fn (Sv.union s) live in
+          let s = List.map (fun (ctx, ls) -> loc :: ctx, Sv.union s ls) live_when_calling_f in
+          Hf.modify_def [] fn (List.rev_append s) live in
         let cbs _loc o xs (_, s) =
             let s = Liveness.dep_lvs s xs in
             match Hashtbl.find slive o with
@@ -1113,7 +1099,10 @@ let global_allocation translate_var get_internal_size (funcs: ('info, 'asm) func
 
         Liveness.iter_call_sites cbf cbs f_with_liveness
       ) funcs;
-    (fun fn -> Hf.find_default live fn Sv.empty), slive
+    (let tbl = Hf.map (fun _ -> List.fold_left (fun acc (_, s) -> Sv.union acc s) Sv.empty) live in
+     fun fn -> Hf.find_default tbl fn Sv.empty),
+    slive,
+    live
   in
   let excluded = Sv.of_list [Arch.rip; Arch.rsp_var] in
   let vars, nv = collect_variables_in_prog ~allvars:false excluded return_addresses Arch.all_registers funcs in
@@ -1183,7 +1172,7 @@ let global_allocation translate_var get_internal_size (funcs: ('info, 'asm) func
 
   List.iter (fun f -> allocate_forced_registers return_addresses translate_var nv vars conflicts f a) funcs;
 
-  if !Glob_options.print_liveness then pp_liveness vars get_liveness liveness_table conflicts a;
+  if !Glob_options.print_liveness then pp_liveness vars liveness_per_callsite liveness_table conflicts a;
 
   greedy_allocation vars nv conflicts fr a;
   let subst = var_subst_of_allocation vars a in

--- a/compiler/tests/success/common/liveness.jazz
+++ b/compiler/tests/success/common/liveness.jazz
@@ -23,3 +23,43 @@ fn f2(reg u32 z) -> reg u32, reg u32 {
   z = z;
   return z, f;
 }
+
+fn leaf() {}
+
+export
+fn f3(reg u32 a) -> reg u32 {
+  a = a;
+  leaf();
+  return a;
+}
+
+export
+fn f4(reg u32 a b) -> reg u32 {
+  a = a;
+  leaf();
+  a ^= b;
+  return a;
+}
+
+fn bot() {}
+fn mid() -> reg u32 {
+  reg u32 p q;
+  p = 1;
+  bot();
+  q = p;
+  bot();
+  q ^= p;
+  return q;
+}
+
+export
+fn top() -> reg u32 {
+  reg u32 r s t;
+  r = 1;
+  bot();
+  s = r;
+  mid();
+  t = s;
+  bot();
+  return t;
+}


### PR DESCRIPTION
When using `-pliveness`, the information about variables from caller functions that are live across the whole function now lists each call site separately and shows relevant location information.