### PR TITLE
Add smart load immediate operator for ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## New features
 
+- ARM now compiles `x = imm;` smartly: for small immediates, a single `MOV`; for
+  immediates whose negation is small, a single `MVN`; and for large immediates
+  a pair of `MOV` and `MOVT`.
+
 - Export functions can have `ptr` arrays as arguments and results.
   The compiler assumes that writable `ptr` are disjoint from the other
   `ptr` arguments and from the global data. This is the responsibility of

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -206,7 +206,9 @@ end = struct
   let chk_imm_reject_shift args n =
     chk_imm args n exn_imm_shifted exn_imm_too_big
 
-  (* Force W-encoding of 16-bits on [EI_shift] and [EI_none]. *)
+  (* We need to avoid encoding T2 when the constant is a shift to avoid setting
+     the carry flag.
+     We force the W-encoding of 16-bits on both [EI_shift] and [EI_none]. *)
   let chk_imm_w16_encoding args n opts =
     chk_imm args n (chk_w16_encoding opts) (chk_w16_encoding opts)
 

--- a/compiler/tests/success/arm-m4/load_immediate.jazz
+++ b/compiler/tests/success/arm-m4/load_immediate.jazz
@@ -1,0 +1,9 @@
+export
+fn load_immediate() {
+    reg u32 x;
+
+    x = 0x000cb000; // This needs a MOV and a MOVT.
+    [x] = x;
+    x = 0x000acaca; // This needs a MOV and a MOVT.
+    [x] = x;
+}

--- a/proofs/compiler/arm_decl.v
+++ b/proofs/compiler/arm_decl.v
@@ -381,6 +381,6 @@ Definition is_expandable_or_shift (n : Z) : bool :=
    | EI_byte | EI_pattern | EI_shift => true
    | EI_none => false
   end.
- 
+
 Definition is_w12_encoding (z : Z) : bool := (z <? Z.pow 2 12)%Z.
 Definition is_w16_encoding (z : Z) : bool := (z <? Z.pow 2 16)%Z.

--- a/proofs/compiler/arm_extra.v
+++ b/proofs/compiler/arm_extra.v
@@ -24,7 +24,10 @@ Unset Printing Implicit Defensive.
 
 Variant arm_extra_op : Type :=
   | Oarm_swap of wsize
-  | Oarm_add_large_imm.
+  | Oarm_add_large_imm
+  | Osmart_li of wsize    (* Load an immediate to a register. *)
+  | Osmart_li_cc of wsize (* Conditional [Osmart_li]. *)
+.
 
 Scheme Equality for arm_extra_op.
 
@@ -62,10 +65,28 @@ Definition Oarm_add_large_imm_instr : instruction_desc :=
    ; semu   := @values.vuincl_app_sopn_v tys tys semi refl_equal
    ; i_safe := [::] |}.
 
+Definition smart_li_instr (ws : wsize) : instruction_desc :=
+  mk_instr_desc
+    (pp_sz "smart_li" ws)
+    [:: sword ws ] [:: E 0 ]
+    [:: sword ws ] [:: E 1 ]
+    (fun x => ok x)
+    [::].
+
+Definition smart_li_instr_cc (ws : wsize) : instruction_desc :=
+  mk_instr_desc
+    (pp_sz "smart_li_cc" ws)
+    [:: sword ws; sbool; sword ws ] [:: E 0; E 2; E 1 ]
+    [:: sword ws ] [:: E 1 ]
+    (fun x b y => ok (if b then x else y))
+    [::].
+
 Definition get_instr_desc (o: arm_extra_op) : instruction_desc :=
   match o with
   | Oarm_swap sz => Oswap_instr (sword sz)
   | Oarm_add_large_imm => Oarm_add_large_imm_instr
+  | Osmart_li ws => smart_li_instr ws
+  | Osmart_li_cc ws => smart_li_instr_cc ws
   end.
 
 (* Without priority 1, this instance is selected when looking for an [asmOp],
@@ -105,7 +126,72 @@ Definition error (ii : instr_info) (msg : string) :=
     pel_internal := false;
   |}.
 
+Definition li_condition_modified ii :=
+  error
+    ii
+    "assignment needs to be split but condition is modified by assignment".
 End E.
+
+Definition asm_args_of_opn_args
+  : seq ARMFopn_core.opn_args -> seq (asm_op_msb_t * lexprs * rexprs) :=
+  map (fun '(les, aop, res) => ((None, aop), les, res)).
+
+Definition uncons X (ii : instr_info) (xs : seq X) : cexec (X * seq X) :=
+  if xs is x :: xs
+  then ok (x, xs)
+  else Error (E.internal_error ii "invalid uncons").
+
+Definition uncons_LLvar
+  (ii : instr_info) (les : seq lexpr) : cexec (var_i * seq lexpr) :=
+  if les is LLvar x :: les
+  then ok (x, les)
+  else Error (E.internal_error ii "invalid lvals").
+
+Definition uncons_rvar
+  (ii : instr_info) (res : seq rexpr) : cexec (var_i * seq rexpr) :=
+  if res is Rexpr (Fvar x) :: res
+  then ok (x, res)
+  else Error (E.internal_error ii "invalid arguments").
+
+Definition uncons_wconst
+  (ii : instr_info) (res : seq rexpr) : cexec (Z * seq rexpr) :=
+  if res is Rexpr (Fapp1 (Oword_of_int _) (Fconst imm)) :: res'
+  then ok (imm, res')
+  else Error (E.internal_error ii "invalid arguments").
+
+Definition smart_li_args ii ws les res :=
+  (* FIXME: This check is because [ARMFopn_core.li] only works with register
+     size, it should not be the case. *)
+  Let _ :=
+    assert
+      (ws == reg_size)
+      (E.error ii "smart immediate assignment is only valid for u32 variables")
+  in
+  Let: (x, les) := uncons_LLvar ii les in
+  Let _ :=
+    assert (vtype (v_var x) == sword ws) (E.internal_error ii "invalid type")
+  in
+  Let _ := assert (nilp les) (E.internal_error ii "invalid lvals") in
+  Let: (imm, res) := uncons_wconst ii res in
+  ok (x, imm, res).
+
+Definition assemble_smart_li ii ws les res :=
+  Let: (x, imm, _) := smart_li_args ii ws les res in
+  ok (asm_args_of_opn_args (ARMFopn_core.li x imm)).
+
+Definition assemble_smart_li_cc
+  ii ws les res : cexec (seq (asm_op_msb_t * lexprs * rexprs)) :=
+  Let: (x, imm, res) := smart_li_args ii ws les res in
+  Let: (cond, res) := uncons ii res in
+  Let _ :=
+    assert (~~ Sv.mem x (free_vars_r cond)) (E.li_condition_modified ii)
+  in
+  Let: (oldx, _) := uncons_rvar ii res in
+  let mk '(les, ARM_op mn opts, res) :=
+    let opts := set_is_conditional opts in
+    ok ((None, ARM_op mn opts), les, res ++ [:: cond; rvar oldx ])
+  in
+  mapM mk (ARMFopn_core.li x imm).
 
 Definition assemble_extra
            (ii: instr_info)
@@ -143,10 +229,12 @@ Definition assemble_extra
          (E.internal_error ii "bad arm_add_large_imm: invalid register") in
       Let _ := assert (all (fun (x:var_i) => vtype x == sword U32) [:: x; y])
           (E.error ii "arm swap only valid for register of type u32") in
-      ok (map (fun '(d, o, e) => ((None, o), d, e)) (ARMFopn_core.smart_addi x y imm))
+      ok (asm_args_of_opn_args (ARMFopn_core.smart_addi x y imm))
     | _, _ =>
       Error (E.internal_error ii "bad arm_add_large_imm: invalid args or dests")
     end
+  | Osmart_li ws => assemble_smart_li ii ws outx inx
+  | Osmart_li_cc ws => assemble_smart_li_cc ii ws outx inx
   end.
 
 #[ export ]

--- a/proofs/compiler/arm_instr_decl_lemmas.v
+++ b/proofs/compiler/arm_instr_decl_lemmas.v
@@ -66,7 +66,7 @@ Proof.
 
   (* Destruct [vprev]. *)
   all:
-    repeat (
+    do 6? (
       case: vprev => [| ? vprev ] //=;
       t_xrbindP=> //;
       repeat
@@ -84,7 +84,7 @@ Proof.
   all: rewrite /exec_sopn /=.
   all: case: vargs => [| ? vargs ] //; t_xrbindP => // v.
   all:
-    repeat (
+    do 6? (
       case: vargs => [| ? vargs ] //;
       t_xrbindP => //;
       match goal with

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -23,7 +23,6 @@ Require Import
   arm_decl
   arm_extra
   arm_instr_decl
-  arm_params_core
   arm_params_common
   arm_lowering
   arm_stack_zeroization.

--- a/proofs/compiler/arm_params_common.v
+++ b/proofs/compiler/arm_params_common.v
@@ -22,11 +22,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Module ARMOpn (Args : OpnArgs).
-
-  Import Args.
-
-  Module Core := ARMOpn_core(Args).
+Module ARMFopn.
 
   #[local]
   Open Scope Z.
@@ -35,59 +31,45 @@ Module ARMOpn (Args : OpnArgs).
 
   Context {atoI : arch_toIdent}.
 
-  Notation opn_args := (seq lval * sopn * seq rval)%type.
+  Definition to_opn '(d, o, e) : fopn_args := (d, Oarm o, e).
 
-  Let op_gen mn x res : opn_args :=
-    ([:: lvar x ], Oarm (ARM_op mn default_opts), res).
-  Let op_un_reg mn x y := op_gen mn x [:: rvar y ].
-  Let op_un_imm mn x imm := op_gen mn x [:: rconst reg_size imm ].
-  Let op_bin_reg mn x y z := op_gen mn x [:: rvar y; rvar z ].
-  Let op_bin_imm mn x y imm := op_gen mn x [:: rvar y; rconst reg_size imm ].
+  Definition mov x y   := to_opn (ARMFopn_core.mov x y).
+  Definition add x y z := to_opn (ARMFopn_core.add x y z).
+  Definition sub x y z := to_opn (ARMFopn_core.sub x y z).
 
-  Definition to_opn '(d, o, e) : opn_args := (d, Oarm o, e).
-
-  Definition mov x y   := to_opn (Core.mov x y).
-  Definition add x y z := to_opn (Core.add x y z).
-  Definition sub x y z := to_opn (Core.sub x y z).
-
-  Definition movi x   imm := to_opn (Core.movi x imm).
-  Definition movt x   imm := to_opn (Core.movt x imm).
-  Definition addi x y imm := to_opn (Core.addi x y imm).
-  Definition subi x y imm := to_opn (Core.subi x y imm).
-
-  Definition bici := op_bin_imm BIC.
-
-  Definition str x y off :=
-    let lv := lmem Aligned reg_size y off in
-    ([:: lv ], Oarm (ARM_op STR default_opts), [:: rvar x ]).
-
+  Definition movi x   imm := to_opn (ARMFopn_core.movi x imm).
+  Definition movt x   imm := to_opn (ARMFopn_core.movt x imm).
+  Definition addi x y imm := to_opn (ARMFopn_core.addi x y imm).
+  Definition subi x y imm := to_opn (ARMFopn_core.subi x y imm).
+  Definition bici x y imm := to_opn (ARMFopn_core.bici x y imm).
+  Definition str x y off := to_opn (ARMFopn_core.str x y off).
   Definition align x y al := bici x y (wsize_size al - 1).
 
   (* Load an immediate to a register. *)
-  Definition li x imm := map to_opn (Core.li x imm).
+  Definition li (x : var_i) (imm : Z) : fopn_args :=
+    let op := Oasm (ExtOp (Osmart_li reg_size)) in
+    ([:: LLvar x ], op, [:: rconst reg_size imm ]).
 
-  Definition smart_mov x y := map to_opn (Core.smart_mov x y).
+  Definition smart_mov x y := map to_opn (ARMFopn_core.smart_mov x y).
 
   (* Compute [R[x] := R[y] + imm % 2^32
      Precondition: if [imm] is large, [x <> y]. *)
-  Definition smart_addi x y imm := map to_opn (Core.smart_addi x y imm).
+  Definition smart_addi x y imm := map to_opn (ARMFopn_core.smart_addi x y imm).
 
   (* Compute [R[x] := R[y] - imm % 2^32
      Precondition: if [imm] is large, [x <> y]. *)
-  Definition smart_subi x y imm := map to_opn (Core.smart_subi x y imm).
+  Definition smart_subi x y imm := map to_opn (ARMFopn_core.smart_subi x y imm).
 
   (* Compute [R[x] := R[x] + imm % 2^32].
      Precondition: if [imm] is large, [x <> tmp]. *)
-  Definition smart_addi_tmp x tmp imm := map to_opn (Core.smart_addi_tmp x tmp imm).
+  Definition smart_addi_tmp x tmp imm :=
+    map to_opn (ARMFopn_core.smart_addi_tmp x tmp imm).
 
   (* Compute [R[x] := R[x] - imm % 2^32].
      Precondition: if [imm] is large, [x <> tmp]. *)
-  Definition smart_subi_tmp x tmp imm := map to_opn (Core.smart_subi_tmp x tmp imm).
-
+  Definition smart_subi_tmp x tmp imm :=
+    map to_opn (ARMFopn_core.smart_subi_tmp x tmp imm).
 
   End WITH_PARAMS.
 
-End ARMOpn.
-
-Module ARMCopn := ARMOpn(CopnArgs).
-Module ARMFopn := ARMOpn(FopnArgs).
+End ARMFopn.

--- a/proofs/compiler/arm_params_common_proof.v
+++ b/proofs/compiler/arm_params_common_proof.v
@@ -167,7 +167,7 @@ Qed.
 (* FIXME try to remove the usage of this lemma, use sem_fopn_args version instead *)
 Lemma movi_eval_instr {lp ls ii imm xname vi} :
   let: (xi, x) := mkv xname vi in
-  (is_expandable_or_shift imm \/ is_w16_encoding imm) ->
+  (is_expandable imm \/ is_w16_encoding imm) ->
   let: li := li_of_fopn_args ii (ARMFopn.movi xi imm) in
   let: vm' := (lvm ls).[x <- Vword (wrepr U32 imm)] in
   eval_instr lp li ls = ok (next_vm_ls ls vm').
@@ -176,6 +176,13 @@ Proof.
   have := [elaborate ARMFopn_coreP.movi_sem_fopn_args (xname := xname) (vi := vi) (s:=to_estate ls) h].
   by rewrite sem_fopn_equiv; apply: sem_fopn_args_eval_instr.
 Qed.
+
+Lemma li_eval_instr {lp ls ii imm xname vi} :
+  let: (xi, x) := mkv xname vi in
+  let: li := li_of_fopn_args ii (ARMFopn.li xi imm) in
+  let: vm' := (lvm ls).[x <- Vword (wrepr U32 imm)] in
+  eval_instr lp li ls = ok (next_vm_ls ls vm').
+Proof. by t_arm_op. Qed.
 
 Lemma str_eval_instr {lp ls m' ii xname vi y off wx} {wy : word reg_size} :
   let: (xi, x) := mkv xname vi in
@@ -197,23 +204,23 @@ Opaque ARMFopn.subi.
 
 Lemma li_lsem lp fn ls ii P Q xname vi imm :
   let: (xi, x) := mkv xname vi in
-  let: lcmd := map (li_of_fopn_args ii) (ARMFopn.li xi imm) in
-  is_linear_of lp fn (P ++ lcmd ++ Q)
+  let: lcmd := li_of_fopn_args ii (ARMFopn.li xi imm) in
+  is_linear_of lp fn (P ++ lcmd :: Q)
   -> lpc ls = size P
   -> lfn ls = fn
   -> exists vm',
-       let: ls' := setpc (lset_vm ls vm') (size P + size lcmd) in
+       let: ls' := setpc (lset_vm ls vm') (size P + 1) in
        [/\ lsem lp ls ls'
          , vm' =[\ Sv.singleton x ] lvm ls
          & get_var true vm' x = ok (Vword (wrepr reg_size imm))
        ].
 Proof.
   move=> hlin hpc hfn.
-  have [vm' []] := ARMFopn_coreP.li_lsem_1 (to_estate ls) xname vi imm.
-  rewrite sem_fopns_equiv => h1 h2 h3.
-  exists vm'; split => //.
-  assert (h := sem_fopns_args_lsem h1 hlin); rewrite size_map.
-  by case: (ls) hfn hpc h => //= *; subst.
+  eexists; split.
+  - rewrite addn1 -lnext_pc_setpc -hpc setpc_id.
+    exact: (eval_lsem_step1 hlin _ _ li_eval_instr).
+  - move=> x /Sv.singleton_spec /nesym /eqP hx. by rewrite Vm.setP_neq.
+  by rewrite get_var_eq.
 Qed.
 Opaque ARMFopn.li.
 

--- a/proofs/compiler/arm_stack_zeroization.v
+++ b/proofs/compiler/arm_stack_zeroization.v
@@ -38,9 +38,6 @@ Let vzf := mk_var_i (to_var ZF).
 Let vflags := [seq mk_var_i (to_var f) | f <- rflags ].
 Let leflags := [seq LLvar f | f <- vflags ].
 
-Notation rvar := (fun v => Rexpr (Fvar v)) (only parsing).
-Notation rconst := (fun ws imm => Rexpr (fconst ws imm)) (only parsing).
-
 (* For both strategies we need to initialize:
    - [saved_sp] to save [SP]
    - [off] to offset from [SP] to already zeroized region
@@ -60,7 +57,7 @@ Definition sz_init : lcmd :=
   let args :=
     ARMFopn.mov vsaved_sp vrsp
     :: ARMFopn.li voff stk_max
-    ++ ARMFopn.align vzero vsaved_sp alignment
+    :: ARMFopn.align vzero vsaved_sp alignment
     :: ARMFopn.mov vrsp vzero
     :: ARMFopn.sub vrsp vrsp voff
     :: [:: ARMFopn.movi vzero 0 ]

--- a/proofs/compiler/arm_stack_zeroization_proof.v
+++ b/proofs/compiler/arm_stack_zeroization_proof.v
@@ -166,81 +166,58 @@ Lemma sz_initP (s1 : estate) :
     state_rel_loop sz_init_vars s1 s2 stk_max top.
 Proof.
   move=> hvalid hrsp.
-  move: hbody; rewrite /= map_cat /=.
+  move: hbody => /=.
   set isave_sp := li_of_fopn_args _ (ARMFopn.mov _ _).
-  set iload_off := map _ (ARMFopn.li _ _).
+  set iload_off := li_of_fopn_args _ (ARMFopn.li _ _).
   set ialign := li_of_fopn_args _ (ARMFopn.align _ _ _).
   set istore_sp := li_of_fopn_args _ (ARMFopn.mov _ _).
   set isub_sp := li_of_fopn_args _ (ARMFopn.sub _ _ _).
   set izero := li_of_fopn_args _ (ARMFopn.movi _ _).
-  rewrite -catA /=; move=> hbody'.
-
-  have [vm2 [hsem2 hvm2 hoff2]] : [elaborate
-    exists vm2, [/\
-      lsem lp
-        (of_estate (with_vm s1 (evm s1).[vsaved_sp <- Vword ptr]) fn (size pre + 1))
-        {| lscs := escs s1;
-           lmem := emem s1;
-           lvm := vm2;
-           lfn := fn;
-           lpc := size (pre ++ isave_sp :: iload_off)
-        |},
-      vm2 =[\Sv.singleton voff] (evm s1).[vsaved_sp <- Vword ptr] &
-      vm2.[voff] = Vword (wrepr Uptr stk_max)]].
-  + move: hbody'; rewrite -cat_rcons => hbody'.
-    have /= := [elaborate
-      let: s1 := with_vm s1 (evm s1).[vsaved_sp <- Vword ptr] in
-      let: ls1 := of_estate s1 _ _ in
-      ARMFopnP.li_lsem (ls := ls1) hbody' erefl erefl
-    ].
-    rewrite -/iload_off size_rcons -{1}addn1 => -[vm2 [hsem2 hvm2 hgetoff]].
-    exists vm2; split=> //.
-    + by rewrite size_cat /= -(addSnnS (size _) (size _)).
-    by move/get_varP: hgetoff => [<- _ _].
+  move=> hbody'.
 
   eexists (Estate _ _ _); split=> /=.
-  move: hbody'; rewrite -cat_rcons catA cat_rcons => hbody'.
-  apply: (lsem_trans6 _ hsem2); apply: lsem_step1.
+  apply: lsem_step6.
 
-  + apply: (eval_lsem1 hbody) => //.
-    rewrite addn1.
+  + apply: (eval_lsem1 hbody') => //.
     apply: ARMFopnP.mov_eval_instr.
     rewrite /get_var hrsp /=.
     reflexivity.
 
-  + apply: (eval_lsem1 hbody') => //.
+  + rewrite /lnext_pc /=.
+    rewrite -cat_rcons in hbody'.
+    apply: (eval_lsem1 hbody' _ _ ARMFopnP.li_eval_instr) => //.
+    by rewrite size_rcons.
+
+  + rewrite /lnext_pc /=.
+    rewrite -2!cat_rcons in hbody'.
+    apply: (eval_lsem1 hbody') => //=; first by rewrite !size_rcons.
     apply: ARMFopnP.align_eval_instr.
-    rewrite /get_var /=.
-    rewrite hvm2;
-      last by move=> /Sv.singleton_spec /= /(@inj_to_var _ _ _ _ _ _).
-    rewrite Vm.setP_eq /=.
-    reflexivity.
+    rewrite /= get_var_neq //; last by move=> /(@inj_to_var _ _ _ _ _ _).
+    by rewrite get_var_eq.
 
   + rewrite /lnext_pc /=.
-    rewrite -cat_rcons -cats1 in hbody'.
-    apply: (eval_lsem1 hbody') => //; first by rewrite !size_cat !addn1.
+    rewrite -3!cat_rcons in hbody'.
+    apply: (eval_lsem1 hbody') => //=.
+    * by rewrite !size_rcons.
     apply: ARMFopnP.mov_eval_instr.
-    rewrite get_var_eq /=; last by [].
-    reflexivity.
+    by rewrite get_var_eq.
 
   + rewrite /lnext_pc /=.
-    rewrite -2!cat_rcons -2!cats1 in hbody'.
-    apply: (eval_lsem1 hbody') => //; first by rewrite !size_cat !addn1.
+    rewrite -4!cat_rcons in hbody'.
+    apply: (eval_lsem1 hbody') => //; first by rewrite !size_rcons.
     apply: ARMFopnP.sub_eval_instr => /=.
     * rewrite get_var_eq /=; last by []. reflexivity.
     rewrite get_var_neq;
       last by move=> h; apply /rsp_nin /sv_of_listP;
       rewrite !in_cons /= -h eqxx /= ?orbT.
     rewrite get_var_neq; last by move=> /(@inj_to_var _ _ _ _ _ _).
-    rewrite /get_var hoff2 /=.
-    reflexivity.
+    by rewrite get_var_eq.
 
   rewrite /lnext_pc /=.
-  rewrite -3!cat_rcons -3!cats1 in hbody'.
-  apply: (eval_lsem1 hbody') => //; first by rewrite !size_cat !addn1.
+  rewrite -5!cat_rcons in hbody'.
+  apply: (eval_lsem1 hbody') => //=; first by rewrite !size_rcons.
   rewrite ARMFopnP.movi_eval_instr; last by left.
-  rewrite !size_cat /= addn4 !addnS.
-  reflexivity.
+  by rewrite /lnext_pc /= -addn4 !addSnnS.
 
   split=> /=.
   + do 4 (rewrite Vm.setP_neq;
@@ -248,29 +225,26 @@ Proof.
         apply /eqP => /(@inj_to_var _ _ _ _ _ _) |
         apply /eqP => h; apply /rsp_nin /sv_of_listP;
           rewrite !in_cons /= -h eqxx /= ?orbT]).
-    exact: hoff2.
+    by rewrite Vm.setP_eq.
+
   split=> //=.
   + move=> p.
     by rewrite Z.sub_diag /between (negbTE (not_zbetween_neg _ _ _ _)).
   + do 4 (rewrite (eq_ex_set_l _ (eq_ex_refl _));
       last by case; apply Sv.add_spec; (left; reflexivity) ||
       right; apply /sv_of_listP; rewrite !in_cons /= eqxx /= ?orbT).
-    have hsub: Sv.Subset (Sv.singleton voff) (Sv.add rspi sz_init_vars).
-    + move=> _ /Sv.singleton_spec ->.
-      apply Sv.add_spec.
-      by right; apply /sv_of_listP; rewrite !in_cons /= eqxx /= ?orbT.
-    rewrite (eq_exI hsub hvm2).
-    by rewrite (eq_ex_set_l _ (eq_ex_refl _));
-      last by case; apply Sv.add_spec; (left; reflexivity) ||
-      right; apply /sv_of_listP; rewrite !in_cons /= eqxx /= ?orbT.
+    apply: eq_ex_set_r.
+    by do 3 (move=> /Sv.add_spec /Decidable.not_or [] ?).
+    rewrite (eq_ex_set_l _ (eq_ex_refl _));
+      last by case; by repeat (apply/Sv.add_spec; ((by left) || right)).
+    done.
   + do 4 (rewrite Vm.setP_neq;
       last by [
         apply /eqP => /(@inj_to_var _ _ _ _ _ _) |
         apply /eqP => h; apply /rsp_nin /sv_of_listP;
           rewrite !in_cons /= -h eqxx /= ?orbT]).
-    rewrite hvm2;
-      last by move=> /Sv.singleton_spec /= /(@inj_to_var _ _ _ _ _ _).
-    by rewrite Vm.setP_eq.
+    rewrite Vm.setP_neq; first by rewrite Vm.setP_eq.
+    by apply/eqP => /(@inj_to_var _ _ _ _ _ _).
   + rewrite Vm.setP_neq;
       last by apply /eqP => h; apply /rsp_nin /sv_of_listP;
       rewrite !in_cons /= -h eqxx /= ?orbT.
@@ -658,11 +632,7 @@ Context (rsp_nin : ~ Sv.In rspi stack_zero_loop_vars).
 Context (hlabel : ~~ has (is_label lbl) pre).
 
 Lemma sz_init_no_lbl : ~~ has (is_label lbl) (sz_init rspi ws_align stk_max).
-Proof.
-  rewrite /= has_map has_cat /= /ARMFopn.li /ARMFopn.Core.li.
-  case: ifP => // _.
-  by case: Z.div_eucl => ??.
-Qed.
+Proof. done. Qed.
 
 Lemma stack_zero_loopP (s1 : estate) :
   valid_between (emem s1) top stk_max ->
@@ -767,10 +737,7 @@ End RSP.
 
 Lemma sz_init_no_ext_lbl rsp ws_align stk_max :
   label_in_lcmd (sz_init rsp ws_align stk_max) = [::].
-Proof.
-  rewrite /= map_cat label_in_lcmd_cat /= cats0 /ARMFopn.li /ARMFopn.Core.li.
-  by case: ifP => // _; case: Z.div_eucl => ??.
-Qed.
+Proof. done. Qed.
 
 Lemma store_zero_no_ext_lbl ii rsp ws off :
   get_label (MkLI ii (store_zero rsp ws off)) = None.

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -298,6 +298,12 @@ Defined.
 (* ------------------------------------------------------------------------ *)
 (* Assembly generation hypotheses. *)
 
+Section ASM_GEN.
+
+Notation assemble_extra_correct :=
+  (assemble_extra_correct x86_agparams) (only parsing).
+
+
 (* FIXME: Is there a way of avoiding this import? *)
 Import arch_sem.
 
@@ -517,21 +523,6 @@ Proof.
   rewrite /word_uincl mul0n.
   by rewrite (@subword0 U128 U256) zero_extend_idem.
 Qed.
-
-Definition assemble_extra_correct (op : x86_extra_op) :=
-  forall rip ii les res m xs ys m' s ops ops',
-    let: assemble :=
-      fun '(op0, ls, rs) => assemble_asm_op x86_agparams rip ii op0 ls rs
-    in
-    sem_rexprs m res = ok xs ->
-    exec_sopn (Oasm (ExtOp op)) xs = ok ys ->
-    write_lexprs les ys m = ok m' ->
-    to_asm ii op les res = ok ops ->
-    mapM assemble ops = ok ops' ->
-    lom_eqv rip m s ->
-    exists2 s',
-      foldM (fun '(op'', asm_args) => eval_op op'' asm_args) s ops' = ok s'
-      & lom_eqv rip m' s'.
 
 Lemma assemble_slh_move_correct : assemble_extra_correct Ox86SLHmove.
 Proof.
@@ -840,9 +831,10 @@ Qed.
 Definition x86_hagparams : h_asm_gen_params (ap_agp x86_params) :=
   {|
     hagp_eval_assemble_cond := eval_assemble_cond;
-    hagp_assemble_extra_op :=
-      fun rip ii op => assemble_extra_op (op := op) (rip := rip) (ii := ii);
+    hagp_assemble_extra_op := assemble_extra_op;
   |}.
+
+End ASM_GEN.
 
 (* ------------------------------------------------------------------------ *)
 (* Speculative execution. *)

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -929,23 +929,3 @@ Definition instr_of_copn_args
   (args : copn_args)
   : instr_r :=
   Copn args.1.1 tg args.1.2 args.2.
-
-
-(* ------------------------------------------------------------------- *)
-
-Module Type OpnArgs.
-  Parameter lval rval : Type.
-  Parameter lvar : var_i -> lval.
-  Parameter lmem : forall {_ : PointerData}, aligned -> wsize -> var_i -> Z -> lval.
-  Parameter rvar : var_i -> rval.
-  Parameter rconst : wsize -> Z -> rval.
-End OpnArgs.
-
-Module CopnArgs <: OpnArgs.
-  Definition lval := lval.
-  Definition rval := pexpr.
-  Definition lvar := Lvar.
-  Definition lmem {_ : PointerData} al ws x z := Lmem al ws x (cast_const z).
-  Definition rvar x := Pvar (mk_lvar x).
-  Definition rconst ws z := cast_w ws (Pconst z).
-End CopnArgs.

--- a/proofs/lang/expr_facts.v
+++ b/proofs/lang/expr_facts.v
@@ -6,6 +6,10 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
+Lemma var_i_surj x :
+  x = {| v_var := v_var x; v_info := v_info x; |}.
+Proof. by move: x => []. Qed.
+
 Lemma is_lvar_is_glob x : is_lvar x = ~~is_glob x.
 Proof. by case: x => ? []. Qed.
 

--- a/proofs/lang/fexpr.v
+++ b/proofs/lang/fexpr.v
@@ -83,12 +83,4 @@ Definition free_vars_r (r:rexpr) : Sv.t :=
 
 Definition rvar (x : var_i) : rexpr := Rexpr (Fvar x).
 Definition rconst (ws : wsize) (z : Z) : rexpr := Rexpr (fconst ws z).
-
-Module FopnArgs <: OpnArgs.
-  Definition lval := lexpr.
-  Definition rval := rexpr.
-  Definition lvar := LLvar.
-  Definition lmem {_ : PointerData} al ws x z := Store al ws x (fconst Uptr z).
-  Definition rvar := rvar.
-  Definition rconst := rconst.
-End FopnArgs.
+Definition lstore {_ : PointerData} al ws x z := Store al ws x (fconst Uptr z).

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -745,6 +745,19 @@ Lemma get_var_set wdb vm x v y :
      else get_var wdb vm y.
 Proof. by rewrite {1}/get_var Vm.setP; case: eqP => // *; rewrite -vm_truncate_val_defined. Qed.
 
+Lemma get_var_set_var wdb vm vm' x y v :
+  (~~ wdb || is_defined v) ->
+  set_var wdb vm y v = ok vm' ->
+  get_var wdb vm' x =
+    if x == y
+    then ok (vm_truncate_val (vtype x) v)
+    else get_var wdb vm x.
+Proof.
+  move=> hv /set_varP [_ ? ->].
+  rewrite get_var_set // eq_sym hv /=.
+  by case: eqP => [->|_].
+Qed.
+
 Lemma get_var_eq wdb x vm v :
   truncatable wdb (vtype x) v ->
   get_var wdb vm.[x <- v] x =

--- a/proofs/lang/pseudo_operator.v
+++ b/proofs/lang/pseudo_operator.v
@@ -63,10 +63,12 @@ Definition pseudo_operator_beq (o1 o2 : pseudo_operator) : bool :=
 
 Lemma pseudo_operator_eq_axiom : Equality.axiom pseudo_operator_beq.
 Proof.
-  case => [o1 l1 | w1 p1 | | w1 | w1 | w1 | t1 ];
-  case => [o2 l2 | w2 p2 | | w2 | w2 | w2 | t2 ] => /=; try by constructor.
-  1,2: by apply (equivP andP);split => [ [/eqP -> /eqP ->]| [-> ->]].
-  all: by apply (equivP eqP); split => [ -> | [->]].
+  case=> [o1 l1 | w1 p1 | | w1 | w1 | w1 | t1];
+    case=> [o2 l2 | w2 p2 | | w2 | w2 | w2 | t2] => /=;
+    by [ constructor
+       | apply (equivP andP); split => [[/eqP -> /eqP ->] | [-> ->]]
+       | apply (equivP eqP); split => [-> | [->]]
+       ].
 Qed.
 
 #[export]
@@ -86,4 +88,3 @@ Definition string_of_pseudo_operator (o : pseudo_operator) : string :=
   | Osubcarry ws => pp_sz "sbb" ws tt
   | Oswap _ => "swap"
   end.
-

--- a/proofs/lang/sopn.v
+++ b/proofs/lang/sopn.v
@@ -211,7 +211,7 @@ Definition Oswap_instr ty :=
      semu   := @swap_semu ty;
      i_safe := [::];
   |}.
-           
+
 Definition pseudo_op_get_instr_desc (o : pseudo_operator) : instruction_desc :=
   match o with
   | Ospill o tys => Ospill_instr o tys


### PR DESCRIPTION
The idea is to move everything in `ARMFopn` to extra ops that the compiler uses transparently and get solved in asm_gen.

This PR does this for loading an immediate in a register. We decided to lower assignments `x = imm` to this operator, even if it can generate two instructions.