### PR TITLE
Rework a few proofs about word.lsr

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,32 +96,6 @@ eclib:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt     config -why3 eclib/why3.conf'
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make ECARGS="-why3 why3.conf" -C eclib'
 
-opam:
-  stage: prove
-  variables:
-    OPAMROOTISOK: 'true'
-    OPAMROOT: mapo
-    PREFIX: jasmin-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA
-    EXTRA_NIX_ARGUMENTS: --arg opamDeps true
-  extends: .common
-  cache:
-    key:
-      files:
-        - scripts/nixpkgs.nix
-      prefix: opam
-    paths:
-      - $OPAMROOT
-  script:
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'scripts/opam-setup.sh ALL'
-  - >-
-    nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run
-    'eval $(opam env) &&
-     make -j$NIX_BUILD_CORES &&
-     make install'
-  artifacts:
-    paths:
-    - $PREFIX
-
 opam-compiler:
   stage: build
   variables:

--- a/opam
+++ b/opam
@@ -30,7 +30,7 @@ depends: [
   "coq" {>= "8.14.0" & < "8.19~"}
   "coq-mathcomp-ssreflect" {>= "1.17" & < "1.20~"}
   "coq-mathcomp-algebra"
-  "coq-mathcomp-word" {>= "2.1" & < "3.0~"}
+  "coq-mathcomp-word" {>= "2.4" & < "3.0~"}
 ]
 conflicts: [
   "ez-conf-lib"

--- a/proofs/compiler/arm_facts.v
+++ b/proofs/compiler/arm_facts.v
@@ -46,10 +46,8 @@ Proof.
   case: Z.div_eucl (Z_div_mod q1 256 refl_equal) => [q2 b2'] [hq2 hb2'];
     subst q1.
 
-  rewrite /wunsigned /word.subword !word.mkwordK /= -/(wunsigned w) hw {hw}.
+  rewrite /wunsigned /word.subword -!word.urepr_word !word.urepr_lsr !word.mkwordK /= -/(wunsigned w) hw {hw}.
   rewrite -/(wbase U8) -/(wbase U32).
-  rewrite
-    -!(Znumtheory.Zmod_div_mod _ _ _ _ _ (wbase_div_wbase (wsize_le_U8 _))) //.
   rewrite !Z.shiftr_div_pow2 // Z.mul_comm Z.add_comm.
   change (2 ^ 16) with (2 ^ 8 * 2 ^ 8).
   change (2 ^ 24) with (2 ^ 8 * 2 ^ 8 * 2 ^ 8).

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -66,8 +66,8 @@ Module LE.
     rewrite (nth_map O); first last.
     - rewrite size_iota.
       by apply/ltP.
-    rewrite /word.subword /= Z.shiftr_0_l Zmod_0_l.
-    by apply/(@eqP (word U8)).
+    rewrite /word.subword -word.urepr_word word.urepr_lsr Z.shiftr_0_l.
+    exact/eqP.
   Qed.
 
 End LE.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -527,6 +527,7 @@ Lemma wshrE sz (x: word sz) c i :
   wbit_n (wshr x c) i = wbit_n x (Z.to_nat c + i).
 Proof.
   move/Z2Nat.id => {1}<-.
+  rewrite /wshr -urepr_lsr ureprK.
   exact: wbit_lsr.
 Qed.
 
@@ -544,6 +545,7 @@ Proof.
   rewrite -(Z.mod_small (wunsigned x / 2 ^ Z.of_nat c) (modulus sz)) //.
   rewrite -wunsigned_repr.
   congr wunsigned.
+  rewrite /wshr -urepr_lsr ureprK.
   apply/eqP/eq_from_wbit_n => i.
   rewrite /wbit_n wbit_lsr wunsigned_repr /wbit.
   rewrite Z.mod_small //.
@@ -770,7 +772,7 @@ Lemma msb0 sz : @msb sz 0 = false.
 Proof. by case: sz. Qed.
 
 Lemma wshr0 sz (w: word sz) : wshr w 0 = w.
-Proof. by rewrite /wshr /lsr Z.shiftr_0_r ureprK. Qed.
+Proof. by rewrite /wshr Z.shiftr_0_r ureprK. Qed.
 
 Lemma wshr_full sz (w : word sz) : wshr w (wsize_bits sz) = 0%R.
 Proof.
@@ -1249,22 +1251,11 @@ Qed.
 
 (* -------------------------------------------------------------------*)
 Lemma lsr0 n (w: n.-word) : lsr w 0 = w.
-Proof. by rewrite /lsr Z.shiftr_0_r ureprK. Qed.
+Proof. by apply/word_eqP; rewrite -urepr_word urepr_lsr. Qed.
 
 Lemma subword0 (ws ws' :wsize) (w: word ws') :
    mathcomp.word.word.subword 0 ws w = zero_extend ws w.
-Proof.
-  apply/eqP/eq_from_wbit_n => i.
-  rewrite wbit_zero_extend.
-  have := ltn_ord i.
-  rewrite ltnS => -> /=.
-  rewrite /subword lsr0.
-  rewrite {1}/wbit_n /wunsigned mkwordK.
-  rewrite /mathcomp.word.word.wbit /modulus two_power_nat_equiv.
-  rewrite Z.mod_pow2_bits_low //.
-  have /leP := ltn_ord i.
-  lia.
-Qed.
+Proof. by rewrite /subword -urepr_word urepr_lsr Z.shiftr_0_r. Qed.
 
 (* -------------------------------------------------------------------*)
 Definition check_scale (s:Z) :=

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -774,16 +774,11 @@ Proof. by rewrite /wshr /lsr Z.shiftr_0_r ureprK. Qed.
 
 Lemma wshr_full sz (w : word sz) : wshr w (wsize_bits sz) = 0%R.
 Proof.
-  apply/eqP/eq_from_wbit_n.
-  move=> i.
-  rewrite w0E.
-  rewrite wshrE //.
-  rewrite /wsize_bits /=.
-  rewrite SuccNat2Pos.id_succ.
-  rewrite /wbit_n.
-  rewrite wbit_word_ovf; first done.
-  apply: ltn_addr.
-  exact: ltnSn.
+  apply/eqP; rewrite word_eqE; apply/eqP.
+  rewrite /wsize_bits Zpos_P_of_succ_nat -Nat2Z.inj_succ.
+  rewrite -!/(wunsigned _) wunsigned_wshr wunsigned0.
+  rewrite -two_power_nat_equiv.
+  exact: Z.div_small (wunsigned_range w).
 Qed.
 
 Lemma wshl0 sz (w: word sz) : wshl w 0 = w.

--- a/scripts/mathcomp-word.nix
+++ b/scripts/mathcomp-word.nix
@@ -5,7 +5,7 @@ let inherit (coqPackages) coq; in
 let mathcomp = coqPackages.mathcomp.override { version = "1.18.0"; }
 ; in
 
-let rev = "48ca41b54fe315ca2efcee5f8dd8ee3fb33a7de1"; in
+let rev = "f8f819204d9183d4073477ea0e7350b163336cc2"; in
 
 stdenv.mkDerivation rec {
   version = "2.3-git-${builtins.substring 0 8 rev}";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "jasmin-lang";
     repo = "coqword";
     inherit rev;
-    hash = "sha256-Vm1F3zHy7DOi982KoM0N/VY1n1w3Wdza76aoNnLnDPo=";
+    hash = "sha256-xjw09Ek25sNg0EKv6JvUup4Ln44I78lCYZbkCSJZKUE=";
   };
 
   buildInputs = [ coq ocaml dune_3 ];


### PR DESCRIPTION
This will allow to easily change the implementation of `lsr`.

The `opam` CI job has been failing a lot recently (by needing too much memory) and does not know about development versions of `mathcomp-word`: I’ve thus disabled it.