### PR TITLE
Checksafety: minimal support of arrays in export functions

### DIFF
--- a/compiler/safety/fail/array-export.jazz
+++ b/compiler/safety/fail/array-export.jazz
@@ -1,0 +1,6 @@
+export
+fn main(reg ptr u8[4] a, reg u64 i) -> reg u8 {
+  reg u8 x;
+  x = a[i];
+  return x;
+}

--- a/compiler/safety/success/array-export.jazz
+++ b/compiler/safety/success/array-export.jazz
@@ -1,0 +1,7 @@
+export
+fn main(reg ptr u8[4] a, reg u64 i) -> reg u8 {
+  reg u8 x;
+  i &= 3;
+  x = a[i];
+  return x;
+}

--- a/compiler/safetylib/domains/safetyPointsTo.ml
+++ b/compiler/safetylib/domains/safetyPointsTo.ml
@@ -26,9 +26,7 @@ module PointsToImpl : PointsTo = struct
              (* top : mem_loc list } *)
 
   let make mls =
-    let make_var v = match v.v_ty with
-      | Arr _ -> raise (Aint_error "Array(s) in export function's inputs")
-      | Bty _ -> Mlocal (Avar v) in
+    let make_var v = Mlocal (Avar v) in
 
     let pts = List.fold_left (fun pts x -> match x with
         | MemLoc v -> Mm.add (make_var v) [x] pts)

--- a/compiler/safetylib/safetyAbsExpr.ml
+++ b/compiler/safetylib/safetyAbsExpr.ml
@@ -940,10 +940,6 @@ module AbsExpr (AbsDom : AbsNumBoolType) = struct
     let abs, warns =
       List.fold_left2 (fun (abs, warns) v source_v ->
           let gv_ws, warn = match v, source_v with
-            | Mlocal (AarraySlice (_,_ws,_)), _ ->
-              (* Export function cannot have arrays as input. *)
-              assert false (* Some ws *)
-
             | Mlocal (Avar gv), Mlocal (Avar source_gv) ->
               begin match gv.v_ty, source_gv.v_ty with
                 | Bty (U ws), Bty (U ws') ->


### PR DESCRIPTION
Do not crash; assume arrays are initialized