### PR TITLE
ASM: print 8-bit immediates unsigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,11 @@
 - The deprecated legacy interface to the CT checker has been removed
   ([PR #769](https://github.com/jasmin-lang/jasmin/pull/769)).
 
+- In x86 assembly, 8-bit immediate operands are printed unsigned,
+  i.e., in the range [0; 255]
+  ([PR #821](https://github.com/jasmin-lang/jasmin/pull/821);
+  fixes [#803](https://github.com/jasmin-lang/jasmin/issues/803)).
+
 # Jasmin 2023.06.3 — 2024-04-10
 
 ## New features

--- a/compiler/src/ppasm.ml
+++ b/compiler/src/ppasm.ml
@@ -373,7 +373,7 @@ module Printer (BP:BPrinter) = struct
   let pp_asm_arg ((ws,op):(W.wsize * (_, _, _, _, _) Arch_decl.asm_arg)) =
     match op with
     | Condt  _   -> assert false
-    | Imm(ws, w) -> pp_imm (Conv.z_of_word ws w)
+    | Imm(ws, w) -> pp_imm ((if ws = U8 then Conv.z_unsigned_of_word else Conv.z_of_word) ws w)
     | Reg r      -> pp_register ~reg_pre (rsize_of_wsize ws) r
     | Regx r     -> pp_register_ext ~reg_pre ws r
     | Addr addr  -> BP.pp_address ws addr

--- a/compiler/tests/success/x86-64/vector.jazz
+++ b/compiler/tests/success/x86-64/vector.jazz
@@ -233,6 +233,8 @@ y = (64u) #VPEXTR_16(a, 3);
 r64 += y;
 y = #VPEXTR_64(a, 1);
 r64 += y;
+y = #VPEXTR_64(a, -0x80);
+r64 += y;
 
 return r64;
 }


### PR DESCRIPTION
This is meant to improve compatibility with GNU binutils 2.41

Fixes #803.