### PR TITLE
CI: update nixpkgs (to channel 24.05)

### DIFF
--- a/scripts/nixpkgs.nix
+++ b/scripts/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/576ecd43d3b864966b4423a853412d6177775e8b.tar.gz";
-  sha256 = "sha256:05gr8w09w7fqfi6zflx7df1n0hhsf8f4p9siikk3wb7k7by2d9sr";
+  url = "https://github.com/NixOS/nixpkgs/archive/805a384895c696f802a9bf5bf4720f37385df547.tar.gz";
+  sha256 = "sha256:1q7y5ygr805l5axcjhn0rn3wj8zrwbrr0c6a8xd981zh8iccmx0p";
 })


### PR DESCRIPTION
It notably includes:

  - GNU binutils 2.41
  - Coq 8.19
  - mathcomp 2.2.0
  - OCaml 5.1.1