### PR TITLE
Add x86 instructions RORX, SARX, SHRX, SHLX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## New features
 
+- The following x86 BMI2 instructions are now available:
+  `RORX`, `SARX`, `SHRX`, and `SHLX`
+  ([PR #824](https://github.com/jasmin-lang/jasmin/pull/824)).
+
 - ARM now compiles `x = imm;` smartly: for small immediates, a single `MOV`; for
   immediates whose negation is small, a single `MVN`; and for large immediates
   a pair of `MOV` and `MOVT`.

--- a/compiler/tests/success/x86-64/shift.jazz
+++ b/compiler/tests/success/x86-64/shift.jazz
@@ -69,3 +69,29 @@ n = 11;
 
 [p + 0] = f;
 }
+
+export
+fn test_rorx(reg u64 x) -> reg u32 {
+  x = #RORX_64(x, 0);
+  x = #RORX_64(x, 1);
+  x = #RORX_64(x, -193);
+  reg u32 y;
+  y = #RORX_32(x, 1);
+  y = #RORX_32(y, 17);
+  return y;
+}
+
+u64[1] g = {0x536764457835516b};
+export
+fn test_bmi_shifts(reg u64 x) -> reg u32 {
+  stack u64 y;
+  y = x;
+  reg u32 z;
+  x = #SARX_64(g[0], x);
+  x = #SHRX_64(y, x);
+  x = #SHLX_64(x, x);
+  z = #SARX_32(g[u32 0], x);
+  z = #SHRX_32(z, x);
+  z = #SHLX_32(x, z);
+  return z;
+}

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -2497,8 +2497,20 @@ abstract theory BitWordSH.
       let r  = sar v i in
       rflags_OF i r rc false.
 
+  op RORX_XX (v: t) (i: W8.t) : t =
+    v `|>>>|` shift_mask i.
+
+  op SARX_XX (v i: t) : t =
+    sar v (to_uint i %% size).
+
+  op SHRX_XX (v i: t) : t =
+    v `>>>` to_uint i %% size.
+
+  op SHLX_XX (v i: t) : t =
+    v `<<<` to_uint i %% size.
+
 end SHIFT.
-  
+
 end BitWordSH.
 
 theory W16.


### PR DESCRIPTION
Shifts & rotations that:

1. do not affect flags
2. may have different source & destination