### PR TITLE
CI: add a coq-master job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,6 +67,14 @@ coq-proof:
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs'
 
+coq-master:
+  stage: prove
+  variables:
+    EXTRA_NIX_ARGUMENTS: --arg coqDeps true --arg coqMaster true
+  extends: .common
+  script:
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs'
+
 ocaml:
   stage: build
   variables:

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@
 , inCI ? false
 , pinned-nixpkgs ? inCI
 , coqDeps ? !inCI
+, coqMaster ? false
 , ocamlDeps ? !inCI
 , testDeps ? !inCI
 , devTools ? !inCI
@@ -14,7 +15,13 @@ with pkgs;
 
 let inherit (lib) optionals; in
 
-let coqPackages = coqPackages_8_18; in
+let coqPackages =
+  if coqMaster then
+    pkgs.coqPackages.overrideScope (self: super: {
+      coq = super.coq.override { version = "master"; };
+    })
+  else coqPackages_8_18
+; in
 
 let mathcomp-word = callPackage scripts/mathcomp-word.nix { inherit coqPackages; }; in
 


### PR DESCRIPTION
This job compiles the Coq sources of the Jasmin compiler with the current master branch of Coq.