### PR TITLE
x86: add VAES instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## New features
 
+- The instructions of the VAES extension are available through a size suffix
+  (e.g., `VAESENC_256`)
+  ([PR #831](https://github.com/jasmin-lang/jasmin/pull/831),
+  fixes [#630](https://github.com/jasmin-lang/jasmin/issues/630)).
+
 - The following x86 BMI2 instructions are now available:
   `RORX`, `SARX`, `SHRX`, and `SHLX`
   ([PR #824](https://github.com/jasmin-lang/jasmin/pull/824)).

--- a/compiler/tests/success/x86-64/aes_instr.jazz
+++ b/compiler/tests/success/x86-64/aes_instr.jazz
@@ -43,3 +43,18 @@ x1 = #VAESKEYGENASSIST((u128)[p], 0);
 r = 0;
 return r;
 }
+
+export
+fn test_vaes(reg u64 p) {
+  reg u256 x y z;
+  x = (u256)[p];
+  y = #VAESENC_256(x, (u256)[p + 32]);
+  z = #VAESENC_256(y, x);
+  x = #VAESENCLAST_256(z, (u256)[p + 64]);
+  y = #VAESENCLAST_256(x, y);
+  z = #VAESDEC_256(y, (u256)[p + 32]);
+  x = #VAESDEC_256(z, y);
+  y = #VAESDECLAST_256(x, (u256)[p]);
+  z = #VAESDECLAST_256(y, x);
+  (u256)[p] = z;
+}

--- a/eclib/JModel_x86.ec
+++ b/eclib/JModel_x86.ec
@@ -923,11 +923,20 @@ op VPTEST_256 (v1 v2: W256.t) =
 (* AES instruction *)
 
 abbrev [-printing] VAESDEC          = AESDEC.
+abbrev [-printing] VAESDEC_128      = AESDEC.
 abbrev [-printing] VAESDECLAST      = AESDECLAST.
+abbrev [-printing] VAESDECLAST_128  = AESDECLAST.
 abbrev [-printing] VAESENC          = AESENC.
+abbrev [-printing] VAESENC_128      = AESENC.
 abbrev [-printing] VAESENCLAST      = AESENCLAST.
+abbrev [-printing] VAESENCLAST_128  = AESENCLAST.
 abbrev [-printing] VAESIMC          = AESIMC.
 abbrev [-printing] VAESKEYGENASSIST = AESKEYGENASSIST.
+
+op VAESDEC_256     = W2u128.map2 VAESDEC_128.
+op VAESDECLAST_256 = W2u128.map2 VAESDECLAST_128.
+op VAESENC_256     = W2u128.map2 VAESENC_128.
+op VAESENCLAST_256 = W2u128.map2 VAESENCLAST_128.
 
 (* ------------------------------------------------------------------- *)
 (* PCLMULQDQ instructions *)


### PR DESCRIPTION
The AES-NI AVX instructions are extended to 256-bit operands.

Fixes #630.