### PR TITLE
Raise lower bound on batteries in opam files

### DIFF
--- a/compiler/jasmin.opam
+++ b/compiler/jasmin.opam
@@ -21,7 +21,7 @@ install: [
 ]
 depends: [
   "ocaml" { >= "4.11" & build }
-  "batteries" {>= "3.4"}
+  "batteries" {>= "3.5"}
   "cmdliner" {>= "1.1" & build }
   "dune" {>= "3.2"}
   "menhir" {>= "20160825" & build }

--- a/opam
+++ b/opam
@@ -16,7 +16,7 @@ install: [
 ]
 depends: [
   "ocaml" { >= "4.10" & build }
-  "batteries" {>= "3.4"}
+  "batteries" {>= "3.5"}
   "cmdliner" { build }
   "menhir" {>= "20160825" & build }
   "menhirLib"


### PR DESCRIPTION
I submitted https://github.com/ocaml/opam-repository/pull/26051 to add the latest Jasmin release to opam, and it revealed that we are not compatible with batteries < 3.5. I think we have been incompatible for a long time, so I don't know why opam's CI that is really good at testing lower bounds did not catch this problem for previous releases.