### PR TITLE
Improvements to lower-spill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Add spill/unspill primitives allowing to spill/unspill reg and reg ptr
   to/from the stack without need to declare the corresponding stack variable.
   If the annotation #spill_to_mmx is used at the variable declaration the variable
-  is spilled into a mmx variable (this works only for x86)
+  is spilled into a mmx variable (this works only for x86).
   See `compiler/tests/success/common/spill.jazz`.
   and `compiler/tests/success/X86-64/spill_mmx.jazz`.
   ([PR #687](https://github.com/jasmin-lang/jasmin/pull/687),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@
   is spilled into a mmx variable (this works only for x86)
   See `compiler/tests/success/common/spill.jazz`.
   and `compiler/tests/success/X86-64/spill_mmx.jazz`.
-  ([PR #687](https://github.com/jasmin-lang/jasmin/pull/687)) and
-  ([PR #692](https://github.com/jasmin-lang/jasmin/pull/692)).
+  ([PR #687](https://github.com/jasmin-lang/jasmin/pull/687),
+  [PR #692](https://github.com/jasmin-lang/jasmin/pull/692), and
+  [PR #836](https://github.com/jasmin-lang/jasmin/pull/836)).
 
 - Add a swap primitive,
     `x, y = #swap(x, y)`

--- a/compiler/tests/fail/lower_spill/needs_to_be_spilled_not_spilled.jazz
+++ b/compiler/tests/fail/lower_spill/needs_to_be_spilled_not_spilled.jazz
@@ -1,0 +1,4 @@
+export fn main () {
+  reg u32 x;
+  () = #unspill(x);
+}

--- a/compiler/tests/fail/lower_spill/needs_to_be_spilled_overwritten.jazz
+++ b/compiler/tests/fail/lower_spill/needs_to_be_spilled_overwritten.jazz
@@ -1,0 +1,8 @@
+export fn main () -> reg u32 {
+  reg u32 res;
+  res = 0;
+  () = #spill(res);
+  res = 2;
+  () = #unspill(res);
+  return res;
+}

--- a/compiler/tests/success/common/dead_spill.jazz
+++ b/compiler/tests/success/common/dead_spill.jazz
@@ -1,0 +1,4 @@
+export
+fn main(reg u32 x) {
+  () = #spill(x);
+}

--- a/proofs/compiler/lower_spill.v
+++ b/proofs/compiler/lower_spill.v
@@ -103,8 +103,8 @@ Definition unspill_x (ii : instr_info) (env : spill_env) (x : var_i) :=
     let sx := {| v_var := sx; v_info := x.(v_info) |} in
     ok (MkI ii (Cassgn (Lvar x) AT_none (vtype x) (Plvar sx)))
   else
-    Error (E.error ii (pp_hov [::pp_s "The variable"; pp_var x;
-            pp_s "needs to be spill before (maybe the variable has been written since the last spill)"])).
+    Error (E.error ii (pp_nobox [:: PPEbreak; pp_hov [::pp_s "The variable"; pp_var x;
+            pp_s "needs to be spilled before (maybe the variable has been written since the last spill)"]])).
 
 Definition unspill_es ii env tys es :=
   Let xs := get_Pvars ii es in
@@ -208,7 +208,7 @@ Definition get_spill (m:Mvar.t var) ii (x:var) :=
   match Mvar.get m x with
   | Some sx => ok sx
   | None => Error (E.error ii
-     (pp_hov [::pp_s "The variable"; pp_var x; pp_s "needs to be spill"]))
+     (pp_hov [::pp_s "The variable"; pp_var x; pp_s "needs to be spilled"]))
   end.
 
 Definition check_map (m:Mvar.t var) X :=

--- a/proofs/compiler/lower_spill.v
+++ b/proofs/compiler/lower_spill.v
@@ -106,7 +106,7 @@ Definition unspill_x (ii : instr_info) (t : assgn_tag) (env : spill_env) (x : va
     ok (MkI ii (Cassgn (Lvar x) t (vtype x) (Plvar sx)))
   else
     Error (E.error ii (pp_hov [::pp_s "The variable"; pp_var x;
-            pp_s "needs to be spill before (maybe the variable has been wrote since the last spill)"])).
+            pp_s "needs to be spill before (maybe the variable has been written since the last spill)"])).
 
 Definition unspill_es ii t env tys es :=
   Let xs := get_Pvars ii es in

--- a/proofs/compiler/lower_spill_proof.v
+++ b/proofs/compiler/lower_spill_proof.v
@@ -624,7 +624,7 @@ Proof.
   case: ifP hf'1.
   + by move=> hX [?]; subst f'; econstructor; eauto => //=; rewrite -eq_p_extra.
   t_xrbindP=> _ hcm [env' c'] hc' ?; subst f'.
-  pose m := init_map fresh_var_ident (foldl to_spill_i Sv.empty c).
+  pose m := init_map fresh_var_ident (foldl to_spill_i (Sv.empty, false) c).1.
   pose X := Sv.union (vars_l fp) (Sv.union (vars_l res) (vars_c c)).
   pose get_spill := lower_spill.get_spill m.
   pose S := {| get_spill     := get_spill;

--- a/proofs/compiler/lower_spill_proof.v
+++ b/proofs/compiler/lower_spill_proof.v
@@ -141,12 +141,12 @@ Proof.
   rewrite /truncate_val hw /=; eauto.
 Qed.
 
-Lemma spill_xP S ii tag x i env env' s vx vt vm :
+Lemma spill_xP S ii x i env env' s vx vt vm :
   get_gvar true gd (evm s) (mk_lvar x) = ok vx ->
   truncate_val (vtype x) vx = ok vt ->
   Sv.Subset (read_gvar (mk_lvar x)) S.(X) ->
   valid_env S env (evm s) vm ->
-  spill_x S.(get_spill) ii tag env x = ok (env', i) ->
+  spill_x S.(get_spill) ii env x = ok (env', i) ->
   exists2 vm' : Vm.t, sem_I p' ev (with_vm s vm) i (with_vm s vm') & valid_env S env' (evm s) vm'.
 Proof.
   rewrite /spill_x; t_xrbindP => hx htr hX [heq hval] sx hsx <- <-.
@@ -175,12 +175,12 @@ Proof.
   by subst sx'; apply/heqx/(get_spill_inj hsx (hsx' ii)).
 Qed.
 
-Lemma spill_esP S ii tag tys es c env env' s vs vs' vm :
+Lemma spill_esP S ii tys es c env env' s vs vs' vm :
   sem_pexprs true gd s es = ok vs ->
   mapM2 ErrType truncate_val tys vs = ok vs' ->
   Sv.Subset (read_es es) S.(X) ->
   valid_env S env (evm s) vm ->
-  spill_es S.(get_spill) ii tag env tys es = ok (env', c) ->
+  spill_es S.(get_spill) ii env tys es = ok (env', c) ->
   exists2 vm' : Vm.t, sem p' ev (with_vm s vm) c (with_vm s vm') & valid_env S env' (evm s) vm'.
 Proof.
   rewrite /spill_es; t_xrbindP.
@@ -198,11 +198,11 @@ Proof.
   by econstructor; eauto.
 Qed.
 
-Lemma unspill_xP S ii tag x i env s vx vt vm :
+Lemma unspill_xP S ii x i env s vx vt vm :
   get_gvar true gd (evm s) (mk_lvar x) = ok vx ->
   truncate_val (vtype x) vx = ok vt ->
   valid_env S env (evm s) vm ->
-  unspill_x S.(get_spill) ii tag env x = ok i ->
+  unspill_x S.(get_spill) ii env x = ok i ->
   exists2 vm' : Vm.t, sem_I p' ev (with_vm s vm) i (with_vm s vm') & valid_env S env (evm s) vm'.
 Proof.
   rewrite /unspill_x;case: Sv_memP => // hin.
@@ -228,11 +228,11 @@ Proof.
   by exists sx1 => //; rewrite (hvm x') (hvm sx1).
 Qed.
 
-Lemma unspill_esP S ii tag tys es c env s vs vs' vm :
+Lemma unspill_esP S ii tys es c env s vs vs' vm :
   sem_pexprs true gd s es = ok vs ->
   mapM2 ErrType truncate_val tys vs = ok vs' ->
   valid_env S env (evm s) vm ->
-  unspill_es S.(get_spill) ii tag env tys es = ok c ->
+  unspill_es S.(get_spill) ii env tys es = ok c ->
   exists2 vm' : Vm.t, sem p' ev (with_vm s vm) c (with_vm s vm') & valid_env S env (evm s) vm'.
 Proof.
   rewrite /unspill_es; t_xrbindP.


### PR DESCRIPTION
 - The lower-spill transformation only skips functions in which no `#spill` or `#unspill` operation appear (fixes #719)
 - This transformation introduces assignment without a flag: this allows the following passes (in particular dead-code-elimination) to remove them when appropriate.

