### PR TITLE
CI: fixes for job coq-master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,6 +69,9 @@ coq-proof:
 
 coq-master:
   stage: prove
+  allow_failure: true
+  rules:
+    - if: $CI_COMMIT_BRANCH !~ /^release-/
   variables:
     EXTRA_NIX_ARGUMENTS: --arg coqDeps true --arg coqMaster true
   extends: .common

--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,10 @@ let coqPackages =
   if coqMaster then
     pkgs.coqPackages.overrideScope (self: super: {
       coq = super.coq.override { version = "master"; };
-      coq-elpi = super.coq-elpi.override { version = "coq-master"; };
+      coq-elpi = callPackage scripts/coq-elpi.nix {
+        version = "master";
+        inherit (self) lib mkCoqDerivation coq;
+      };
       hierarchy-builder = super.hierarchy-builder.override { version = "1.7.0"; };
     })
   else coqPackages_8_19

--- a/scripts/coq-elpi.nix
+++ b/scripts/coq-elpi.nix
@@ -1,0 +1,20 @@
+{ lib, mkCoqDerivation, coq, version }:
+
+let elpi =
+  coq.ocamlPackages.elpi.override {
+    version = "v1.18.2";
+  }
+; in
+
+mkCoqDerivation {
+  pname = "elpi";
+  repo  = "coq-elpi";
+  owner = "LPCIC";
+  inherit version;
+
+  mlPlugin = true;
+  useDune = true;
+  propagatedBuildInputs = [ elpi ]
+  ++ (with coq.ocamlPackages; [ findlib ppx_optcomp ]);
+
+}

--- a/scripts/nixpkgs.nix
+++ b/scripts/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/805a384895c696f802a9bf5bf4720f37385df547.tar.gz";
-  sha256 = "sha256:1q7y5ygr805l5axcjhn0rn3wj8zrwbrr0c6a8xd981zh8iccmx0p";
+  url = "https://github.com/NixOS/nixpkgs/archive/110fd8d57734d192f5ea43eb5bc0b41d2004a143.tar.gz";
+  sha256 = "sha256:1m3xsj0k6bw4a6008zf22i07jb2i1f6cfxydsphkifh2ki79h97x";
 })


### PR DESCRIPTION
 - Update `nixpkgs` to support latest `coq-elpi`
 - Fix `coq-elpi` derivation
 - Allow the `coq-master` CI job to fail and disable it on `release-*` branches.