### PR TITLE
Add .editorconfig file for OCaml files formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root=true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf8
+
+[*.{ml,mli}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
`.editorconfig` is a file to tell most text editors how to format files (indentation, ...)

https://editorconfig.org/