### PR TITLE
CI: fix libjade jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,7 +205,7 @@ libjade-compile-to-asm:
   artifacts:
     when: always
     paths:
-    - libjade-main/src/check.tar.gz
+    - libjade/src/check.tar.gz
 
 libjade-extract-to-ec:
   stage: test
@@ -224,7 +224,7 @@ libjade-extract-to-ec:
   artifacts:
     when: always
     paths:
-    - libjade-main/proof/check.tar.gz
+    - libjade/proof/check.tar.gz
 
 test-extract-to-ec:
   stage: test

--- a/scripts/test-libjade.sh
+++ b/scripts/test-libjade.sh
@@ -5,11 +5,11 @@ NAME=libjade
 BRANCH=main
 
 FILE="$NAME.tar.gz"
-ROOT="$NAME-$BRANCH"
+ROOT=$(echo -n $NAME-$BRANCH | tr / -)
 
 [ 1 -le $# ] || exit 127
 
-DIR="$ROOT/$1"
+DIR="libjade/$1"
 
 MAKELINE="-C $DIR CI=1 JASMIN=$PWD/compiler/jasminc"
 
@@ -18,7 +18,11 @@ export EXCLUDE=""
 
 echo "Info: $MAKELINE (EXCLUDE=$EXCLUDE)"
 
-curl -v -o $FILE https://codeload.github.com/$REPO/$NAME/tar.gz/refs/heads/$BRANCH
+curl -v -o $FILE https://codeload.github.com/$REPO/$NAME/tar.gz/$BRANCH
 tar xvf $FILE
+rm -rf libjade/
+mv $ROOT libjade
+
+mv libjade/oldsrc-should-delete/ libjade/src
 
 make $MAKELINE


### PR DESCRIPTION
Libjade is undergoing heavy refactoring. This is a hacky fix to keep things working meanwhile.