### PR TITLE
Modifying jasmin2tex integer representation to fit source integer representation better

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ The following people have contributed code and/or ideas to Jasmin:
 
 Aaron Kaiser
 Adrien Koutsos
+Alexandre Bourbeillon
 Amber Sprenkels
 Antoine Séré
 Antoine Toussaint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed
   ([PR #869](https://github.com/jasmin-lang/jasmin/pull/869)).
+
 - The checker for S-CT accepts copies of outdated MSF
   ([PR #885](https://github.com/jasmin-lang/jasmin/pull/885)).
+  
 - Preserve formatting of integer literals in the lexer and when pretty-printing to LATEX
   ([PR #886](https://github.com/jasmin-lang/jasmin/pull/886)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - The deprecated legacy interface to the LATEX pretty-printer has been removed
   ([PR #869](https://github.com/jasmin-lang/jasmin/pull/869)).
 - Modification of jasmin2tex to support source file integer representation.
+- Adding new integer syntax
 
 # Jasmin 2024.07.0 — Sophia-Antipolis, 2024-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed
   ([PR #869](https://github.com/jasmin-lang/jasmin/pull/869)).
-- Modification of jasmin2tex to support source file integer representation.
+
+- Preserve formatting of integer literals in the lexer and when pretty-printing to LATEX
+  ([PR #886](https://github.com/jasmin-lang/jasmin/pull/886)).
 
 # Jasmin 2024.07.0 — Sophia-Antipolis, 2024-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 - The deprecated legacy interface to the LATEX pretty-printer has been removed
   ([PR #869](https://github.com/jasmin-lang/jasmin/pull/869)).
 - Modification of jasmin2tex to support source file integer representation.
-- Adding new integer syntax
 
 # Jasmin 2024.07.0 — Sophia-Antipolis, 2024-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed
   ([PR #869](https://github.com/jasmin-lang/jasmin/pull/869)).
+- Modification of jasmin2tex to support source file integer representation.
 
 # Jasmin 2024.07.0 — Sophia-Antipolis, 2024-07-09
 

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -157,7 +157,7 @@ let rec pp_expr_rec prio fmt pe =
   | PEpack (vs,es) ->
     F.fprintf fmt "(%a)[@[%a@]]" pp_svsize vs (pp_list ",@ " pp_expr) es
   | PEBool b -> F.fprintf fmt "%s" (if b then "true" else "false")
-  | PEInt i -> F.fprintf fmt "%s" i.raw
+  | PEInt i -> F.fprintf fmt "%s" i
   | PECall (f, args) -> F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args
   | PECombF (f, args) -> 
     F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -157,7 +157,7 @@ let rec pp_expr_rec prio fmt pe =
   | PEpack (vs,es) ->
     F.fprintf fmt "(%a)[@[%a@]]" pp_svsize vs (pp_list ",@ " pp_expr) es
   | PEBool b -> F.fprintf fmt "%s" (if b then "true" else "false")
-  | PEInt i -> F.fprintf fmt "%a" Z.pp_print i
+  | PEInt i -> F.fprintf fmt "%s" i.raw
   | PECall (f, args) -> F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args
   | PECombF (f, args) -> 
     F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -135,10 +135,10 @@ rule main = parse
 
   (* Why this is needed *)
   | ((*'-'?*) digit+) as s   
-      { INT {zvalue=Z.of_string s;raw=s}} 
+      {INT s} 
 
   | ('0' ['x' 'X'] hexdigit+) as s
-      { INT {zvalue=Z.of_string s;raw=s} }
+      {INT s}
 
   | ident as s
       { Option.default (NID s) (Hash.find_option keywords s) }

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -135,10 +135,10 @@ rule main = parse
 
   (* Why this is needed *)
   | ((*'-'?*) digit+) as s   
-      { INT (Z.of_string s) } 
+      { INT {zvalue=Z.of_string s;raw=s}} 
 
   | ('0' ['x' 'X'] hexdigit+) as s
-      { INT (Z.of_string s) }
+      { INT {zvalue=Z.of_string s;raw=s} }
 
   | ident as s
       { Option.default (NID s) (Hash.find_option keywords s) }

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -82,7 +82,7 @@
 %token EXPORT
 %token ARRAYINIT
 %token <string> NID
-%token <Syntax.pbasedinteger> INT
+%token <string> INT
 %token <string> STRING
 %nonassoc COLON QUESTIONMARK
 %left PIPEPIPE
@@ -127,8 +127,8 @@ annotationlabel:
   | s=loc(STRING) { s }
 
 int: 
-  | i=INT       { i.zvalue }
-  | MINUS i=INT { Z.neg i.zvalue } 
+  | i=INT       { Z.of_string i }
+  | MINUS i=INT { Z.neg (Z.of_string i) } 
 
 simple_attribute:
   | i=int          { Aint i    }

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -82,7 +82,7 @@
 %token EXPORT
 %token ARRAYINIT
 %token <string> NID
-%token <string> INT
+%token <Syntax.int_representation> INT
 %token <string> STRING
 %nonassoc COLON QUESTIONMARK
 %left PIPEPIPE
@@ -127,8 +127,8 @@ annotationlabel:
   | s=loc(STRING) { s }
 
 int: 
-  | i=INT       { Z.of_string i }
-  | MINUS i=INT { Z.neg (Z.of_string i) } 
+  | i=INT       { Syntax.parse_int i }
+  | MINUS i=INT { Z.neg (Syntax.parse_int i ) } 
 
 simple_attribute:
   | i=int          { Aint i    }

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -82,7 +82,7 @@
 %token EXPORT
 %token ARRAYINIT
 %token <string> NID
-%token <Z.t> INT
+%token <Syntax.pbasedinteger> INT
 %token <string> STRING
 %nonassoc COLON QUESTIONMARK
 %left PIPEPIPE
@@ -127,8 +127,8 @@ annotationlabel:
   | s=loc(STRING) { s }
 
 int: 
-  | i=INT       { i }
-  | MINUS i=INT { Z.neg i } 
+  | i=INT       { i.zvalue }
+  | MINUS i=INT { Z.neg i.zvalue } 
 
 simple_attribute:
   | i=int          { Aint i    }

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -2152,7 +2152,7 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   | S.PFundef pf -> tt_fundef arch_info env (L.loc pt) pf
   | S.PGlobal pg -> tt_global arch_info.pd env (L.loc pt) pg
   | S.Pexec   pf ->
-    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):string*string) -> (S.parse_int x),(S.parse_int y)) pf.pex_mem) env
+    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun (x,y) -> S.parse_int x,S.parse_int y) pf.pex_mem) env
   | S.Prequire (from, fs) ->
     List.fold_left (tt_file_loc arch_info from) env fs
   | S.PNamespace (ns, items) ->

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1045,7 +1045,7 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     P.Pbool b, P.tbool
 
   | S.PEInt i ->
-    P.Pconst i.zvalue, P.tint
+    P.Pconst (Z.of_string i), P.tint
 
   | S.PEVar x ->
     let x, ty = tt_var_global mode env x in
@@ -2152,7 +2152,7 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   | S.PFundef pf -> tt_fundef arch_info env (L.loc pt) pf
   | S.PGlobal pg -> tt_global arch_info.pd env (L.loc pt) pg
   | S.Pexec   pf ->
-    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):S.pbasedinteger*S.pbasedinteger) -> x.zvalue,y.zvalue) pf.pex_mem) env
+    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):string*string) -> (Z.of_string x),(Z.of_string y)) pf.pex_mem) env
   | S.Prequire (from, fs) ->
     List.fold_left (tt_file_loc arch_info from) env fs
   | S.PNamespace (ns, items) ->

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1045,7 +1045,7 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     P.Pbool b, P.tbool
 
   | S.PEInt i ->
-    P.Pconst (Z.of_string i), P.tint
+    P.Pconst (S.parse_int i), P.tint
 
   | S.PEVar x ->
     let x, ty = tt_var_global mode env x in
@@ -2152,7 +2152,7 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   | S.PFundef pf -> tt_fundef arch_info env (L.loc pt) pf
   | S.PGlobal pg -> tt_global arch_info.pd env (L.loc pt) pg
   | S.Pexec   pf ->
-    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):string*string) -> (Z.of_string x),(Z.of_string y)) pf.pex_mem) env
+    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):string*string) -> (S.parse_int x),(S.parse_int y)) pf.pex_mem) env
   | S.Prequire (from, fs) ->
     List.fold_left (tt_file_loc arch_info from) env fs
   | S.PNamespace (ns, items) ->

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1045,7 +1045,7 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     P.Pbool b, P.tbool
 
   | S.PEInt i ->
-    P.Pconst i, P.tint
+    P.Pconst i.zvalue, P.tint
 
   | S.PEVar x ->
     let x, ty = tt_var_global mode env x in
@@ -2144,6 +2144,7 @@ let tt_global pd (env : 'asm Env.env) _loc (gd: S.pglobal) : 'asm Env.env =
 
   Env.Vars.push_global env (x,d)
 
+
 (* -------------------------------------------------------------------- *)
 let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   match L.unloc pt with
@@ -2151,7 +2152,7 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   | S.PFundef pf -> tt_fundef arch_info env (L.loc pt) pf
   | S.PGlobal pg -> tt_global arch_info.pd env (L.loc pt) pg
   | S.Pexec   pf ->
-    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name pf.pex_mem env
+    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):S.pbasedinteger*S.pbasedinteger) -> x.zvalue,y.zvalue) pf.pex_mem) env
   | S.Prequire (from, fs) ->
     List.fold_left (tt_file_loc arch_info from) env fs
   | S.PNamespace (ns, items) ->

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -24,7 +24,7 @@ type castop1 = CSS of sowsize | CVS of svsize
 type castop = castop1 L.located option
 
 type int_representation = string
-let parse_int (ir:int_representation) : Z.t = Z.of_string ir
+let parse_int = Z.of_string
 
 let bits_of_wsize : wsize -> int = Annotations.int_of_ws 
 

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -23,6 +23,9 @@ type svsize  = vsize * sign * vesize
 type castop1 = CSS of sowsize | CVS of svsize 
 type castop = castop1 L.located option
 
+type int_representation = string
+let parse_int (ir:int_representation) : Z.t = Z.of_string ir
+
 let bits_of_wsize : wsize -> int = Annotations.int_of_ws 
 
 let suffix_of_sign : sign -> string =
@@ -153,7 +156,7 @@ type pexpr_r =
   | PEFetch  of mem_access
   | PEpack   of svsize * pexpr list
   | PEBool   of bool
-  | PEInt    of string
+  | PEInt    of int_representation
   | PECall   of pident * pexpr list
   | PECombF  of pident * pexpr list
   | PEPrim   of pident * pexpr list
@@ -263,7 +266,7 @@ type pglobal = { pgd_type: ptype; pgd_name: pident ; pgd_val: gpexpr }
 (* -------------------------------------------------------------------- *)
 type pexec = {
   pex_name: pident;
-  pex_mem: (string * string) list;
+  pex_mem: (int_representation * int_representation) list;
 }
 
 (* -------------------------------------------------------------------- *)
@@ -280,3 +283,4 @@ type pitem =
 
 (* -------------------------------------------------------------------- *)
 type pprogram = pitem L.located list
+

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -13,6 +13,7 @@ type arr_access = Warray_.arr_access
 
 type sign = [ `Unsigned | `Signed ]
 
+type pbasedinteger =  {zvalue:Z.t;raw:string}
 type vesize = [`W1 | `W2 | `W4 | `W8 | `W16 | `W32 | `W64 | `W128]
 type vsize   = [ `V2 | `V4 | `V8 | `V16 | `V32 ]
 
@@ -153,7 +154,7 @@ type pexpr_r =
   | PEFetch  of mem_access
   | PEpack   of svsize * pexpr list
   | PEBool   of bool
-  | PEInt    of Z.t
+  | PEInt    of pbasedinteger
   | PECall   of pident * pexpr list
   | PECombF  of pident * pexpr list
   | PEPrim   of pident * pexpr list
@@ -263,7 +264,7 @@ type pglobal = { pgd_type: ptype; pgd_name: pident ; pgd_val: gpexpr }
 (* -------------------------------------------------------------------- *)
 type pexec = {
   pex_name: pident;
-  pex_mem: (Z.t * Z.t) list;
+  pex_mem: (pbasedinteger * pbasedinteger) list;
 }
 
 (* -------------------------------------------------------------------- *)

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -13,7 +13,6 @@ type arr_access = Warray_.arr_access
 
 type sign = [ `Unsigned | `Signed ]
 
-type pbasedinteger =  {zvalue:Z.t;raw:string}
 type vesize = [`W1 | `W2 | `W4 | `W8 | `W16 | `W32 | `W64 | `W128]
 type vsize   = [ `V2 | `V4 | `V8 | `V16 | `V32 ]
 
@@ -154,7 +153,7 @@ type pexpr_r =
   | PEFetch  of mem_access
   | PEpack   of svsize * pexpr list
   | PEBool   of bool
-  | PEInt    of pbasedinteger
+  | PEInt    of string
   | PECall   of pident * pexpr list
   | PECombF  of pident * pexpr list
   | PEPrim   of pident * pexpr list
@@ -264,7 +263,7 @@ type pglobal = { pgd_type: ptype; pgd_name: pident ; pgd_val: gpexpr }
 (* -------------------------------------------------------------------- *)
 type pexec = {
   pex_name: pident;
-  pex_mem: (pbasedinteger * pbasedinteger) list;
+  pex_mem: (string * string) list;
 }
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
# Issue

jasmin2tex program always convert integer from source file to base 10. In certain cases, it makes readability of the program harder. For example : 

```jazz
tab[i] = 0xab;
```
is converted to :

```tex
\jasminindent{2}tab[i] = 172;\\
```

# Solution 

We implement a new Syntax node `pbinteger` that store the raw integer string coming from source file : 
```ml
type pbinteger = {zvalue:Z.t; raw:string}
```

At pretyping, we convert this type back to `Z.t`, which mean that it does not affect the behavior of the compiler for all next compilation steps. Since `latex_printer` is executed before pre-typing, we can use the raw string for generating latex file. The new output is now : 

```tex
\jasminindent{2}tab[i] = 0xab;\\
```

# Changelog 
* Add new Syntax Node `pbasedinteger` which dissapear at pretyping
* Changing parser and lexer accordingly
* Changing latex_printer integer handling