### PR TITLE
checksafety: support dynamically scoped global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   ([PR #892](https://github.com/jasmin-lang/jasmin/pull/892));
   fixes [#870](https://github.com/jasmin-lang/jasmin/issues/870)).
 
+- Safety checker handles dynamically scoped global variables
+  ([PR #890](https://github.com/jasmin-lang/jasmin/pull/890);
+  fixes [#662](https://github.com/jasmin-lang/jasmin/issues/662)).
+
 ## Other changes
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed

--- a/compiler/safety/success/dynglob.jazz
+++ b/compiler/safety/success/dynglob.jazz
@@ -1,0 +1,9 @@
+export fn main(reg ptr u8[8] s) -> reg u8 {
+  global u64 index;
+  index = 5;
+  reg u64 i;
+  i = index;
+  reg u8 r;
+  r = s[i];
+  return r;
+}

--- a/compiler/safetylib/safetyAbsExpr.ml
+++ b/compiler/safetylib/safetyAbsExpr.ml
@@ -1002,11 +1002,9 @@ module AbsExpr (AbsDom : AbsNumBoolType) = struct
     | Lmem _ -> MLnone
     | Lvar x  ->
       let ux = L.unloc x in
-      begin match ux.v_kind, ux.v_ty with
-        | Global,_ -> assert false (* this case should not be possible *)
-        (* MLvar (Mglobal (ux.v_name,ux.v_ty)) *)
-        | _, Bty _ -> MLvar (loc, Mlocal (Avar ux))
-        | _, Arr _ -> MLvar (loc, Mlocal (Aarray ux)) end
+      begin match ux.v_ty with
+        | Bty _ -> MLvar (loc, Mlocal (Avar ux))
+        | Arr _ -> MLvar (loc, Mlocal (Aarray ux)) end
 
     | Laset (_, acc, ws, x, ei) ->
       begin


### PR DESCRIPTION
Fixes #662.