### PR TITLE
editorconfig: fix spelling of utf-8 charset

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root=true
 [*]
 end_of_line = lf
 insert_final_newline = true
-charset = utf8
+charset = utf-8
 
 [*.{ml,mli}]
 indent_style = space


### PR DESCRIPTION
According to the [spec](https://spec.editorconfig.org/index.html#supported-pairs), `utf8` is not a supported value for the `charset` key.

Fixes #891.