### PR TITLE
Integer representation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ The following people have contributed code and/or ideas to Jasmin:
 
 Aaron Kaiser
 Adrien Koutsos
+Alexandre Bourbeillon
 Amber Sprenkels
 Antoine Séré
 Antoine Toussaint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - The deprecated legacy interface to the LATEX pretty-printer has been removed
   ([PR #869](https://github.com/jasmin-lang/jasmin/pull/869)).
 - Modification of jasmin2tex to support source file integer representation.
+- Support for new integer syntax
 
 # Jasmin 2024.07.0 — Sophia-Antipolis, 2024-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed
   ([PR #869](https://github.com/jasmin-lang/jasmin/pull/869)).
+- Modification of jasmin2tex to support source file integer representation.
 
 # Jasmin 2024.07.0 — Sophia-Antipolis, 2024-07-09
 

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -157,7 +157,7 @@ let rec pp_expr_rec prio fmt pe =
   | PEpack (vs,es) ->
     F.fprintf fmt "(%a)[@[%a@]]" pp_svsize vs (pp_list ",@ " pp_expr) es
   | PEBool b -> F.fprintf fmt "%s" (if b then "true" else "false")
-  | PEInt i -> F.fprintf fmt "%s" i.raw
+  | PEInt i -> F.fprintf fmt "%s" i
   | PECall (f, args) -> F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args
   | PECombF (f, args) -> 
     F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -157,7 +157,7 @@ let rec pp_expr_rec prio fmt pe =
   | PEpack (vs,es) ->
     F.fprintf fmt "(%a)[@[%a@]]" pp_svsize vs (pp_list ",@ " pp_expr) es
   | PEBool b -> F.fprintf fmt "%s" (if b then "true" else "false")
-  | PEInt i -> F.fprintf fmt "%a" Z.pp_print i
+  | PEInt i -> F.fprintf fmt "%s" i.raw
   | PECall (f, args) -> F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args
   | PECombF (f, args) -> 
     F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -134,10 +134,10 @@ rule main = parse
   | '"' (([^'"' '\\']|'\\' _)* as s) '"' { STRING (unescape (L.of_lexbuf lexbuf) s) }
 
   (* Why this is needed *)
-  | ((*'-'?*) digit+) as s   
-      {INT s} 
+  | ((*'-'?*) digit+ ('_'digit+)* ) as s   
+      {INT Str.(global_replace (regexp "_") "" s)} 
 
-  | ('0' ['x' 'X'] hexdigit+) as s
+  | ('0' ['x' 'X' 'b' 'B' 'o' 'O'] hexdigit+) as s
       {INT s}
 
   | ident as s

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -135,10 +135,10 @@ rule main = parse
 
   (* Why this is needed *)
   | ((*'-'?*) digit+) as s   
-      { INT {zvalue=Z.of_string s;raw=s}} 
+      {INT s} 
 
   | ('0' ['x' 'X'] hexdigit+) as s
-      { INT {zvalue=Z.of_string s;raw=s} }
+      {INT s}
 
   | ident as s
       { Option.default (NID s) (Hash.find_option keywords s) }

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -135,10 +135,10 @@ rule main = parse
 
   (* Why this is needed *)
   | ((*'-'?*) digit+) as s   
-      { INT (Z.of_string s) } 
+      { INT {zvalue=Z.of_string s;raw=s}} 
 
   | ('0' ['x' 'X'] hexdigit+) as s
-      { INT (Z.of_string s) }
+      { INT {zvalue=Z.of_string s;raw=s} }
 
   | ident as s
       { Option.default (NID s) (Hash.find_option keywords s) }

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -82,7 +82,7 @@
 %token EXPORT
 %token ARRAYINIT
 %token <string> NID
-%token <Syntax.pbasedinteger> INT
+%token <string> INT
 %token <string> STRING
 %nonassoc COLON QUESTIONMARK
 %left PIPEPIPE
@@ -127,8 +127,8 @@ annotationlabel:
   | s=loc(STRING) { s }
 
 int: 
-  | i=INT       { i.zvalue }
-  | MINUS i=INT { Z.neg i.zvalue } 
+  | i=INT       { Z.of_string i }
+  | MINUS i=INT { Z.neg (Z.of_string i) } 
 
 simple_attribute:
   | i=int          { Aint i    }

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -82,7 +82,7 @@
 %token EXPORT
 %token ARRAYINIT
 %token <string> NID
-%token <Z.t> INT
+%token <Syntax.pbasedinteger> INT
 %token <string> STRING
 %nonassoc COLON QUESTIONMARK
 %left PIPEPIPE
@@ -127,8 +127,8 @@ annotationlabel:
   | s=loc(STRING) { s }
 
 int: 
-  | i=INT       { i }
-  | MINUS i=INT { Z.neg i } 
+  | i=INT       { i.zvalue }
+  | MINUS i=INT { Z.neg i.zvalue } 
 
 simple_attribute:
   | i=int          { Aint i    }

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -2152,7 +2152,7 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   | S.PFundef pf -> tt_fundef arch_info env (L.loc pt) pf
   | S.PGlobal pg -> tt_global arch_info.pd env (L.loc pt) pg
   | S.Pexec   pf ->
-    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun (x,y)-> (Z.of_string x),(Z.of_string y)) pf.pex_mem) env
+    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun (x,y)-> Z.of_string x,Z.of_string y) pf.pex_mem) env
   | S.Prequire (from, fs) ->
     List.fold_left (tt_file_loc arch_info from) env fs
   | S.PNamespace (ns, items) ->

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1045,7 +1045,7 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     P.Pbool b, P.tbool
 
   | S.PEInt i ->
-    P.Pconst i.zvalue, P.tint
+    P.Pconst (Z.of_string i), P.tint
 
   | S.PEVar x ->
     let x, ty = tt_var_global mode env x in
@@ -2152,7 +2152,7 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   | S.PFundef pf -> tt_fundef arch_info env (L.loc pt) pf
   | S.PGlobal pg -> tt_global arch_info.pd env (L.loc pt) pg
   | S.Pexec   pf ->
-    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):S.pbasedinteger*S.pbasedinteger) -> x.zvalue,y.zvalue) pf.pex_mem) env
+    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):string*string) -> (Z.of_string x),(Z.of_string y)) pf.pex_mem) env
   | S.Prequire (from, fs) ->
     List.fold_left (tt_file_loc arch_info from) env fs
   | S.PNamespace (ns, items) ->

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -2152,7 +2152,7 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   | S.PFundef pf -> tt_fundef arch_info env (L.loc pt) pf
   | S.PGlobal pg -> tt_global arch_info.pd env (L.loc pt) pg
   | S.Pexec   pf ->
-    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):string*string) -> (Z.of_string x),(Z.of_string y)) pf.pex_mem) env
+    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun (x,y)-> (Z.of_string x),(Z.of_string y)) pf.pex_mem) env
   | S.Prequire (from, fs) ->
     List.fold_left (tt_file_loc arch_info from) env fs
   | S.PNamespace (ns, items) ->

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1045,7 +1045,7 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     P.Pbool b, P.tbool
 
   | S.PEInt i ->
-    P.Pconst i, P.tint
+    P.Pconst i.zvalue, P.tint
 
   | S.PEVar x ->
     let x, ty = tt_var_global mode env x in
@@ -2144,6 +2144,7 @@ let tt_global pd (env : 'asm Env.env) _loc (gd: S.pglobal) : 'asm Env.env =
 
   Env.Vars.push_global env (x,d)
 
+
 (* -------------------------------------------------------------------- *)
 let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   match L.unloc pt with
@@ -2151,7 +2152,7 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   | S.PFundef pf -> tt_fundef arch_info env (L.loc pt) pf
   | S.PGlobal pg -> tt_global arch_info.pd env (L.loc pt) pg
   | S.Pexec   pf ->
-    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name pf.pex_mem env
+    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun ((x,y):S.pbasedinteger*S.pbasedinteger) -> x.zvalue,y.zvalue) pf.pex_mem) env
   | S.Prequire (from, fs) ->
     List.fold_left (tt_file_loc arch_info from) env fs
   | S.PNamespace (ns, items) ->

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -13,6 +13,7 @@ type arr_access = Warray_.arr_access
 
 type sign = [ `Unsigned | `Signed ]
 
+type pbasedinteger =  {zvalue:Z.t;raw:string}
 type vesize = [`W1 | `W2 | `W4 | `W8 | `W16 | `W32 | `W64 | `W128]
 type vsize   = [ `V2 | `V4 | `V8 | `V16 | `V32 ]
 
@@ -153,7 +154,7 @@ type pexpr_r =
   | PEFetch  of mem_access
   | PEpack   of svsize * pexpr list
   | PEBool   of bool
-  | PEInt    of Z.t
+  | PEInt    of pbasedinteger
   | PECall   of pident * pexpr list
   | PECombF  of pident * pexpr list
   | PEPrim   of pident * pexpr list
@@ -263,7 +264,7 @@ type pglobal = { pgd_type: ptype; pgd_name: pident ; pgd_val: gpexpr }
 (* -------------------------------------------------------------------- *)
 type pexec = {
   pex_name: pident;
-  pex_mem: (Z.t * Z.t) list;
+  pex_mem: (pbasedinteger * pbasedinteger) list;
 }
 
 (* -------------------------------------------------------------------- *)

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -13,7 +13,6 @@ type arr_access = Warray_.arr_access
 
 type sign = [ `Unsigned | `Signed ]
 
-type pbasedinteger =  {zvalue:Z.t;raw:string}
 type vesize = [`W1 | `W2 | `W4 | `W8 | `W16 | `W32 | `W64 | `W128]
 type vsize   = [ `V2 | `V4 | `V8 | `V16 | `V32 ]
 
@@ -154,7 +153,7 @@ type pexpr_r =
   | PEFetch  of mem_access
   | PEpack   of svsize * pexpr list
   | PEBool   of bool
-  | PEInt    of pbasedinteger
+  | PEInt    of string
   | PECall   of pident * pexpr list
   | PECombF  of pident * pexpr list
   | PEPrim   of pident * pexpr list
@@ -264,7 +263,7 @@ type pglobal = { pgd_type: ptype; pgd_name: pident ; pgd_val: gpexpr }
 (* -------------------------------------------------------------------- *)
 type pexec = {
   pex_name: pident;
-  pex_mem: (pbasedinteger * pbasedinteger) list;
+  pex_mem: (string * string) list;
 }
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
# Issue 
The syntax currently only accept few integer representation (decimal, hexa). For user convenience, new integer syntax could be added, for example : 
```jazz
reg u64 a=0b10001001
reg u64 b=0o016  //not sure if octal base is very useful but it actually is trivial to implement so why not
reg u64 c= 1_000_000_000
```
# Solution
A little modification of the lexer is sufficient to support all these syntax without affecting the compiler execution

# Changelog
* modifying lexer to support new integer parsing