### PR TITLE
pretyping: small cleaning

### DIFF
--- a/compiler/src/checkAnnot.ml
+++ b/compiler/src/checkAnnot.ml
@@ -40,7 +40,6 @@ let check_stack_size fds =
       | None -> ()
       | Some expected ->
           let actual = sf_align in
-          let expected = Pretyping.tt_ws expected in
           if actual = expected then (
             if !debug then
               Format.eprintf "INFO: %s has the expected stack alignment (%s)@."

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -240,9 +240,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
   in
 
   let szs_of_fn fn =
-    match (get_annot fn).stack_zero_strategy with
-    | Some (s, ows) -> Some (s, Option.map Pretyping.tt_ws ows)
-    | None -> None
+    (get_annot fn).stack_zero_strategy
   in
 
   let cparams =

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1202,10 +1202,6 @@ let tt_vardecls_push dfl_writable pd (env : 'asm Env.env) pxs =
   (env, xs)
 
 (* -------------------------------------------------------------------- *)
-let tt_vardecl_push dfl_writable pd (env : 'asm Env.env) px =
-  snd_map as_seq1 (tt_vardecls_push dfl_writable pd env [px])
-
-(* -------------------------------------------------------------------- *)
 let tt_param pd (env : 'asm Env.env) _loc (pp : S.pparam) : 'asm Env.env =
   let ty = tt_type pd env pp.ppa_ty in
   let pe, ety = tt_expr ~mode:`OnlyParam pd env pp.S.ppa_init in
@@ -1891,8 +1887,6 @@ and tt_cmd arch_info env c =
 
 (* -------------------------------------------------------------------- *)
 let tt_funbody arch_info env (pb : S.pfunbody) =
- (* let vars = List.(pb.pdb_vars |> map (fun (ty, vs) -> map (fun v -> (ty, v)) vs) |> flatten) in 
-  let env = fst (tt_vardecls_push (fun _ -> true) env vars) in *)
   let env, bdy = tt_cmd arch_info env pb.S.pdb_instr in
   let ret =
     let for1 x = L.mk_loc (L.loc x) (tt_var `AllVar env x) in
@@ -2152,7 +2146,10 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   | S.PFundef pf -> tt_fundef arch_info env (L.loc pt) pf
   | S.PGlobal pg -> tt_global arch_info.pd env (L.loc pt) pg
   | S.Pexec   pf ->
-    Env.Exec.push (L.loc pt) (fst (tt_fun env pf.pex_name)).P.f_name (List.map (fun (x,y) -> S.parse_int x,S.parse_int y) pf.pex_mem) env
+    Env.Exec.push (L.loc pt)
+      (fst (tt_fun env pf.pex_name)).P.f_name
+      (List.map (fun (x, y) -> S.parse_int x, S.parse_int y) pf.pex_mem)
+      env
   | S.Prequire (from, fs) ->
     List.fold_left (tt_file_loc arch_info from) env fs
   | S.PNamespace (ns, items) ->

--- a/compiler/src/pretyping.mli
+++ b/compiler/src/pretyping.mli
@@ -39,7 +39,6 @@ module Env : sig
   end
 end
 
-val tt_ws : Annotations.wsize -> Wsize.wsize
 val tt_prim : 'op Sopn.asmOp -> Annotations.symbol Location.located -> 'op
 
 type ('a, 'b, 'c, 'd, 'e, 'f, 'g) arch_info = {

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -376,7 +376,6 @@ let memory_analysis pp_err ~debug up =
             (* no stack to clear, we don't change the alignment *)
             align
           else
-            let ws = Pretyping.tt_ws ws in
             if wsize_lt align ws then ws else align
       | _, _ -> align
     in
@@ -415,7 +414,7 @@ let memory_analysis pp_err ~debug up =
       | Export _, Some (_, ows) ->
           let ws =
             match ows with
-            | Some ws -> Pretyping.tt_ws ws
+            | Some ws -> ws
             | None -> align (* the default clear step is the alignment *)
           in
           Conv.z_of_cz (Memory_model.round_ws ws (Conv.cz_of_z max_size))


### PR DESCRIPTION
Remove a dead function, a legacy comment, and the now obsolete `tt_ws` function.