### PR TITLE
Authorizing variable initialisation at declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ compiler/src/CIL/*.mli
 *.glob
 *.aux
 *.lock
+*.vscode
 _build
 *.run.out
 *.run.err

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed
   ([PR #869](https://github.com/jasmin-lang/jasmin/pull/869)).
+- Modification of jasmin2tex to support source file integer representation.
 
 - The checker for S-CT accepts copies of outdated MSF
   ([PR #885](https://github.com/jasmin-lang/jasmin/pull/885)).

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -235,6 +235,19 @@ let pp_args fmt (sty, xs) =
     pp_sto_ty sty
     (pp_list " " pp_var) xs
 
+let pp_decl fmt (x:vardecl )= 
+  match x with
+  | NotInitVarDecl v -> F.fprintf fmt "%s" (L.unloc v)
+  | InitVarDecl (v,e) ->  F.fprintf fmt "%s" (L.unloc v); pp_expr fmt e
+
+
+let pp_decls fmt (sty,vd) = 
+  F.fprintf
+    fmt 
+    "%a %a"
+    pp_sto_ty sty
+    (pp_list " " pp_decl) vd
+
 let pp_rty =
   pp_opt
     (fun fmt tys ->
@@ -263,8 +276,9 @@ let pp_eqop fmt op =
 let pp_sidecond fmt =
   F.fprintf fmt " %a %a" kw "if" pp_expr
 
-let pp_vardecls fmt d =
-  F.fprintf fmt "%a;" pp_args d
+let pp_vardecls fmt (d:vardecls) =
+  let i,v = d in 
+  F.fprintf fmt "%a;" pp_decls (i, List.map (L.unloc) v)
 
 let rec pp_instr depth fmt (annot, p) =
   if annot <> [] then F.fprintf fmt "%a%a" indent depth pp_top_annotations annot;

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -422,11 +422,14 @@ storage:
 | INLINE         { `Inline }
 | GLOBAL         { `Global }
 
-%inline pvardecl(S):
-| ty=stor_type vs=separated_nonempty_list(S, var) { (ty, vs) }
 
-annot_pvardecl: 
-| a=annotations vd=pvardecl(empty) { (a,vd) }
+%inline decl:
+| v=var {Syntax.NotInitVarDecl(v)}
+| v=var EQ e=pexpr {Syntax.InitVarDecl (v,e)}
+
+%inline pvardecl(S):
+| ty=stor_type vs=separated_nonempty_list(S, loc(decl)) { (ty, vs) }
+
 
 pfunbody :
 | LBRACE
@@ -440,12 +443,22 @@ call_conv :
 | EXPORT { `Export }
 | INLINE { `Inline }
 
+
+
+pparamdecl(S): 
+    ty=stor_type vs=separated_nonempty_list(S, var) { (ty, vs) }
+
+annot_pparamdecl:
+| a=annotations vd=pparamdecl(empty) {(a,vd)}
+
+
+
 pfundef:
 |  pdf_annot = annotations
     cc=call_conv?
     FN
     name = ident
-    args = parens_tuple(annot_pvardecl)
+    args = parens_tuple(annot_pparamdecl)
     rty  = prefix(RARROW, tuple(annot_stor_type))?
     body = pfunbody
 

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -13,6 +13,7 @@ type arr_access = Warray_.arr_access
 
 type sign = [ `Unsigned | `Signed ]
 
+type pbasedinteger =  {zvalue:Z.t;raw:string}
 type vesize = [`W1 | `W2 | `W4 | `W8 | `W16 | `W32 | `W64 | `W128]
 type vsize   = [ `V2 | `V4 | `V8 | `V16 | `V32 ]
 
@@ -211,13 +212,23 @@ type align = [`Align | `NoAlign]
 
 type plvals = annotations L.located option * plvalue list
 
-type vardecls = pstotype * pident list
+
+type notinitvardecl = pident
+type initvardecl = pident * pexpr
+type vardecl = InitVarDecl of initvardecl | NotInitVarDecl of notinitvardecl
+type vardecls = pstotype * vardecl L.located list
+
+let var_decl_id (v:vardecl) : pident = 
+  match v with 
+  | InitVarDecl (ty,exp) -> ty
+  | NotInitVarDecl (ty) -> ty
+
+
+type passign =  plvals * peqop * pexpr * pexpr option
 
 type pinstr_r =
   | PIArrayInit of pident
-      (** ArrayInit(x); *)
-  | PIAssign    of plvals * peqop * pexpr * pexpr option
-      (** x, y += z >> 4 if c; *)
+  | PIAssign    of passign
   | PIIf        of pexpr * pblock * pblock option
       (** if e { … } else { … } *)
   | PIFor       of pident * (fordir * pexpr * pexpr) * pblock
@@ -252,11 +263,13 @@ type pcall_conv = [
   | `Inline
 ]
 
+type paramdecls = pstotype * pident list
+
 type pfundef = {
   pdf_annot : annotations;
   pdf_cc   : pcall_conv option;
   pdf_name : pident;
-  pdf_args : (annotations * vardecls) list;
+  pdf_args : (annotations * paramdecls) list;
   pdf_rty  : (annotations * pstotype) list option;
   pdf_body : pfunbody;
 }

--- a/compiler/tests/success/common/variable_initialisation.jazz
+++ b/compiler/tests/success/common/variable_initialisation.jazz
@@ -1,0 +1,18 @@
+/*
+Test for intialising variable during declaration
+The used semantic is the following : 
+reg u32 x=3; 
+
+is traduced to 
+reg u32 x;
+x=3;
+*/
+
+fn test() -> reg u32 {
+    reg u32 x=3;
+    reg u32 y=x;
+
+    reg u32 x=4,y=x;
+
+    return y;
+} 


### PR DESCRIPTION
# Issue 
describe in Issue #743. The idea of this new feature is to authorize initialization of variables at their declaration. For example:
```jazz
reg u64 x=1;
```
# Implementation

With the proposed implementation, we can also initialize multiple variables at the same time: 
```jazz
reg u64 x=1,y=2,z,t=3;
```

The current implementation doesn't support array initializing with this feature because array can currently be explicitly created only at top level. Allowing it would require reworking a large part of the grammar and pre-typing analysis. 

In terms of semantic, the proposed implementation works as follow : 
```jazz
reg u64 x=3;
```
is abstractly equivalent to :
```jazz
reg u64 x;
x=3;
```