### PR TITLE
Remove dummy locations from errors before printing them

### DIFF
--- a/compiler/src/utils.ml
+++ b/compiler/src/utils.ml
@@ -296,9 +296,21 @@ let add_iloc e i_loc =
   in
   { e with err_loc }
 
+let remove_dummy_locations =
+  let open Location in
+  function
+  | Lnone -> Lnone
+  | Lone l when isdummy l -> Lnone
+  | Lone _ as x -> x
+  | Lmore {  base_loc ; stack_loc ; _ } ->
+     match List.filter (fun x -> not (isdummy x)) (base_loc :: stack_loc) with
+     | [] -> Lnone
+     | [ x ] -> Lone x
+     | x :: xs -> Lmore (i_loc x xs)
+
 let pp_hierror fmt e =
   let pp_loc fmt =
-    match e.err_loc with
+    match remove_dummy_locations e.err_loc with
     | Lnone -> ()
     | Lone l -> Format.fprintf fmt "%a:@ " (pp_print_bold Location.pp_loc) l
     | Lmore i_loc -> Format.fprintf fmt "%a:@ " (pp_print_bold Location.pp_iloc) i_loc


### PR DESCRIPTION
Best would be to avoid these dummy locations in the first place. Meanwhile, this is an attempt at saving the user from seeing scary locations.