### PR TITLE
x86-lowering: do not introduce dummy instr info

### DIFF
--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -601,7 +601,7 @@ Fixpoint lower_i (i:instr) : cmd :=
      [:: MkI ii (Cfor v (d, lo, hi) (conc_map lower_i c))]
   | Cwhile a c e c' =>
      let '(pre, e) := lower_condition (var_info_of_ii ii) e in
-       map (MkI ii) [:: Cwhile a ((conc_map lower_i c) ++ map (MkI dummy_instr_info) pre) e (conc_map lower_i c')]
+       map (MkI ii) [:: Cwhile a ((conc_map lower_i c) ++ map (MkI ii) pre) e (conc_map lower_i c')]
   | _ =>   map (MkI ii) [:: ir]
   end.
 

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -1789,7 +1789,7 @@ Section PROOF.
     have [s2' [Hs2'1 Hs2'2]] := Hc Hc1 _ Hs1'.
     have [s3' [Hs3'1 Hs3'2 Hs3'3]] :=
       lower_condition_corr
-        dummy_instr_info
+        ii
         Hcond
         Hs2'2
         (eeq_exc_sem_pexpr Hdisje Hs2'2 Hz).
@@ -1816,7 +1816,7 @@ Section PROOF.
     have [s2' [Hs2'1 Hs2'2]] := Hc Hc1 _ Hs1'.
     have [s3' [Hs3'1 Hs3'2 Hs3'3]] :=
       lower_condition_corr
-        dummy_instr_info
+        ii
         Hcond
         Hs2'2
         (eeq_exc_sem_pexpr Hdisje Hs2'2 Hz).


### PR DESCRIPTION
Similarly to what is done with if statements, the instructions corresponding to the lowering of the condition inherit the instr-info from the complete statement.