### PR TITLE
Debug of issue #871

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
   ([PR #890](https://github.com/jasmin-lang/jasmin/pull/890);
   fixes [#662](https://github.com/jasmin-lang/jasmin/issues/662)).
 
+- Adding label to global variables in assembly generation to avoid name conflicts
+  ([PR #907](https://github.com/jasmin-lang/jasmin/pull/907);
+  fixes [#871](https://github.com/jasmin-lang/jasmin/issues/871)).
+
 ## Other changes
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed

--- a/compiler/src/printASM.ml
+++ b/compiler/src/printASM.ml
@@ -25,11 +25,18 @@ let print_asm_lines fmt lns =
 let string_of_label name p =
   Format.asprintf "L%s$%d" (escape name) (Conv.int_of_pos p)
 
-let string_of_glob x =
-  Format.asprintf "G$%s" (escape x.v_name)
+let string_of_glob occurrences x =
+  Hash.modify_def (-1) x.v_name Stdlib.Int.succ occurrences;
+  let count =  Hash.find occurrences x.v_name in
+  (* Adding the number of occurrences to the label to avoid names conflict *)
+  let suffix = if count > 0 then Format.asprintf "$%d" count else "" in
+  Format.asprintf "G$%s%s" (escape x.v_name) suffix
+
 
 (* -------------------------------------------------------------------- *)
 let format_glob_data globs names =
+  (* Creating a Hashtable to count occurrences of a label name*)
+  let occurrences = Hash.create 42 in
   let names =
     List.map (fun ((x, _), p) -> (Conv.var_of_cvar x, Conv.z_of_cz p)) names
   in
@@ -39,5 +46,5 @@ let format_glob_data globs names =
          let b = LByte (Z.to_string (Conv.z_of_int8 b)) in
          match List.find (fun (_, p) -> Z.equal (Z.of_int i) p) names with
          | exception Not_found -> [ b ]
-         | x, _ -> [ LLabel (string_of_glob x); b ])
+         | x, _ -> [ LLabel (string_of_glob occurrences x); b ])
        globs)

--- a/compiler/tests/success/common/bug_871.jazz
+++ b/compiler/tests/success/common/bug_871.jazz
@@ -1,0 +1,16 @@
+inline fn get(inline u32 i) -> reg u32 {
+  reg u32 r;
+  global u32 g;
+  g = i;
+  r = g;
+  return r;
+}
+
+export
+fn main() -> reg u32 {
+  reg u32 a b;
+  a = get(0xa);
+  b = get(0xb);
+  b += a;
+  return b;
+}


### PR DESCRIPTION
The `PrintASM.format_glob_data` function was able to write the same label multiple times, causing the produced assembly code to be incorrect. 

By adding a Map to count occurrences of the same variable, the problem is corrected.

There is a test to write (for example the file written by @vbgl in the issue). I wasn't sure where to put it so I didn't (We will need to add it before merging).