### PR TITLE
Variable intialization at declare time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Extraction as EasyCrypt code targets version 2024.09
   ([PR #910](https://github.com/jasmin-lang/jasmin/pull/910)).
 
+- Local variables may be initialized when declared, as for instance
+  `reg u32 x = 1, y, z = 2; stack u64 s = 1, u, t = z;`
+  ([PR #908](https://github.com/jasmin-lang/jasmin/pull/908)).
+
 ## Bug fixes
 
 - Easycrypt extraction for CT : fix decreasing for loops

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -31,14 +31,14 @@ okdirs = CCT/success/speculative
 bin     = ./scripts/check-x86-64
 args    = -ATT
 okdirs  = examples/**/x86-64 tests/success/**/x86-64 tests/success/**/common
-kodirs  = tests/fail/**/x86-64
+kodirs  = tests/fail/**/x86-64 tests/fail/**/common
 exclude = tests/fail/warning
 
 [test-x86-64-Intel]
 bin = ./scripts/check-x86-64
 args = -intel
 okdirs = examples/**/x86-64 tests/success/**/x86-64 tests/success/**/common
-kodirs = tests/fail/**/x86-64
+kodirs = tests/fail/**/x86-64 tests/fail/**/common
 exclude = tests/fail/warning
 
 [test-x86-64-print]
@@ -55,7 +55,7 @@ exclude = tests/success/noextract
 [test-arm-m4]
 bin = ./scripts/check-arm-m4
 okdirs = examples/**/arm-m4 tests/success/**/arm-m4 tests/success/**/common
-kodirs = tests/fail/**/arm-m4
+kodirs = tests/fail/**/arm-m4 tests/fail/**/common
 
 [test-arm-m4-print]
 bin = ./scripts/parse-print-parse

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -235,6 +235,18 @@ let pp_args fmt (sty, xs) =
     pp_sto_ty sty
     (pp_list " " pp_var) xs
 
+let pp_decl fmt (x: vardecl L.located) =
+  let x, e = L.unloc x in
+  let pp fmt = F.fprintf fmt " = %a" pp_expr in
+  F.fprintf fmt "%s%a" (L.unloc x) (pp_opt pp) e
+
+let pp_decls fmt (sty, vd) =
+  F.fprintf
+    fmt
+    "%a %a"
+    pp_sto_ty sty
+    (pp_list " " pp_decl) vd
+
 let pp_rty =
   pp_opt
     (fun fmt tys ->
@@ -263,8 +275,8 @@ let pp_eqop fmt op =
 let pp_sidecond fmt =
   F.fprintf fmt " %a %a" kw "if" pp_expr
 
-let pp_vardecls fmt d =
-  F.fprintf fmt "%a;" pp_args d
+let pp_vardecls fmt (d:vardecls) =
+  F.fprintf fmt "%a;" pp_decls d
 
 let rec pp_instr depth fmt (annot, p) =
   if annot <> [] then F.fprintf fmt "%a%a" indent depth pp_top_annotations annot;

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -422,11 +422,19 @@ storage:
 | INLINE         { `Inline }
 | GLOBAL         { `Global }
 
-%inline pvardecl(S):
-| ty=stor_type vs=separated_nonempty_list(S, var) { (ty, vs) }
 
-annot_pvardecl: 
-| a=annotations vd=pvardecl(empty) { (a,vd) }
+%inline decl:
+| v=var { v, None }
+| v=var EQ e=pexpr { v, Some e }
+
+%inline pvardecl(S):
+| ty=stor_type vs=separated_nonempty_list(S, loc(decl)) { (ty, vs) }
+
+pparamdecl(S): 
+    ty=stor_type vs=separated_nonempty_list(S, var) { (ty, vs) }
+
+annot_pparamdecl:
+| a=annotations vd=pparamdecl(empty) { (a,vd) }
 
 pfunbody :
 | LBRACE
@@ -445,7 +453,7 @@ pfundef:
     cc=call_conv?
     FN
     name = ident
-    args = parens_tuple(annot_pvardecl)
+    args = parens_tuple(annot_pparamdecl)
     rty  = prefix(RARROW, tuple(annot_stor_type))?
     body = pfunbody
 

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1682,17 +1682,17 @@ let tt_annot_vardecls dfl_writable pd env (annot, (ty,vs)) =
 let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm Env.env * (unit, 'asm) P.pinstr list  =
   let mk_i ?(annot=annot) instr =
     { P.i_desc = instr; P.i_loc = L.of_loc pi; P.i_info = (); P.i_annot = annot} in
-  let rec tt_assign env ls eqop pe ocp =
+  let rec tt_assign env_lhs env_rhs ls eqop pe ocp =
     match ls, eqop, pe, ocp with
     | ls, `Raw, { L.pl_desc = S.PECall (f, args); pl_loc = el }, None when is_combine_flags f ->
-      tt_assign env ls `Raw (L.mk_loc el (S.PECombF(f, args))) None
+      tt_assign env_lhs env_rhs ls `Raw (L.mk_loc el (S.PECombF(f, args))) None
 
     | ls, `Raw, { L.pl_desc = S.PECall (f, args); pl_loc = el }, None ->
-      let (f,tlvs) = tt_fun env f in
+      let (f,tlvs) = tt_fun env_rhs f in
       let _tlvs, tes = f_sig f in
-      let lvs, is = tt_lvalues arch_info env (L.loc pi) ls None tlvs in
+      let lvs, is = tt_lvalues arch_info env_lhs (L.loc pi) ls None tlvs in
       assert (is = []);
-      let es  = tt_exprs_cast arch_info.pd env (L.loc pi) args tes in
+      let es  = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args tes in
       let is_inline = P.is_inline annot f.P.f_cc in
       let annot =
         if is_inline || FInfo.is_export f.P.f_cc
@@ -1705,7 +1705,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
     let op = L.unloc f in
     if ls <> None then rs_tyerror ~loc:(L.loc pi) (string_error "%s expects no implicit result" op);
     if xs <> [] then rs_tyerror ~loc:(L.loc pi) (string_error "%s expects no result" op);
-    let es = tt_exprs arch_info.pd env args in
+    let es = tt_exprs arch_info.pd env_rhs args in
     let doit (e, _) = 
       match e with 
       | P.Pvar x when P.is_reg_kind (P.kind_i x.gv) -> e
@@ -1722,7 +1722,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       let loc, x, ty =
         match xs with
         | [x] ->
-          let loc, x, oty = tt_lvalue arch_info.pd env x in
+          let loc, x, oty = tt_lvalue arch_info.pd env_lhs x in
           let ty =
             match oty with
             | None -> rs_tyerror ~loc (string_error "_ lvalue not accepted here")
@@ -1732,7 +1732,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
           rs_tyerror ~loc:(L.loc pi)
             (string_error "only a single variable is allowed as destination of randombytes") in
       let _ = tt_as_array (loc, ty) in
-      let es = tt_exprs_cast arch_info.pd env (L.loc pi) args [ty] in
+      let es = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args [ty] in
       [mk_i (P.Csyscall([x], Syscall_t.RandomBytes (Conv.pos_of_int 1), es))]
 
   | (ls, xs), `Raw, { pl_desc = PEPrim (f, args) }, None when L.unloc f = "swap" ->
@@ -1740,8 +1740,8 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       let lvs, ty =
         match xs with
         | [x; y] ->
-          let loc, x, oxty = tt_lvalue arch_info.pd env x in
-          let yloc, y, _oytu = tt_lvalue arch_info.pd env y in
+          let loc, x, oxty = tt_lvalue arch_info.pd env_lhs x in
+          let yloc, y, _oytu = tt_lvalue arch_info.pd env_lhs y in
           let ty =
             match oxty with
             | None -> rs_tyerror ~loc (string_error "_ lvalue not accepted here")
@@ -1761,15 +1761,15 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
            rs_tyerror ~loc:(L.loc pi)
              (string_error "the swap primitive is not available at type %a" PrintCommon.pp_btype ty)
       in
-      let es = tt_exprs_cast arch_info.pd env (L.loc pi) args [ty; ty] in
+      let es = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args [ty; ty] in
       let p = Sopn.Opseudo_op (Oswap Type.Coq_sbool) in  (* The type is fixed latter *)
       [mk_i (P.Copn(lvs, AT_keep, p, es))]
 
   | ls, `Raw, { pl_desc = PEPrim (f, args) }, None ->
       let p = tt_prim arch_info.asmOp f in
       let tlvs, tes, arguments = prim_sig arch_info.asmOp p in
-      let lvs, einstr = tt_lvalues arch_info env (L.loc pi) ls (Some arguments) tlvs in
-      let es  = tt_exprs_cast arch_info.pd env (L.loc pi) args tes in
+      let lvs, einstr = tt_lvalues arch_info env_lhs (L.loc pi) ls (Some arguments) tlvs in
+      let es  = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args tes in
       mk_i (P.Copn(lvs, AT_keep, p, es)) :: einstr
 
   | ls, `Raw, { pl_desc = PEOp1 (`Cast(`ToWord ct), {pl_desc = PEPrim (f, args) })} , None
@@ -1780,13 +1780,13 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       let id = Sopn.asm_op_instr arch_info.asmOp p in
       let p = cast_opn ~loc:(L.loc pi) id ws p in
       let tlvs, tes, arguments = prim_sig arch_info.asmOp p in
-      let lvs, einstr = tt_lvalues arch_info env (L.loc pi) ls (Some arguments) tlvs in
-      let es  = tt_exprs_cast arch_info.pd env (L.loc pi) args tes in
+      let lvs, einstr = tt_lvalues arch_info env_lhs (L.loc pi) ls (Some arguments) tlvs in
+      let es  = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args tes in
       mk_i (P.Copn(lvs, AT_keep, p, es)) :: einstr
 
   | (None,[lv]), `Raw, pe, None ->
-      let _, flv, vty = tt_lvalue arch_info.pd env lv in
-      let e, ety = tt_expr ~mode:`AllVar arch_info.pd env pe in
+      let _, flv, vty = tt_lvalue arch_info.pd env_lhs lv in
+      let e, ety = tt_expr ~mode:`AllVar arch_info.pd env_rhs pe in
       let e = vty |> Option.map_default (cast (L.loc pe) e ety) e in
       let ety =
         match vty with
@@ -1803,7 +1803,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
   | ls, `Raw, pe, None ->
       (* Try to match addc, subc, mulu *)
       let pe = prim_of_pe pe in
-      tt_assign env ls `Raw pe None
+      tt_assign env_lhs env_rhs ls `Raw pe None
 
   | (pimp,ls), eqop, pe, None ->
       let op = oget (peop2_of_eqop eqop) in
@@ -1812,18 +1812,18 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       if List.is_empty ls then raise exn;
       let pe1 = pexpr_of_plvalue exn (List.last ls) in
       let pe  = L.mk_loc loc (S.PEOp2(op,(pe1,pe))) in
-      tt_assign env (pimp, ls) `Raw pe None
+      tt_assign env_lhs env_rhs (pimp, ls) `Raw pe None
 
   | ls, eqop, e, Some cp ->
       let loc = L.loc pi in
       let exn = Unsupported "if not allowed here" in
-      let i = tt_assign env ls eqop e None in
+      let i = tt_assign env_lhs env_rhs ls eqop e None in
       let x, ty, e, is =
         match i with
         | { i_desc = P.Cassgn (x, _, ty, e) ; _ } :: is -> x, ty, e, is
         | _ -> rs_tyerror ~loc exn in
       let e' = oget ~exn:(tyerror ~loc exn) (P.expr_of_lval x) in
-      let c = tt_expr_bool arch_info.pd env cp in
+      let c = tt_expr_bool arch_info.pd env_rhs cp in
       mk_i (P.Cassgn (x, AT_none, ty, Pif (ty, c, e, e'))) :: is
   in
   match L.unloc pi with
@@ -1836,7 +1836,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
     let xi = (L.mk_loc lc x) in
     env, [mk_i (arr_init xi)]
 
-  | S.PIAssign (ls, eqop, pe, ocp) -> env, tt_assign env ls eqop pe ocp
+  | S.PIAssign (ls, eqop, pe, ocp) -> env, tt_assign env env ls eqop pe ocp
 
   | PIIf (cp, st, sf) ->
       let c  = tt_expr_bool arch_info.pd env cp in

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1699,7 +1699,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
         then Annotations.add_symbol ~loc:el "inline" annot
         else annot
       in
-      env, [mk_i ~annot (mk_call (L.loc pi) is_inline lvs f es)]
+      [mk_i ~annot (mk_call (L.loc pi) is_inline lvs f es)]
   | (ls, xs), `Raw, { pl_desc = PEPrim (f, args) }, None
         when L.unloc f = "spill" || L.unloc f = "unspill"  ->
     let op = L.unloc f in
@@ -1713,7 +1713,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
     let es = List.map doit es in
     let op = if op = "spill" then Pseudo_operator.Spill else Pseudo_operator.Unspill in
     let p = Sopn.Opseudo_op (Ospill(op, [] (* dummy info, will be fixed latter *))) in 
-    env, [mk_i ~annot (P.Copn([], AT_keep, p, es))]
+    [mk_i ~annot (P.Copn([], AT_keep, p, es))]
 
   | (ls, xs), `Raw, { pl_desc = PEPrim (f, args) }, None when L.unloc f = "randombytes" ->
       (* FIXME syscall *)
@@ -1733,7 +1733,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
             (string_error "only a single variable is allowed as destination of randombytes") in
       let _ = tt_as_array (loc, ty) in
       let es = tt_exprs_cast arch_info.pd env (L.loc pi) args [ty] in
-      env, [mk_i (P.Csyscall([x], Syscall_t.RandomBytes (Conv.pos_of_int 1), es))]
+      [mk_i (P.Csyscall([x], Syscall_t.RandomBytes (Conv.pos_of_int 1), es))]
 
   | (ls, xs), `Raw, { pl_desc = PEPrim (f, args) }, None when L.unloc f = "swap" ->
       if ls <> None then rs_tyerror ~loc:(L.loc pi) (string_error "swap expects no implicit arguments");
@@ -1763,14 +1763,14 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       in
       let es = tt_exprs_cast arch_info.pd env (L.loc pi) args [ty; ty] in
       let p = Sopn.Opseudo_op (Oswap Type.Coq_sbool) in  (* The type is fixed latter *)
-      env, [mk_i (P.Copn(lvs, AT_keep, p, es))]
+      [mk_i (P.Copn(lvs, AT_keep, p, es))]
 
   | ls, `Raw, { pl_desc = PEPrim (f, args) }, None ->
       let p = tt_prim arch_info.asmOp f in
       let tlvs, tes, arguments = prim_sig arch_info.asmOp p in
       let lvs, einstr = tt_lvalues arch_info env (L.loc pi) ls (Some arguments) tlvs in
       let es  = tt_exprs_cast arch_info.pd env (L.loc pi) args tes in
-      env, mk_i (P.Copn(lvs, AT_keep, p, es)) :: einstr
+      mk_i (P.Copn(lvs, AT_keep, p, es)) :: einstr
 
   | ls, `Raw, { pl_desc = PEOp1 (`Cast(`ToWord ct), {pl_desc = PEPrim (f, args) })} , None
       ->
@@ -1782,7 +1782,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       let tlvs, tes, arguments = prim_sig arch_info.asmOp p in
       let lvs, einstr = tt_lvalues arch_info env (L.loc pi) ls (Some arguments) tlvs in
       let es  = tt_exprs_cast arch_info.pd env (L.loc pi) args tes in
-      env, mk_i (P.Copn(lvs, AT_keep, p, es)) :: einstr
+      mk_i (P.Copn(lvs, AT_keep, p, es)) :: einstr
 
   | (None,[lv]), `Raw, pe, None ->
       let _, flv, vty = tt_lvalue arch_info.pd env lv in
@@ -1798,7 +1798,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
         P.(match v with
             | Lvar v -> (match kind_i v with Inline -> E.AT_inline | _ -> E.AT_none)
             | _ -> AT_none) in
-      env, [mk_i (cassgn_for v tg ety e)]
+      [mk_i (cassgn_for v tg ety e)]
 
   | ls, `Raw, pe, None ->
       (* Try to match addc, subc, mulu *)
@@ -1817,14 +1817,14 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
   | ls, eqop, e, Some cp ->
       let loc = L.loc pi in
       let exn = Unsupported "if not allowed here" in
-      let env, i = tt_assign env ls eqop e None in
+      let i = tt_assign env ls eqop e None in
       let x, ty, e, is =
         match i with
         | { i_desc = P.Cassgn (x, _, ty, e) ; _ } :: is -> x, ty, e, is
         | _ -> rs_tyerror ~loc exn in
       let e' = oget ~exn:(tyerror ~loc exn) (P.expr_of_lval x) in
       let c = tt_expr_bool arch_info.pd env cp in
-      env, mk_i (P.Cassgn (x, AT_none, ty, Pif (ty, c, e, e'))) :: is
+      mk_i (P.Cassgn (x, AT_none, ty, Pif (ty, c, e, e'))) :: is
   in
   match L.unloc pi with
   | S.PIdecl tvs ->
@@ -1836,7 +1836,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
     let xi = (L.mk_loc lc x) in
     env, [mk_i (arr_init xi)]
 
-  | S.PIAssign (ls, eqop, pe, ocp) -> tt_assign env ls eqop pe ocp
+  | S.PIAssign (ls, eqop, pe, ocp) -> env, tt_assign env ls eqop pe ocp
 
   | PIIf (cp, st, sf) ->
       let c  = tt_expr_bool arch_info.pd env cp in

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -214,7 +214,11 @@ type align = [`Align | `NoAlign]
 
 type plvals = annotations L.located option * plvalue list
 
-type vardecls = pstotype * pident list
+
+type vardecl = pident * pexpr option
+type vardecls = pstotype * vardecl L.located list
+
+let var_decl_id (v, _ : vardecl) : pident = v
 
 type pinstr_r =
   | PIArrayInit of pident
@@ -255,11 +259,13 @@ type pcall_conv = [
   | `Inline
 ]
 
+type paramdecls = pstotype * pident list
+
 type pfundef = {
   pdf_annot : annotations;
   pdf_cc   : pcall_conv option;
   pdf_name : pident;
-  pdf_args : (annotations * vardecls) list;
+  pdf_args : (annotations * paramdecls) list;
   pdf_rty  : (annotations * pstotype) list option;
   pdf_body : pfunbody;
 }

--- a/compiler/tests/fail/common/var_initialize_if.jazz
+++ b/compiler/tests/fail/common/var_initialize_if.jazz
@@ -1,0 +1,3 @@
+fn test () {
+    reg u32 x = 0 if true;
+}

--- a/compiler/tests/fail/common/var_initialize_undecl.jazz
+++ b/compiler/tests/fail/common/var_initialize_undecl.jazz
@@ -1,0 +1,4 @@
+export fn main() -> reg u32 {
+  reg u32 x = x;
+  return x;
+}

--- a/compiler/tests/success/common/variable_initialization.jazz
+++ b/compiler/tests/success/common/variable_initialization.jazz
@@ -1,0 +1,48 @@
+/*
+Test for intialising variable during declaration
+The used semantic is the following : 
+reg u32 x=3; 
+
+is traduced to 
+reg u32 x;
+x=3;
+*/
+
+fn test_basic() -> reg u32 {
+    reg u32 x=3;
+    reg u32 y=x;
+    return y;
+} 
+
+fn test_multiples () -> reg u32,reg u32 {
+    reg u32 x=1,y=2;
+    return x,y;
+}
+
+fn test_primitive(){
+    reg ptr u32[1] a;
+    a[0] = 1;
+    stack u32[1] b = #copy_32(a[0:1]);
+}
+
+fn test_randombytes () {
+    reg ptr u8[1] r;
+    reg ptr u8[1] q = #randombytes(r);
+}
+
+fn test_calls () {
+    reg u32  x= test_basic();
+}
+
+export fn whitespace() -> reg u32 {
+  reg u32 x = 1 y = x + 1;
+  return y;
+}
+
+#[stacksize = 4]
+export fn rand() -> reg u32 {
+  stack u8[4] _x x = #randombytes(_x);
+  reg u32 r;
+  r = x[u32 0];
+  return r;
+}


### PR DESCRIPTION
# Issue 

This is a duplicate of issue #899 based on #901 refactoring of pre-typing.
The feature requested is to add a new syntax that authorize variable initialization when they are declared.

The syntax is as follow :

```
reg u64 x=1,y=2,z,t=3;
```

# Implementation

With the proposed implementation, we can also initialize multiple variables at the same time: 
```jazz
reg u64 x=1,y=2,z,t=3;
```

The current implementation doesn't support array initializing with this feature because array can currently be explicitly created only at top level. Allowing it would require reworking a large part of the grammar and pre-typing analysis. 

In terms of semantic, the proposed implementation works as follow : 
```jazz
reg u64 x=3;
```
is abstractly equivalent to :
```jazz
reg u64 x;
x=3;
```

