### PR TITLE
Adding support for type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@
   ([PR #907](https://github.com/jasmin-lang/jasmin/pull/907);
   fixes [#871](https://github.com/jasmin-lang/jasmin/issues/871)).
 
+- Adding support for type aliases definition in the global scope (and namespace global scope)
+   * Syntax for definition is `type <name> = <type>;`
+   * Syntax for use is `reg <typename> <varname> ...`
+  ([PR #911](https://github.com/jasmin-lang/jasmin/pull/911)).
+
 ## Other changes
 
 - The checker for S-CT accepts copies of outdated MSF

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -203,15 +203,18 @@ and pp_mem_access fmt (al, ty,x,e) =
     | Some (`Add, e) -> Format.fprintf fmt " + %a" pp_expr e 
     | Some (`Sub, e) -> Format.fprintf fmt " - %a" pp_expr e in
   F.fprintf fmt "%a[%a%a%a]" (pp_opt (pp_paren pp_ws)) ty pp_aligned al pp_var x pp_e e
-  
+
+
 and pp_type fmt ty =
   match L.unloc ty with
   | TBool -> F.fprintf fmt "%a" ptype "bool"
   | TInt -> F.fprintf fmt "%a" ptype "int"
   | TWord w -> pp_ws fmt w
-  | TArray (w, e) -> F.fprintf fmt "%a[%a]" ptype (string_of_wsize w) pp_expr e
+  | TArray (w, e) -> F.fprintf fmt "%a[%a]" ptype (Syntax.string_of_sizetype w) pp_expr e
+  | TAlias id -> F.fprintf fmt "%a" ptype (L.unloc id)
 
 and pp_ws fmt w = F.fprintf fmt "%a" ptype (string_of_wsize w)
+
 and pp_expr fmt e = pp_expr_rec Pmin fmt e
 
 and pp_arr_access fmt al aa ws x e len=
@@ -419,6 +422,9 @@ let pp_global fmt { pgd_type ; pgd_name ; pgd_val } =
 let pp_path fmt s =
   F.fprintf fmt "%S " (L.unloc s)
 
+let pp_typealias fmt id ty =
+  F.fprintf fmt "%a %a = %a;" kw "type" dname (L.unloc id) pp_type ty
+
 let rec pp_pitem fmt pi =
   match L.unloc pi with
   | PFundef f -> pp_fundef fmt f
@@ -439,6 +445,7 @@ let rec pp_pitem fmt pi =
      List.iter (pp_pitem fmt) pis;
      F.fprintf fmt eol;
      closebrace fmt ()
+  | PTypeAlias (id,ty) -> pp_typealias fmt id ty (**)
 
 let pp_prog fmt =
   F.pp_print_list ~pp_sep:(fun fmt () -> F.fprintf fmt eol) pp_pitem fmt

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -18,6 +18,7 @@
       raise (Syntax.ParseError (loc, Some (Format.asprintf "ill-formed string (%s)" msg)))
 
   let _keywords = [
+    "type"  , TYPE   ;
     "u8"    , T_U8   ;
     "u16"   , T_U16  ;
     "u32"   , T_U32  ;

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -42,6 +42,7 @@
 %token FN
 %token FOR
 %token FROM
+%token TYPE
 %token <Syntax.sign>GE
 %token GLOBAL
 %token <Syntax.sign>GT
@@ -166,6 +167,10 @@ utype:
 | T_U128 { Wsize.U128 }
 | T_U256 { Wsize.U256 }
 
+utype_array:
+| ws=utype {TypeWsize ws}
+| id=ident {TypeSizeAlias id}
+
 ptype_r:
 | T_BOOL
     { TBool }
@@ -176,8 +181,9 @@ ptype_r:
 | ut=utype
     { TWord ut }
 
-| ut=utype d=brackets(pexpr)
+| ut=utype_array d=brackets(pexpr)
     { TArray (ut, d) }
+| x=ident {TAlias x}
 
 ptype:
 | x=loc(ptype_r) { x }
@@ -503,6 +509,8 @@ top:
 | x=pglobal  { Syntax.PGlobal x }
 | x=pexec    { Syntax.Pexec   x }
 | x=prequire { Syntax.Prequire x}
+| TYPE name = ident EQ ty = ptype SEMICOLON
+    { Syntax.PTypeAlias (name, ty)}
 | NAMESPACE name = ident LBRACE pfs = loc(top)* RBRACE
     { Syntax.PNamespace (name, pfs) }
 (* -------------------------------------------------------------------- *)

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -31,6 +31,9 @@ type tyerror =
   | InvalidArgCount     of int * int
   | InvalidLvalCount    of int * int
   | DuplicateFun        of A.symbol * L.t
+  | DuplicateAlias      of A.symbol * P.pty L.located * P.pty L.located
+  | TypeNotFound        of A.symbol
+  | InvalidTypeAlias    of A.symbol * P.pty
   | InvalidCast         of P.pty pair
   | InvalidTypeForGlobal of P.pty
   | NotAPointer         of P.plval
@@ -158,6 +161,24 @@ let pp_tyerror fmt (code : tyerror) =
         "The function %s is already declared at %s"
         f (L.tostring loc)
 
+  | DuplicateAlias (id, newtype, oldtype) ->
+      F.fprintf fmt
+        "Type '%s' (ie: '%a') is already declared at %s (with type : '%a')"
+        id
+        Printer.pp_ptype (L.unloc newtype)
+        (L.tostring (L.loc oldtype))
+        Printer.pp_ptype (L.unloc oldtype)
+
+  | TypeNotFound (id) ->
+      F.fprintf fmt
+      "Type '%s' not found"
+      id
+
+  | InvalidTypeAlias (id,typ) ->
+      F.fprintf fmt
+      "Type '%s' (ie: '%a') is not allowed as array element. Only machine words (u8, u16 ...) allowed"
+      id Printer.pp_ptype typ
+
   | EqOpWithNoLValue ->
       F.fprintf fmt
         "operator-assign requires a lvalue"
@@ -252,6 +273,11 @@ module Env : sig
     val clear_locals : 'asm env -> 'asm env
   end
 
+  module TypeAlias : sig
+    val push : 'asm env -> A.pident -> P.pty -> 'asm env
+    val get : 'asm env -> A.pident -> P.pty L.located
+  end
+
   module Funs : sig
     val push : 'asm env -> (unit, 'asm) P.pfunc -> P.pty list -> 'asm env
     val find : A.symbol -> 'asm env -> ((unit, 'asm) P.pfunc * P.pty list) option
@@ -272,6 +298,7 @@ end  = struct
     } 
 
   type 'asm global_bindings = {
+      gb_types : (A.symbol, P.pty L.located) Map.t;
       gb_vars : (A.symbol, P.pvar * E.v_scope) Map.t;
       gb_funs : (A.symbol, (unit, 'asm) P.pfunc * P.pty list) Map.t;
     }
@@ -295,7 +322,7 @@ end  = struct
     ; from = Map.empty
     }
 
-  let empty_gb = { gb_vars = Map.empty ; gb_funs = Map.empty }
+  let empty_gb = { gb_vars = Map.empty ; gb_funs = Map.empty; gb_types = Map.empty }
 
   let empty : 'asm env =
     { e_bindings = [], empty_gb
@@ -325,20 +352,24 @@ end  = struct
         let n = qualify ns n in
         begin match Map.find n dst with
         | exception Not_found -> ()
-        | (k, _) -> on_duplicate n (fst v) k end;
+        | k -> on_duplicate n v k end;
         Map.add n v dst)
 
-  let warn_duplicate_var name v v' =
+  let warn_duplicate_var name (v, _) (v', _) =
     warning DuplicateVar (L.i_loc0 v.P.v_dloc)
       "the variable %s is already declared at %a"
       name L.pp_loc v'.P.v_dloc
 
-  let err_duplicate_fun name v fd =
+  let err_duplicate_fun name (v, _) (fd, _) =
     rs_tyerror ~loc:v.P.f_loc (DuplicateFun(name, fd.P.f_loc))
+
+  let err_duplicate_type name t1 t2 =
+    rs_tyerror ~loc:(L.loc t2) (DuplicateAlias (name,t1,t2))
 
   let merge_bindings (ns, src) dst =
     { gb_vars = merge_bindings warn_duplicate_var ns src.gb_vars dst.gb_vars
     ; gb_funs = merge_bindings err_duplicate_fun ns src.gb_funs dst.gb_funs
+    ; gb_types = merge_bindings err_duplicate_type ns src.gb_types dst.gb_types
     }
 
   let exit_namespace env =
@@ -431,7 +462,7 @@ end  = struct
       let name = v.P.v_name in
       match Map.find name map with
       | exception Not_found -> ()
-      | v', _ -> warn_duplicate_var name v v'
+      | v' -> warn_duplicate_var name (v, ()) v'
 
     let push_core (env : 'asm env) (name: P.Name.t) (v : P.pvar) (s : E.v_scope) =
       let doit m =
@@ -479,6 +510,31 @@ end  = struct
 
   end
 
+  module TypeAlias = struct
+
+    let push (env: 'asm env) (id: A.pident) (ty: P.pty) : 'asm env =
+      match find (fun x -> x.gb_types) (L.unloc id) env with
+      | Some alias ->
+         rs_tyerror  ~loc:(L.loc id)  (DuplicateAlias (L.unloc id, (L.mk_loc (L.loc id) ty) ,alias) )
+      | None ->
+          let ty = L.mk_loc (L.loc id) ty in
+          let doit v = {v with gb_types = Map.add (L.unloc id) ty v.gb_types }
+          in let binds =
+          match env.e_bindings with
+          | ([],gb) -> [],doit gb
+          | ((ns,gb):: stack, glob) -> (ns,doit gb):: stack , glob
+          in
+          {env with e_bindings = binds}
+
+    let get (env: 'asm env) (id: A.pident) : P.pty L.located =
+      let typea = find (fun b -> b.gb_types) (L.unloc id) env in
+      match typea with
+      | None ->
+        rs_tyerror  ~loc:(L.loc id) (TypeNotFound (L.unloc id))
+      | Some e -> e
+
+  end
+
   module Funs = struct
     let find (x : A.symbol) (env : 'asm env) =
       find (fun b -> b.gb_funs) x env
@@ -498,8 +554,8 @@ end  = struct
               (ns, doit top) :: stack, bot
       in
       { env with e_bindings; e_decls = P.MIfun v :: env.e_decls }
-      | Some (fd,_) ->
-         err_duplicate_fun name v fd
+      | Some fd ->
+         err_duplicate_fun name (v, ()) fd
 
   end
 
@@ -1171,7 +1227,15 @@ and tt_type pd (env : 'asm Env.env) (pty : S.ptype) : P.pty =
   | S.TInt      -> P.tint
   | S.TWord  ws -> P.Bty (P.U ws)
   | S.TArray (ws, e) ->
-      P.Arr (ws, fst (tt_expr ~mode:`OnlyParam pd env e))
+     let ws = match ws with
+       | TypeWsize ws -> ws
+       | TypeSizeAlias id ->
+          let extern_type = Env.TypeAlias.get env id in
+          match L.unloc extern_type with
+          | P.Bty (P.U ws) -> ws
+          | ty -> rs_tyerror  ~loc:(L.loc id) (InvalidTypeAlias ((L.unloc id),ty))
+     in P.Arr (ws, fst (tt_expr ~mode:`OnlyParam pd env e))
+  | S.TAlias id -> L.unloc (Env.TypeAlias.get env id)
 
 (* -------------------------------------------------------------------- *)
 let tt_exprs pd (env : 'asm Env.env) es = List.map (tt_expr ~mode:`AllVar pd env) es
@@ -2149,6 +2213,10 @@ let tt_global pd (env : 'asm Env.env) _loc (gd: S.pglobal) : 'asm Env.env =
   Env.Vars.push_global env (x,d)
 
 
+let tt_typealias arch_info env id ty =
+  let alias = tt_type arch_info.pd env ty in
+  Env.TypeAlias.push env id alias
+
 (* -------------------------------------------------------------------- *)
 let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
   match L.unloc pt with
@@ -2167,6 +2235,7 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
      let env = List.fold_left (tt_item arch_info) env items in
      let env = Env.exit_namespace env in
      env
+  | S.PTypeAlias (id,ty) -> tt_typealias arch_info env id ty
 
 and tt_file_loc arch_info from env fname =
   fst (tt_file arch_info env from (Some (L.loc fname)) (L.unloc fname))

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -172,7 +172,8 @@ and pexpr = pexpr_r L.located
 and mem_access = [ `Aligned | `Unaligned ] option * wsize option * pident * ([`Add | `Sub] * pexpr) option
 
 (* -------------------------------------------------------------------- *)
-and ptype_r = TBool | TInt | TWord of wsize | TArray of wsize * pexpr
+and psizetype = TypeWsize of wsize | TypeSizeAlias of pident
+and ptype_r = TBool | TInt | TWord of wsize | TArray of psizetype * pexpr | TAlias of pident
 and ptype   = ptype_r L.located
 
 (* -------------------------------------------------------------------- *)
@@ -240,6 +241,11 @@ and fordir   = [ `Down | `Up ]
 and pinstr = annotations * pinstr_r L.located
 and pblock = pblock_r L.located
 
+let string_of_sizetype =
+  function
+  | TypeWsize ws -> string_of_ws ws
+  | TypeSizeAlias pident -> L.unloc pident
+
 (* -------------------------------------------------------------------- *)
 type pparam = {
   ppa_ty   : ptype;
@@ -295,6 +301,7 @@ type pitem =
   | Pexec of pexec
   | Prequire of (pident option * prequire list)
   | PNamespace of pident * pitem L.located list
+  | PTypeAlias of pident * ptype
 
 (* -------------------------------------------------------------------- *)
 type pprogram = pitem L.located list

--- a/compiler/tests/fail/common/typealias_annotation_param.jazz
+++ b/compiler/tests/fail/common/typealias_annotation_param.jazz
@@ -1,0 +1,8 @@
+
+type arch_size = u64;
+
+#stackzero=loop
+export fn main0(reg u64 p) { f(p); }
+
+#stackzero=loop #stackzerosize=arch_size
+export fn main1(reg u64 p) { f(p); }

--- a/compiler/tests/fail/common/typealias_arrayelement.jazz
+++ b/compiler/tests/fail/common/typealias_arrayelement.jazz
@@ -1,0 +1,8 @@
+
+
+type x = u64[3];
+
+
+fn test() {
+    reg x[3] y;
+}

--- a/compiler/tests/fail/common/typealias_arrayelement_integer.jazz
+++ b/compiler/tests/fail/common/typealias_arrayelement_integer.jazz
@@ -1,0 +1,7 @@
+
+type x = int;
+
+
+fn test() {
+    reg x[t] y;
+}

--- a/compiler/tests/fail/common/typealias_duplicate.jazz
+++ b/compiler/tests/fail/common/typealias_duplicate.jazz
@@ -1,0 +1,3 @@
+
+type x = u64;
+type x = u64;

--- a/compiler/tests/fail/common/typealias_notfound.jazz
+++ b/compiler/tests/fail/common/typealias_notfound.jazz
@@ -1,0 +1,3 @@
+export fn test() {
+    reg regtype x;
+}

--- a/compiler/tests/success/arm-m4/typealias_armv7.jazz
+++ b/compiler/tests/success/arm-m4/typealias_armv7.jazz
@@ -1,0 +1,26 @@
+param int bloc_size = 4046;
+type arch_size = u32;
+
+
+export fn memncopy 
+(
+    reg ptr arch_size[bloc_size] target, 
+    reg ptr arch_size[bloc_size] source,
+    reg arch_size size
+) 
+->  
+    reg ptr arch_size[bloc_size],
+    reg ptr arch_size[bloc_size] 
+{
+    reg arch_size i;
+    i=0;
+
+    while (i< size) {
+        reg arch_size x;
+        x = source[i];
+        target[i] = x;
+        i+=1;
+    }
+
+    return (target,source);
+}

--- a/compiler/tests/success/common/typealias.jazz
+++ b/compiler/tests/success/common/typealias.jazz
@@ -1,0 +1,27 @@
+
+
+type data = u32;
+type data2 = u32[4];
+
+export fn test() -> reg data {
+    reg data x;
+    x = 1;
+    return x;
+}
+
+namespace A {
+    type x = u32;
+
+    fn s() -> {
+        reg x test;
+        test += 1;
+    }
+}
+
+fn test2(reg A::x v, reg data2 y) -> reg A::x {
+    reg A::x v2;
+    v2 = v;
+    v2+=1;
+    y[0] = 1;
+    return v2;
+}

--- a/compiler/tests/success/x86-64/typealias_amd64.jazz
+++ b/compiler/tests/success/x86-64/typealias_amd64.jazz
@@ -1,0 +1,24 @@
+param int bloc_size = 4046;
+type arch_size = u64;
+
+
+export fn memncopy 
+(
+    reg ptr arch_size[bloc_size] target, 
+    reg ptr arch_size[bloc_size] source,
+    reg arch_size size
+) 
+->  
+    reg ptr arch_size[bloc_size],
+    reg ptr arch_size[bloc_size] 
+{
+    reg arch_size i;
+    i=0;
+
+    while (i< size) {
+        target[i] = source[i];
+        i+=1;
+    }
+
+    return (target,source);
+}


### PR DESCRIPTION
# Feature

As described in #501, the objective of this feature is to allow declaration of type alias within jasmin syntax. The chosen keyword 'type' follow rust language specification. 

You can declare a type alias as follow :
``` 
type typename = u64;
type typename = u64[4];
type typename = othertypename;
``` 

types can then be called during variable declaration :
```
reg typename var;
reg typename[5] var;
``` 
This feature increase portability of programs. For example : 
``` 
// test.jazz
require "arch.jinc";
export fn inc(reg arch_type x) -> reg arch_type {
    reg arch_type y;
    y=x;
    y+=1;
    return y;
}
```
we can write a required header file that define arch_type (or even making it a part of compilation reserved types) for each targeted architecture.
```
// arch.jinc for x86_amd64 target
type arch_type = u64;
```
```
// arch_armv7.jinc armV7 target
type arch_type = u32;
```

avoiding rewriting of code

# Implementation details : 

The declaration of storage type cannot be aliases, making the following declaration invalid (raising TypeError):
```
type typename = reg u64 x;
```
We can consider that 'reg' 'inline' 'stack' are equivalent to 'let' or 'var' keyword in other languages, so it would not make sense to make it aliasable (at least in my point of view).

Types semantic is resolved during pre-typing step of compilation. For the moment, alias are resolved at the moment they are read by the compiler, making the following declarations invalid : 
```
type type1 = type2;
type type2 = u64;
```

We could modify the implementation to allow such semantic (by treating type resolution lazily). 
