### PR TITLE
Adding ocaml-lsp and ocaml-format to nix dependancies for better devellopement experience

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,6 +61,8 @@ stdenv.mkDerivation {
     ++ optionals testDeps ([ curl.bin oP.apron.out libllvm ] ++ (with python3Packages; [ python pyyaml ]))
     ++ optionals ocamlDeps ([ mpfr ppl ] ++ (with oP; [
          ocaml findlib dune_3
+          ocaml-lsp 
+         ocamlformat
          cmdliner
          angstrom
          batteries


### PR DESCRIPTION
Just a little modification of nix.default to include `ocaml-lsp` and `ocaml-format` (needed by default by IDE like Vscode for Ocaml code analysis)