### PR TITLE
Support far global variable accesses in ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@
 - Add support for the MMX instruction `POR`
   ([PR #917](https://github.com/jasmin-lang/jasmin/pull/917)).
 
+- ARM now emits two instructions instead of `ADR` to load the low and high
+  parts of global addresses
+  ([PR#921](https://github.com/jasmin-lang/jasmin/pull/921)).
+
 ## Bug fixes
 
 - Easycrypt extraction for CT : fix decreasing for loops

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -224,6 +224,23 @@ end = struct
     | _ -> ""
 end
 
+(* Split an [ADR] instruction to a global symbol into a [MOVW]/[MOVT] pair. *)
+let pp_ADR pp opts args =
+  let name_lo = pp_mnemonic_ext (ARM_op(MOV, opts)) "w" args in
+  let name_hi = pp_mnemonic_ext (ARM_op(MOVT, opts)) "" args in
+  let args =
+    List.filter_map (fun (_, a) -> pp_asm_arg a) pp.pp_aop_args
+  in
+  let args_lo, args_hi =
+    match args with
+    | dst :: addr :: rest ->
+        let lo = "#:lower16:" ^ addr in
+        let hi = "#:upper16:" ^ addr in
+        (dst :: lo :: rest, dst :: hi :: rest)
+    | _ -> assert false
+  in
+  [ LInstr(name_lo, args_lo); LInstr(name_hi, args_hi) ]
+
 let pp_instr fn i =
   match i with
   | ALIGN ->
@@ -266,12 +283,18 @@ let pp_instr fn i =
   | AsmOp (op, args) ->
       let id = instr_desc arm_decl arm_op_decl (None, op) in
       let pp = id.id_pp_asm args in
+      (* We need to perform the check even if we don't use the suffix, for
+         instance for [LDR] or [STR]. *)
       let suff = ArgChecker.check_args op pp.pp_aop_args in
-      let name = pp_mnemonic_ext op suff args in
-      let args = List.filter_map (fun (_, a) -> pp_asm_arg a) pp.pp_aop_args in
-      let args = pp_shift op args in
-      get_IT i @ [ LInstr (name, args) ]
-
+      match op, args with
+      | ARM_op(ADR, opts), _ :: Addr (Arip _) :: _ -> pp_ADR pp opts args
+      | _, _ ->
+          let name = pp_mnemonic_ext op suff args in
+          let args =
+            List.filter_map (fun (_, a) -> pp_asm_arg a) pp.pp_aop_args
+          in
+          let args = pp_shift op args in
+          get_IT i @ [ LInstr (name, args) ]
 
 (* -------------------------------------------------------------------- *)
 

--- a/compiler/tests/success/arm-m4/far_global_access.jazz
+++ b/compiler/tests/success/arm-m4/far_global_access.jazz
@@ -1,0 +1,21 @@
+param int L = 4100;
+
+u32[2] a = { 1, 2 };
+
+export
+fn main() -> reg u32 {
+    reg ptr u32[2] p = a;
+    reg u32 t = p[0];
+    reg u32 tmp = p[1];
+    t += tmp;
+
+    reg ptr u32[1] q = a[1:1];
+    reg u32 tmp = q[0];
+    t += tmp;
+
+    reg u32 v = 0;
+    inline int i;
+    for i = 0 to L { v += t; }
+
+    return v;
+}


### PR DESCRIPTION
Temporary patch for #619. I assume that `ADR` instructions are only generated for accesses to the data section, which seems to be true. I don't think it's a robust solution, but I don't see how to do it otherwise. Also, I believe we can't tell whether we can perform the relative access or not, so as to generate two instructions only when needed. The other options discussed in the issue didn't work, and I can't explain why.