### PR TITLE
CI/coq-master: use elpi 1.20.0

### DIFF
--- a/scripts/coq-elpi.nix
+++ b/scripts/coq-elpi.nix
@@ -2,7 +2,7 @@
 
 let elpi =
   coq.ocamlPackages.elpi.override {
-    version = "v1.18.2";
+    version = "v1.20.0";
   }
 ; in
 


### PR DESCRIPTION
Compiling Coq-elpi master with elpi 1.18.2 has been failing with:

~~~
File "src/coq_elpi_builtins_synterp.ml", line 1220, characters 21-28:
1220 |       ~scope ~dbname clauses ~depth ~options state)),
                            ^^^^^^^
Error: This expression has type
         (string option *
          ([> `After | `Before | `Remove | `Replace ] * string) option *
          Elpi.API.Data.term)
         list
       but an expression was expected of type
         (string option * ([ `After | `Before | `Replace ] * string) option *
          Elpi.API.Data.term)
         list
       The second variant type does not allow tag(s) `Remove
~~~

Updating elpi to 1.20.0 works around this issue.

cc @gares (for your information).