### PR TITLE
ARM: add instruction SBC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## New features
 
+- Add support for ARM instruction `SBC`
+  ([PR #936](https://github.com/jasmin-lang/jasmin/pull/936)).
+
 - Add support for x86 instructions `BTR` and `BTS` with the bit base operand in
   register
   ([PR #932](https://github.com/jasmin-lang/jasmin/pull/932);

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -66,6 +66,7 @@ module Arm_core = struct
     | ARM_op(REVSH, _) -> false (* Not DIT *)
     | ARM_op(ROR, _) -> true
     | ARM_op(RSB, _) -> false (* Not DIT *)
+    | ARM_op(SBC, _) -> true
     | ARM_op(SBFX, _) -> true
     | ARM_op(SDIV, _) -> false (* Not DIT *)
     | ARM_op(SMLA_hw _, _) -> false (* Not DIT *)

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -215,7 +215,7 @@ end = struct
 
   let check_args (ARM_op (mn, opts)) args =
     match mn with
-    | ADC | RSB -> chk_imm_accept_shift args 2
+    | ADC | SBC | RSB -> chk_imm_accept_shift args 2
     | CMP | CMN -> chk_imm_accept_shift args 1
     | ADD | SUB -> chk_imm_accept_shift_w12 args 2 opts
     | MOV -> chk_imm_w16_encoding args 1 opts

--- a/compiler/tests/success/arm-m4/intrinsic_sbc.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_sbc.jazz
@@ -1,0 +1,70 @@
+export
+fn sbc(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x;
+    reg bool c;
+
+    _, _, c, _ = #MOVS(arg0);
+
+    x = #SBC(arg0, arg1, c);
+
+    // Immediates.
+    x = #SBC(x, 0, c);
+    x = #SBC(x, 1, c);
+    x = #SBC(x, 255, c);
+    x = #SBC(x, 0xcacacaca, c); // `bbbb` pattern.
+    x = #SBC(x, 0xca00ca00, c); // `b0b0` pattern.
+    x = #SBC(x, 0x00ca00ca, c); // `0b0b` pattern.
+    x = #SBC(x, 0x000cb000, c); // Shifted byte.
+
+    // Shifts.
+    x = #SBC(x, arg0 << 0, c);
+    x = #SBC(x, arg0 << 31, c);
+    x = #SBC(x, arg0 >> 1, c);
+    x = #SBC(x, arg0 >> 32, c);
+    x = #SBC(x, arg0 >>s 1, c);
+    x = #SBC(x, arg0 >>s 32, c);
+    x = #SBC(x, arg0 >>r 1, c);
+    x = #SBC(x, arg0 >>r 31, c);
+    // x = #SBC(x, arg0, #RRX(1));
+
+    // Set flags.
+    reg bool n, z, v;
+    n, z, c, v, x = #SBCS(x, arg0, c);
+    n, z, c, v, x = #SBCS(x, 1, c);
+    n, z, c, v, x = #SBCS(x, 0xcacacaca, c);
+    n, z, c, v, x = #SBCS(x, 0xca00ca00, c);
+    n, z, c, v, x = #SBCS(x, 0x00ca00ca, c);
+    n, z, c, v, x = #SBCS(x, 0x000cb000, c);
+    n, z, c, v, x = #SBCS(x, arg0 << 3, c);
+
+    // Conditions.
+    x = #SBCcc(x, arg0, c, z, x);            // EQ
+    x = #SBCcc(x, arg0, c, !z, x);           // NE
+    x = #SBCcc(x, arg0, c, c, x);            // CS
+    x = #SBCcc(x, arg0, c, !c, x);           // CC
+    x = #SBCcc(x, arg0, c, n, x);            // MI
+    x = #SBCcc(x, arg0, c, !n, x);           // PL
+    x = #SBCcc(x, arg0, c, v, x);            // VS
+    x = #SBCcc(x, arg0, c, !v, x);           // VC
+    x = #SBCcc(x, arg0, c, c && !z, x);      // HI
+    x = #SBCcc(x, arg0, c, !c || z, x);      // LS
+    x = #SBCcc(x, arg0, c, n == v, x);       // GE
+    x = #SBCcc(x, arg0, c, n != v, x);       // LT
+    x = #SBCcc(x, arg0, c, !z && n == v, x); // GT
+    x = #SBCcc(x, arg0, c, z || n != v, x);  // LE
+
+    x = #SBCcc(x, 1, c, !!!!z, x);
+    n, z, c, v, x = #SBCScc(x, arg0, c, n == v, n, z, c, v, x);
+    n, z, c, v, x = #SBCScc(x, 2, c, !c || z, n, z, c, v, x);
+    x = #SBCcc(x, arg0 << 3, c, z, x);
+    n, z, c, v, x = #SBCScc(x, arg0 << 3, c, z, n, z, c, v, x);
+
+    reg bool zf, cf;
+    ?{CF = c}, x = #SBCS(x, arg0, c);
+    ?{CF = c, ZF = zf}, x = #SBCS(x, arg0, c);
+    ?{cf}, x = #SBCS(x, arg0, c);
+
+    reg u32 res;
+    res = x;
+    return res;
+}

--- a/eclib/JModel_m4.ec
+++ b/eclib/JModel_m4.ec
@@ -201,6 +201,12 @@ op SUB x y = let (_n, _z, _c, _v, r) = SUBS x y in r.
 op SUBScc x y g n z c v o = if g then SUBS x y else (n, z, c, v, o).
 op SUBcc x y g o = if g then SUB x y else o.
 
+op SBCS (x y: W32.t) (c: bool) : bool * bool * bool * bool * W32.t =
+  ADCS x (invw y) c.
+op SBC x y c = let (_n, _z, _c, _v, r) = SBCS x y c in r.
+op SBCScc x y b g n z c v o = if g then SBCS x y b else (n, z, c, v, o).
+op SBCcc x y c g o = if g then SBC x y c else o.
+
 op TST (x y: W32.t) : bool * bool * bool =
   nzc (andw x y).
 op TSTcc x y g n z c = if g then TST x y else (n, z, c).

--- a/proofs/compiler/arm_instr_decl_lemmas.v
+++ b/proofs/compiler/arm_instr_decl_lemmas.v
@@ -59,7 +59,7 @@ Lemma exec_sopn_conditional mn sf osk b vargs vprev vres0 vres1 :
 Proof.
   all: case: sf.
   all: case: osk => [sk|].
-  all: case: mn => [||||||||||||||||??|??|?|||||||||||||||||||||||||||||||||].
+  all: case: mn => [|||||||||||||||||??|??|?|||||||||||||||||||||||||||||||||].
   all: rewrite /truncate_args /truncate_val.
 
   (* Destruct [vprev]. *)

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -410,7 +410,7 @@ Definition lower_base_op
           then Some (lvs, Oasm (BaseOp (None, ARM_op mn (with_shift opts sh))), x :: ebase :: esham :: rest)
           else Some (lvs, Oasm (BaseOp (None, ARM_op mn opts)), es)
       | _ => None end
-    else if ADC == mn
+    else if mn \in [:: ADC; SBC ]
     then
       match es with
       | x :: y :: z :: rest =>


### PR DESCRIPTION
Using it is lowering is hard: the Jasmin semantics for the resulting carry flag does not match the ARM semantics…

Should we accept instructions like: `!c, x = y - z - !c;`?