### PR TITLE
Do not use RAX to save the stack pointer on x86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@
 
 ## Bug fixes
 
-- Multiplication instructions hava data-independent timing on x86
+- Multiplication instructions have data-independent timing on x86
   ([PR #927](https://github.com/jasmin-lang/jasmin/pull/927)).
+
+- Do not use RAX to save the stack pointer on x86
+  ([PR #937](https://github.com/jasmin-lang/jasmin/pull/937);
+  fixes [#895](https://github.com/jasmin-lang/jasmin/issues/895)).
 
 ## Other changes
 

--- a/compiler/tests/success/x86-64/bug_895.jazz
+++ b/compiler/tests/success/x86-64/bug_895.jazz
@@ -1,0 +1,42 @@
+fn f1() -> reg u32 {
+    reg u32 r z y;
+    r = 0;
+    y = 0;
+    z = 0;
+    r = r ^ y;
+    r = r ^ z;
+    return r;
+}
+
+fn f2(reg u32 _a _b _c) -> reg u32 {
+    reg u32 r;
+    r = 0;
+    return r;
+}
+
+fn g(reg ptr u32[12] state, reg u64 column) -> reg ptr u32[12] {
+    reg u32 x y z a;
+    x = 0;
+    y = 0;
+    z = 0;
+    a = f1();
+    state[column] = a;
+    a = f2(x,y,z);
+    state[column] = a;
+
+    return state;
+}
+
+export
+fn jazz_g(reg ptr u32[12] state, reg u64 c) -> reg ptr u32[12] {
+    #inline state = g(state, c);
+    return state;
+}
+
+export
+fn jazz_g2(reg ptr u32[12] state) -> reg ptr u32[12] {
+    reg u64 c;
+    c = 0;
+    state = g(state, c);
+    return state;
+}

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -111,11 +111,13 @@ Definition x86_lload (xd xs: var_i) (ofs : Z) :=
   let ws := wsize_of_stype (vtype xd) in
   x86_lassign (LLvar xd) ws (Load Aligned ws xs (fconst Uptr ofs)).
 
+Definition x86_tmp := vname (v_var vtmpi).
+
 Definition x86_liparams : linearization_params :=
   {|
-    lip_tmp := vname (v_var vtmpi);
+    lip_tmp := x86_tmp;
     lip_tmp2 := vname (v_var vtmp2i);
-    lip_not_saved_stack := [::];
+    lip_not_saved_stack := [:: x86_tmp ];
     lip_allocate_stack_frame := x86_allocate_stack_frame;
     lip_free_stack_frame := x86_free_stack_frame;
     lip_set_up_sp_register := x86_set_up_sp_register;


### PR DESCRIPTION
Fixes #895.