### PR TITLE
moving type alias feature in changelog (probably moved during a merge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   ([PR #932](https://github.com/jasmin-lang/jasmin/pull/932);
   fixes [#928](https://github.com/jasmin-lang/jasmin/issues/928)).
 
+- Adding support for type aliases definition in the global scope (and namespace global scope)
+   * Syntax for definition is `type <name> = <type>;`
+   * Syntax for use is `reg <typename> <varname> ...`
+  ([PR #911](https://github.com/jasmin-lang/jasmin/pull/911)).
+
 ## Bug fixes
 
 - Multiplication instructions have data-independent timing on x86
@@ -82,11 +87,6 @@
 - Adding label to global variables in assembly generation to avoid name conflicts
   ([PR #907](https://github.com/jasmin-lang/jasmin/pull/907);
   fixes [#871](https://github.com/jasmin-lang/jasmin/issues/871)).
-
-- Adding support for type aliases definition in the global scope (and namespace global scope)
-   * Syntax for definition is `type <name> = <type>;`
-   * Syntax for use is `reg <typename> <varname> ...`
-  ([PR #911](https://github.com/jasmin-lang/jasmin/pull/911)).
 
 ## Other changes
 


### PR DESCRIPTION
Just a little correction of changelog where type alias feature was placed under 2024.07.1 bug fixes