### PR TITLE
Risc-v: proper management of the return address

### DIFF
--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -4,9 +4,14 @@ open Arch_extra
 open Prog
 
 type 'a callstyle =
-  | StackDirect           (* call instruction push the return address on top of the stack *)
-  | ByReg of 'a option    (* call instruction store the return address on a register,
-                               (Some r) neams that the register is forced to be r *)
+  | StackDirect
+    (* call instruction push the return address on top of the stack *)
+  | ByReg of { call : 'a option; return : bool }
+    (* call instruction store the return address on a register,
+       - call: (Some r) means that the register is forced to be r
+       - return:
+         + true means that the register is also used for the return
+         + false means that there is no constraint (stack is also ok) *)
 
 (* TODO: check that we cannot use sth already defined on the Coq side *)
 
@@ -191,7 +196,7 @@ module Arch_from_Core_arch (A : Core_arch) :
   let callstyle =
     match A.callstyle with
     | StackDirect -> StackDirect
-    | ByReg o -> ByReg (Option.map var_of_reg o)
+    | ByReg { call; return } -> ByReg { call = Option.map var_of_reg call; return }
 
   let arch_info = Pretyping.{
       pd = reg_size;

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -3,9 +3,15 @@ open Arch_extra
 open Prog
 
 type 'a callstyle =
-  | StackDirect           (* call instruction push the return address on top of the stack *)
-  | ByReg of 'a option    (* call instruction store the return address on a register, 
-                               (Some r) neams that the register is forced to be r *)
+  | StackDirect
+    (* call instruction push the return address on top of the stack *)
+  | ByReg of { call : 'a option; return : bool }
+    (* call instruction store the return address on a register,
+       - call: (Some r) means that the register is forced to be r
+       - return:
+         + true means that the register is also used for the return
+         + false means that there is no constraint (stack is also ok) *)
+
 (* x86    : StackDirect 
    arm v7 : ByReg (Some ra)
    riscV  : ByReg (can it be StackDirect too ?)

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -115,5 +115,5 @@ module Arm (Lowering_params : Arm_input) : Arch_full.Core_arch = struct
 
   let pp_asm = Pp_arm_m4.print_prog
 
-  let callstyle = Arch_full.ByReg (Some LR)
+  let callstyle = Arch_full.ByReg { call = Some LR; return = false }
 end

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -375,14 +375,22 @@ let pp_saved_stack ~debug fmt = function
 let pp_tmp_option ~debug =
    Format.pp_print_option (fun fmt x -> Format.fprintf fmt " [tmp = %a]" (pp_var ~debug) (Conv.var_of_cvar x))
 
+let pp_ra_call ~debug =
+  Format.pp_print_option (fun fmt ra_call -> Format.fprintf fmt "%a -> " (pp_var ~debug) (Conv.var_of_cvar ra_call))
+
+let pp_ra_return ~debug =
+  Format.pp_print_option (fun fmt ra_return -> Format.fprintf fmt " -> %a" (pp_var ~debug) (Conv.var_of_cvar ra_return))
+
 let pp_return_address ~debug fmt = function
   | Expr.RAreg (x, o) ->
     Format.fprintf fmt "%a%a" (pp_var ~debug) (Conv.var_of_cvar x) (pp_tmp_option ~debug) o
 
-  | Expr.RAstack(Some x, z, o) ->
-    Format.fprintf fmt "%a, RSP + %a%a" (pp_var ~debug) (Conv.var_of_cvar x) Z.pp_print (Conv.z_of_cz z) (pp_tmp_option ~debug) o
-  | Expr.RAstack(None, z, o) ->
-    Format.fprintf fmt "RSP + %a%a" Z.pp_print (Conv.z_of_cz z) (pp_tmp_option ~debug) o
+  | Expr.RAstack(ra_call, ra_return, z, o) ->
+    Format.fprintf fmt "%aRSP + %a%a%a"
+      (pp_ra_call ~debug) ra_call Z.pp_print (Conv.z_of_cz z)
+      (pp_tmp_option ~debug) o
+      (pp_ra_return ~debug) ra_return
+
   | Expr.RAnone   -> Format.fprintf fmt "_"
 
 let pp_sprog ~debug pd asmOp fmt ((funcs, p_extra):('info, 'asm) Prog.sprog) =

--- a/compiler/src/regalloc.mli
+++ b/compiler/src/regalloc.mli
@@ -4,7 +4,7 @@ val fill_in_missing_names : ('info, 'asm) Prog.func -> ('info, 'asm) Prog.func
 
 type retaddr = 
   | StackDirect
-  | StackByReg of var * var option
+  | StackByReg of var * var option * var option
   | ByReg of var * var option
 
 type reg_oracle_t = {

--- a/compiler/src/riscv_arch_full.ml
+++ b/compiler/src/riscv_arch_full.ml
@@ -51,5 +51,5 @@ module Riscv (Lowering_params : Riscv_input) : Arch_full.Core_arch = struct
 
   let pp_asm = Pp_riscv.print_prog
 
-  let callstyle = Arch_full.ByReg (Some RA)
+  let callstyle = Arch_full.ByReg { call = Some RA; return = true }
 end

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -319,7 +319,7 @@ let memory_analysis pp_err ~debug up =
         sao_rsp  = saved_stack;
         sao_return_address =
           (* This is a dummy value it will be fixed in fix_csao *)
-          RAstack (None, Conv.cz_of_int 0, None)
+          RAstack (None, None, Conv.cz_of_int 0, None)
       } in
     Hf.replace atbl fn csao
   in
@@ -339,8 +339,9 @@ let memory_analysis pp_err ~debug up =
       Stack_alloc.{ csao with
         sao_return_address =
           match ro.ro_return_address with
-          | StackDirect  -> RAstack (None, Conv.cz_of_int 0, None) (* FIXME stackDirect should provide a tmp register *)
-          | StackByReg (r, tmp) -> RAstack (Some (Conv.cvar_of_var r), Conv.cz_of_int 0, Option.map Conv.cvar_of_var tmp)
+          | StackDirect  -> RAstack (None, None, Conv.cz_of_int 0, None) (* FIXME stackDirect should provide a tmp register *)
+          | StackByReg (ra_call, ra_return, tmp) ->
+            RAstack (Some (Conv.cvar_of_var ra_call), Option.map Conv.cvar_of_var ra_return, Conv.cz_of_int 0, Option.map Conv.cvar_of_var tmp)
           | ByReg (r, tmp)      -> RAreg (Conv.cvar_of_var r, Option.map Conv.cvar_of_var tmp)
       } in
       Hf.replace atbl fn csao

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -396,13 +396,13 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
         false (* For export function ra is not counted in the frame *)
     | Subroutine _ -> 
       match callstyle with 
-      | Arch_full.StackDirect -> 
+      | Arch_full.StackDirect ->
         if fd.f_annot.retaddr_kind = Some OnReg then 
           Utils.warning Always (L.i_loc fd.f_loc [])
             "for function %s, return address by reg not allowed for that architecture, annotation is ignored"
             fd.f_name.fn_name;
         true
-      | Arch_full.ByReg oreg ->  (* oreg = Some r implies that all call use r,
+      | Arch_full.ByReg { call = oreg } ->  (* oreg = Some r implies that all call use r,
                                     so if the function performs some call r will be overwritten,
                                     so ra need to be saved on stack *)
         let dfl = oreg <> None && has_call_or_syscall fd.f_body in

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -144,6 +144,7 @@ Definition arm_liparams : linearization_params :=
     lip_lmove := arm_lmove;
     lip_check_ws := arm_check_ws;
     lip_lstore  := arm_lstore;
+    lip_lload := arm_lload;
     lip_lstores := lstores_imm_dfl arm_tmp2 arm_lstore ARMFopn.smart_addi is_arith_small;
     lip_lloads  := lloads_imm_dfl arm_tmp2 arm_lload  ARMFopn.smart_addi is_arith_small;
   |}.

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -264,9 +264,8 @@ Qed.
 
 Lemma arm_lload_correct : lload_correct_aux (lip_check_ws arm_liparams) arm_lload.
 Proof.
-  move=> xd xs ofs s vm top hgets.
-  case heq: vtype => [|||ws] //; t_xrbindP.
-  move=> _ <- /eqP ? w hread hset; subst ws.
+  move=> xd xs ofs ws top s w vm heq hcheck hgets hread hset.
+  move/eqP: hcheck => ?; subst ws.
   rewrite /arm_lload /= hgets /= truncate_word_u /= hread /=.
   by rewrite /exec_sopn /= truncate_word_u /= zero_extend_u hset.
 Qed.
@@ -294,6 +293,7 @@ Definition arm_hliparams :
     spec_lip_set_up_sp_register   := arm_spec_lip_set_up_sp_register;
     spec_lip_lmove                := arm_lmove_correct;
     spec_lip_lstore               := arm_lstore_correct;
+    spec_lip_lload                := arm_lload_correct;
     spec_lip_lstores              := arm_lstores_correct;
     spec_lip_lloads               := arm_lloads_correct;
     spec_lip_tmp                  := arm_tmp_correct;

--- a/proofs/compiler/merge_varmaps_proof.v
+++ b/proofs/compiler/merge_varmaps_proof.v
@@ -727,8 +727,9 @@ Section LEMMA.
     case: (checkP ok_p ok_fd) => ok_wrf.
     rewrite /check_fd; t_xrbindP => D.
     set ID := (ID in check_cmd _ ID _).
+    set DF := Sv.union _ D.
     set res := sv_of_list v_var (f_res fd).
-    set params := sv_of_list v_var(f_params fd).
+    set params := sv_of_list v_var (f_params fd).
     move => checked_body hdisj
       checked_params RSP_not_result preserved_magic
       checked_save_stack htmp_call_magic checked_ra.
@@ -741,7 +742,9 @@ Section LEMMA.
          ~Sv.In ra (magic_variables p) &
          ~Sv.In ra params
         ]
-      | RAstack ra _ _ => if ra is Some r then [/\ vtype r == sword Uptr & ~Sv.In r (magic_variables p)] else True
+      | RAstack ra_call ra_return _ _ =>
+        (if ra_call is Some r then [/\ vtype r == sword Uptr & ~Sv.In r (magic_variables p)] else True) /\
+        (if ra_return is Some r then [/\ vtype r == sword Uptr & ~Sv.In r (magic_variables p)] else True)
       | RAnone =>
           let to_save := sv_of_list fst (sf_to_save (f_extra fd)) in
         [/\ disjoint to_save res,
@@ -751,25 +754,40 @@ Section LEMMA.
            (f_params fd)
           ]
       end.
-    - case heq : sf_return_address checked_ra => [ | ra ? | ra ofs ?].
+    - case heq : sf_return_address checked_ra => [ | ra ? | ra_call ra_return ofs ?].
       + by t_xrbindP => ??.
       + t_xrbindP => -> /Sv_memP ra_not_written.
         by rewrite SvP.union_mem negb_or => /andP[] /Sv_memP ra_not_magic /Sv_memP ra_not_param.
-      case: ra heq => [ r | ] // heq.
-      move: preserved_magic; rewrite /writefun_ra ok_fd /ra_vm heq /disjoint.
-      by t_xrbindP => /Sv.is_empty_spec h ->; split => //; SvD.fsetdec.
+      t_xrbindP=> hcall hreturn.
+      move: preserved_magic;
+        rewrite /writefun_ra ok_fd /ra_undef /ra_vm /ra_vm_return heq /disjoint => hempty.
+      split.
+      + case: ra_call heq hempty hcall => [ r | ] // heq.
+        by t_xrbindP => /Sv.is_empty_spec /= h ->; split => //; SvD.fsetdec.
+      case: ra_return heq hempty hreturn => [ r | ] // heq.
+      by t_xrbindP => /Sv.is_empty_spec /= h ->; split => //; SvD.fsetdec.
     have ra_neq_magic :
       match sf_return_address (f_extra fd) with 
-      | RAreg ra _ | RAstack (Some ra) _ _ =>
-         [&& ra != vgd, ra != vrsp & vtype ra == sword Uptr]
+      | RAreg ra _ => [&& ra != vgd, ra != vrsp & vtype ra == sword Uptr]
+      | RAstack ra_call ra_return _ _ =>
+        (if ra_call is Some ra then [&& ra != vgd, ra != vrsp & vtype ra == sword Uptr] else true) &&
+        (if ra_return is Some ra then [&& ra != vgd, ra != vrsp & vtype ra == sword Uptr] else true)
       | _ => True
       end.
-    - case: sf_return_address checked_ra => // [ ra _ | [ ra | ] _ _] //.
+    - case: sf_return_address checked_ra => // [ ra _ | ra_call ra_return _ _].
       + rewrite /magic_variables -/vgd -/vrsp /= => -[].
-        rewrite Sv.add_spec  Sv.singleton_spec => -> ra_not_written.
+        rewrite Sv.add_spec Sv.singleton_spec => -> ra_not_written.
         by case/Decidable.not_or => /eqP -> /eqP -> _.
       rewrite /magic_variables -/vgd -/vrsp /= => -[].
-      rewrite Sv.add_spec  Sv.singleton_spec => ->.
+      move=> hcall hreturn.
+      apply /andP; split.
+      + case: ra_call hcall => [ra_call|//].
+        rewrite /magic_variables -/vgd -/vrsp /= => -[].
+        rewrite Sv.add_spec Sv.singleton_spec => ->.
+        by case/Decidable.not_or => /eqP -> /eqP ->.
+      case: ra_return hreturn => [ra_return|//].
+      rewrite /magic_variables -/vgd -/vrsp /= => -[].
+      rewrite Sv.add_spec Sv.singleton_spec => ->.
       by case/Decidable.not_or => /eqP -> /eqP ->.
     set t1' := with_vm s0 (set_RSP p (emem s0) (ra_undef_vm fd tvm1 var_tmps)).
     have pre1 : merged_vmap_precondition (write_c (f_body fd)) (sf_align (f_extra fd)) (emem s1) (evm t1').
@@ -827,12 +845,12 @@ Section LEMMA.
       + move: vgd (ra_undef _ _) (wrf _) hin not_GD; clear; SvD.fsetdec.
       have z_not_arr : ~~ is_sarr (vtype z).
       + move: hin ra_neq_magic checked_save_stack; clear => /SvD.F.union_1[].
-        * rewrite /ra_vm; case: sf_return_address => [ | ra _ | ra rastack _ ].
+        * rewrite /ra_vm; case: sf_return_address => [ | ra _ | ra_call ra_return rastack _ ].
           - case/SvD.F.union_iff => [ | /vflagsP ->] //.
             by case/SvD.F.add_iff => [<- | /Sv.singleton_spec ->].
           - by move => /Sv.singleton_spec -> /and3P[] _ _ /eqP ->.
-          case: ra; last by SvD.fsetdec.  
-          by move => r /Sv.singleton_spec -> /and3P [] _ _ /eqP ->.
+          case: ra_call; last by SvD.fsetdec.
+          by move => r /Sv.singleton_spec -> /andP[] /and3P [] _ _ /eqP -> _.
         rewrite /saved_stack_vm.
         case: sf_save_stack => [ | ra | ofs ] /=; only 1, 3: SvD.fsetdec.
         by move/Sv.singleton_spec => -> _; t_xrbindP => /eqP ->.
@@ -846,11 +864,11 @@ Section LEMMA.
 
     have [ t2 [ k texec hk ] sim2 ] := ih _ _ _ t1' checked_body pre1 sim1.
     have [tres ok_tres res_uincl] :
-      let: vm := set_RSP p (free_stack (emem t2)) (evm t2) in
+      let: vm := set_RSP p (free_stack (emem t2)) (kill_vars (ra_vm_return fd.(f_extra)) (evm t2)) in
       exists2 tres,
         get_var_is false vm (f_res fd) = ok tres
         & List.Forall2 value_uincl vres' tres.
-    - have : forall x, (x \in [seq (v_var i) | i <- f_res fd]) -> ~Sv.In x D.
+    - have : forall x, (x \in [seq (v_var i) | i <- f_res fd]) -> ~ Sv.In x DF.
       + move=> x hx; have /Sv_memP: Sv.mem x res by rewrite /res sv_of_listE.
         by move /Sv.is_empty_spec: hdisj; SvD.fsetdec.
       move: ok_vres'; rewrite /dc_truncate_val /= => /mapM2_id ?; subst vres'.
@@ -862,12 +880,16 @@ Section LEMMA.
       move => x xs vx hvxs <- ?; rewrite inE negb_or => /andP [ hne hnin] h; subst vx.
       have {ih} [ | tres -> /= res_uincl ] := ih _ hvxs hnin.
       + by move=> ? h1; apply h; rewrite inE h1 orbT.
-      have ex : value_uincl vm.[x] (set_RSP p m vm').[x].
-      + by rewrite /set_RSP Vm.setP_neq //; apply: hvm; apply h; rewrite inE eqxx.
+      have ex : value_uincl vm.[x] (set_RSP p m (kill_vars (ra_vm_return fd.(f_extra)) vm')).[x].
+      + rewrite /set_RSP Vm.setP_neq //.
+        have := h x; rewrite inE eqxx => /(_ erefl).
+        rewrite Sv.union_spec => /Decidable.not_or [hra hD].
+        rewrite kill_varsE; case: Sv_memP => // _.
+        by apply: hvm.
       by eexists; first reflexivity; constructor.
     exists
-       (Sv.union k (Sv.union (ra_vm fd.(f_extra) var_tmps) (saved_stack_vm fd))),
-       (set_RSP p (free_stack (emem t2)) (evm t2)), tres; split.
+       (Sv.union k (Sv.union (ra_undef fd var_tmps) (ra_vm_return fd.(f_extra)))),
+       (set_RSP p (free_stack (emem t2)) (kill_vars (ra_vm_return fd.(f_extra)) (evm t2))), tres; split.
     - econstructor.
       + exact: ok_fd.
       + move: ok_wrf.
@@ -875,7 +897,10 @@ Section LEMMA.
         case: sf_return_address ra_neq_magic checked_ra => //.
         + move => ra _ /and3P [] -> -> -> /= [] _ hra ?? /Sv.subset_spec ok_wrf.
           by apply/Sv_memP => ?; apply: hra; apply: ok_wrf; exact: hk.
-        by case => // ? ? ? /and3P [] -> ->.
+        move=> ra_call ra_return _ _ /andP [hcall hreturn] _ _.
+        apply /andP; split.
+        + by case: ra_call hcall => [ra_call|//] /and3P[] -> -> _.
+        by case: ra_return hreturn => [ra_return|//] /and3P[] -> -> _.
       + move: ok_wrf.
         rewrite /valid_writefun /write_fd /saved_stack_valid /=.
         case: sf_save_stack checked_save_stack => // r; t_xrbindP => _ /Sv_memP r_not_written.
@@ -941,6 +966,7 @@ Proof.
   rewrite /check_fd; t_xrbindP => D.
   rewrite /top_stack_aligned {1  2}Export.
   set ID := (ID in check_c _ ID _).
+  set DF := Sv.union _ D.
   set results := sv_of_list v_var (f_res fd).
   set params := sv_of_list v_var (f_params fd).
   move => checked_body hdisj checked_params RSP_not_result preserved_magic checked_save_stack tmp_call_magic.
@@ -962,13 +988,20 @@ Proof.
   + move/Sv.subset_spec: ok_callee_saved ok_k.
     move: (writefun_ra _ _ _ _) => W.
     move: (sv_of_list _ _) => C.
-    move: (Sv.union _ (saved_stack_vm _)) => X.
+    move: (ra_undef _ _) => X.
     clear.
     SvD.fsetdec.
   + by move: texec; rewrite /ra_undef /ra_undef_vm_none /ra_vm Export /ra_undef_none.
   rewrite -ok_res'.
   apply: mapM_ext => /= r hr.
-  rewrite {2}/get_var Vm.setP_neq //; apply/eqP => K.
+  rewrite {2}/get_var Vm.setP_neq.
+  + rewrite /= kill_varsE.
+    case: Sv_memP => // hra.
+    move: hdisj => /disjoint_union [+ _].
+    rewrite /results => /disjointP => {}hdisj.
+    case: (hdisj r hra).
+    by apply /sv_of_listP/in_map; exists r.
+  apply/eqP => K.
   move: RSP_not_result.
   rewrite /results sv_of_listE => /in_map; apply.
   by exists r.

--- a/proofs/compiler/riscv_decl.v
+++ b/proofs/compiler/riscv_decl.v
@@ -197,7 +197,7 @@ Instance riscv_decl : arch_decl register register_ext xregister rflag condt :=
      To be on the safe side, GP and TP (thread pointer) are marked as callee-saved. *)
   Definition riscv_linux_call_conv : calling_convention :=
   {| callee_saved :=
-   map ARReg [:: SP; RA; GP; TP; X8; X9; X18; X19; X20; X21; X22; X23; X24; X25; X26; X27 ]
+      map ARReg [:: SP; GP; TP; X8; X9; X18; X19; X20; X21; X22; X23; X24; X25; X26; X27 ]
    ; callee_saved_not_bool := erefl true
    ; call_reg_args  := [:: X10; X11; X12; X13; X14; X15; X16; X17 ]
    ; call_xreg_args := [::]

--- a/proofs/compiler/riscv_params.v
+++ b/proofs/compiler/riscv_params.v
@@ -145,6 +145,7 @@ Definition riscv_liparams : linearization_params :=
     lip_lmove := riscv_lmove;
     lip_check_ws := riscv_check_ws;
     lip_lstore  := riscv_lstore;
+    lip_lload := riscv_lload;
     lip_lstores := lstores_imm_dfl riscv_tmp2 riscv_lstore RISCVFopn.smart_addi is_arith_small;
     lip_lloads  := lloads_imm_dfl riscv_tmp2 riscv_lload  RISCVFopn.smart_addi is_arith_small;
   |}.

--- a/proofs/compiler/riscv_params_proof.v
+++ b/proofs/compiler/riscv_params_proof.v
@@ -255,9 +255,8 @@ Qed.
 
 Lemma riscv_lload_correct : lload_correct_aux (lip_check_ws riscv_liparams) riscv_lload.
 Proof.
-  move=> xd xs ofs s vm top hgets.
-  case heq: vtype => [|||ws] //; t_xrbindP.
-  move=> _ <- /eqP ? w hread hset; subst ws.
+  move=> xd xs ofs ws top s w vm heq hcheck hgets hread hset.
+  move/eqP: hcheck => ?; subst ws.
   rewrite /riscv_lload /= hgets /= truncate_word_u /= hread /=.
   by rewrite /exec_sopn /= truncate_word_u /= sign_extend_u hset.
 Qed.
@@ -285,6 +284,7 @@ Definition riscv_hliparams :
     spec_lip_set_up_sp_register   := riscv_spec_lip_set_up_sp_register;
     spec_lip_lmove                := riscv_lmove_correct;
     spec_lip_lstore               := riscv_lstore_correct;
+    spec_lip_lload                := riscv_lload_correct;
     spec_lip_lstores              := riscv_lstores_correct;
     spec_lip_lloads               := riscv_lloads_correct;
     spec_lip_tmp                  := riscv_tmp_correct;

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -124,6 +124,7 @@ Definition x86_liparams : linearization_params :=
     lip_lmove := x86_lmove;
     lip_check_ws := x86_check_ws;
     lip_lstore := x86_lstore;
+    lip_lload := x86_lload;
     lip_lstores := lstores_dfl x86_lstore;
     lip_lloads := lloads_dfl x86_lload;
   |}.

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -242,9 +242,7 @@ Proof. apply/lstores_dfl_correct/x86_lstore_correct. Qed.
 
 Lemma x86_lload_correct : lload_correct_aux (lip_check_ws x86_liparams) x86_lload.
 Proof.
-  move=> xd xs ofs s vm top hgets.
-  case heq: vtype => [|||ws] //; t_xrbindP.
-  move=> _ <- hchk w hread hset.
+  move=> xd xs ofs ws top s w vm heq hcheck hgets hread hset.
   rewrite /x86_lload heq.
   apply: x86_lassign_correct => /=.
   + by rewrite hgets /= truncate_word_u /= hread /= truncate_word_u.
@@ -269,6 +267,7 @@ Definition x86_hliparams {call_conv : calling_convention} : h_linearization_para
     spec_lip_set_up_sp_register   := x86_spec_lip_set_up_sp_register;
     spec_lip_lmove                := x86_lmove_correct;
     spec_lip_lstore               := x86_lstore_correct;
+    spec_lip_lload                := x86_lload_correct;
     spec_lip_lstores              := x86_lstores_correct;
     spec_lip_lloads               := x86_lloads_correct;
     spec_lip_tmp                  := x86_tmp_correct;

--- a/proofs/lang/one_varmap.v
+++ b/proofs/lang/one_varmap.v
@@ -45,10 +45,17 @@ Definition ra_vm (e: stk_fun_extra) (tmp: Sv.t) : Sv.t :=
   match e.(sf_return_address) with
   | RAreg ra _ =>
     Sv.singleton ra
-  | RAstack ra _ _ =>
-    if ra is Some ra then Sv.singleton ra else Sv.empty
-  | RAnone => 
-   Sv.union tmp vflags
+  | RAstack ra_call _ _ _ =>
+    sv_of_option ra_call
+  | RAnone =>
+    Sv.union tmp vflags
+  end.
+
+(* TODO: ra_vm, ra_undef, ra_undef_vm... -> pick better names *)
+Definition ra_vm_return (e : stk_fun_extra) : Sv.t :=
+  match e.(sf_return_address) with
+  | RAstack _ ra_return _ _ => sv_of_option ra_return
+  | _ => Sv.empty
   end.
 
 Definition ra_undef fd (tmp: Sv.t) :=
@@ -56,7 +63,7 @@ Definition ra_undef fd (tmp: Sv.t) :=
 
 Definition tmp_call (e: stk_fun_extra) : Sv.t :=
   match e.(sf_return_address) with
-  | RAreg _ (Some r) | RAstack _ _ (Some r) => Sv.singleton r
+  | RAreg _ (Some r) | RAstack _ _ _ (Some r) => Sv.singleton r
   | _ => Sv.empty
   end.
 


### PR DESCRIPTION
On RISC-V, the return address is read from register RA. This was not reflected in the model and generated wrong programs.

The `RAstack` case of return_address_location is given an additional optional argument `ra_return` that specifies what register to use (if any) when returning from a function. linearization is adapted to generate the right code. reg alloc and merge_varmaps take into account this potential new register.

I'm unsure of the changes I did. In particular, for linearization_proof, I have the impression that there is some kind of duplication between the semantics (ra_vm, ra_undef, ...) and the proof that introduces `killed_by_entry`, `killed_on_exit`, `killed_by_exit`. I managed to have a working version of the proof, but this may not be the principled one.

And the history is horrible, I still have some changes to do, I'll clean it at some point.