### PR TITLE
asm-gen: improve “invalid scale” message

### DIFF
--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -175,7 +175,7 @@ Definition scale_of_z ii (z: Z) : cexec nat :=
   | 2%Z => ok 1
   | 4%Z => ok 2
   | 8%Z => ok 3
-  | _ => Error (E.error ii (pp_s "invalid scale"))
+  | _ => Error (E.error ii (pp_nobox [:: pp_s "invalid scale (should be 1, 2, 4, or 8): "; pp_z z ]))
   end.
 
 Definition reg_of_ovar ii (x:option var_i) : cexec (option reg_t) :=

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -254,7 +254,8 @@ Proof.
   case heq: mk_lea_rec => [lea | //].
   assert (hsemlea := mk_lea_recP hsz64 hsz heq he).
   case hb: lea_base => [b | ]; last by apply (assemble_leaP hsz64 hsz lom hsemlea).
-  case: eqP => [ | _]; last by apply (assemble_leaP hsz64 hsz lom hsemlea).
+  case: eqP => [ | _]; first last.
+  - move=> /map_errP. exact: (assemble_leaP hsz64 hsz lom hsemlea).
   t_xrbindP => hbrip.
   case ho: lea_offset => [ // | ] _ <- /=.
   move: hsemlea; rewrite /sem_lea ho hb /= hbrip (lom_rip _ lom) /= truncate_word_le //= => /ok_inj <-.

--- a/proofs/compiler/compiler_util.v
+++ b/proofs/compiler/compiler_util.v
@@ -141,6 +141,17 @@ Definition add_funname {A} fn (r:cexec A) : cexec A :=
   | Error pp => Error (pp_at_fn fn pp)
   end.
 
+Definition with_pel_msg (e : pp_error_loc) (msg : pp_error) : pp_error_loc :=
+  {|
+    pel_msg := msg;
+    pel_fn := e.(pel_fn);
+    pel_fi := e.(pel_fi);
+    pel_ii := e.(pel_ii);
+    pel_vi := e.(pel_vi);
+    pel_pass := e.(pel_pass);
+    pel_internal := e.(pel_internal)
+  |}.
+
 Lemma add_iinfoP {A a} ii (e:cexec A):
   add_iinfo ii e = ok a -> 
   e = ok a.

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -164,6 +164,13 @@ Definition bind eT aT rT (f : aT -> result eT rT) g :=
 Definition map eT aT rT (f : aT -> rT) := bind (fun x => Ok eT (f x)).
 Definition default eT aT := @apply eT aT aT (fun x => x).
 
+Definition map_err
+  eT1 eT2 aT (f : eT1 -> eT2) (r : result eT1 aT) : result eT2 aT :=
+  match r with
+  | Ok x => Ok _ x
+  | Error e => Error (f e)
+  end.
+
 End Result.
 
 Definition o2r eT aT (e : eT) (o : option aT) :=
@@ -205,6 +212,12 @@ Lemma assertP E b e u :
 Proof. by case: b. Qed.
 
 Arguments assertP {E b e u} _.
+
+Lemma map_errP eT1 eT2 aT (f : eT1 -> eT2) (r : result eT1 aT) x :
+  Result.map_err f r = ok x ->
+  r = ok x.
+Proof. by case: r => //= ? [->]. Qed.
+Arguments map_errP {_ _ _ _ _ _}.
 
 Variant error :=
  | ErrOob | ErrAddrUndef | ErrAddrInvalid | ErrStack | ErrType | ErrArith | ErrSemUndef.


### PR DESCRIPTION
Fixes #949.

Do not hesitate to suggest more improvements to the error message.