### PR TITLE
Fix handling of the arch parameter in jasmin2ec

### DIFF
--- a/compiler/entry/commonCLI.ml
+++ b/compiler/entry/commonCLI.ml
@@ -1,26 +1,24 @@
 open Jasmin
 open Cmdliner
 
-type arch = Amd64 | CortexM
-
 let get_arch_module arch call_conv : (module Arch_full.Arch) =
   (module Arch_full.Arch_from_Core_arch
             ((val match arch with
-                  | Amd64 ->
+                  | Utils.X86_64 ->
                       (module (val CoreArchFactory.core_arch_x86 ~use_lea:false
                                      ~use_set0:false call_conv)
                       : Arch_full.Core_arch)
-                  | CortexM ->
+                  | Utils.ARM_M4 ->
                       (module CoreArchFactory.Core_arch_ARM
                       : Arch_full.Core_arch))))
 
 let arch =
-  let alts = [ ("x86-64", Amd64); ("arm-m4", CortexM) ] in
+  let alts = [ ("x86-64", Utils.X86_64); ("arm-m4", Utils.ARM_M4) ] in
   let doc =
     Format.asprintf "The target architecture (%s)" (Arg.doc_alts_enum alts)
   in
   let arch = Arg.enum alts in
-  Arg.(value & opt arch Amd64 & info [ "arch" ] ~doc)
+  Arg.(value & opt arch Utils.X86_64 & info [ "arch" ] ~doc)
 
 let call_conv =
   let alts =

--- a/compiler/entry/commonCLI.mli
+++ b/compiler/entry/commonCLI.mli
@@ -1,8 +1,6 @@
 open Jasmin
 open Cmdliner
 
-type arch
-
-val get_arch_module : arch -> Glob_options.call_conv -> (module Arch_full.Arch)
-val arch : arch Term.t
+val get_arch_module : Utils.architecture -> Glob_options.call_conv -> (module Arch_full.Arch)
+val arch : Utils.architecture Term.t
 val call_conv : Glob_options.call_conv Term.t

--- a/compiler/entry/jasmin2ec.ml
+++ b/compiler/entry/jasmin2ec.ml
@@ -3,7 +3,7 @@ open Cmdliner
 open CommonCLI
 open Utils
 
-let extract_to_file prog pd asmOp model fnames array_dir outfile =
+let extract_to_file prog arch pd asmOp model fnames array_dir outfile =
   let array_dir =
     if array_dir = None then Option.map Filename.dirname outfile else array_dir
   in
@@ -18,7 +18,7 @@ let extract_to_file prog pd asmOp model fnames array_dir outfile =
   begin try
     BatPervasives.finally
       (fun () -> close ())
-      (fun () -> ToEC.extract prog pd asmOp model fnames array_dir fmt)
+      (fun () -> ToEC.extract prog arch pd asmOp model fnames array_dir fmt)
       ()
   with e ->
     BatPervasives.ignore_exceptions
@@ -45,7 +45,7 @@ let parse_and_extract arch call_conv =
       with Typing.TyError (loc, code) ->
         hierror ~loc:(Lmore loc) ~kind:"typing error" "%s" code
     in
-    extract_to_file prog A.reg_size A.asmOp model functions array_dir output
+    extract_to_file prog arch A.reg_size A.asmOp model functions array_dir output
   in
   fun model functions array_dir output file ->
     match extract model functions array_dir output file with

--- a/compiler/scripts/extract-and-check
+++ b/compiler/scripts/extract-and-check
@@ -12,16 +12,16 @@ if [ -d "${DIR}" ]; then rm -r ${DIR}; fi
 mkdir -p $DIR
 
 if [ "$1" = "arm" ]; then
-	ARCH="-arch arm-m4"
+	ARCH="--arch=arm-m4"
 else
-	ARCH="-arch x86-64"
+	ARCH="--arch=x86-64"
 fi
 
 set -x
 set -o xtrace
 
-$(dirname $0)/../jasminc ${ARCH} -oecarray ${DIR} -oec ${EC} "$2"
-$(dirname $0)/../jasminc ${ARCH} -oecarray ${DIR} -CT -oec ${CT} "$2"
+$(dirname $0)/../jasmin2ec ${ARCH} -o ${EC} "$2"
+$(dirname $0)/../jasmin2ec ${ARCH} -o ${CT} -m CT "$2"
 
 easycrypt -I Jasmin:${ECLIB} ${ECARGS} ${EC}
 easycrypt -I Jasmin:${ECLIB} ${ECARGS} ${CT}

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -46,9 +46,6 @@ let set_stack_zero_strategy s =
 let stack_zero_size = ref None
 let set_stack_zero_size s = stack_zero_size := Some (Annot.ws_of_string s)
 
-type architecture =
-  | X86_64
-  | ARM_M4
 let target_arch = ref X86_64
 
 let set_target_arch a =

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -181,7 +181,7 @@ let main () =
         BatPervasives.finally
           (fun () -> close ())
           (fun () ->
-            ToEC.extract prog Arch.reg_size Arch.asmOp !model !ec_list (Some !ec_array_path) fmt
+            ToEC.extract prog !Glob_options.target_arch Arch.reg_size Arch.asmOp !model !ec_list (Some !ec_array_path) fmt
           )
           ()
       with e ->

--- a/compiler/src/toEC.mli
+++ b/compiler/src/toEC.mli
@@ -2,6 +2,7 @@ val ty_expr : Prog.expr -> Prog.ty
 val ty_lval : Prog.lval -> Prog.ty
 val extract :
   ('info, ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op) Prog.prog ->
+  Utils.architecture ->
   Wsize.wsize ->
   ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op Sopn.asmOp ->
   Utils.model ->

--- a/compiler/src/utils.ml
+++ b/compiler/src/utils.ml
@@ -231,6 +231,11 @@ let pp_string fmt s =
   Format.fprintf fmt "%s" s
 
 (* -------------------------------------------------------------------- *)
+type architecture =
+  | X86_64
+  | ARM_M4
+
+(* -------------------------------------------------------------------- *)
 type model =
   | ConstantTime
   | Normal

--- a/compiler/src/utils.mli
+++ b/compiler/src/utils.mli
@@ -133,6 +133,11 @@ val pp_maybe_paren : bool -> 'a pp -> 'a pp
 val pp_string : string pp
  
 (* -------------------------------------------------------------------- *)
+type architecture =
+  | X86_64
+  | ARM_M4
+
+(* -------------------------------------------------------------------- *)
 type model = 
   | ConstantTime
   | Normal


### PR DESCRIPTION
Was generating `require import JModel_x86` on ARM due to using `Glob_options`. Prevent from regressing by moving tests of extraction from `jasminc` to `jasmin2ec`.