### PR TITLE
x86: improve description of AVX shift instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
   `-ec`, `-oec`, `-oecarray` and `-CT` command-line options are deprecated
   ([PR #914](https://github.com/jasmin-lang/jasmin/pull/914)).
 
+- Improve description of x86 AVX shift instructions; this changes the type of
+  the vectorized shift operations: the second argument is now a 128-bit value
+  ([PR #955](https://github.com/jasmin-lang/jasmin/pull/955);
+  fixes [#950](https://github.com/jasmin-lang/jasmin/issues/950)).
+
 # Jasmin 2024.07.1 — Nancy, 2024-10-03
 
 ## New features

--- a/compiler/examples/gimli/proofs/gimliv.ec
+++ b/compiler/examples/gimli/proofs/gimliv.ec
@@ -19,5 +19,6 @@ proof.
   proc; inline *; wp.
   while (={round} /\ eqstate (x{1}, y{1}, z{1}) state{2}); auto.
   unroll for{2} ^while; wp; skip => />.
-  by rewrite !/VPSHUFD_128 !/VPSHUFD_128_B /= zeroextu128E.
+  rewrite !/VPSHUFD_128 !/VPSHUFD_128_B /= zeroextu128E.
+  by rewrite /VPSLL_4u32 /VPSRL_4u32 /(`|<<|`) /(`<<`) !rol_xor.
 qed.

--- a/compiler/tests/success/x86-64/vector.jazz
+++ b/compiler/tests/success/x86-64/vector.jazz
@@ -306,3 +306,46 @@ e ^= d;
 
 (u256)[p + 32 ] = e;
 }
+
+export
+fn test_vpsra(reg u64 p) {
+  reg u128 x y;
+  x = (u128)[p];
+  y = #VPSRA_8u16(x, (u128)[p + 16 * 1]);
+  x = #VPSRA_8u16(x, y);
+  y = #VPSRA_8u16(x, 7);
+
+  x = #VPSRA_4u32(y, (u128)[p + 16 * 2]);
+  y = #VPSRA_4u32(x, y);
+  x = #VPSRA_4u32(y, 17);
+
+  x >> 8s16 = (u128)[p + 16 * 3];
+  x >> 8s16 = y;
+  x >> 8s16 = 12;
+
+  x >> 4s32 = (u128)[p + 16 * 4];
+  x >> 4s32 = y;
+  x >> 4s32 = 22;
+
+  (u128)[p] = x;
+
+  reg u256 z t;
+  z = (u256)[p + 32 * 2];
+  t = #VPSRA_16u16(z, (u128)[p + 16 * 6]);
+  z = #VPSRA_16u16(z, t);
+  t = #VPSRA_16u16(z, 5);
+
+  z = #VPSRA_8u32(t, (u128)[p + 16 * 7]);
+  t = #VPSRA_8u32(z, t);
+  z = #VPSRA_8u32(z, 23);
+
+  z >> 16s16 = (u128)[p + 16 * 8];
+  z >> 16s16 = t;
+  z >> 16s16 = 14;
+
+  z >> 8s32 = (u128)[p + 16 * 9];
+  z >> 8s32 = t;
+  z >> 8s32 = 24;
+
+  (u256)[p] = z;
+}

--- a/eclib/JModel_x86.ec
+++ b/eclib/JModel_x86.ec
@@ -6,20 +6,20 @@ require export JModel_common JArray JWord_array Jslh JMemory AES.
 (* ------------------------------------------------------------------- *)
 
 (* Semantics for expressions *)
-abbrev [-printing] (\vshr8u128)  (w1:W128.t) (w2:W8.t) = VPSRL_16u8 w1 w2.
-abbrev [-printing] (\vshr16u128) (w1:W128.t) (w2:W8.t) = VPSRL_8u16 w1 w2.
-abbrev [-printing] (\vshr32u128) (w1:W128.t) (w2:W8.t) = VPSRL_4u32 w1 w2.
-abbrev [-printing] (\vshr64u128) (w1:W128.t) (w2:W8.t) = VPSRL_2u64 w1 w2.
+abbrev [-printing] (\vshr8u128)  (w1:W128.t) (w2:W128.t) = VPSRL_16u8 w1 w2.
+abbrev [-printing] (\vshr16u128) (w1:W128.t) (w2:W128.t) = VPSRL_8u16 w1 w2.
+abbrev [-printing] (\vshr32u128) (w1:W128.t) (w2:W128.t) = VPSRL_4u32 w1 w2.
+abbrev [-printing] (\vshr64u128) (w1:W128.t) (w2:W128.t) = VPSRL_2u64 w1 w2.
 
-abbrev [-printing] (\vshl8u128)  (w1:W128.t) (w2:W8.t) = VPSLL_16u8 w1 w2.
-abbrev [-printing] (\vshl16u128) (w1:W128.t) (w2:W8.t) = VPSLL_8u16 w1 w2.
-abbrev [-printing] (\vshl32u128) (w1:W128.t) (w2:W8.t) = VPSLL_4u32 w1 w2.
-abbrev [-printing] (\vshl64u128) (w1:W128.t) (w2:W8.t) = VPSLL_2u64 w1 w2.
+abbrev [-printing] (\vshl8u128)  (w1:W128.t) (w2:W128.t) = VPSLL_16u8 w1 w2.
+abbrev [-printing] (\vshl16u128) (w1:W128.t) (w2:W128.t) = VPSLL_8u16 w1 w2.
+abbrev [-printing] (\vshl32u128) (w1:W128.t) (w2:W128.t) = VPSLL_4u32 w1 w2.
+abbrev [-printing] (\vshl64u128) (w1:W128.t) (w2:W128.t) = VPSLL_2u64 w1 w2.
 
-abbrev [-printing] (\vsar8u128)  (w1:W128.t) (w2:W8.t) = VPSRA_16u8 w1 w2.
-abbrev [-printing] (\vsar16u128) (w1:W128.t) (w2:W8.t) = VPSRA_8u16 w1 w2.
-abbrev [-printing] (\vsar32u128) (w1:W128.t) (w2:W8.t) = VPSRA_4u32 w1 w2.
-abbrev [-printing] (\vsar64u128) (w1:W128.t) (w2:W8.t) = VPSRA_2u64 w1 w2.
+abbrev [-printing] (\vsar8u128)  (w1:W128.t) (w2:W128.t) = VPSRA_16u8 w1 w2.
+abbrev [-printing] (\vsar16u128) (w1:W128.t) (w2:W128.t) = VPSRA_8u16 w1 w2.
+abbrev [-printing] (\vsar32u128) (w1:W128.t) (w2:W128.t) = VPSRA_4u32 w1 w2.
+abbrev [-printing] (\vsar64u128) (w1:W128.t) (w2:W128.t) = VPSRA_2u64 w1 w2.
 
 abbrev [-printing] (\vadd8u128)  (w1 w2:W128.t) = VPADD_16u8 w1 w2.
 abbrev [-printing] (\vadd16u128) (w1 w2:W128.t) = VPADD_8u16 w1 w2.
@@ -36,20 +36,20 @@ abbrev [-printing] (\vmul16u128) (w1 w2:W128.t) = VPMULL_8u16 w1 w2.
 abbrev [-printing] (\vmul32u128) (w1 w2:W128.t) = VPMULL_4u32 w1 w2.
 abbrev [-printing] (\vmul64u128) (w1 w2:W128.t) = VPMULL_2u64 w1 w2.
 
-abbrev [-printing] (\vshr8u256)  (w1:W256.t) (w2:W8.t) = VPSRL_32u8 w1 w2.
-abbrev [-printing] (\vshr16u256) (w1:W256.t) (w2:W8.t) = VPSRL_16u16 w1 w2.
-abbrev [-printing] (\vshr32u256) (w1:W256.t) (w2:W8.t) = VPSRL_8u32 w1 w2.
-abbrev [-printing] (\vshr64u256) (w1:W256.t) (w2:W8.t) = VPSRL_4u64 w1 w2.
+abbrev [-printing] (\vshr8u256)  (w1:W256.t) (w2:W128.t) = VPSRL_32u8 w1 w2.
+abbrev [-printing] (\vshr16u256) (w1:W256.t) (w2:W128.t) = VPSRL_16u16 w1 w2.
+abbrev [-printing] (\vshr32u256) (w1:W256.t) (w2:W128.t) = VPSRL_8u32 w1 w2.
+abbrev [-printing] (\vshr64u256) (w1:W256.t) (w2:W128.t) = VPSRL_4u64 w1 w2.
 
-abbrev [-printing] (\vshl8u256)  (w1:W256.t) (w2:W8.t) = VPSLL_32u8 w1 w2.
-abbrev [-printing] (\vshl16u256) (w1:W256.t) (w2:W8.t) = VPSLL_16u16 w1 w2.
-abbrev [-printing] (\vshl32u256) (w1:W256.t) (w2:W8.t) = VPSLL_8u32 w1 w2.
-abbrev [-printing] (\vshl64u256) (w1:W256.t) (w2:W8.t) = VPSLL_4u64 w1 w2.
+abbrev [-printing] (\vshl8u256)  (w1:W256.t) (w2:W128.t) = VPSLL_32u8 w1 w2.
+abbrev [-printing] (\vshl16u256) (w1:W256.t) (w2:W128.t) = VPSLL_16u16 w1 w2.
+abbrev [-printing] (\vshl32u256) (w1:W256.t) (w2:W128.t) = VPSLL_8u32 w1 w2.
+abbrev [-printing] (\vshl64u256) (w1:W256.t) (w2:W128.t) = VPSLL_4u64 w1 w2.
 
-abbrev [-printing] (\vsar8u256)  (w1:W256.t) (w2:W8.t) = VPSRA_32u8 w1 w2.
-abbrev [-printing] (\vsar16u256) (w1:W256.t) (w2:W8.t) = VPSRA_16u16 w1 w2.
-abbrev [-printing] (\vsar32u256) (w1:W256.t) (w2:W8.t) = VPSRA_8u32 w1 w2.
-abbrev [-printing] (\vsar64u256) (w1:W256.t) (w2:W8.t) = VPSRA_4u64 w1 w2.
+abbrev [-printing] (\vsar8u256)  (w1:W256.t) (w2:W128.t) = VPSRA_32u8 w1 w2.
+abbrev [-printing] (\vsar16u256) (w1:W256.t) (w2:W128.t) = VPSRA_16u16 w1 w2.
+abbrev [-printing] (\vsar32u256) (w1:W256.t) (w2:W128.t) = VPSRA_8u32 w1 w2.
+abbrev [-printing] (\vsar64u256) (w1:W256.t) (w2:W128.t) = VPSRA_4u64 w1 w2.
 
 abbrev [-printing] (\vadd8u256)  (w1 w2:W256.t) = VPADD_32u8 w1 w2.
 abbrev [-printing] (\vadd16u256) (w1 w2:W256.t) = VPADD_16u16 w1 w2.

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -2519,14 +2519,14 @@ abstract theory W_WS.
    op VPMULH_'Ru'S (w1 : WB.t) (w2 : WB.t) =
      map2 (fun (x y:WS.t) => wmulhs x y) w1 w2.
 
-   op VPSLL_'Ru'S (w : WB.t) (cnt : W8.t) =
-     map (fun (w:WS.t) => w `<<` cnt) w.
+   op VPSLL_'Ru'S (w : WB.t) (cnt : W128.t) =
+     map (fun (w:WS.t) => w `<<<` (to_uint cnt %% sizeS)) w.
 
-   op VPSRL_'Ru'S (w : WB.t) (cnt : W8.t) =
-     map (fun (w:WS.t) => w `>>` cnt) w.
+   op VPSRL_'Ru'S (w : WB.t) (cnt : W128.t) =
+     map (fun (w:WS.t) => w `>>>` (to_uint cnt %% sizeS)) w.
 
-   op VPSRA_'Ru'S (w : WB.t) (cnt : W8.t) =
-     map (fun (w:WS.t) => w `|>>` cnt) w.
+   op VPSRA_'Ru'S (w : WB.t) (cnt : W128.t) =
+     map (fun (w:WS.t) => w `|>>>` (to_uint cnt %% sizeS)) w.
 
    op VPBROADCAST_'Ru'S (w : WS.t) =
      pack'R (map (fun i => w) (iota_ 0 r)).
@@ -2564,28 +2564,6 @@ abstract theory W_WS.
    op VPSRLV_'Ru'S (w1:WB.t) (w2:WB.t) =
      let srl = fun (x1 x2:WS.t) => x1 `>>>` WS.to_uint x2 in
      map2 srl w1 w2.
-
-   (** TODO CHECKME : still x86 **)
-   lemma x86_'Ru'S_rol_xor i w : 0 < i < sizeS =>
-      VPSLL_'Ru'S w (W8.of_int i) +^ VPSRL_'Ru'S w (W8.of_int (sizeS - i)) =
-      map (fun w0 => WS.rol w0 i) w.
-   proof.
-     move=> hr;rewrite /VPSRL_'Ru'S /VPSLL_'Ru'S.
-     apply wordP => j hj.
-     by rewrite xorb'SE !mapbE 1..3:// /= rol_xor_shft.
-   qed.
-
-   (** TODO CHECKME : still x86 **)
-   lemma x86_'Ru'S_rol_xor_red w1 w2 i si:
-     w1 = w2 => W8.to_uint si = sizeS - W8.to_uint i => 0 < W8.to_uint i < sizeS =>
-     VPSLL_'Ru'S w1 i +^ VPSRL_'Ru'S w2 si =
-     map (fun w0 => WS.rol w0 (W8.to_uint i)) w1.
-   proof.
-     by move=> -> hsi hi; rewrite -(W8.to_uintK i) -(W8.to_uintK si) hsi x86_'Ru'S_rol_xor.
-   qed.
-
-   (** TODO CHECKME : same **)
-   hint simplify x86_'Ru'S_rol_xor_red.
 
 end W_WS.
 

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -362,7 +362,7 @@ Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
     | Ovlsr ve sz =>
       kb ((U16 <= ve) && (U128 <= sz))%CMP sz (LowerCopn (Ox86 (VPSRL ve sz)) [::a; b])
     | Ovasr ve sz =>
-      kb ((U16 <= ve) && (U128 <= sz))%CMP sz (LowerCopn (Ox86 (VPSRA ve sz)) [::a; b])
+      kb ((size_16_32 ve) && (U128 <= sz))%CMP sz (LowerCopn (Ox86 (VPSRA ve sz)) [::a; b])
 
     | _ => LowerAssgn
     end

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -1040,7 +1040,7 @@ Section PROOF.
         move => ?; subst v.
         move: Hv'; rewrite /truncate_val /= truncate_word_u => /ok_inj ?; subst v'.
         rewrite ok_v1 /= ok_v2 /= /x86_VPSRA /x86_u128_shift /=.
-        rewrite (size_128_256_ge hle2) (size_16_64_ve hle1) /=.
+        rewrite (size_128_256_ge hle2) hle1 /=.
         by rewrite !truncate_word_le.
     (* PappN *)
     + case: op => // - [] // - [] //.

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -156,8 +156,9 @@ Definition type_of_op2 (o: sop2) : stype * stype * stype :=
   | Oland s | Olor s | Olxor s | Ovadd _ s | Ovsub _ s | Ovmul _ s
     => let t := sword s in (t, t, t)
   | Olsr s | Olsl (Op_w s) | Oasr (Op_w s) | Oror s | Orol s
-  | Ovlsr _ s | Ovlsl _ s | Ovasr _ s
     => let t := sword s in (t, sword8, t)
+  | Ovlsr _ s | Ovlsl _ s | Ovasr _ s
+    => let t := sword s in (t, sword128, t)
   | Oeq Op_int | Oneq Op_int
   | Olt Cmp_int | Ole Cmp_int
   | Ogt Cmp_int | Oge Cmp_int

--- a/proofs/lang/sem_op_typed.v
+++ b/proofs/lang/sem_op_typed.v
@@ -46,13 +46,13 @@ Definition sem_vadd (ve:velem) {ws:wsize} := (lift2_vec ve +%R ws).
 Definition sem_vsub (ve:velem) {ws:wsize} := (lift2_vec ve (fun x y => x - y)%R ws).
 Definition sem_vmul (ve:velem) {ws:wsize} := (lift2_vec ve *%R ws).
 
-Definition sem_vshr (ve:velem) {ws:wsize} (v : word ws) (i:u8) :=
+Definition sem_vshr (ve:velem) {ws:wsize} (v : word ws) (i: u128) :=
   lift1_vec ve (fun x => wshr x (wunsigned i)) ws v.
 
-Definition sem_vsar (ve:velem) {ws:wsize} (v : word ws) (i:u8) :=
+Definition sem_vsar (ve:velem) {ws:wsize} (v : word ws) (i: u128) :=
   lift1_vec ve (fun x => wsar x (wunsigned i)) ws v.
 
-Definition sem_vshl (ve:velem) {ws:wsize} (v : word ws) (i:u8) :=
+Definition sem_vshl (ve:velem) {ws:wsize} (v : word ws) (i: u128) :=
   lift1_vec ve (fun x => wshl x (wunsigned i)) ws v.
 
 Definition signed {A:Type} (fu fs:A) s :=


### PR DESCRIPTION
- VPSRA only supports 16 or 32 bit elements
- count argument can be in xmm register or in memory