### PR TITLE
Patch for issue 943

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
   ([PR #948](https://github.com/jasmin-lang/jasmin/pull/948);
   fixes [#931](https://github.com/jasmin-lang/jasmin/issues/931)).
 
+- Correcting shift in location produced by multiline string annotations 
+  ([PR #959](https://github.com/jasmin-lang/jasmin/pull/959);
+  fixes [[#943](https://github.com/jasmin-lang/jasmin/issues/943)])
+
 ## Other changes
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 - Correcting shift in location produced by multiline string annotations 
   ([PR #959](https://github.com/jasmin-lang/jasmin/pull/959);
-  fixes [[#943](https://github.com/jasmin-lang/jasmin/issues/943)])
+  fixes [#943](https://github.com/jasmin-lang/jasmin/issues/943)).
 
 ## Other changes
 

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -141,7 +141,7 @@ rule main = parse
   | "//" [^'\n']* newline { Lexing.new_line lexbuf; main lexbuf }
   | "//" [^'\n']* eof     { main lexbuf }
 
-  | '"' (([^'"' '\\']|'\\' _)* as s) '"' { increment_newline s lexbuf;STRING (unescape (L.of_lexbuf lexbuf) s) }
+  | '"' (([^'"' '\\']|'\\' _)* as s) '"' { increment_newline s lexbuf; STRING (unescape (L.of_lexbuf lexbuf) s) }
 
   | (digit+(('_')+ digit+)*) as s
 

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -7,11 +7,9 @@
 
   let increment_newline s lexbuf =
     let newlines = String.count_char s '\n' in 
-    let rec loop count = 
-      match count with
-      | 0 -> ()
-      | _ -> Lexing.new_line lexbuf; loop (count - 1)
-    in loop newlines
+    for _ = 1 to newlines do
+      Lexing.new_line lexbuf
+    done
 
 
   let unterminated_comment loc =

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -5,21 +5,13 @@
   module L = Location
   module S = Syntax
 
-  let count_newline s = 
-   let rec sub s acc = 
-   match s with 
-    | c::q when c='\n' -> sub q (acc+1)
-    | c::q -> sub q acc
-    | [] -> acc
-    in 
-    sub (String.explode s) 0
-
   let increment_newline s lexbuf =
-    let newlines = ref(count_newline s) in 
-    while !newlines > 0 do
-      Lexing.new_line lexbuf;
-      newlines := !newlines - 1
-    done
+    let newlines = String.count_char s '\n' in 
+    let rec loop count = 
+      match count with
+      | 0 -> ()
+      | _ -> Lexing.new_line lexbuf; loop (count - 1)
+    in loop newlines
 
 
   let unterminated_comment loc =

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -5,6 +5,23 @@
   module L = Location
   module S = Syntax
 
+  let count_newline s = 
+   let rec sub s acc = 
+   match s with 
+    | c::q when c='\n' -> sub q (acc+1)
+    | c::q -> sub q acc
+    | [] -> acc
+    in 
+    sub (String.explode s) 0
+
+  let increment_newline s lexbuf =
+    let newlines = ref(count_newline s) in 
+    while !newlines > 0 do
+      Lexing.new_line lexbuf;
+      newlines := !newlines - 1
+    done
+
+
   let unterminated_comment loc =
     raise (S.ParseError (loc, Some "unterminated comment"))
 
@@ -134,7 +151,7 @@ rule main = parse
   | "//" [^'\n']* newline { Lexing.new_line lexbuf; main lexbuf }
   | "//" [^'\n']* eof     { main lexbuf }
 
-  | '"' (([^'"' '\\']|'\\' _)* as s) '"' { STRING (unescape (L.of_lexbuf lexbuf) s) }
+  | '"' (([^'"' '\\']|'\\' _)* as s) '"' { increment_newline s lexbuf;STRING (unescape (L.of_lexbuf lexbuf) s) }
 
   | (digit+(('_')+ digit+)*) as s
 

--- a/compiler/tests/fail/common/newline_in_annotation_string.jazz
+++ b/compiler/tests/fail/common/newline_in_annotation_string.jazz
@@ -1,8 +1,0 @@
-#annot = "
-This annotation looks \n
-very long to me \n
-so it should skip 
-multiple lines
-while parsed by the compiler
-"
-export fn main(stack u8[1] a) {}

--- a/compiler/tests/fail/common/newline_in_annotation_string.jazz
+++ b/compiler/tests/fail/common/newline_in_annotation_string.jazz
@@ -1,0 +1,8 @@
+#annot = "
+This annotation looks \n
+very long to me \n
+so it should skip 
+multiple lines
+while parsed by the compiler
+"
+export fn main(stack u8[1] a) {}

--- a/compiler/tests/sct-checker/reject.expected
+++ b/compiler/tests/sct-checker/reject.expected
@@ -31,12 +31,12 @@ File bug_887.jazz:
 Failed as expected test_venv: "fail/bug_887.jazz", line 13 (3-4):
                               speculative constant type checker: r has type #secret but should be at most #public
 File conditional-expr.jazz:
-Failed as expected leak_cond: "fail/conditional-expr.jazz", line 6 (11-12):
+Failed as expected leak_cond: "fail/conditional-expr.jazz", line 10 (11-12):
                               speculative constant type checker: return type for x is #[ptr = secret, val = secret] it should be less than #[ptr = secret, val = public]
 File corruption.jazz:
-Failed as expected does_corrupt_memory: "fail/corruption.jazz", line 26 (12-13):
+Failed as expected does_corrupt_memory: "fail/corruption.jazz", line 32 (12-13):
                                         speculative constant type checker: return type for y is #[ptr = public, val = transient] it should be less than #[ptr = public, val = public]
-Failed as expected corrupts_memory: "fail/corruption.jazz", line 12 (12-13):
+Failed as expected corrupts_memory: "fail/corruption.jazz", line 15 (12-13):
                                     speculative constant type checker: return type for y is #[ptr = public, val = transient] it should be less than #[ptr = public, val = public]
 File functions.jazz:
 Failed as expected call_kills_msf: "fail/functions.jazz", line 9 (2-10):


### PR DESCRIPTION
A little correction for issue 943. We count the number of linebreaks inside annotation string and increment the variable by this amount