### PR TITLE
DIV + REM

### DIFF
--- a/compiler/tests/success/risc-v/div.jazz
+++ b/compiler/tests/success/risc-v/div.jazz
@@ -1,0 +1,16 @@
+export
+fn div(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x;
+
+    // Signed
+    x = arg0 /32s arg1;
+    [x] = x;
+
+    // Unsigned
+    x = arg0 /32u arg1;
+    [x] = x;
+
+    reg u32 res;
+    res = x;
+    return res;
+}

--- a/compiler/tests/success/risc-v/intrinsic_div.jazz
+++ b/compiler/tests/success/risc-v/intrinsic_div.jazz
@@ -1,0 +1,17 @@
+export
+fn div(reg u32 arg0, reg u32 arg1) -> reg u32 {
+  reg u32 x;
+
+  // Signed
+  x = #DIV(arg0, arg1);
+  [x] = x;
+
+  // Unsigned
+  x = #DIVU(arg0, arg1);
+  [x] = x;
+
+  reg u32 res;
+  res = x;
+
+  return res;
+}

--- a/compiler/tests/success/risc-v/intrinsic_rem.jazz
+++ b/compiler/tests/success/risc-v/intrinsic_rem.jazz
@@ -1,0 +1,17 @@
+export
+fn div(reg u32 arg0, reg u32 arg1) -> reg u32 {
+  reg u32 x;
+
+  // Signed
+  x = #REM(arg0, arg1);
+  [x] = x;
+
+  // Unsigned
+  x = #REMU(arg0, arg1);
+  [x] = x;
+
+  reg u32 res;
+  res = x;
+
+  return res;
+}

--- a/compiler/tests/success/risc-v/rem.jazz
+++ b/compiler/tests/success/risc-v/rem.jazz
@@ -1,0 +1,16 @@
+export
+fn rem(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x;
+
+    // Signed
+    x = arg0 %32s arg1;
+    [x] = x;
+
+    // Unsigned
+    x = arg0 %32u arg1;
+    [x] = x;
+
+    reg u32 res;
+    res = x;
+    return res;
+}

--- a/eclib/JModel_riscv.ec
+++ b/eclib/JModel_riscv.ec
@@ -61,8 +61,8 @@ abbrev [-printing] MULHU = W32.mulhi.
 
 op MULHSU (x y : W32.t) : W32.t = W32.of_int ((to_sint x * to_uint y) %/ W32.modulus).
 
-abbrev [-printing] DIV = W32.(\sdiv).
-abbrev [-printing] DIVU = W32.(\udiv).
+abbrev [-printing] DIV (x y : W32.t) : W32.t = if y = W32.of_int(0) then W32.of_int(-1) else W32.(\sdiv) x y.
+abbrev [-printing] DIVU (x y : W32.t) : W32.t = if y = W32.of_int(0) then W32.of_int(-1) else W32.(\udiv) x y.
 
 abbrev [-printing] REM = W32.(\smod).
 abbrev [-printing] REMU = W32.(\umod).

--- a/eclib/JModel_riscv.ec
+++ b/eclib/JModel_riscv.ec
@@ -60,3 +60,9 @@ abbrev [-printing] MULH = W32.wmulhs.
 abbrev [-printing] MULHU = W32.mulhi.
 
 op MULHSU (x y : W32.t) : W32.t = W32.of_int ((to_sint x * to_uint y) %/ W32.modulus).
+
+abbrev [-printing] DIV = W32.(\sdiv).
+abbrev [-printing] DIVU = W32.(\udiv).
+
+abbrev [-printing] REM = W32.(\smod).
+abbrev [-printing] REMU = W32.(\umod).

--- a/proofs/compiler/riscv_decl.v
+++ b/proofs/compiler/riscv_decl.v
@@ -24,8 +24,10 @@ Definition riscv_xreg_size := U64. (* Unused *)
 
 (* -------------------------------------------------------------------- *)
 (* Registers. *)
+(* According to the RISC-V ABI, X3/GP and X4/TP are unallocatable, so we do not
+   model them. *)
 Variant register : Type :=
-| RA  | SP  | GP  | TP  | X5  | X6  | X7  | X8  (* General-purpose registers. *)
+| RA  | SP  | X5  | X6  | X7  | X8              (* General-purpose registers. *)
 | X9  | X10 | X11 | X12 | X13 | X14 | X15 | X16 (* General-purpose registers. *)
 | X17 | X18 | X19 | X20 | X21 | X22 | X23 | X24 (* General-purpose registers. *)
 | X25 | X26 | X27 | X28 | X29 | X30 | X31.      (* General-purpose registers. *)
@@ -44,7 +46,7 @@ Instance eqTC_register : eqTypeC register :=
 Canonical riscv_register_eqType := @ceqT_eqType _ eqTC_register.
 
 Definition registers :=
-  [::  RA;  SP;  GP;  TP;  X5;  X6;  X7;  X8;
+  [::  RA;  SP;  X5;  X6;  X7;  X8;
        X9; X10; X11; X12; X13; X14; X15; X16;
       X17; X18; X19; X20; X21; X22; X23; X24;
       X25; X26; X27; X28; X29; X30; X31
@@ -67,8 +69,6 @@ Definition register_to_string (r : register) : string :=
   match r with
   | RA  => "ra"
   | SP  => "sp"
-  | GP  => "gp"
-  | TP  => "tp"
   | X5  => "x5"
   | X6  => "x6"
   | X7  => "x7"
@@ -197,7 +197,7 @@ Instance riscv_decl : arch_decl register register_ext xregister rflag condt :=
      To be on the safe side, GP and TP (thread pointer) are marked as callee-saved. *)
   Definition riscv_linux_call_conv : calling_convention :=
   {| callee_saved :=
-      map ARReg [:: SP; GP; TP; X8; X9; X18; X19; X20; X21; X22; X23; X24; X25; X26; X27 ]
+      map ARReg [:: SP; X8; X9; X18; X19; X20; X21; X22; X23; X24; X25; X26; X27 ]
    ; callee_saved_not_bool := erefl true
    ; call_reg_args  := [:: X10; X11; X12; X13; X14; X15; X16; X17 ]
    ; call_xreg_args := [::]

--- a/proofs/compiler/riscv_lowering.v
+++ b/proofs/compiler/riscv_lowering.v
@@ -114,11 +114,17 @@ Definition lower_Papp2
   let%opt _ := chk_ws_reg ws in
   match op with
   | Oadd (Op_w _) => decide_op_reg_imm U32 e0 e1 (BaseOp(None, ADD)) (BaseOp(None, ADDI))
+  | Omul (Op_w _) => Some (BaseOp (None, MUL), [:: e0; e1])
   | Osub (Op_w _) => decide_op_reg_imm_neg U32 e0 e1 (BaseOp(None, SUB)) (BaseOp(None, ADDI))
+  | Odiv (Cmp_w sg U32) =>
+    let o := if sg is Signed then DIV else DIVU in
+    Some (BaseOp (None, o), [:: e0; e1])
+  | Omod (Cmp_w sg U32) =>
+    let o := if sg is Signed then REM else REMU in
+    Some (BaseOp (None, o), [:: e0; e1])
   | Oland _ => decide_op_reg_imm U32 e0 e1 (BaseOp(None, AND)) (BaseOp(None, ANDI))
   | Olor _ => decide_op_reg_imm U32 e0 e1 (BaseOp(None, OR)) (BaseOp(None, ORI))
   | Olxor _ => decide_op_reg_imm U32 e0 e1 (BaseOp(None, XOR)) (BaseOp(None, XORI))
-  | Omul (Op_w _) => Some (BaseOp (None, MUL), [:: e0; e1])
   | Olsr U32 =>
     if check_shift_amount e1 is Some(e1) then
       let op := if is_wconst U8 e1 then SRLI else SRL in

--- a/proofs/compiler/riscv_lowering_proof.v
+++ b/proofs/compiler/riscv_lowering_proof.v
@@ -489,6 +489,56 @@ Proof.
     have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
       Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
     by apply sem_correct; rewrite /= wsub_zero_extend.
+  + case: o ok_v => // -[] [] //=.
+    + rewrite /sem_sop2 /=.
+      t_xrbindP=> w1 ok_w1 w2 ok_w2.
+      rewrite /mk_sem_divmod /=.
+      case w2_nzero: eq_op => //=.
+      case: andb => //.
+      move=> _ [<-] ?; subst v.
+      move=> [<- <- <-].
+      rewrite /sem_sopn /= ok_v1 ok_v2 /=.
+      rewrite /exec_sopn /= ok_w1 ok_w2 /=.
+      rewrite /riscv_div_semi w2_nzero.
+      rewrite (truncate_val_subtype_eq htrunc) //.
+      by rewrite hwrite.
+    rewrite /sem_sop2 /=.
+    t_xrbindP=> w1 ok_w1 w2 ok_w2.
+    rewrite /mk_sem_divmod /=.
+    case w2_nzero: eq_op => //=.
+    case: andb => //.
+    move=> _ [<-] ?; subst v.
+    move=> [<- <- <-].
+    rewrite /sem_sopn /= ok_v1 ok_v2 /=.
+    rewrite /exec_sopn /= ok_w1 ok_w2 /=.
+    rewrite /riscv_divu_semi w2_nzero.
+    rewrite (truncate_val_subtype_eq htrunc) //.
+    by rewrite hwrite.
+  + case: o ok_v => // -[] [] //=.
+    + rewrite /sem_sop2 /=.
+      t_xrbindP=> w1 ok_w1 w2 ok_w2.
+      rewrite /mk_sem_divmod /=.
+      case: eq_op => //=.
+      case: andb => //.
+      move=> _ [<-] ?; subst v.
+      move=> [<- <- <-].
+      rewrite /sem_sopn /= ok_v1 ok_v2 /=.
+      rewrite /exec_sopn /= ok_w1 ok_w2 /=.
+      rewrite /riscv_rem_semi.
+      rewrite (truncate_val_subtype_eq htrunc) //.
+      by rewrite hwrite.
+    rewrite /sem_sop2 /=.
+    t_xrbindP=> w1 ok_w1 w2 ok_w2.
+    rewrite /mk_sem_divmod /=.
+    case: eq_op => //=.
+    case: andb => //.
+    move=> _ [<-] ?; subst v.
+    move=> [<- <- <-].
+    rewrite /sem_sopn /= ok_v1 ok_v2 /=.
+    rewrite /exec_sopn /= ok_w1 ok_w2 /=.
+    rewrite /riscv_div_semi.
+    rewrite (truncate_val_subtype_eq htrunc) //.
+    by rewrite hwrite.
   + case h: decide_op_reg_imm => [[ol esi] | ] //= [<- <- <-].
     apply: (decide_op_reg_immP ok_v1 ok_v2 h erefl).
     set op2' := Oasm _.
@@ -529,15 +579,15 @@ Proof.
     rewrite /= zero_extend_wshl //; last by have [? _] := wunsigned_range w2.
     by rewrite -/(sem_shift _ _ _) eq_shift.  
   case: o ok_v => // -[] // ok_v.
-    case good_shift: check_shift_amount => [ sa | ] //.
-    move=> [<- <- <-].
-    rewrite !fun_if if_same.
-    set op2' := Oasm _.
-    have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] := 
-      Hassgn_op2_shift ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
-    have [_ [wa ok_wa eq_shift]] := check_shift_amountP good_shift ok_v2 ok_w2.
-    apply (sem_correct _ _ ok_wa).
-    by rewrite /= !zero_extend_u /sem_sar eq_shift.    
+  case good_shift: check_shift_amount => [ sa | ] //.
+  move=> [<- <- <-].
+  rewrite !fun_if if_same.
+  set op2' := Oasm _.
+  have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
+    Hassgn_op2_shift ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
+  have [_ [wa ok_wa eq_shift]] := check_shift_amountP good_shift ok_v2 ok_w2.
+  apply (sem_correct _ _ ok_wa).
+  by rewrite /= !zero_extend_u /sem_sar eq_shift.
 Qed.
 
 #[ local ]


### PR DESCRIPTION
Also:
+ reorder riscv_instr_decl.v for consistency
+ remove GP/TP from the formalization (according to the RISC-V ABI, they are "unallocatable")