### PR TITLE
Add nowarning option to jasmin-ct, jasmin2tex, and jasmin2ec

### DIFF
--- a/compiler/entry/commonCLI.ml
+++ b/compiler/entry/commonCLI.ml
@@ -30,3 +30,7 @@ let call_conv =
     value
     & opt call_conv Glob_options.Linux
     & info [ "call-conv"; "cc" ] ~docv:"OS" ~doc)
+
+let nowarning =
+  let doc = "Suppress warnings" in
+  Arg.(value & flag & info [ "nowarning" ] ~doc)

--- a/compiler/entry/commonCLI.ml
+++ b/compiler/entry/commonCLI.ml
@@ -31,6 +31,6 @@ let call_conv =
     & opt call_conv Glob_options.Linux
     & info [ "call-conv"; "cc" ] ~docv:"OS" ~doc)
 
-let nowarning =
-  let doc = "Suppress warnings" in
-  Arg.(value & flag & info [ "nowarning" ] ~doc)
+let warn =
+  let doc = "Print warnings" in
+  Arg.(value & flag & info [ "warn" ] ~doc)

--- a/compiler/entry/commonCLI.mli
+++ b/compiler/entry/commonCLI.mli
@@ -4,3 +4,4 @@ open Cmdliner
 val get_arch_module : Utils.architecture -> Glob_options.call_conv -> (module Arch_full.Arch)
 val arch : Utils.architecture Term.t
 val call_conv : Glob_options.call_conv Term.t
+val nowarning : bool Term.t

--- a/compiler/entry/commonCLI.mli
+++ b/compiler/entry/commonCLI.mli
@@ -4,4 +4,4 @@ open Cmdliner
 val get_arch_module : Utils.architecture -> Glob_options.call_conv -> (module Arch_full.Arch)
 val arch : Utils.architecture Term.t
 val call_conv : Glob_options.call_conv Term.t
-val nowarning : bool Term.t
+val warn : bool Term.t

--- a/compiler/entry/jasmin2ec.ml
+++ b/compiler/entry/jasmin2ec.ml
@@ -48,7 +48,8 @@ let parse_and_extract arch call_conv =
     let amodel = if old_array then ToEC.ArrayOld else ToEC.ArrayEclib in
     extract_to_file prog arch A.reg_size A.asmOp model amodel functions array_dir output
   in
-  fun model amodel functions array_dir output file ->
+  fun model amodel functions array_dir output file nowarning ->
+    if nowarning then Utils.nowarning ();
     match extract model amodel functions array_dir output file with
     | () -> ()
     | exception HiError e ->
@@ -93,6 +94,10 @@ let file =
   let doc = "The Jasmin source file to extract" in
   Arg.(required & pos 0 (some non_dir_file) None & info [] ~docv:"JAZZ" ~doc)
 
+let nowarning =
+  let doc = "Suppress warnings" in
+  Arg.(value & flag & info [ "nowarning" ] ~doc)
+
 let () =
   let doc = "Extract Jasmin program to easycrypt" in
   let man =
@@ -107,7 +112,6 @@ let () =
     Cmd.info "jasmin2ec" ~version:Glob_options.version_string ~doc ~man
   in
   Cmd.v info
-    Term.(
-      const parse_and_extract $ arch $ call_conv $ model $ old_array $ functions $ array_dir
-      $ output $ file)
+    Term.(const parse_and_extract $ arch $ call_conv $ model $ old_array
+      $ functions $ array_dir $ output $ file $ nowarning)
   |> Cmd.eval |> exit

--- a/compiler/entry/jasmin2ec.ml
+++ b/compiler/entry/jasmin2ec.ml
@@ -48,8 +48,8 @@ let parse_and_extract arch call_conv =
     let amodel = if old_array then ToEC.ArrayOld else ToEC.ArrayEclib in
     extract_to_file prog arch A.reg_size A.asmOp model amodel functions array_dir output
   in
-  fun model amodel functions array_dir output file nowarning ->
-    if nowarning then Utils.nowarning ();
+  fun model amodel functions array_dir output file warn ->
+    if not warn then nowarning ();
     match extract model amodel functions array_dir output file with
     | () -> ()
     | exception HiError e ->
@@ -109,5 +109,5 @@ let () =
   in
   Cmd.v info
     Term.(const parse_and_extract $ arch $ call_conv $ model $ old_array
-      $ functions $ array_dir $ output $ file $ CommonCLI.nowarning)
+      $ functions $ array_dir $ output $ file $ warn)
   |> Cmd.eval |> exit

--- a/compiler/entry/jasmin2ec.ml
+++ b/compiler/entry/jasmin2ec.ml
@@ -94,10 +94,6 @@ let file =
   let doc = "The Jasmin source file to extract" in
   Arg.(required & pos 0 (some non_dir_file) None & info [] ~docv:"JAZZ" ~doc)
 
-let nowarning =
-  let doc = "Suppress warnings" in
-  Arg.(value & flag & info [ "nowarning" ] ~doc)
-
 let () =
   let doc = "Extract Jasmin program to easycrypt" in
   let man =
@@ -113,5 +109,5 @@ let () =
   in
   Cmd.v info
     Term.(const parse_and_extract $ arch $ call_conv $ model $ old_array
-      $ functions $ array_dir $ output $ file $ nowarning)
+      $ functions $ array_dir $ output $ file $ CommonCLI.nowarning)
   |> Cmd.eval |> exit

--- a/compiler/entry/jasmin2tex.ml
+++ b/compiler/entry/jasmin2tex.ml
@@ -26,10 +26,6 @@ let output =
   in
   Arg.(value & opt (some string) None & info [ "o"; "output" ] ~docv:"TEX" ~doc)
 
-let nowarning =
-  let doc = "Suppress warnings" in
-  Arg.(value & flag & info [ "nowarning" ] ~doc)
-
 let () =
   let doc = "Pretty-print Jasmin source programs into LATEX" in
   let man =
@@ -44,5 +40,5 @@ let () =
     Cmd.info "jasmin2tex" ~version:Glob_options.version_string ~doc ~man
   in
   Cmd.v info Term.(const parse_and_print $ arch $ call_conv $ output $ file
-    $ nowarning)
+    $ CommonCLI.nowarning)
   |> Cmd.eval |> exit

--- a/compiler/entry/jasmin2tex.ml
+++ b/compiler/entry/jasmin2tex.ml
@@ -4,8 +4,8 @@ open CommonCLI
 
 let parse_and_print arch call_conv =
   let module A = (val get_arch_module arch call_conv) in
-  fun output file nowarning ->
-    if nowarning then Utils.nowarning ();
+  fun output file warn ->
+    if not warn then Utils.nowarning ();
     let _, _, ast = Compile.parse_file A.arch_info file in
     let out, close =
       match output with
@@ -40,5 +40,5 @@ let () =
     Cmd.info "jasmin2tex" ~version:Glob_options.version_string ~doc ~man
   in
   Cmd.v info Term.(const parse_and_print $ arch $ call_conv $ output $ file
-    $ CommonCLI.nowarning)
+    $ warn)
   |> Cmd.eval |> exit

--- a/compiler/entry/jasmin2tex.ml
+++ b/compiler/entry/jasmin2tex.ml
@@ -4,7 +4,8 @@ open CommonCLI
 
 let parse_and_print arch call_conv =
   let module A = (val get_arch_module arch call_conv) in
-  fun output file ->
+  fun output file nowarning ->
+    if nowarning then Utils.nowarning ();
     let _, _, ast = Compile.parse_file A.arch_info file in
     let out, close =
       match output with
@@ -25,6 +26,10 @@ let output =
   in
   Arg.(value & opt (some string) None & info [ "o"; "output" ] ~docv:"TEX" ~doc)
 
+let nowarning =
+  let doc = "Suppress warnings" in
+  Arg.(value & flag & info [ "nowarning" ] ~doc)
+
 let () =
   let doc = "Pretty-print Jasmin source programs into LATEX" in
   let man =
@@ -38,5 +43,6 @@ let () =
   let info =
     Cmd.info "jasmin2tex" ~version:Glob_options.version_string ~doc ~man
   in
-  Cmd.v info Term.(const parse_and_print $ arch $ call_conv $ output $ file)
+  Cmd.v info Term.(const parse_and_print $ arch $ call_conv $ output $ file
+    $ nowarning)
   |> Cmd.eval |> exit

--- a/compiler/entry/jasmin_ct.ml
+++ b/compiler/entry/jasmin_ct.ml
@@ -114,10 +114,6 @@ let doit =
   let doc = "Allow only DOIT instructions on secrets" in
   Arg.(value & flag & info [ "doit" ] ~doc)
 
-let nowarning =
-  let doc = "Suppress warnings" in
-  Arg.(value & flag & info [ "nowarning" ] ~doc)
-
 let () =
   let doc = "Check Constant-Time security of Jasmin programs" in
   let man =
@@ -134,5 +130,5 @@ let () =
   Cmd.v info
     Term.(
       const parse_and_check $ arch $ call_conv $ infer $ slice $ speculative
-      $ compile $ file $ doit $ nowarning)
+      $ compile $ file $ doit $ CommonCLI.nowarning)
   |> Cmd.eval |> exit

--- a/compiler/entry/jasmin_ct.ml
+++ b/compiler/entry/jasmin_ct.ml
@@ -63,8 +63,8 @@ let parse_and_check arch call_conv =
       in
       Stdlib.Option.iter on_err errs
   in
-  fun infer ct_list speculative compile file doit nowarning ->
-    if nowarning then Utils.nowarning ();
+  fun infer ct_list speculative compile file doit warn ->
+    if not warn then nowarning ();
     let compile =
       if doit && compile < Compiler.PropagateInline then
         Compiler.PropagateInline
@@ -130,5 +130,5 @@ let () =
   Cmd.v info
     Term.(
       const parse_and_check $ arch $ call_conv $ infer $ slice $ speculative
-      $ compile $ file $ doit $ CommonCLI.nowarning)
+      $ compile $ file $ doit $ warn)
   |> Cmd.eval |> exit

--- a/compiler/entry/jasmin_ct.ml
+++ b/compiler/entry/jasmin_ct.ml
@@ -63,7 +63,8 @@ let parse_and_check arch call_conv =
       in
       Stdlib.Option.iter on_err errs
   in
-  fun infer ct_list speculative compile file doit ->
+  fun infer ct_list speculative compile file doit nowarning ->
+    if nowarning then Utils.nowarning ();
     let compile =
       if doit && compile < Compiler.PropagateInline then
         Compiler.PropagateInline
@@ -113,6 +114,10 @@ let doit =
   let doc = "Allow only DOIT instructions on secrets" in
   Arg.(value & flag & info [ "doit" ] ~doc)
 
+let nowarning =
+  let doc = "Suppress warnings" in
+  Arg.(value & flag & info [ "nowarning" ] ~doc)
+
 let () =
   let doc = "Check Constant-Time security of Jasmin programs" in
   let man =
@@ -129,5 +134,5 @@ let () =
   Cmd.v info
     Term.(
       const parse_and_check $ arch $ call_conv $ infer $ slice $ speculative
-      $ compile $ file $ doit)
+      $ compile $ file $ doit $ nowarning)
   |> Cmd.eval |> exit

--- a/compiler/tests/sct-checker/common.ml
+++ b/compiler/tests/sct-checker/common.ml
@@ -9,7 +9,6 @@ module Arch =
        (module Arch_full.Arch_from_Core_arch (C) : Arch_full.Arch))
 
 let load_file name =
-  Utils.nowarning ();
   let open Pretyping in
   try
     name

--- a/compiler/tests/sct-checker/common.ml
+++ b/compiler/tests/sct-checker/common.ml
@@ -9,6 +9,7 @@ module Arch =
        (module Arch_full.Arch_from_Core_arch (C) : Arch_full.Arch))
 
 let load_file name =
+  Utils.nowarning ();
   let open Pretyping in
   try
     name


### PR DESCRIPTION
There is no way of suppressing these warning in these tools. I also disabled the warnings for SCT checker tests. The tests under CCT don't need this since the warnings are already caught somewhere else.