### PR TITLE
Use liveness info to speed up allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   `-ec`, `-oec`, `-oecarray` and `-CT` command-line options are deprecated
   ([PR #914](https://github.com/jasmin-lang/jasmin/pull/914)).
 
+- The “allocation” pass now uses the liveness information to reduce the sizes
+  of the tables it uses internally; it should be faster on large functions
+  ([PR #965](https://github.com/jasmin-lang/jasmin/pull/965)).
+
 # Jasmin 2024.07.2 — Nancy, 2024-11-21
 
 ## New features

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -55,6 +55,14 @@ let var_of_cvar cv =
   assert (cty_of_ty v.v_ty = cv.Var.vtype);
   v
 
+let csv_of_sv s =
+  let open Var0.SvExtra.Sv in
+  Sv.fold (fun x cs -> add (Obj.magic (cvar_of_var x)) cs) s empty
+
+let sv_of_csv cs =
+  let open Var0.SvExtra.Sv in
+  fold (fun x s -> Sv.add (var_of_cvar (Obj.magic x)) s) cs Sv.empty
+
 (* ------------------------------------------------------------------------ *)
 
 let cvari_of_vari v =

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -37,6 +37,9 @@ val cvar_of_var :  var -> Var0.Var.var
 val var_of_cvar :  Var0.Var.var -> var
 val vari_of_cvari :  Expr.var_i -> var L.located
 
+val csv_of_sv : Sv.t -> Var0.SvExtra.Sv.t
+val sv_of_csv : Var0.SvExtra.Sv.t -> Sv.t
+
 val lval_of_clval :  Expr.lval -> Prog.lval
 
 val cexpr_of_expr :  expr -> Expr.pexpr

--- a/compiler/src/liveness.ml
+++ b/compiler/src/liveness.ml
@@ -50,7 +50,14 @@ and live_d weak d (s_o: Sv.t) =
     let s2, c2 = live_c weak c2 s_o in
     Sv.union (vars_e e) (Sv.union s1 s2), s_o, Cif(e, c1, c2)
 
-  | Cfor _ -> assert false (* Should have been removed before *)
+  | Cfor (x, (_dir, e1, e2 as r), c) ->
+    let rec loop s_o =
+      let s_i, c = live_c weak c s_o in
+      let s_i = Sv.remove (L.unloc x) s_i in
+      if Sv.subset s_i s_o then s_o, c
+      else loop (Sv.union s_i s_o) in
+    let s_i, c = loop s_o in
+    Sv.union (vars_es [ e1; e2 ]) s_i, s_o, Cfor (x, r, c)
 
   | Cwhile(a,c,e,c') ->
     let ve = (vars_e e) in

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -289,7 +289,7 @@ Proof.
   move: (alloc_pc _ get_fdc).
   have [_ _ ->]:= dead_code_fd_meta ok_fdc.
   rewrite /sf_total_stack.
-  have [ <- <- <- ] := [elaborate @check_fundef_meta _ _ _ _ _ _ _ (_, fda) _ _ _ ok_fdb].
+  have [ <- <- <- ] := [elaborate @check_fundef_meta _ _ _ _ _ _ _ _ (_, fda) _ _ _ ok_fdb].
   have [_ _ ->]:= dead_code_fd_meta ok_fda.
   done.
 Qed.

--- a/proofs/compiler/inline.v
+++ b/proofs/compiler/inline.v
@@ -35,6 +35,7 @@ Context
   {asm_op syscall_state : Type}
   {asmop:asmOp asm_op}
   (rename_fd : instr_info -> funname -> ufundef -> ufundef)
+  (dead_vars_fd : ufun_decl -> instr_info -> Sv.t)
 .
 
 Definition get_flag (x:lval) flag :=
@@ -66,7 +67,7 @@ Definition locals fd :=
   Sv.diff (locals_p fd) (sparams fd).
 
 Definition check_rename f (fd1 fd2:ufundef) (s:Sv.t) :=
-  Let _ := check_ufundef tt tt (f,fd1) (f,fd2) tt in
+  Let _ := check_ufundef dead_vars_fd tt tt (f,fd1) (f,fd2) tt in
   let s2 := locals_p fd2 in
   if disjoint s s2 then ok tt
   else Error (inline_error (pp_s "invalid refreshing in function")).

--- a/proofs/compiler/inline_proof.v
+++ b/proofs/compiler/inline_proof.v
@@ -18,15 +18,16 @@ Context
   {ep : EstateParams syscall_state}
   {spp : SemPexprParams}
   {sip : SemInstrParams asm_op syscall_state}
-  (rename_fd : instr_info -> funname -> ufundef -> ufundef).
+  (rename_fd : instr_info -> funname -> ufundef -> ufundef)
+  (dead_vars_fd : ufun_decl -> instr_info -> Sv.t).
 
 Lemma get_funP p f fd :
   get_fun p f = ok fd -> get_fundef p f = Some fd.
 Proof. by rewrite /get_fun;case:get_fundef => // ? [->]. Qed.
 
-Notation inline_i' := (inline_i rename_fd).
-Notation inline_fd' := (inline_fd rename_fd).
-Notation inline_prog' := (inline_prog rename_fd).
+Notation inline_i' := (inline_i rename_fd dead_vars_fd).
+Notation inline_fd' := (inline_fd rename_fd dead_vars_fd).
+Notation inline_prog' := (inline_prog rename_fd dead_vars_fd).
 
 #[local] Existing Instance indirect_c.
 
@@ -585,7 +586,7 @@ Section PROOF.
 End PROOF.
 
 Lemma inline_call_errP p p' f ev scs mem scs' mem' va va' vr:
-  inline_prog_err rename_fd p = ok p' ->
+  inline_prog_err rename_fd dead_vars_fd p = ok p' ->
   List.Forall2 value_uincl va va' ->
   sem_call p ev scs mem f va scs' mem' vr ->
   exists2 vr',


### PR DESCRIPTION
The tables used in allocation can be huge. We remove the dead variables from the tables, to reduce their sizes and speed up the pass. Inspired by CompCert that does something similar to reduce the cost of the value analysis.

Please review carefully the changes to Liveness, because I don't know what I did.

On [this implementation of Keccak](https://github.com/formosa-crypto/formosa-mldsa/tree/01ec03dd53e0fe43abf8c77091fd178560017ce6/src/libjade/keccakf1600), the time taken by the analysis after inlining goes down from 20s to 1.5s. It still feels too much for 4 inlined functions (size 1700, 3800 variables). (More functions are inlined, but these are the ones where the time is spent).