### PR TITLE
SCT-checker: do not build a (large) list of booleans

### DIFF
--- a/compiler/src/constraints.ml
+++ b/compiler/src/constraints.ml
@@ -170,8 +170,8 @@ end = struct
         if vl1 = vl' then  (* e <= e1 = e' *)
           add_path vl1 e1
         else
-          let tests = List.map find (successors e1) in
-          if List.exists (fun b -> b) tests then (* e1 <= s <= e' *)
+          let found = List.fold_left (fun b e2 -> find e2 || b) false (successors e1) in
+          if found then (* e1 <= s <= e' *)
             add_path vl1 e1
           else add_nopath vl1 in
      ignore (find e);

--- a/compiler/src/sct_checker_forward.ml
+++ b/compiler/src/sct_checker_forward.ml
@@ -34,7 +34,6 @@ let sstrict   = "strict"
 (* ----------------------------------------------------------- *)
 (* Info provided by the user                                   *)
 type ulevel =
-  | Poly of string L.located (* * string L.located *) (* normal, speculative *)
   | Secret
   | Transient
   | Public
@@ -1292,7 +1291,6 @@ let init_constraint fenv f =
       l in
 
   let to_lvl = function
-    | Poly s -> add_lvl (L.unloc s)
     | Secret -> Env.secret2 env
     | Transient -> Env.transient env
     | Public | Msf -> Env.public2 env in


### PR DESCRIPTION
This is a small performance optimization