### PR TITLE
Fix EC extraction in case on nested loops

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Ján Jančár
 Jean-Christophe Léchenet
 José Bacelar Almeida
 Kai-Chun Ning
+Lionel Blatter
 Lucas Tabary-Maujean
 Manuel Barbosa
 Miguel Quaresma

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Fix EasyCrypt semantics of shift operators
   ([PR#973](https://github.com/jasmin-lang/jasmin/pull/973)).
 
+- Fix EC extraction in case on nested loops
+  ([PR #971](https://github.com/jasmin-lang/jasmin/pull/971)).
+
 ## Other changes
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed


### PR DESCRIPTION
The EC extraction is wrong In the case of nested loop. Consider following Jasmin program:
```
param int a = 10;

fn __for_nest() -> ()
{
  inline int i;
  inline int j;

  for i = 0 to (a + a)
  {
     for j = 0 to (a * a){}
  }

  return;
}
```
The result is currently :
```
require import AllCore IntDiv CoreMap List Distr.

from Jasmin require import JModel_x86.

import SLH64.

module M = {
  proc __for_nest () : unit = {
    var int:aux;
    var j:int;
    var i:int;
    aux <- (10 + 10);
    i <- 0;
    while ((i < aux)) {
      aux <- (10 * 10);
      j <- 0;
      while ((j < aux)) {
        j <- (j + 1);
      }
      i <- (i + 1);
    }
    return ();
  }
}.
```
It is not correct to use `aux` for the second loop.
This PR fix this. The result for the previous Jasmin example is now :
```
require import AllCore IntDiv CoreMap List Distr.

from Jasmin require import JModel_x86.

import SLH64.

module M = {
  proc __for_nest () : unit = {
    var int:inc;
    var int:inc_0;
    var j:int;
    var i:int;
    inc <- (10 + 10);
    i <- 0;
    while ((i < inc)) {
      inc_0 <- (10 * 10);
      j <- 0;
      while ((j < inc_0)) {
        j <- (j + 1);
      }
      i <- (i + 1);
    }
    return ();
  }
}.
```
