### PR TITLE
Propagate errors from compiler in CT checker

### DIFF
--- a/compiler/entry/commonCLI.ml
+++ b/compiler/entry/commonCLI.ml
@@ -82,16 +82,18 @@ let parse_and_compile (type reg regx xreg rflag cond asm_op extra_op)
         exception Found
       end in
       let res = ref prog in
-      match
-        Compile.compile
-          (module Arch)
-          (fun ~debug:_ step prog ->
-            if step = pass then (
-              res := prog;
-              raise E.Found))
-          prog (Conv.cuprog_of_prog prog)
-      with
+      let stop ~debug:_ step prog =
+        if step = pass then (
+          res := prog;
+          raise E.Found)
+      in
+      let cp = Conv.cuprog_of_prog prog in
+      (* We need to avoid catching compilation errors. *)
+      match Compile.compile (module Arch) stop prog cp with
+      | Utils0.Ok _ -> assert false
+      | Utils0.Error e ->
+          let e = Conv.error_of_cerror (Printer.pp_err ~debug:false) e in
+          raise (HiError e)
       | exception E.Found -> !res
-      | _ -> assert false
   in
   prog


### PR DESCRIPTION
This program
```
export
fn ble() {
  reg u64 x = 0;
  () = #spill(x);
  x = 0;
  () = #unspill(x);
}
```
with `jasmin-ct ble.jazz --compile lowering` produces
```
jasmin-ct: internal error, uncaught exception:
           File "entry/jasmin_ct.ml", line 43, characters 15-21: Assertion failed
```
