### PR TITLE
Add message in the result of jasmin2tex about location of .sty file

### DIFF
--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -447,5 +447,14 @@ let rec pp_pitem fmt pi =
      closebrace fmt ()
   | PTypeAlias (id,ty) -> pp_typealias fmt id ty (**)
 
+let pp_info fmt =
+  F.fprintf fmt "@[<v>@[%% The produced LATEX snippet is meant to be included in a@] @ ";
+  F.fprintf fmt "@[%% jasmincode environment provided by the jasmin package@] @ ";
+  F.fprintf fmt "@[%% defined in file: @] @ ";
+  F.fprintf fmt "@[%% https://github.com/jasmin-lang/jasmin/wiki/resources/jasmin.sty@]@]";
+  F.pp_print_newline fmt ();
+  F.pp_print_newline fmt ()
+
 let pp_prog fmt =
+  pp_info fmt;
   F.pp_print_list ~pp_sep:(fun fmt () -> F.fprintf fmt eol) pp_pitem fmt


### PR DESCRIPTION
Add to the Jasmin project the `jasmin.sty` file needed when using the result of the `jasmin2tex` extraction.