### PR TITLE
Dune: restore standard flags

### DIFF
--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -91,7 +91,7 @@ module Arm_core = struct
 
 
   (* All of the extra ops compile into CT instructions (no DIV). *)
-  let is_ct_asm_extra (o : extra_op) = true
+  let is_ct_asm_extra (_o : extra_op) = true
 
   (* All of the extra ops compile into DIT instructions only, but this needs to be checked manually. *)
   let is_doit_asm_extra (o : extra_op) =

--- a/compiler/src/dune
+++ b/compiler/src/dune
@@ -10,7 +10,7 @@
 (library
  (name jasmin)
  (public_name jasmin.jasmin)
- (flags -rectypes)
+ (flags (:standard -rectypes -w -9-27-32-33-34-37-50))
  (modules :standard \ main_compiler x86_safety)
  (libraries angstrom batteries.unthreaded zarith menhirLib uint63))
 

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1969,8 +1969,8 @@ let tt_funbody arch_info env (pb : S.pfunbody) =
 
 
 (* -------------------------------------------------------------------- *)
-      
-let tt_call_conv loc params returns cc =
+
+let tt_call_conv _loc params returns cc =
   match cc with
   | Some `Inline -> FInfo.Internal
 

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -468,7 +468,7 @@ let rec spilled_i s i =
   match i.i_desc with
   | Copn(_, _, Sopn.Opseudo_op (Pseudo_operator.Ospill _), es) -> rvars_es Sv.add s es
   | Cassgn _ | Csyscall _ | Ccall _ | Copn _-> s
-  | Cif(e,c1,c2)     -> spilled_c (spilled_c s c1) c2
+  | Cif(_e, c1, c2)  -> spilled_c (spilled_c s c1) c2
   | Cfor(_, _, c)    -> spilled_c s c
   | Cwhile(_,c,_,c') -> spilled_c (spilled_c s c) c'
 

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -976,7 +976,7 @@ let callsite_tree (s : (Location.i_loc list * Sv.t) list) =
 
 
 
-let pp_liveness vars liveness_per_callsite liveness_table conflicts a =
+let pp_liveness vars liveness_per_callsite liveness_table a =
   (* Prints the program with forced registers, equivalence classes, and liveness information *)
   let open Format in
   let open PrintCommon in
@@ -1257,7 +1257,7 @@ let global_allocation translate_var get_internal_size (funcs: ('info, 'asm) func
 
   List.iter (fun f -> allocate_forced_registers return_addresses translate_var nv vars conflicts f a) funcs;
 
-  if !Glob_options.print_liveness then pp_liveness vars liveness_per_callsite liveness_table conflicts a;
+  if !Glob_options.print_liveness then pp_liveness vars liveness_per_callsite liveness_table a;
 
   greedy_allocation vars nv conflicts fr a;
   let subst = var_subst_of_allocation vars a in

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -196,7 +196,7 @@ module X86_core = struct
     | XOR _ -> true
 
   (* All of the extra ops compile into CT instructions (no DIV). *)
-  let is_ct_asm_extra (o : extra_op) = true
+  let is_ct_asm_extra (_o : extra_op) = true
 
   (* All of the extra ops compile into DOIT instructions only, but this needs to be checked manually. *)
   let is_doit_asm_extra (o : extra_op) =
@@ -204,7 +204,7 @@ module X86_core = struct
     | Oset0 _           -> true
     | Oconcat128        -> true
     | Ox86MOVZX32       -> true
-    | Ox86MULX ws       -> true
+    | Ox86MULX _ws      -> true
     | Ox86MULX_hi _     -> true
     | Ox86SLHinit       -> true
     | Ox86SLHupdate     -> true


### PR DESCRIPTION
Some warnings are disabled; enabling them is left as future work.