### PR TITLE
Check no for loop in coq

### DIFF
--- a/compiler/src/checkAnnot.ml
+++ b/compiler/src/checkAnnot.ml
@@ -60,27 +60,6 @@ let check_stack_size fds =
                 Z.pp_print actual Z.pp_print expected)
     fds
 
-let rec check_no_for_loop ~funname s =
-  List.iter (check_no_for_loop_i ~funname) s
-
-and check_no_for_loop_i ~funname { i_desc; i_loc; _ } =
-  check_no_for_loop_i_r ~funname ~loc:i_loc i_desc
-
-and check_no_for_loop_i_r ~funname ~loc = function
-  | Cassgn _ | Copn _ | Csyscall _ | Ccall _ -> ()
-  | Cif (_, a, b) | Cwhile (_, a, _, _, b) ->
-      check_no_for_loop ~funname a;
-      check_no_for_loop ~funname b
-  | Cfor _ ->
-      hierror ~funname ~loc:(Lmore loc) ~kind:"compilation error"
-        ~sub_kind:"loop unrolling" ~internal:false "for loops remain"
-
-let check_no_for_loop (_, fds) =
-  List.iter
-    (fun { f_name; f_body; _ } ->
-      check_no_for_loop ~funname:f_name.fn_name f_body)
-    fds
-
 let rec check_no_inline_instr ~funname s =
   List.iter (check_no_inline_instr_i ~funname) s
 

--- a/compiler/src/checkAnnot.mli
+++ b/compiler/src/checkAnnot.mli
@@ -1,8 +1,5 @@
 val check_stack_size : (Expr.stk_fun_extra * _ Prog.func) list -> unit
 (** Check the stacksize, stackallocsize & stackalign annotations, if any *)
 
-val check_no_for_loop : _ Prog.prog -> unit
-(** Check that no for loop remain. *)
-
 val check_no_inline_instr : _ Prog.prog -> unit
 (** Check that no “inline”-annotated instruction remain. *)

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -163,7 +163,6 @@ let main () =
         |> fun () -> exit 0
       else
       (
-        if s == Unrolling then CheckAnnot.check_no_for_loop p;
         if s == Unrolling then CheckAnnot.check_no_inline_instr p;
         eprint s (Printer.pp_prog ~debug Arch.reg_size Arch.asmOp) p
       ) in

--- a/compiler/tests/fail/common/not-unrollable-for-loop.jazz
+++ b/compiler/tests/fail/common/not-unrollable-for-loop.jazz
@@ -1,0 +1,11 @@
+export
+fn main(reg u32 x) -> reg u32 {
+  reg u32 r = 0;
+  inline int i j;
+  for i = 0 to 4 {
+    for j = 0 to x {
+      r += 1;
+    }
+  }
+  return r;
+}

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -83,6 +83,7 @@ compiler/makeReferenceArguments.v
 compiler/makeReferenceArguments_proof.v
 compiler/merge_varmaps.v
 compiler/merge_varmaps_proof.v
+compiler/post_unrolling_check.v
 compiler/propagate_inline.v
 compiler/propagate_inline_proof.v
 compiler/remove_globals.v

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -26,6 +26,7 @@ Require Import
   linearization
   lowering
   makeReferenceArguments
+  post_unrolling_check
   propagate_inline
   slh_lowering
   remove_globals
@@ -266,6 +267,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
   Let p := inlining to_keep p in
 
   Let p := unroll_loop (ap_is_move_op aparams) p in
+  Let: tt := check_no_for_loop p in
   let p := cparams.(print_uprog) Unrolling p in
 
   Let p := dead_calls_err_seq to_keep p in

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -188,7 +188,7 @@ Proof.
   rewrite /compiler_first_part; t_xrbindP => pa0.
   rewrite print_uprogP => ok_pa0 pb.
   rewrite print_uprogP => ok_pb pa.
-  rewrite print_uprogP => ok_pa pc ok_pc.
+  rewrite print_uprogP => ok_pa pc ok_pc ok_puc.
   rewrite !print_uprogP => pd ok_pd.
   rewrite !print_uprogP => pe ok_pe.
   rewrite !print_uprogP => pf ok_pf.

--- a/proofs/compiler/post_unrolling_check.v
+++ b/proofs/compiler/post_unrolling_check.v
@@ -1,0 +1,55 @@
+From mathcomp Require Import ssreflect.
+Require Import expr compiler_util.
+
+Import Utf8.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Module Import E.
+
+  Definition pass : string := "loop unrolling".
+
+  Definition for_loop_remains :=
+    {| pel_msg := pp_s "for loops remain"
+    ; pel_fn := None
+    ; pel_fi := None
+    ; pel_ii := None
+    ; pel_vi := None
+    ; pel_pass := Some pass
+    ; pel_internal := false |}.
+
+End E.
+
+Section ASM_OP.
+
+Context `{asmop: asmOp}.
+
+Section CHECK_NO_FOR_LOOP_CMD.
+  Context (check_no_for_loop_instr: instr → cexec unit).
+
+  Definition check_no_for_loop_cmd c := allM check_no_for_loop_instr c.
+
+End CHECK_NO_FOR_LOOP_CMD.
+
+Fixpoint check_no_for_loop_instr_r i : cexec unit :=
+  match i with
+  | (Cassgn _ _ _ _ | Copn _ _ _ _ | Csyscall _ _ _ | Ccall _ _ _)
+    => ok tt
+  | (Cif _ c c' | Cwhile _ c _ c') =>
+      check_no_for_loop_cmd check_no_for_loop_instr c >> check_no_for_loop_cmd check_no_for_loop_instr c'
+  | Cfor _ _ _ => Error E.for_loop_remains
+  end
+with check_no_for_loop_instr i : cexec unit :=
+  let: MkI ii i := i in
+  add_iinfo ii (check_no_for_loop_instr_r i).
+
+Definition check_no_for_loop_fd (f : funname * ufundef) :=
+  let: (fn, fd) := f in
+  add_funname fn (add_finfo (f_info fd) (check_no_for_loop_cmd check_no_for_loop_instr (f_body fd))).
+
+Definition check_no_for_loop (p: uprog) :=
+  allM check_no_for_loop_fd (p_funcs p).
+
+End ASM_OP.


### PR DESCRIPTION
For loops must be gone after unrolling. The compiler relies on this fact. The no-for-loop check makes sure that if this is not the case, the user sees a proper error message.

Currently, this check is only run in the `jasminc` front-end. This PR moves this check to the compiler itself, where it belongs.