### PR TITLE
latex_printer: do not print a blank line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
 - Compiling the OCaml source code no longer requires `-rectypes`
   ([PR #980](https://github.com/jasmin-lang/jasmin/pull/980)).
 
+- The printer to LATEX shows a comment informing about jasmin.sty support file
+  ([PR #976](https://github.com/jasmin-lang/jasmin/pull/976) and
+  [PR #986](https://github.com/jasmin-lang/jasmin/pull/986)).
+
 # Jasmin 2024.07.2 — Nancy, 2024-11-21
 
 ## New features

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -448,11 +448,11 @@ let rec pp_pitem fmt pi =
   | PTypeAlias (id,ty) -> pp_typealias fmt id ty (**)
 
 let pp_info fmt =
-  F.fprintf fmt "@[<v>@[%% The produced LATEX snippet is meant to be included in a@] @ ";
-  F.fprintf fmt "@[%% jasmincode environment provided by the jasmin package@] @ ";
-  F.fprintf fmt "@[%% defined in file: @] @ ";
-  F.fprintf fmt "@[%% https://github.com/jasmin-lang/jasmin/wiki/resources/jasmin.sty@]@]";
-  F.pp_print_newline fmt ();
+  F.fprintf fmt "@[<v>@[%% The produced LATEX snippet is meant to be included in a@]@ ";
+  F.fprintf fmt "@[%% jasmincode environment provided by the jasmin package@]@ ";
+  F.fprintf fmt "@[%% defined in file: @]@ ";
+  F.fprintf fmt "@[%% https://github.com/jasmin-lang/jasmin/wiki/resources/jasmin.sty@]@ ";
+  F.fprintf fmt "@[%%@]@]";
   F.pp_print_newline fmt ()
 
 let pp_prog fmt =


### PR DESCRIPTION
An empty blank line is meaningful in TEX. This fixes a regression introduced in #976 and also adds a changelog entry.