### PR TITLE
CI: disable the “cache dependencies” job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,7 @@ cache dependencies:
   only:
     variables:
     - $CACHIX_SIGNING_KEY
+    - $CACHIX_JOB_DISABLED
   script:
   - >-
     nix-shell -p cachix --run


### PR DESCRIPTION
Something is wrong with CI. Who knows what…

This PR might help.