### PR TITLE
fix avx2 shift semantics

### DIFF
--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -2514,13 +2514,13 @@ abstract theory W_WS.
      map2 (fun (x y:WS.t) => wmulhs x y) w1 w2.
 
    op VPSLL_'Ru'S (w : WB.t) (cnt : W128.t) =
-     map (fun (w:WS.t) => w `<<<` (to_uint cnt %% sizeS)) w.
+     map (fun (w:WS.t) => w `<<<` to_uint cnt) w.
 
    op VPSRL_'Ru'S (w : WB.t) (cnt : W128.t) =
-     map (fun (w:WS.t) => w `>>>` (to_uint cnt %% sizeS)) w.
+     map (fun (w:WS.t) => w `>>>` to_uint cnt) w.
 
    op VPSRA_'Ru'S (w : WB.t) (cnt : W128.t) =
-     map (fun (w:WS.t) => w `|>>>` (to_uint cnt %% sizeS)) w.
+     map (fun (w:WS.t) => w `|>>>` to_uint cnt) w.
 
    op VPBROADCAST_'Ru'S (w : WS.t) =
      pack'R (map (fun i => w) (iota_ 0 r)).


### PR DESCRIPTION
This is a follow-up of ([PR#973](https://github.com/jasmin-lang/jasmin/pull/973)), as it removes masking on shift operations, specifically on the AVX(2) variants. In fact, in AVX2, such masking should never occur (c.f., e.g., https://www.felixcloutier.com/x86/psllw:pslld:psllq)).