### PR TITLE
Check in Coq that #[inline]-annotated instructions are gone after unrolling

### DIFF
--- a/compiler/src/checkAnnot.mli
+++ b/compiler/src/checkAnnot.mli
@@ -1,5 +1,2 @@
 val check_stack_size : (Expr.stk_fun_extra * _ Prog.func) list -> unit
 (** Check the stacksize, stackallocsize & stackalign annotations, if any *)
-
-val check_no_inline_instr : _ Prog.prog -> unit
-(** Check that no “inline”-annotated instruction remain. *)

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -163,7 +163,6 @@ let main () =
         |> fun () -> exit 0
       else
       (
-        if s == Unrolling then CheckAnnot.check_no_inline_instr p;
         eprint s (Printer.pp_prog ~debug Arch.reg_size Arch.asmOp) p
       ) in
 

--- a/compiler/tests/fail/common/inline-remains.jazz
+++ b/compiler/tests/fail/common/inline-remains.jazz
@@ -1,0 +1,10 @@
+export fn main(reg u32 x) -> reg u32 {
+  reg u32 r;
+  #[inline]
+  if x <s x + 1 {
+    r = -1;
+  } else {
+    r = 0;
+  }
+  return r;
+}

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -264,6 +264,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: prog) : cexec uprog :=
 
   Let p := unroll_loop (ap_is_move_op aparams) p in
   Let: tt := check_no_for_loop p in
+  Let: tt := check_no_inline_instr p in
   let p := cparams.(print_uprog) Unrolling p in
 
   Let p := dead_calls_err_seq to_keep p in

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -184,7 +184,7 @@ Proof.
   rewrite /compiler_first_part; t_xrbindP => pa0.
   rewrite print_uprogP => ok_pa0 pb.
   rewrite print_uprogP => ok_pb pa.
-  rewrite print_uprogP => ok_pa pc ok_pc ok_puc.
+  rewrite print_uprogP => ok_pa pc ok_pc ok_puc ok_puc'.
   rewrite !print_uprogP => pd ok_pd.
   rewrite !print_uprogP => pe ok_pe.
   rewrite !print_uprogP => pf ok_pf.

--- a/proofs/compiler/post_unrolling_check.v
+++ b/proofs/compiler/post_unrolling_check.v
@@ -16,6 +16,15 @@ Module Import E.
     ; pel_pass := Some pass
     ; pel_internal := false |}.
 
+  Definition inline_instr_remains :=
+    {| pel_msg := pp_s "“inline”-annotated instructions remain"
+    ; pel_fn := None
+    ; pel_fi := None
+    ; pel_ii := None
+    ; pel_vi := None
+    ; pel_pass := Some pass
+    ; pel_internal := false |}.
+
 End E.
 
 Section ASM_OP.
@@ -47,5 +56,27 @@ Definition check_no_for_loop_fd (f : funname * ufundef) :=
 
 Definition check_no_for_loop (p: uprog) :=
   allM check_no_for_loop_fd (p_funcs p).
+
+Definition check_no_inline_instr_cmd (i: instr → cexec unit) (c: cmd) := allM i c.
+
+Fixpoint check_no_inline_instr_instr_r i : cexec unit :=
+  match i with
+  | (Cassgn _ _ _ _ | Copn _ _ _ _ | Csyscall _ _ _ | Cfor _ _ _ | Ccall _ _ _)
+      => ok tt
+  | (Cif _ c c' | Cwhile _ c _ _ c') =>
+      check_no_inline_instr_cmd check_no_inline_instr_instr c >> check_no_inline_instr_cmd check_no_inline_instr_instr c'
+  end
+with check_no_inline_instr_instr i : cexec unit :=
+  let: MkI ii i := i in
+  add_iinfo ii (
+      assert (negb (ii_is_inline ii)) E.inline_instr_remains >>
+      check_no_inline_instr_instr_r i).
+
+Definition check_no_inline_instr_fd (f : funname * ufundef) :=
+  let: (fn, fd) := f in
+  add_funname fn (add_finfo (f_info fd) (check_no_inline_instr_cmd check_no_inline_instr_instr (f_body fd))).
+
+Definition check_no_inline_instr (p: uprog) :=
+  allM check_no_inline_instr_fd (p_funcs p).
 
 End ASM_OP.


### PR DESCRIPTION
Continuation of #979.