### PR TITLE
Cryptoline fix examples

### DIFF
--- a/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_0p.jazz
+++ b/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_0p.jazz
@@ -3,20 +3,20 @@ abstract predicate tuple single(int);
 abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
-abstract predicate u256 rlimbs4(tuple);
+abstract predicate u256 limbs_4u64(tuple);
 abstract predicate tuple quad(u64, u64, u64, u64);
 
 fn __tobytes4(reg u64[4] f) -> reg u64[4]
-  requires #[prover=smt] {(256u)0 <= rlimbs4(quad(f[0], f[1], f[2], f[3]))}
-  requires #[prover=smt] {rlimbs4(quad(f[0], f[1], f[2], f[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+  requires #[prover=smt] {(256u)0 <= limbs_4u64(quad(f[0], f[1], f[2], f[3]))}
+  requires #[prover=smt] {limbs_4u64(quad(f[0], f[1], f[2], f[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
   ensures #[prover=cas] {
   eqmod (
     \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
     \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(f[ii])),
     single((pow(2,255)) - 19))
     }
-  ensures #[prover=smt] {(256u)0 <= rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
-  ensures #[prover=smt] {rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+  ensures #[prover=smt] {(256u)0 <= limbs_4u64(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
+  ensures #[prover=smt] {limbs_4u64(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
 {
   reg bool cf;
   reg u64 t;

--- a/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_0p.jazz
+++ b/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_0p.jazz
@@ -1,0 +1,91 @@
+abstract predicate bool eqmod(int, int, tuple);
+abstract predicate tuple single(int);
+abstract predicate int b2i(bool);
+abstract predicate int u64i(u64);
+abstract predicate int pow(int, int);
+abstract predicate u256 rlimbs4(tuple);
+abstract predicate tuple quad(u64, u64, u64, u64);
+
+fn __tobytes4(reg u64[4] f) -> reg u64[4]
+  requires #[prover=smt] {(256u)0 <= rlimbs4(quad(f[0], f[1], f[2], f[3]))}
+  requires #[prover=smt] {rlimbs4(quad(f[0], f[1], f[2], f[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+  ensures #[prover=cas] {
+  eqmod (
+    \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
+    \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(f[ii])),
+    single((pow(2,255)) - 19))
+    }
+  ensures #[prover=smt] {(256u)0 <= rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
+  ensures #[prover=smt] {rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+{
+  reg bool cf;
+  reg u64 t;
+
+  t = f[3] + f[3];
+  t >>= 1;
+  #[kind=Assert, prover=smt] assert (t == f[3]);
+  #[kind=Assume, prover=cas] assert (u64i(t) == u64i(f[3]));
+
+  #[tran=smt2] ?{}, f[3] = #SAR(f[3], 63);
+  f[3] &= 19;
+  f[3] += 19;
+  #[kind=Assert, prover=smt] assert (f[3] == (64u)19);
+  #[kind=Assume, prover=cas] assert (u64i(f[3]) == 19);
+
+  cf, f[0] += f[3];
+  cf, f[1] += 0 + cf;
+  cf, f[2] += 0 + cf;
+  cf, t    += 0 + cf;
+  #[kind=Assert, prover=smt] assert (!cf);
+  #[kind=Assume, prover=cas] assert (b2i(cf) == 0);
+
+  f[3] = t + t;
+  f[3] >>= 1;
+  #[kind=Assert, prover=smt] assert (f[3] == t);
+  #[kind=Assume, prover=cas] assert (u64i(f[3]) == u64i(t));
+
+  #[tran=smt2] ?{}, t = #SAR(t, 63);
+  t = !t;
+  t &= 19;
+  #[kind=Assert, prover=smt] assert (t == (64u)19);
+  #[kind=Assume, prover=cas] assert (u64i(t) == 19);
+
+  cf, f[0] -= t;
+  cf, f[1] -= 0 - cf;
+  cf, f[2] -= 0 - cf;
+  cf, f[3] -= 0 - cf;
+  #[kind=Assert, prover=smt] assert (!cf);
+  #[kind=Assume, prover=cas] assert (b2i(cf) == 0);
+
+  return f;
+
+}
+
+inline fn __store4(reg u64 p, reg u64[4] a)
+{
+  inline int i;
+
+  for i=0 to 4
+  { [p + 8*i] = a[i]; }
+}
+
+
+inline fn __load4(reg u64 p) -> reg u64[4]
+{
+  inline int i;
+  reg u64[4] a;
+
+  for i=0 to 4
+  { a[i] = [p + 8*i]; }
+
+  return a;
+}
+
+
+export fn tobytes(reg u64 rp, reg u64 zp) {
+  reg u64[4] z;
+  reg u64[4] r;
+  z = __load4(zp);
+  r = __tobytes4(z);
+  __store4(rp, r);
+}

--- a/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_2_2552p.jazz
+++ b/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_2_2552p.jazz
@@ -1,0 +1,91 @@
+abstract predicate bool eqmod(int, int, tuple);
+abstract predicate tuple single(int);
+abstract predicate int b2i(bool);
+abstract predicate int u64i(u64);
+abstract predicate int pow(int, int);
+abstract predicate u256 rlimbs4(tuple);
+abstract predicate tuple quad(u64, u64, u64, u64);
+
+fn __tobytes4(reg u64[4] f) -> reg u64[4]
+  requires #[prover=smt] {(256u)0x8000000000000000000000000000000000000000000000000000000000000000 <= rlimbs4(quad(f[0], f[1], f[2], f[3]))}
+  requires #[prover=smt] {rlimbs4(quad(f[0], f[1], f[2], f[3])) < (256u)0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffda}
+ensures #[prover=cas] {
+ eqmod (
+   \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
+   \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(f[ii])),
+   single((pow(2,255)) - 19))
+   }
+  ensures #[prover=smt] {(256u)0 <= rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
+  ensures #[prover=smt] {rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+{
+  reg bool cf;
+  reg u64 t;
+
+  t = f[3] + f[3];
+  t >>= 1;
+  #[kind=Assert, prover=smt] assert (t == f[3] - (0x8000000000000000));
+  #[kind=Assume, prover=cas] assert (u64i(t) == u64i(f[3]) - pow(2,63));
+
+  #[tran=smt2] ?{}, f[3] = #SAR(f[3], 63);
+  f[3] &= 19;
+  f[3] += 19;
+  #[kind=Assert, prover=smt] assert (f[3] == (64u)38);
+  #[kind=Assume, prover=cas] assert (u64i(f[3]) == 38);
+
+  cf, f[0] += f[3];
+  cf, f[1] += 0 + cf;
+  cf, f[2] += 0 + cf;
+  cf, t    += 0 + cf;
+  #[kind=Assert, prover=smt] assert (!cf);
+  #[kind=Assume, prover=cas] assert (b2i(cf) == 0);
+
+  f[3] = t + t;
+  f[3] >>= 1;
+  #[kind=Assert, prover=smt] assert (f[3] == t);
+  #[kind=Assume, prover=cas] assert (u64i(f[3]) == u64i(t));
+
+  #[tran=smt2] ?{}, t = #SAR(t, 63);
+  t = !t;
+  t &= 19;
+  #[kind=Assert, prover=smt] assert (t == (64u)19);
+  #[kind=Assume, prover=cas] assert (u64i(t) == 19);
+
+  cf, f[0] -= t;
+  cf, f[1] -= 0 - cf;
+  cf, f[2] -= 0 - cf;
+  cf, f[3] -= 0 - cf;
+  #[kind=Assert, prover=smt] assert (!cf);
+  #[kind=Assume, prover=cas] assert (b2i(cf) == 0);
+
+  return f;
+
+}
+
+inline fn __store4(reg u64 p, reg u64[4] a)
+{
+  inline int i;
+
+  for i=0 to 4
+  { [p + 8*i] = a[i]; }
+}
+
+
+inline fn __load4(reg u64 p) -> reg u64[4]
+{
+  inline int i;
+  reg u64[4] a;
+
+  for i=0 to 4
+  { a[i] = [p + 8*i]; }
+
+  return a;
+}
+
+
+export fn tobytes(reg u64 rp, reg u64 zp) {
+  reg u64[4] z;
+  reg u64[4] r;
+  z = __load4(zp);
+  r = __tobytes4(z);
+  __store4(rp, r);
+}

--- a/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_2_2552p.jazz
+++ b/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_2_2552p.jazz
@@ -3,20 +3,20 @@ abstract predicate tuple single(int);
 abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
-abstract predicate u256 rlimbs4(tuple);
+abstract predicate u256 limbs_4u64(tuple);
 abstract predicate tuple quad(u64, u64, u64, u64);
 
 fn __tobytes4(reg u64[4] f) -> reg u64[4]
-  requires #[prover=smt] {(256u)0x8000000000000000000000000000000000000000000000000000000000000000 <= rlimbs4(quad(f[0], f[1], f[2], f[3]))}
-  requires #[prover=smt] {rlimbs4(quad(f[0], f[1], f[2], f[3])) < (256u)0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffda}
+  requires #[prover=smt] {(256u)0x8000000000000000000000000000000000000000000000000000000000000000 <= limbs_4u64(quad(f[0], f[1], f[2], f[3]))}
+  requires #[prover=smt] {limbs_4u64(quad(f[0], f[1], f[2], f[3])) < (256u)0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffda}
 ensures #[prover=cas] {
  eqmod (
    \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
    \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(f[ii])),
    single((pow(2,255)) - 19))
    }
-  ensures #[prover=smt] {(256u)0 <= rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
-  ensures #[prover=smt] {rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+  ensures #[prover=smt] {(256u)0 <= limbs_4u64(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
+  ensures #[prover=smt] {limbs_4u64(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
 {
   reg bool cf;
   reg u64 t;

--- a/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_2p2_256.jazz
+++ b/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_2p2_256.jazz
@@ -3,20 +3,20 @@ abstract predicate tuple single(int);
 abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
-abstract predicate u256 rlimbs4(tuple);
+abstract predicate u256 limbs_4u64(tuple);
 abstract predicate tuple quad(u64, u64, u64, u64);
 
 fn __tobytes4(reg u64[4] f) -> reg u64[4]
-  requires #[prover=smt] {(256u)0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffda <= rlimbs4(quad(f[0], f[1], f[2], f[3]))}
-  requires #[prover=smt] {rlimbs4(quad(f[0], f[1], f[2], f[3])) < (256u)0x10000000000000000000000000000000000000000000000000000000000000000}
+  requires #[prover=smt] {(256u)0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffda <= limbs_4u64(quad(f[0], f[1], f[2], f[3]))}
+  requires #[prover=smt] {limbs_4u64(quad(f[0], f[1], f[2], f[3])) < (256u)0x10000000000000000000000000000000000000000000000000000000000000000}
 ensures #[prover=cas] {
  eqmod (
    \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
    \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(f[ii])),
    single((pow(2,255)) - 19))
    }
-  ensures #[prover=smt] {(256u)0 <= rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
-  ensures #[prover=smt] {rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+  ensures #[prover=smt] {(256u)0 <= limbs_4u64(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
+  ensures #[prover=smt] {limbs_4u64(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
 {
   reg bool cf;
   reg u64 t;

--- a/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_2p2_256.jazz
+++ b/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_2p2_256.jazz
@@ -1,0 +1,91 @@
+abstract predicate bool eqmod(int, int, tuple);
+abstract predicate tuple single(int);
+abstract predicate int b2i(bool);
+abstract predicate int u64i(u64);
+abstract predicate int pow(int, int);
+abstract predicate u256 rlimbs4(tuple);
+abstract predicate tuple quad(u64, u64, u64, u64);
+
+fn __tobytes4(reg u64[4] f) -> reg u64[4]
+  requires #[prover=smt] {(256u)0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffda <= rlimbs4(quad(f[0], f[1], f[2], f[3]))}
+  requires #[prover=smt] {rlimbs4(quad(f[0], f[1], f[2], f[3])) < (256u)0x10000000000000000000000000000000000000000000000000000000000000000}
+ensures #[prover=cas] {
+ eqmod (
+   \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
+   \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(f[ii])),
+   single((pow(2,255)) - 19))
+   }
+  ensures #[prover=smt] {(256u)0 <= rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
+  ensures #[prover=smt] {rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+{
+  reg bool cf;
+  reg u64 t;
+
+  t = f[3] + f[3];
+  t >>= 1;
+  #[kind=Assert, prover=smt] assert (t == f[3] - (0x8000000000000000));
+  #[kind=Assume, prover=cas] assert (u64i(t) == u64i(f[3]) - pow(2,63));
+
+  #[tran=smt2] ?{}, f[3] = #SAR(f[3], 63);
+  f[3] &= 19;
+  f[3] += 19;
+  #[kind=Assert, prover=smt] assert (f[3] == (64u)38);
+  #[kind=Assume, prover=cas] assert (u64i(f[3]) == 38);
+
+  cf, f[0] += f[3];
+  cf, f[1] += 0 + cf;
+  cf, f[2] += 0 + cf;
+  cf, t    += 0 + cf;
+  #[kind=Assert, prover=smt] assert (!cf);
+  #[kind=Assume, prover=cas] assert (b2i(cf) == 0);
+
+  f[3] = t + t;
+  f[3] >>= 1;
+  #[kind=Assert, prover=smt] assert (f[3] == t - - (0x8000000000000000));
+  #[kind=Assume, prover=cas] assert (u64i(f[3]) == u64i(t) - pow(2,63));
+
+  #[tran=smt2] ?{}, t = #SAR(t, 63);
+  t = !t;
+  t &= 19;
+  #[kind=Assert, prover=smt] assert (t == (64u)0);
+  #[kind=Assume, prover=cas] assert (u64i(t) == 0);
+
+  cf, f[0] -= t;
+  cf, f[1] -= 0 - cf;
+  cf, f[2] -= 0 - cf;
+  cf, f[3] -= 0 - cf;
+  #[kind=Assert, prover=smt] assert (!cf);
+  #[kind=Assume, prover=cas] assert (b2i(cf) == 0);
+
+  return f;
+
+}
+
+inline fn __store4(reg u64 p, reg u64[4] a)
+{
+  inline int i;
+
+  for i=0 to 4
+  { [p + 8*i] = a[i]; }
+}
+
+
+inline fn __load4(reg u64 p) -> reg u64[4]
+{
+  inline int i;
+  reg u64[4] a;
+
+  for i=0 to 4
+  { a[i] = [p + 8*i]; }
+
+  return a;
+}
+
+
+export fn tobytes(reg u64 rp, reg u64 zp) {
+  reg u64[4] z;
+  reg u64[4] r;
+  z = __load4(zp);
+  r = __tobytes4(z);
+  __store4(rp, r);
+}

--- a/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_p2_255.jazz
+++ b/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_p2_255.jazz
@@ -1,0 +1,91 @@
+abstract predicate bool eqmod(int, int, tuple);
+abstract predicate tuple single(int);
+abstract predicate int b2i(bool);
+abstract predicate int u64i(u64);
+abstract predicate int pow(int, int);
+abstract predicate u256 rlimbs4(tuple);
+abstract predicate tuple quad(u64, u64, u64, u64);
+
+fn __tobytes4(reg u64[4] f) -> reg u64[4]
+  requires #[prover=smt] {(256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed <= rlimbs4(quad(f[0], f[1], f[2], f[3]))}
+  requires #[prover=smt] {rlimbs4(quad(f[0], f[1], f[2], f[3])) < (256u)0x8000000000000000000000000000000000000000000000000000000000000000}
+ensures #[prover=cas] {
+ eqmod (
+   \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
+   \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(f[ii])),
+   single((pow(2,255)) - 19))
+   }
+  ensures #[prover=smt] {(256u)0 <= rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
+  ensures #[prover=smt] {rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+{
+  reg bool cf;
+  reg u64 t;
+
+  t = f[3] + f[3];
+  t >>= 1;
+  #[kind=Assert, prover=smt] assert (t == f[3]);
+  #[kind=Assume, prover=cas] assert (u64i(t) == u64i(f[3]));
+
+  #[tran=smt2] ?{}, f[3] = #SAR(f[3], 63);
+  f[3] &= 19;
+  f[3] += 19;
+  #[kind=Assert, prover=smt] assert (f[3] == (64u)19);
+  #[kind=Assume, prover=cas] assert (u64i(f[3]) == 19);
+
+  cf, f[0] += f[3];
+  cf, f[1] += 0 + cf;
+  cf, f[2] += 0 + cf;
+  cf, t    += 0 + cf;
+  #[kind=Assert, prover=smt] assert (!cf);
+  #[kind=Assume, prover=cas] assert (b2i(cf) == 0);
+
+  f[3] = t + t;
+  f[3] >>= 1;
+  #[kind=Assert, prover=smt] assert (f[3] == t - (0x8000000000000000));
+  #[kind=Assume, prover=cas] assert (u64i(f[3]) == u64i(t) - pow(2, 63));
+
+  #[tran=smt2] ?{}, t = #SAR(t, 63);
+  t = !t;
+  t &= 19;
+  #[kind=Assert, prover=smt] assert (t == (64u)0);
+  #[kind=Assume, prover=cas] assert (u64i(t) == 0);
+
+  cf, f[0] -= t;
+  cf, f[1] -= 0 - cf;
+  cf, f[2] -= 0 - cf;
+  cf, f[3] -= 0 - cf;
+  #[kind=Assert, prover=smt] assert (!cf);
+  #[kind=Assume, prover=cas] assert (b2i(cf) == 0);
+
+  return f;
+
+}
+
+inline fn __store4(reg u64 p, reg u64[4] a)
+{
+  inline int i;
+
+  for i=0 to 4
+  { [p + 8*i] = a[i]; }
+}
+
+
+inline fn __load4(reg u64 p) -> reg u64[4]
+{
+  inline int i;
+  reg u64[4] a;
+
+  for i=0 to 4
+  { a[i] = [p + 8*i]; }
+
+  return a;
+}
+
+
+export fn tobytes(reg u64 rp, reg u64 zp) {
+  reg u64[4] z;
+  reg u64[4] r;
+  z = __load4(zp);
+  r = __tobytes4(z);
+  __store4(rp, r);
+}

--- a/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_p2_255.jazz
+++ b/compiler/examples/jazzline/curve25519/common/tobytes/tobytes_p2_255.jazz
@@ -3,20 +3,20 @@ abstract predicate tuple single(int);
 abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
-abstract predicate u256 rlimbs4(tuple);
+abstract predicate u256 limbs_4u64(tuple);
 abstract predicate tuple quad(u64, u64, u64, u64);
 
 fn __tobytes4(reg u64[4] f) -> reg u64[4]
-  requires #[prover=smt] {(256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed <= rlimbs4(quad(f[0], f[1], f[2], f[3]))}
-  requires #[prover=smt] {rlimbs4(quad(f[0], f[1], f[2], f[3])) < (256u)0x8000000000000000000000000000000000000000000000000000000000000000}
+  requires #[prover=smt] {(256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed <= limbs_4u64(quad(f[0], f[1], f[2], f[3]))}
+  requires #[prover=smt] {limbs_4u64(quad(f[0], f[1], f[2], f[3])) < (256u)0x8000000000000000000000000000000000000000000000000000000000000000}
 ensures #[prover=cas] {
  eqmod (
    \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
    \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(f[ii])),
    single((pow(2,255)) - 19))
    }
-  ensures #[prover=smt] {(256u)0 <= rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
-  ensures #[prover=smt] {rlimbs4(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
+  ensures #[prover=smt] {(256u)0 <= limbs_4u64(quad(result.0[0], result.0[1], result.0[2], result.0[3]))}
+  ensures #[prover=smt] {limbs_4u64(quad(result.0[0], result.0[1], result.0[2], result.0[3])) < (256u)0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed}
 {
   reg bool cf;
   reg u64 t;

--- a/compiler/examples/jazzline/curve25519/mulx/mul4/mul4_rsr.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/mul4/mul4_rsr.jazz
@@ -20,10 +20,11 @@ inline fn __mul4_c0
   reg u64 lo;
   reg u64[4] h r;
 
+
   (h[1], h[0]) = #MULX ( f0, g[0] );
 
   ( h[2], lo ) = #MULX ( f0, g[1] );
-    cf, h[1]   = #ADCX ( h[1], lo, cf );
+  cf, h[1]   = #ADCX ( h[1], lo, cf );
 
   ( h[3], lo ) = #MULX ( f0, g[2] );
     cf, h[2]   = #ADCX ( h[2], lo, cf );
@@ -162,7 +163,7 @@ inline fn __mul4_c3
   return h, r, cf, of;
 }
 
-inline fn __mul4_rsr(stack u64[4] fs, reg u64[4] g) -> reg u64[4]
+fn __mul4_rsr(reg u64[4] fs, reg u64[4] g) -> reg u64[4]
  ensures #[prover=cas] {
   eqmod (
      \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
@@ -176,8 +177,8 @@ inline fn __mul4_rsr(stack u64[4] fs, reg u64[4] g) -> reg u64[4]
   reg u64[4] h r g0;
   reg u64 _38 f z;
 
+  of, cf, _, _, _, z = #set0();
   g0 = #copy(g);
-  z = 0;
 
   f = fs[0];
   h, r, cf, of = __mul4_c0(      f, g0, z, cf, of);

--- a/compiler/examples/jazzline/curve25519/mulx/mul4/mul4_rsr.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/mul4/mul4_rsr.jazz
@@ -20,11 +20,10 @@ inline fn __mul4_c0
   reg u64 lo;
   reg u64[4] h r;
 
-
   (h[1], h[0]) = #MULX ( f0, g[0] );
 
   ( h[2], lo ) = #MULX ( f0, g[1] );
-  cf, h[1]   = #ADCX ( h[1], lo, cf );
+   cf, h[1]   = #ADCX ( h[1], lo, cf );
 
   ( h[3], lo ) = #MULX ( f0, g[2] );
     cf, h[2]   = #ADCX ( h[2], lo, cf );

--- a/compiler/examples/jazzline/curve25519/mulx/mul4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/mul4/reduce4.jazz
@@ -4,7 +4,7 @@ abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
 
-inline fn __reduce4
+fn __reduce4
 ( reg u64[4] x,
   reg u64[4] r,
   reg u64 _38,
@@ -28,8 +28,8 @@ inline fn __reduce4
   h0 = #copy(r);
 
   ( hi, lo )   = #MULX ( _38,  h0[0] );
-  of, h[0]     = #ADOX ( h[0], lo, of );
-  cf, h[1]     = #ADCX ( h[1], hi, cf );
+  #[tran=clear] of, h[0]     = #ADOX ( h[0], lo, of );
+  #[tran=clear] cf, h[1]     = #ADCX ( h[1], hi, cf );
 
   ( hi, lo )   = #MULX ( _38,  h0[1] );
   of, h[1]     = #ADOX ( h[1], lo, of );

--- a/compiler/examples/jazzline/curve25519/mulx/mul4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/mul4/reduce4.jazz
@@ -28,8 +28,8 @@ fn __reduce4
   h0 = #copy(r);
 
   ( hi, lo )   = #MULX ( _38,  h0[0] );
-  #[tran=clear] of, h[0]     = #ADOX ( h[0], lo, of );
-  #[tran=clear] cf, h[1]     = #ADCX ( h[1], hi, cf );
+  of, h[0]     = #ADOX ( h[0], lo, of );
+  cf, h[1]     = #ADCX ( h[1], hi, cf );
 
   ( hi, lo )   = #MULX ( _38,  h0[1] );
   of, h[1]     = #ADOX ( h[1], lo, of );

--- a/compiler/examples/jazzline/curve25519/mulx/reduce4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/reduce4/reduce4.jazz
@@ -4,7 +4,7 @@ abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
 
-inline fn __reduce4
+fn __reduce4
 ( reg u64[4] x,
   reg u64[4] r,
   reg u64 _38,
@@ -28,8 +28,8 @@ inline fn __reduce4
   h0 = #copy(r);
 
   ( hi, lo )   = #MULX ( _38,  h0[0] );
-  of, h[0]     = #ADOX ( h[0], lo, of );
-  cf, h[1]     = #ADCX ( h[1], hi, cf );
+  #[tran=clear] of, h[0]     = #ADOX ( h[0], lo, of );
+  #[tran=clear] cf, h[1]     = #ADCX ( h[1], hi, cf );
 
   ( hi, lo )   = #MULX ( _38,  h0[1] );
   of, h[1]     = #ADOX ( h[1], lo, of );

--- a/compiler/examples/jazzline/curve25519/mulx/reduce4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/reduce4/reduce4.jazz
@@ -28,8 +28,8 @@ fn __reduce4
   h0 = #copy(r);
 
   ( hi, lo )   = #MULX ( _38,  h0[0] );
-  #[tran=clear] of, h[0]     = #ADOX ( h[0], lo, of );
-  #[tran=clear] cf, h[1]     = #ADCX ( h[1], hi, cf );
+  of, h[0]     = #ADOX ( h[0], lo, of );
+  cf, h[1]     = #ADCX ( h[1], hi, cf );
 
   ( hi, lo )   = #MULX ( _38,  h0[1] );
   of, h[1]     = #ADOX ( h[1], lo, of );

--- a/compiler/examples/jazzline/curve25519/mulx/sqr4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/sqr4/reduce4.jazz
@@ -23,13 +23,13 @@ fn __reduce4
   reg u64 hi lo;
   reg bool carryo;
   z = 0;
-  _38 = 38;
+  r38 = 38;
   h = #copy(x);
   h0 = #copy(r);
 
   ( hi, lo )   = #MULX ( _38,  h0[0] );
-  #[tran=clear] of, h[0]     = #ADOX ( h[0], lo, of );
-  #[tran=clear] cf, h[1]     = #ADCX ( h[1], hi, cf );
+  of, h[0]     = #ADOX ( h[0], lo, of );
+   cf, h[1]     = #ADCX ( h[1], hi, cf );
 
   ( hi, lo )   = #MULX ( _38,  h0[1] );
   of, h[1]     = #ADOX ( h[1], lo, of );

--- a/compiler/examples/jazzline/curve25519/mulx/sqr4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/sqr4/reduce4.jazz
@@ -4,7 +4,7 @@ abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
 
-inline fn __reduce4
+fn __reduce4
 ( reg u64[4] x,
   reg u64[4] r,
   reg u64 _38,
@@ -28,8 +28,8 @@ inline fn __reduce4
   h0 = #copy(r);
 
   ( hi, lo )   = #MULX ( _38,  h0[0] );
-  of, h[0]     = #ADOX ( h[0], lo, of );
-  cf, h[1]     = #ADCX ( h[1], hi, cf );
+  #[tran=clear] of, h[0]     = #ADOX ( h[0], lo, of );
+  #[tran=clear] cf, h[1]     = #ADCX ( h[1], hi, cf );
 
   ( hi, lo )   = #MULX ( _38,  h0[1] );
   of, h[1]     = #ADOX ( h[1], lo, of );

--- a/compiler/examples/jazzline/curve25519/mulx/sqr4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/sqr4/reduce4.jazz
@@ -23,13 +23,13 @@ fn __reduce4
   reg u64 hi lo;
   reg bool carryo;
   z = 0;
-  r38 = 38;
+  _38 = 38;
   h = #copy(x);
   h0 = #copy(r);
 
   ( hi, lo )   = #MULX ( _38,  h0[0] );
   of, h[0]     = #ADOX ( h[0], lo, of );
-   cf, h[1]     = #ADCX ( h[1], hi, cf );
+  cf, h[1]     = #ADCX ( h[1], hi, cf );
 
   ( hi, lo )   = #MULX ( _38,  h0[1] );
   of, h[1]     = #ADOX ( h[1], lo, of );

--- a/compiler/examples/jazzline/curve25519/mulx/sqr4/sqr4.jazz
+++ b/compiler/examples/jazzline/curve25519/mulx/sqr4/sqr4.jazz
@@ -6,7 +6,7 @@ abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
 
-inline fn __sqr4_rr(reg u64[4] f) -> reg u64[4]
+fn __sqr4_rr(reg u64[4] f) -> reg u64[4]
  ensures #[prover=cas] {
   eqmod (
      \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),

--- a/compiler/examples/jazzline/curve25519/ref4/mul4/mul4_a24.jazz
+++ b/compiler/examples/jazzline/curve25519/ref4/mul4/mul4_a24.jazz
@@ -18,7 +18,7 @@ inline fn __mul4_a24_rs(reg u64[4] xa) -> reg u64[4]
   reg bool cf;
   stack u64 dc;
 
-  c = (64u)121666;
+  c = (64u)121665;
   #[kind=Assert, prover=smt] assert (c == (64u)121665);
   #[kind=Assume, prover=cas] assert (u64i(c) == 121665);
 

--- a/compiler/examples/jazzline/curve25519/ref4/mul4/mul4_rss.jazz
+++ b/compiler/examples/jazzline/curve25519/ref4/mul4/mul4_rss.jazz
@@ -6,7 +6,7 @@ abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
 
-inline fn __mul4_rss(stack u64[4] xa ya) -> reg u64[4]
+fn __mul4_rss(reg u64[4] xa ya) -> reg u64[4]
  ensures #[prover=cas] {
   eqmod (
      \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),

--- a/compiler/examples/jazzline/curve25519/ref4/mul4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/ref4/mul4/reduce4.jazz
@@ -4,7 +4,7 @@ abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
 
-inline fn __reduce4(reg u64[8] z) -> reg u64[4]
+fn __reduce4(reg u64[8] z) -> reg u64[4]
      ensures #[prover=cas] {
   eqmod (
      \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),

--- a/compiler/examples/jazzline/curve25519/ref4/reduce4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/ref4/reduce4/reduce4.jazz
@@ -4,7 +4,7 @@ abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
 
-inline fn __reduce4(reg u64[8] z) -> reg u64[4]
+fn __reduce4(reg u64[8] z) -> reg u64[4]
      ensures #[prover=cas] {
   eqmod (
      \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),

--- a/compiler/examples/jazzline/curve25519/ref4/sqr4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/ref4/sqr4/reduce4.jazz
@@ -18,7 +18,7 @@ fn __reduce4(reg u64[8] z) -> reg u64[4]
   reg u64[4] r;
   reg bool cf;
   inline int i;
-  , cf, _, _, _, _ = #set0();
+  _, cf, _, _, _, _ = #set0();
 
    r38 = 38;
 

--- a/compiler/examples/jazzline/curve25519/ref4/sqr4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/ref4/sqr4/reduce4.jazz
@@ -4,7 +4,7 @@ abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
 
-inline fn __reduce4(reg u64[8] z) -> reg u64[4]
+fn __reduce4(reg u64[8] z) -> reg u64[4]
      ensures #[prover=cas] {
   eqmod (
      \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),
@@ -18,9 +18,9 @@ inline fn __reduce4(reg u64[8] z) -> reg u64[4]
   reg u64[4] r;
   reg bool cf;
   inline int i;
+  of, _, _, _, _, _ = #set0();
 
-   r38 = 38;
-
+  r38 = 38;
 	rax = z[4];
 	h, l = rax * r38;
 	r[0] = l;

--- a/compiler/examples/jazzline/curve25519/ref4/sqr4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/ref4/sqr4/reduce4.jazz
@@ -20,7 +20,8 @@ fn __reduce4(reg u64[8] z) -> reg u64[4]
   inline int i;
   of, _, _, _, _, _ = #set0();
 
-  r38 = 38;
+   r38 = 38;
+
 	rax = z[4];
 	h, l = rax * r38;
 	r[0] = l;

--- a/compiler/examples/jazzline/curve25519/ref4/sqr4/reduce4.jazz
+++ b/compiler/examples/jazzline/curve25519/ref4/sqr4/reduce4.jazz
@@ -18,7 +18,7 @@ fn __reduce4(reg u64[8] z) -> reg u64[4]
   reg u64[4] r;
   reg bool cf;
   inline int i;
-  of, _, _, _, _, _ = #set0();
+  , cf, _, _, _, _ = #set0();
 
    r38 = 38;
 

--- a/compiler/examples/jazzline/curve25519/ref4/sqr4/sqr4.jazz
+++ b/compiler/examples/jazzline/curve25519/ref4/sqr4/sqr4.jazz
@@ -6,7 +6,7 @@ abstract predicate int b2i(bool);
 abstract predicate int u64i(u64);
 abstract predicate int pow(int, int);
 
-inline fn __sqr4_rs(stack u64[4] xa) -> reg u64[4]
+fn __sqr4_rs(reg u64[4] xa) -> reg u64[4]
  ensures #[prover=cas] {
   eqmod (
      \sum (ii \in 0:4) (pow(2, 64*ii)*u64i(result.0[ii])),

--- a/compiler/src/toCL.ml
+++ b/compiler/src/toCL.ml
@@ -1215,26 +1215,32 @@ module X86BaseOpU : BaseOp
       i1 @ i2 @ [CL.Instr.Op2_2.mull l_tmp l_tmp1 a1 a2] @ i3
 
     | ADCX ws ->
+      begin
+      let l = ["default", `Default ; "clear", `Clear] in
+      let trans = trans annot l in
       let a1, i1 = cast_atome ws (List.nth es 0) in
       let a2, i2 = cast_atome ws (List.nth es 1) in
       let l1 = I.glval_to_lval (List.nth xs 0) in
       let l2 = I.glval_to_lval (List.nth xs 1) in
       let v = I.gexp_to_var (List.nth es 2) in
-      let instructions =
-      i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
-    in
-    instructions
+      match trans with
+        | `Default -> i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
+        | `Clear -> i1 @ i2 @ [CL.Instr.clear v; CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
+      end
 
     | ADOX ws ->
+      begin
+      let l = ["default", `Default ; "clear", `Clear] in
+      let trans = trans annot l in
       let a1, i1 = cast_atome ws (List.nth es 0) in
       let a2, i2 = cast_atome ws (List.nth es 1) in
       let l1 = I.glval_to_lval (List.nth xs 0) in
       let l2 = I.glval_to_lval (List.nth xs 1) in
       let v = I.gexp_to_var (List.nth es 2) in
-      let instructions =
-      i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
-    in
-    instructions
+      match trans with
+        | `Default -> i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
+        | `Clear -> i1 @ i2 @ [CL.Instr.clear v; CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
+      end
 
     | _ ->
       let x86_id = X86_instr_decl.x86_instr_desc Build_Tabstract o in

--- a/compiler/src/toCL.ml
+++ b/compiler/src/toCL.ml
@@ -527,6 +527,7 @@ module I (S:S): I = struct
     | PappN(Oabstract {pa_name="se_16_64"}, [v]) -> Rsext (!> v, 48)
     | PappN(Oabstract {pa_name="se_32_64"}, [v]) -> Rsext (!> v, 32)
     | PappN(Oabstract {pa_name="ze_16_64"}, [v]) -> Ruext (!> v, 48)
+    | PappN (Oabstract {pa_name="limbs_4u64"}, [q]) -> Rlimbs ((Z.of_int 64), (List.map (!>) (extract_list q [])))
     | PappN(Oabstract {pa_name="u256_as_16u16"}, [Pvar x ; Pconst z]) ->
         UnPack (to_var ~sign x, 16, Z.to_int z)
     | _ -> error e
@@ -1215,32 +1216,22 @@ module X86BaseOpU : BaseOp
       i1 @ i2 @ [CL.Instr.Op2_2.mull l_tmp l_tmp1 a1 a2] @ i3
 
     | ADCX ws ->
-      begin
-      let l = ["default", `Default ; "clear", `Clear] in
-      let trans = trans annot l in
       let a1, i1 = cast_atome ws (List.nth es 0) in
       let a2, i2 = cast_atome ws (List.nth es 1) in
       let l1 = I.glval_to_lval (List.nth xs 0) in
       let l2 = I.glval_to_lval (List.nth xs 1) in
       let v = I.gexp_to_var (List.nth es 2) in
-      match trans with
-        | `Default -> i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
-        | `Clear -> i1 @ i2 @ [CL.Instr.clear v; CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
-      end
+     i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
+
 
     | ADOX ws ->
-      begin
-      let l = ["default", `Default ; "clear", `Clear] in
-      let trans = trans annot l in
       let a1, i1 = cast_atome ws (List.nth es 0) in
       let a2, i2 = cast_atome ws (List.nth es 1) in
       let l1 = I.glval_to_lval (List.nth xs 0) in
       let l2 = I.glval_to_lval (List.nth xs 1) in
       let v = I.gexp_to_var (List.nth es 2) in
-      match trans with
-        | `Default -> i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
-        | `Clear -> i1 @ i2 @ [CL.Instr.clear v; CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
-      end
+      i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
+
 
     | _ ->
       let x86_id = X86_instr_decl.x86_instr_desc Build_Tabstract o in

--- a/compiler/src/toCL.ml
+++ b/compiler/src/toCL.ml
@@ -518,7 +518,7 @@ module I (S:S): I = struct
     match e with
     | Papp1 (Oword_of_int ws, Pconst z) -> Rconst(int_of_ws ws, w2i ~sign z ws)
     | Papp1 (Oword_of_int ws, Pvar x) -> Rvar (L.unloc x.gv, Uint (int_of_ws ws))
-        | Pvar x -> Rvar (to_var ~sign x)
+    | Pvar x -> Rvar (to_var ~sign x)
     | Papp1(Oneg _, e) -> neg !> e
     | Papp1(Olnot _, e) -> not !> e
     | Papp2(Oadd _, e1, e2) -> add !> e1 !> e2
@@ -1221,7 +1221,7 @@ module X86BaseOpU : BaseOp
       let l1 = I.glval_to_lval (List.nth xs 0) in
       let l2 = I.glval_to_lval (List.nth xs 1) in
       let v = I.gexp_to_var (List.nth es 2) in
-     i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
+      i1 @ i2 @ [CL.Instr.Op2_2c.adcs l1 l2 a2 a1 v]
 
 
     | ADOX ws ->

--- a/compiler/src/toCL.ml
+++ b/compiler/src/toCL.ml
@@ -503,14 +503,14 @@ module I (S:S): I = struct
 
 
   let rec extract_list e aux =
-    match e with
-    | Pabstract ({name="single"}, [h]) -> [h]
-    | Pabstract ({name="pair"}, [h1;h2]) -> [h1;h2]
-    | Pabstract ({name="triple"}, [h1;h2;h3]) -> [h1;h2;h3]
-    | Pabstract ({name="quad"}, [h1;h2;h3;h4]) -> [h1;h2;h3;h4]
-    | Pabstract ({name="word_nil"}, []) -> List.rev aux
-    | Pabstract ({name="word_cons"}, [h;q]) -> extract_list q (h :: aux)
-    | _ -> assert false
+      match e with
+      | PappN (Oabstract {pa_name="single"}, [h]) -> [h]
+      | PappN (Oabstract {pa_name="pair"}, [h1;h2]) -> [h1;h2]
+      | PappN (Oabstract {pa_name="triple"}, [h1;h2;h3]) -> [h1;h2;h3]
+      | PappN (Oabstract {pa_name="quad"}, [h1;h2;h3;h4]) -> [h1;h2;h3;h4]
+      | PappN (Oabstract {pa_name="word_nil"}, []) -> List.rev aux
+      | PappN (Oabstract {pa_name="word_cons"}, [h;q]) -> extract_list q (h :: aux)
+      | _ -> assert false
 
   let rec gexp_to_rexp ?(sign=S.s) e : CL.R.rexp =
     let open CL.R in

--- a/compiler/src/toCL.mli
+++ b/compiler/src/toCL.mli
@@ -41,6 +41,7 @@ module CL : sig
       | Rbinop of rexp * string * rexp
       | RVget  of tyvar * const
       | UnPack of  tyvar * int * int
+      | Rlimbs of const * rexp list
 
     type rpred =
       | RPcmp   of rexp * string * rexp


### PR DESCRIPTION
This PR does the following:

1. Implements a straightforward arithmetic right shift translation 
2. Implements limbs (4_u64) for range predicates (requires a new kind of list, "quad")
3. Fixes NOT translation
4. New tobytes examples
5. Fixes examples  

Please let me know if the changes make sense!