### PR TITLE
Require Ztac to use it in lang/utils.v (for coq/coq#19997)

### DIFF
--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -4,6 +4,7 @@ From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice.
 From mathcomp Require Import fintype finfun.
 From Coq.Unicode Require Import Utf8.
 From Coq Require Import ZArith Zwf Setoid Morphisms CMorphisms CRelationClasses.
+From Coq Require Ztac. (* deprecated since 9.0 *)
 Require Import xseq oseq.
 From mathcomp Require Import word_ssrZ.
 


### PR DESCRIPTION
For https://github.com/coq/coq/pull/19997