### PR TITLE
x86: add BLENDV intrinsics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   ([PR #1009](https://github.com/jasmin-lang/jasmin/pull/1009);
   fixes [#1008](https://github.com/jasmin-lang/jasmin/issues/1008)).
 
+- Add support for x86 `VBLENDVPS` and `VBLENDVPD` instructions, through the new
+  intrinsics `#BLENDV` which also maps to the `VPBLENDVB` instruction;
+  therefore old intrinsic `#VPBLENDVB` is deprecated
+  ([PR #1010](https://github.com/jasmin-lang/jasmin/pull/1010)).
+
 ## Bug fixes
 
 - Fix EasyCrypt semantics of shift operators

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -62,6 +62,8 @@ module X86_core = struct
     | AESKEYGENASSIST -> true
     | AND _ -> true
     | ANDN _ -> true
+    | BLENDV (VE8, _) -> true
+    | BLENDV _ -> false (* Not DOIT *)
     | BSWAP _ -> false (* Not DOIT *)
     | BT _ -> true
     | BTR _ -> true

--- a/compiler/tests/success/x86-64/vpblendvb.jazz
+++ b/compiler/tests/success/x86-64/vpblendvb.jazz
@@ -15,3 +15,20 @@ fn test_vpblendvb(reg u64 rp) {
   h0 = #VPBLENDVB_128(h0, h1, n);
   (u128)[rp + 32] = h0;
 }
+
+export
+fn test_blendv(reg u64 p) {
+  reg u256
+    x = (u256)[p]
+    m = (u256)[p + 32]
+    y = #BLENDV_32u8(x, (u256)[p + 16], m);
+  x = #BLENDV_8u32(y, m, x);
+  y = #BLENDV_4u64(m, x, x);
+
+  reg u128
+    z = #BLENDV_16u8(x, y, m)
+    w = #BLENDV_4u32(y, m, z);
+  z = #BLENDV_2u64(m, z, w);
+
+  (u128)[p] = z;
+}

--- a/eclib/JModel_x86.ec
+++ b/eclib/JModel_x86.ec
@@ -566,6 +566,33 @@ op VPBLENDVB_256 (v1 v2 m: W256.t) : W256.t =
 
 (* ------------------------------------------------------------------- *)
 (*
+| BLENDV of velem & vsize
+*)
+abbrev BLENDV_16u8 = VPBLENDVB_128.
+abbrev BLENDV_32u8 = VPBLENDVB_256.
+
+op BLENDV_4u32 (v1 v2 m: W128.t) : W128.t =
+  let choose = fun n =>
+    let w = if msb (m \bits32 n) then v2 else v1 in
+    w \bits32 n in
+  pack4 [ choose 0; choose 1; choose 2; choose 3 ].
+
+op BLENDV_8u32 (v1 v2 m: W256.t) : W256.t =
+  pack2 [ BLENDV_4u32 (v1 \bits128 0) (v2 \bits128 0) (m \bits128 0);
+          BLENDV_4u32 (v1 \bits128 1) (v2 \bits128 1) (m \bits128 1) ].
+
+op BLENDV_2u64 (v1 v2 m: W128.t) : W128.t =
+  let choose = fun n =>
+    let w = if msb (m \bits64 n) then v2 else v1 in
+    w \bits64 n in
+  pack2 [ choose 0; choose 1 ].
+
+op BLENDV_4u64 (v1 v2 m: W256.t) : W256.t =
+  pack2 [ BLENDV_2u64 (v1 \bits128 0) (v2 \bits128 0) (m \bits128 0);
+          BLENDV_2u64 (v1 \bits128 1) (v2 \bits128 1) (m \bits128 1) ].
+
+(* ------------------------------------------------------------------- *)
+(*
 | VPACKUS  `(velem) `(wsize)
 *)
 op packus_8u16 (w: W128.t) : W64.t =

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -1695,12 +1695,14 @@ Definition wpmovmskb (dsz ssz: wsize) (w : word ssz) : word dsz :=
   wrepr dsz (t2w_def [tuple of map msb (split_vec U8 w)]).
 
 (* -------------------------------------------------------------------*)
-Definition wpblendvb sz (w1 w2 m: word sz): word sz :=
-  let v1 := split_vec U8 w1 in
-  let v2 := split_vec U8 w2 in
-  let b  := map msb (split_vec U8 m)  in
+Definition blendv (ve: velem) sz (w1 w2 m: word sz): word sz :=
+  let v1 := split_vec ve w1 in
+  let v2 := split_vec ve w2 in
+  let b  := map msb (split_vec ve m)  in
   let r := map3 (fun bi v1i v2i => if bi then v2i else v1i) b v1 v2 in
   make_vec sz r.
+
+Definition wpblendvb := blendv VE8.
 
 (* -------------------------------------------------------------------*)
 Lemma pow2pos q : 0 < 2 ^ Z.of_nat q.


### PR DESCRIPTION
This intrinsics covers the following AVX instructions:

 - VPBLENDVB (using suffixes 16u8 and 32u8)
 - VBLENDVPS (using suffixes 4u32 and 8u32)
 - VBLENDVPD (using suffixes 2u64 and 4u64)

This new intrinsic subsumes #VPBLENDVB which is therefore deprecated.