### PR TITLE
SCT: drop support for implicit spilling

### DIFF
--- a/compiler/entry/jasmin_ct.ml
+++ b/compiler/entry/jasmin_ct.ml
@@ -9,6 +9,14 @@ let parse_and_check arch call_conv =
     let prog = parse_and_compile (module A) pass file in
 
     if speculative then
+      let prog =
+        (* Ensure there are no spill/unspill operations left *)
+        if pass < Compiler.LowerSpill then
+          match Compile.do_spill_unspill A.asmOp prog with
+          | Ok p -> p
+          | Error err -> raise (HiError err)
+        else prog
+      in
       match Sct_checker_forward.ty_prog (A.is_ct_sopn ~doit) prog ct_list with
       | exception Annot.AnnotationError (loc, code) ->
           hierror ~loc:(Lone loc) ~kind:"annotation error" "%t" code

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -44,6 +44,18 @@ let rec warn_extra_i pd asmOp i =
 
 let warn_extra_fd pd asmOp (_, fd) = List.iter (warn_extra_i pd asmOp) fd.f_body
 
+(* -------------------------------------------------------------------- *)
+
+let do_spill_unspill asmop ?(debug = false) cp =
+  let p = Conv.cuprog_of_prog cp in
+  match
+    Lower_spill.spill_uprog asmop
+      (fun k ii -> Conv.fresh_var_ident k ii (Uint63.of_int 0))
+      p
+  with
+  | Utils0.Error msg -> Error (Conv.error_of_cerror (Printer.pp_err ~debug) msg)
+  | Utils0.Ok p -> Ok (Conv.prog_of_cuprog p)
+
 (*--------------------------------------------------------------------- *)
 
 let compile (type reg regx xreg rflag cond asm_op extra_op)

--- a/compiler/src/compile.mli
+++ b/compiler/src/compile.mli
@@ -31,8 +31,14 @@ val parse_file :
   * Syntax.pprogram
 (** Parsing and pre-typing of a complete file.
 
-  Raises `Pretyping.TyError` and `Syntax.ParseError`.
-  *)
+    Raises `Pretyping.TyError` and `Syntax.ParseError`. *)
+
+val do_spill_unspill :
+  'asm asmOp ->
+  ?debug:bool ->
+  (unit, 'asm) prog ->
+  ((unit, 'asm) prog, Utils.hierror) result
+(** Removes (aka implements) #spill and #unspill instructions. *)
 
 val compile :
   (module Arch_full.Arch

--- a/compiler/src/sct_checker_forward.ml
+++ b/compiler/src/sct_checker_forward.ml
@@ -42,12 +42,11 @@ type special_op =
   | Update_msf
   | Mov_msf
   | Protect
-  | Spill of Pseudo_operator.spill_op
   | Other
 
 let is_special o =
   match o with
-  | Sopn.Opseudo_op (Pseudo_operator.Ospill (o, _)) -> Spill o
+  | Sopn.Opseudo_op (Pseudo_operator.Ospill _) -> assert false
   | Sopn.Opseudo_op _ -> Other
   | Oasm _ -> Other
   | Oslh o ->
@@ -166,7 +165,7 @@ let rec modmsf_i fenv i =
     begin match is_special o with
     | Init_msf -> modified_here (* LFENCE modifies msf *)
     | Update_msf -> modified_here (* not sure it is needed *)
-    | Mov_msf | Protect | Spill _ | Other -> NotModified
+    | Mov_msf | Protect | Other -> NotModified
     end
   | Cfor(_, _, c) -> modmsf_c fenv c
   | Ccall (_, f, _) ->
@@ -356,8 +355,6 @@ let rec infer_msf_i ~withcheck fenv (tbl:(L.i_loc, Sv.t) Hashtbl.t) i ms =
 
     | Protect, _, _ -> assert false
 
-    | Spill _, _, _ -> ms
-
     | Other, xs, _ -> checks ms xs; ms
 
 and infer_msf_c ~withcheck fenv tbl c ms =
@@ -412,16 +409,10 @@ module Env : sig
 
   val get_resulting_corruption : venv -> VlPairs.t
 
-  (* This is part is used to keep track of spill/unspill *)
-  val add_spill : env -> var -> var option
-  val set_spill : env -> venv -> var_i list -> venv
-  val set_unspill : env -> venv -> var_i list -> venv
-
 end = struct
 
   type env = {
       constraints : C.constraints;
-      spilled     : var option Hv.t;  (* None means that the variable is spill to mmx and not in the stack *)
       msf_oracle  : (L.i_loc, Sv.t) Hashtbl.t;
     }
 
@@ -436,7 +427,6 @@ end = struct
 
   let init () =
     { constraints = C.init ();
-      spilled     = Hv.create 97;
       msf_oracle  = Hashtbl.create 97; }
 
   let constraints env = env.constraints
@@ -599,40 +589,6 @@ end = struct
   let corruption_speculative env venv (_, s) = corruption env venv (public env, s)
 
   let get_resulting_corruption venv = venv.resulting_corruption
-
-  let get_spilled env (x:var_i) =
-    try Option.map (L.mk_loc (L.loc x)) (Hv.find env.spilled (L.unloc x))
-    with Not_found -> assert false
-
-  let add_spill env x =
-    let sx =
-      if CoreIdent.Cident.spill_to_mmx x then None
-      else
-        let kind =
-          match x.v_kind with
-          | Const | Inline | Stack _ -> assert false
-          | Global -> if is_ty_arr x.v_ty then Wsize.Stack(Pointer Constant) else Wsize.Stack(Direct)
-          | Reg (_, r) -> Stack(r) in
-        Some (V.mk x.v_name kind x.v_ty x.v_dloc [])
-    in
-    Hv.add env.spilled x sx;
-    sx
-
-  let set_spill env venv xs =
-    let add venv (x:var_i) =
-      Option.map_default (fun sx ->
-          let ty = get_i venv x in
-          set_ty env venv sx ty) venv (get_spilled env x)
-    in
-    List.fold_left add venv xs
-
-  let set_unspill env venv xs =
-    let add venv (x:var_i) =
-      Option.map_default (fun sx ->
-      let ty = get_i venv sx in
-      set_ty env venv x ty) venv (get_spilled env x)
-   in
-   List.fold_left add venv xs
 
 end
 
@@ -1051,11 +1007,6 @@ let rec ty_instr is_ct_asm fenv env ((msf,venv) as msf_e :msf_e) i =
 
     | Protect, _, _ -> assert false
 
-    | Spill o, _, es ->
-        let xs = List.map (reg_expr ~direct:false loc) es in
-        if o = Pseudo_operator.Spill then msf, Env.set_spill env venv xs
-        else msf, Env.set_unspill env venv xs
-
     | Other, _, _  ->
       let public = not (CT.is_ct_sopn is_ct_asm o) in
       let ety = ty_exprs_max ~public env venv loc es in
@@ -1418,11 +1369,6 @@ let init_constraint fenv f =
     Env.add_var env venv x vty in
 
   let venv = Sv.fold do_local (locals f) venv in
-
-  let do_spill x venv =
-    Option.map_default (fun sx -> do_local sx venv) venv (Env.add_spill env x) in
-
-  let venv = Sv.fold do_spill (spilled f) venv in
 
   (* infer modmsf and check consistency with user info *)
   let modmsf = modmsf_c fenv f.f_body in

--- a/compiler/src/sct_checker_forward.mli
+++ b/compiler/src/sct_checker_forward.mli
@@ -3,7 +3,19 @@ open Prog
 type ty_fun
 
 val pp_funty : Format.formatter -> Name.t * ty_fun -> unit
-val ty_prog : ('asm -> bool) -> ('info, 'asm) prog -> Name.t list -> (Name.t * ty_fun) list
+
+val ty_prog :
+  ('asm -> bool) -> ('info, 'asm) prog -> Name.t list -> (Name.t * ty_fun) list
+(** Type-check a program.
+
+    A call [ty_prog is_ct_asm p f] type-checks (for Speculative Constant-Time)
+    the functions of the program [p] whose names are given in the list [f]
+    (defaults to all functions if [f] is the empty list).
+
+    Argument [is_ct_asm] classifies which assembly operators are assumed to be
+    constant time (i.e., assumed to be safe to apply to sensitive data).
+
+    The program must not contain any #spill or #unspill pseudo-operation. *)
 
 val compile_infer_msf :
   ('info, 'asm) prog -> (Slh_lowering.slh_t list * Slh_lowering.slh_t list) Hf.t

--- a/compiler/tests/sct-checker/common.ml
+++ b/compiler/tests/sct-checker/common.ml
@@ -10,15 +10,20 @@ module Arch =
 
 let load_file name =
   let open Pretyping in
-  try
+  match
     name
     |> tt_file Arch.arch_info Env.empty None None
     |> fst |> Env.decls
     |> Compile.preprocess Arch.reg_size Arch.asmOp
+    |> Compile.do_spill_unspill Arch.asmOp
   with
-  | TyError (loc, e) ->
+  | exception TyError (loc, e) ->
       Format.eprintf "%a: %a@." Location.pp_loc loc pp_tyerror e;
       assert false
-  | Syntax.ParseError (loc, None) ->
+  | exception Syntax.ParseError (loc, None) ->
       Format.eprintf "Parse error: %a@." Location.pp_loc loc;
       assert false
+  | Error msg ->
+      Format.eprintf "%a@." Utils.pp_hierror msg;
+      assert false
+  | Ok p -> p

--- a/proofs/compiler/lower_spill.v
+++ b/proofs/compiler/lower_spill.v
@@ -184,6 +184,7 @@ Fixpoint spill_i (env : spill_env) (i : instr) : cexec (spill_env * cmd) :=
 
 End GET.
 
+Section PROGT.
 Context {pT: progT}.
 
 Definition init_map (s:Sv.t) :=
@@ -226,5 +227,10 @@ Definition spill_fd {eft} (fn:funname) (fd: _fundef eft) : cexec (_fundef eft) :
 Definition spill_prog (p: prog) : cexec prog :=
   Let funcs := map_cfprog_name spill_fd (p_funcs p) in
   ok {| p_extra := p_extra p; p_globs := p_globs p; p_funcs := funcs |}.
+
+End PROGT.
+
+Definition spill_uprog (p: _uprog) : cexec _uprog :=
+  spill_prog (p: @prog _ _ progUnit).
 
 End ASM_OP.

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -62,6 +62,7 @@ Separate Extraction
   sopn
   expr
   stack_zero_strategy
+  lower_spill.spill_uprog
   psem_defs
   sem_params_of_arch_extra
   arch_decl


### PR DESCRIPTION
The aim is to simplify the implementation of the SCT checker by requiring that the program to be analyzed does not use any `#spill` or `#unspill` pseudo-operator. This pre-condition is straightforward to achieve, given the availability of the “lower-spill” compilation pass. For convenience the first commit makes available a convenient interface to this program transformation.
