### PR TITLE
minor fix in JWord.ec

### DIFF
--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -2566,7 +2566,7 @@ abstract theory W_WS.
      if cmp (to_sint x) (to_sint y) then (WS.of_int (-1)) else (WS.of_int 0).
 
    op VPCMPGT_'Ru'S (w1 : WB.t) (w2: WB.t) =
-     map2 (wcmp Int.(<=)) w2 w1.
+     map2 (wcmp Int.(<)) w2 w1.
 
    op VPCMPEQ_'Ru'S (w1 : WB.t) (w2: WB.t) =
      map2 (wcmp (=)) w1 w2.


### PR DESCRIPTION
This PR does two (independent) minor fixes to `JWord.ec` (unsure if it should be split into two PRs).

The first one is to add the newly supported`[rigid]` tag to the hints dealing with `modulus` (abbreviation of `2^size`). The feature was added to EC#main in https://github.com/EasyCrypt/easycrypt/commit/5f7be80cc247e5ad91606e139b9b20c30be91d3c) in order to solve efficiency issues when the `BitWord` theory is instantiated with big sizes (e.g. 512). It was tested on MLKEM, where the issue was detected, and apart from solving the efficiency problem that prompted the additional feature, it had no further impact on the whole proof. But it is true that the behavior concerning those hints has changed slightly, so it has the potential to trigger some backward compatibility issues (although, I believe, it would be unlikely and/or easily fixable...).

A second issue is to fix an apparent typo in the semantics of op. `VPCMPGT_'Ru'S` (to use `Int.(<)` instead of `Int.(<=)`) -- see, e.g. https://www.felixcloutier.com/x86/pcmpgtb:pcmpgtw:pcmpgtd. 


