### PR TITLE
eclib: add [rigid] to hints on 'modulus'

### DIFF
--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -86,7 +86,8 @@ proof. smt (ge2_modulus). qed.
 lemma max_size : max 0 size = size.
 proof. by rewrite /max gt0_size. qed.
 
-hint exact : ge0_size gt0_size gt0_modulus ge2_modulus ge0_modulus max_size.
+hint exact : ge0_size gt0_size max_size.
+hint [rigid] exact : gt0_modulus ge2_modulus ge0_modulus.
 
 lemma half_modulus : 2 ^ (size -1) = modulus %/ 2.
 proof. rewrite (expr_pred 2 size) // /#. qed.


### PR DESCRIPTION
This PR adds a `[rigid]` attribute to hints dealing with `modulus` on the `BitWord` theory. This is a new feature added to EC in https://github.com/EasyCrypt/easycrypt/commit/5f7be80cc247e5ad91606e139b9b20c30be91d3c (although not yet available in a released version), which solves an efficiency problem when instantiating the theory `BitWord` with big sizes (e.g., 512 bits).