### PR TITLE
Adding code editor config directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ a.out
 .DS_Store
 test_jasmin.rs
 
+# Code editor config directories
+.vscode
+.vscode/*
+.idea
+.idea/*
+
 Makefile.coq
 Makefile.coq.bak
 Makefile.coq.conf


### PR DESCRIPTION
A little quality of life modification to gitignore to avoid adding code editor config to a commit by mistake