### PR TITLE
Fixing type checking of function return storage type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
   ([PR #1027](https://github.com/jasmin-lang/jasmin/pull/1027);
   fixes [#1026](https://github.com/jasmin-lang/jasmin/issues/1026)).
 
+- Compiler now enforces coherence between function storage type and return variable storage type
+  ([PR#1028](https://github.com/jasmin-lang/jasmin/pull/1028);
+  fixes [#18](https://github.com/jasmin-lang/jasmin/issues/18)).
+
 ## Other changes
 
 - Adding an annotation to function (`'info` type). Useful to store result of analysis. (see [[#1016](https://github.com/jasmin-lang/jasmin/issues/1016)])

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -228,23 +228,8 @@ and pp_arr_access fmt al aa ws x e len=
     pp_aligned (Option.bind len (fun _ -> al))
     (pp_opt pp_ws) ws (pp_opt pp_space) ws pp_expr e pp_olen len
 
-let pp_writable = function
-  | Some `Constant -> " const"
-  | Some `Writable -> " mut"
-  | None  -> ""
-
-let pp_pointer = function
-  | `Pointer w-> pp_writable w ^ " ptr"
-  | `Direct  -> ""
-  
-  
 let pp_storage fmt s =
-  latex "storageclass" fmt
-    (match s with
-     | `Reg(ptr) -> "reg" ^ (pp_pointer ptr)
-     | `Stack ptr -> "stack" ^ (pp_pointer ptr)
-     | `Inline -> "inline"
-     | `Global -> "global")
+    latex "storageclass" fmt (pp_storage s)
 
 let pp_sto_ty fmt (sto, ty) =
   F.fprintf fmt "%a %a" pp_storage sto pp_type ty

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -229,7 +229,7 @@ and pp_arr_access fmt al aa ws x e len=
     (pp_opt pp_ws) ws (pp_opt pp_space) ws pp_expr e pp_olen len
 
 let pp_storage fmt s =
-    latex "storageclass" fmt (pp_storage s)
+  latex "storageclass" fmt (pp_storage s)
 
 let pp_sto_ty fmt (sto, ty) =
   F.fprintf fmt "%a %a" pp_storage sto pp_type ty

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -145,7 +145,7 @@ let pp_tyerror fmt (code : tyerror) =
       F.fprintf fmt "return statement of function %s has %d values instead of %d (as claimed by the signature)" name.P.fn_name given expected
 
   | InvalidSignatureStorage (fname, sto, var_name, var_kind) ->
-      F.fprintf fmt "In function “%s” return statement variable “%s” has storage type “%a”, which differ from declared return storage type “%s”"
+      F.fprintf fmt "In function “%s”, return statement variable “%s” has storage type “%a”, which differs from declared return storage type “%s”"
         fname.P.fn_name
         var_name
         PrintCommon.pp_kind var_kind
@@ -666,25 +666,25 @@ let check_return_statement ~loc name (declared : P.pty list) (given : (L.t * P.p
 
 let check_return_storage ~loc fname =
   List.iter2 (
-    fun x (y:'len P.gvar_i) ->
-      match x, (L.unloc y).v_kind with
+    fun sto (y:'len P.gvar_i) ->
+      match sto, (L.unloc y).v_kind with
       | `Inline, W.Inline -> ()
       | `Reg ptr, W.Reg (_, ref) | `Stack ptr, W.Stack ref -> (
         match ptr, ref with
-        (* Valid type rule*)
+        (* Valid type rule *)
         | `Pointer (Some `Writable), W.Pointer W.Writable
         | `Pointer (Some `Constant), W.Pointer W.Constant
         | `Pointer None, W.Pointer _
         | `Direct, W.Direct -> ()
 
         (* Invalid type rule *)
-        | `Pointer (Some `Writable), ( W.Pointer W.Constant | W.Direct)
-        | `Pointer (Some `Constant), (W.Pointer W.Writable |  W.Direct)
-        | `Pointer None, (W.Direct)
-        | `Direct, (W.Pointer _)
-        -> rs_tyerror ~loc (InvalidSignatureStorage(fname, x, (L.unloc y).v_name, (L.unloc y).v_kind))
+        | `Pointer (Some `Writable), (W.Pointer W.Constant | W.Direct)
+        | `Pointer (Some `Constant), (W.Pointer W.Writable | W.Direct)
+        | `Pointer None, W.Direct
+        | `Direct, W.Pointer _
+        -> rs_tyerror ~loc (InvalidSignatureStorage(fname, sto, (L.unloc y).v_name, (L.unloc y).v_kind))
       )
-      (* Global should never be returned, it is checked before this function is called in tt_fundef*)
+      (* Global should never be returned, it is checked before this function is called in tt_fundef *)
       | _ , W.Global -> assert false
       | `Global , _ -> assert false
 
@@ -692,7 +692,7 @@ let check_return_storage ~loc fname =
       | `Reg _,   (W.Stack _ | W.Inline  | W.Const)
       | `Stack _, (W.Reg _   | W.Inline  | W.Const)
       | `Inline,  (W.Reg _   | W.Stack _ | W.Const)
-      -> rs_tyerror ~loc (InvalidSignatureStorage(fname, x, (L.unloc y).v_name,(L.unloc y).v_kind))
+      -> rs_tyerror ~loc (InvalidSignatureStorage(fname, sto, (L.unloc y).v_name,(L.unloc y).v_kind))
     )
 
 (* -------------------------------------------------------------------- *)

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -246,6 +246,21 @@ let string_of_sizetype =
   | TypeWsize ws -> string_of_ws ws
   | TypeSizeAlias pident -> L.unloc pident
 
+let pp_writable = function
+  | Some `Constant -> " const"
+  | Some `Writable -> " mut"
+  | None  -> ""
+
+let pp_pointer = function
+  | `Pointer w-> pp_writable w ^ " ptr"
+  | `Direct  -> ""
+
+let pp_storage = function
+  | `Reg(ptr) -> "reg" ^ (pp_pointer ptr)
+  | `Stack ptr -> "stack" ^ (pp_pointer ptr)
+  | `Inline -> "inline"
+  | `Global -> "global"
+
 (* -------------------------------------------------------------------- *)
 type pparam = {
   ppa_ty   : ptype;

--- a/compiler/tests/fail/common/storage_signature_mismatch.jazz
+++ b/compiler/tests/fail/common/storage_signature_mismatch.jazz
@@ -1,0 +1,4 @@
+export fn sum() -> stack u32 {
+  reg u32 r = 0;
+  return r;
+}

--- a/compiler/tests/success/common/bug_607.jazz
+++ b/compiler/tests/success/common/bug_607.jazz
@@ -1,4 +1,4 @@
-fn f(reg ptr u64[1] a, reg u64 x) -> stack u64[1], reg u64 {
+fn f(reg ptr u64[1] a, reg u64 x) -> reg ptr u64[1], reg u64 {
     stack ptr u64[1] s;
     s = a;
     a = s;

--- a/compiler/tests/success/x86-64/test_ptr_fn_inline.jazz
+++ b/compiler/tests/success/x86-64/test_ptr_fn_inline.jazz
@@ -1,5 +1,5 @@
 inline
-fn init (reg mut ptr u64[3] p) -> reg u64[3] {
+fn init (reg mut ptr u64[3] p) -> reg mut ptr u64[3] {
    inline int i;
    for i = 0 to 3 {
       p[i] = i;


### PR DESCRIPTION
# Issue 

Compiler wasn't checking coherence of storage types between declared return storage type and return variable storage type. For more informations see #18 

# Solution 

Defining a new function in `pre-typing` to check for this.

# Implication

This change break retrocompatibility making some old program not valid. (some tests of the test suite had to be modified)

Fixes #18 