### PR TITLE
Location: remove dead code

### DIFF
--- a/compiler/src/location.ml
+++ b/compiler/src/location.ml
@@ -100,12 +100,6 @@ let merge (p1 : t) (p2 : t) =
       loc_bchar = min p1.loc_bchar p2.loc_bchar;
       loc_echar = max p1.loc_echar p2.loc_echar; }
 
-let mergeall (p : t list) =
-  match p with
-  | []      -> _dummy
-  | t :: ts -> List.fold_left merge t ts
-
-
 (* -------------------------------------------------------------------- *)
 type 'a located = {
   pl_loc  : t;
@@ -115,29 +109,9 @@ type 'a located = {
 (* -------------------------------------------------------------------- *)
 let loc    x = x.pl_loc
 let unloc  x = x.pl_desc
-let unlocs x = List.map unloc x
-
-let lmap f x =
-  { x with pl_desc = f x.pl_desc }
 
 let mk_loc loc x =
   { pl_loc = loc; pl_desc = x; }
-
-(* -------------------------------------------------------------------- *)
-exception LocError of t * exn
-
-let locate_error loc exn =
-  match exn with
-  | LocError _ -> raise exn
-  | _ -> raise (LocError(loc,exn))
-
-let set_loc loc f x =
-  try f x with e -> locate_error loc e
-
-let set_oloc oloc f x =
-  match oloc with
-  | None     -> f x
-  | Some loc -> set_loc loc f x
 
 (* -------------------------------------------------------------------- *)
 let i_loc_uid = ref 0

--- a/compiler/src/location.mli
+++ b/compiler/src/location.mli
@@ -26,7 +26,6 @@ val pp_sloc   : Format.formatter -> t -> unit
 val pp_iloc   : Format.formatter -> i_loc -> unit
 val pp_iloc_short : Format.formatter -> i_loc -> unit
 val merge     : t -> t -> t
-val mergeall  : t list -> t
 val isdummy   : t -> bool
 
 (* -------------------------------------------------------------------- *)
@@ -37,17 +36,7 @@ type 'a located = {
 
 val loc    : 'a located -> t
 val unloc  : 'a located -> 'a
-val unlocs : ('a located) list -> 'a list
 val mk_loc : t -> 'a -> 'a located
-val lmap   : ('a -> 'b) -> 'a located -> 'b located
-
-(* -------------------------------------------------------------------- *)
-exception LocError of t * exn
-
-val locate_error : t -> exn -> 'a
-
-val set_loc  : t -> ('a -> 'b) -> 'a -> 'b
-val set_oloc : t option -> ('a -> 'b) -> 'a -> 'b
 
 (* -------------------------------------------------------------------- *)
 val i_loc : t -> t list -> i_loc


### PR DESCRIPTION
The following functions have been removed

  mergeall
  unlocs
  lmap
  locate_error
  set_loc
  set_oloc

The exception LocError has been removed