### PR TITLE
check-risc-v: avoid non-POSIX (bash) constructions

### DIFF
--- a/compiler/scripts/check-risc-v
+++ b/compiler/scripts/check-risc-v
@@ -19,16 +19,16 @@ ASSEMBLY_CHECKER_OPTIONS=${ASSEMBLY_CHECKER_OPTIONS:---triple=riscv32 --mcpu=gen
 UNAME_S=$(uname -s)
 
 # Conditionally set ASSEMBLY_CHECKER for Darwin (macOS)
-if [ "$UNAME_S" == "Darwin" ]; then
+if [ "$UNAME_S" = "Darwin" ]; then
     ASSEMBLY_CHECKER="riscv64-unknown-elf-as"
     ASSEMBLY_CHECKER_OPTIONS=""
-elif [ "$UNAME_S" == "Linux" ]; then
+elif [ "$UNAME_S" = "Linux" ]; then
     ASSEMBLY_CHECKER="llvm-mc"
     ASSEMBLY_CHECKER_OPTIONS="--triple=riscv32 --mcpu=generic-rv32 -mattr=+m --filetype=obj"
 fi
 
 # Check if the assembly checker binary exists and is executable
-if ! command -v "$ASSEMBLY_CHECKER" &> /dev/null; then
+if ! command -v "$ASSEMBLY_CHECKER" > /dev/null 2>&1; then
     echo "Error: $ASSEMBLY_CHECKER is not installed or not found in PATH."
     exit 1
 fi


### PR DESCRIPTION
This makes it possible to run the RISC-V checks without Bash.

Side-note: changing the name of the assembler depending on the OS kernel is wrong.

Reported by Alexandre (@MrDaiki).