### PR TITLE
OCaml: remove dead code

### DIFF
--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -484,10 +484,6 @@ let spilled fc = spilled_c Sv.empty fc.f_body
 let clamp (sz : wsize) (z : Z.t) =
   Z.erem z (Z.shift_left Z.one (int_of_ws sz))
 
-let clamp_pe (sz : pelem) (z : Z.t) =
-  Z.erem z (Z.shift_left Z.one (int_of_pe sz))
-
-
 (* --------------------------------------------------------------------- *)
 type ('info,'asm) sfundef = Expr.stk_fun_extra * ('info,'asm) func
 type ('info,'asm) sprog   = ('info,'asm) sfundef list * Expr.sprog_extra

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -278,7 +278,6 @@ val is_inline : Annotations.annotations -> FInfo.call_conv -> bool
 
 (* -------------------------------------------------------------------- *)
 val clamp : wsize -> Z.t -> Z.t
-val clamp_pe : pelem -> Z.t -> Z.t
 
 (* -------------------------------------------------------------------- *)
 type ('info,'asm) sfundef = Expr.stk_fun_extra * ('info,'asm) func 

--- a/compiler/src/subst.ml
+++ b/compiler/src/subst.ml
@@ -274,11 +274,6 @@ let isubst_prog glob prog =
 
 exception NotAConstantExpr
 
-let clamp_k k e = 
-  match k with 
-  | E.Op_w ws -> clamp ws e
-  | E.Op_int  -> e
-
 let rec constant_of_expr (e: Prog.expr) : Z.t =
   let open Prog in
 


### PR DESCRIPTION
Removes `Prog.clamp_pe` and `Subst.clamp_k`, and in `Pretyping.ml`: `check_lval_pointer`, `is_constant`, `tt_as_bool`, `tt_as_int`, `tt_as_word`, and the exception `NotAPointer`.