### PR TITLE
Homogeneise risc-v test script with arm-m4 testing

### DIFF
--- a/compiler/scripts/check-risc-v
+++ b/compiler/scripts/check-risc-v
@@ -1,36 +1,33 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
-DIR=$(mktemp -d jasminXXXXXX)
+# User defined assembly checker binary or llvm-mc
+# for macos homebrew install : export ASSEMBLY_CHECKER=riscv64-unknown-elf-as
+ASSEMBLY_CHECKER=${ASSEMBLY_CHECKER:-llvm-mc}
+# User defined assembly checker options or default for linux
+# for macos homebrew install : export ASSEMBLY_CHECKER_OPTIONS=" "
+ASSEMBLY_CHECKER_OPTIONS=${ASSEMBLY_CHECKER_OPTIONS:---triple=riscv32 --mcpu=generic-rv32 --mattr=+m --filetype=obj}
+
+ROOT_DIR=tests/results/check-risc-v
+TEST_FILE="${@: -1}"
+# Concatenate all args (except test file name - last arg)
+ARGS_CAT=args-$(
+	IFS=""
+	echo "${*:1:$#-1}"
+)
+DIR=$ROOT_DIR/${TEST_FILE%.jazz}/$ARGS_CAT
 ASM=${DIR}/jasmin.s
 OBJ=${DIR}/jasmin.o
 
-trap "rm -r ${DIR}" EXIT
+if [ -d "${DIR}" ]; then rm -r ${DIR}; fi
+mkdir -p $DIR
 
 set -x
 
 $(dirname $0)/../jasminc -g -arch riscv -o ${ASM} "$@"
-
-# Set default ASSEMBLY_CHECKER
-ASSEMBLY_CHECKER=${ASSEMBLY_CHECKER:-llvm-mc}
-ASSEMBLY_CHECKER_OPTIONS=${ASSEMBLY_CHECKER_OPTIONS:---triple=riscv32 --mcpu=generic-rv32 -mattr=+m --filetype=obj}
-# Detect operating system
-UNAME_S=$(uname -s)
-
-# Conditionally set ASSEMBLY_CHECKER for Darwin (macOS)
-if [ "$UNAME_S" = "Darwin" ]; then
-    ASSEMBLY_CHECKER="riscv64-unknown-elf-as"
-    ASSEMBLY_CHECKER_OPTIONS=""
-elif [ "$UNAME_S" = "Linux" ]; then
-    ASSEMBLY_CHECKER="llvm-mc"
-    ASSEMBLY_CHECKER_OPTIONS="--triple=riscv32 --mcpu=generic-rv32 -mattr=+m --filetype=obj"
-fi
-
-# Check if the assembly checker binary exists and is executable
-if ! command -v "$ASSEMBLY_CHECKER" > /dev/null 2>&1; then
-    echo "Error: $ASSEMBLY_CHECKER is not installed or not found in PATH."
-    exit 1
-fi
+# Negative test cases should have failed by now
+# Succeed early if it's not the case (i.e., do not try to assemble the result)
+(echo "$@" | grep -q fail) && exit 0
 
 ${ASSEMBLY_CHECKER} ${ASSEMBLY_CHECKER_OPTIONS} -o ${OBJ} ${ASM}


### PR DESCRIPTION
Problem was:
- risc-v test suite script adds additional and unnecessary constraints to the testing suite

Solution is:
- Remove the constraints while allowing to use user-defined assembly checker binaries to ease development on other distributions / package managers.
- Document how to set ASSEMBLY_CHECKER and ASSEMBLY_CHECKER_OPTIONS for macos brew.