### PR TITLE
Make compatible with current mathcomp

### DIFF
--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -1,6 +1,5 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype ssralg.
 Require Import
-  oseq
   compiler_util
   expr
   fexpr
@@ -12,7 +11,7 @@ Require Import
   arch_decl
   arch_extra.
 Import Utf8 String.
-Import compiler_util.
+Import compiler_util oseq.
 
 Module E.
 

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -2,7 +2,6 @@ From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype.
 From mathcomp Require Import fintype finfun ssralg.
 From Coq Require Import Relation_Operators.
 Require Import
-  oseq
   compiler_util
   psem
   psem_facts
@@ -20,6 +19,7 @@ Require Import
   sem_params_of_arch_extra.
 Require Export asm_gen.
 Import Utf8.
+Import oseq.
 
 Section ASM_EXTRA.
 

--- a/proofs/compiler/arm_stack_zeroization_proof.v
+++ b/proofs/compiler/arm_stack_zeroization_proof.v
@@ -2,7 +2,6 @@ From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype ssralg.
 From mathcomp Require Import word_ssrZ.
 From Coq Require Import Lia.
 
-Require Import seq_extra.
 Require Import
   expr
   fexpr
@@ -24,6 +23,7 @@ Require Import
   arm_instr_decl
   arm_params_common_proof.
 Require Export arm_stack_zeroization.
+Import seq_extra.
 
 (* FIXME: We should use the higher-level [eval_lsem] lemmas. *)
 Section FIXME.

--- a/proofs/compiler/riscv_stack_zeroization_proof.v
+++ b/proofs/compiler/riscv_stack_zeroization_proof.v
@@ -2,7 +2,6 @@ From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype ssralg.
 From mathcomp Require Import word_ssrZ.
 Require Import Lia.
 
-Require Import seq_extra.
 Require Import
   expr
   fexpr
@@ -24,6 +23,7 @@ Require Import
   riscv_instr_decl
   riscv_params_common_proof.
 Require Export riscv_stack_zeroization.
+Import seq_extra.
 
 (* FIXME: We should use the higher-level [eval_lsem] lemmas. *)
 Section FIXME.

--- a/proofs/compiler/tunneling_proof.v
+++ b/proofs/compiler/tunneling_proof.v
@@ -2,13 +2,13 @@ From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype.
 From Coq Require Import ZArith.
 From Coq Require Import Utf8.
 
-Require Import oseq expr_facts compiler_util label linear linear_sem.
+Require Import expr_facts compiler_util label linear linear_sem.
 Require Import sem_params.
 Import word_ssrZ.
 
 Local Open Scope seq_scope.
 
-Require Import seq_extra unionfind tunneling unionfind_proof.
+Require Import oseq seq_extra unionfind tunneling unionfind_proof.
 Require Import linear_sem.
 
 

--- a/proofs/compiler/x86_stack_zeroization_proof.v
+++ b/proofs/compiler/x86_stack_zeroization_proof.v
@@ -2,7 +2,6 @@ From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype ssralg.
 From mathcomp Require Import word_ssrZ.
 From Coq Require Import Lia.
 
-Require Import seq_extra.
 Require Import
   expr
   fexpr
@@ -23,6 +22,7 @@ Require Import
   x86_extra
   x86_instr_decl.
 Require Export x86_stack_zeroization.
+Import seq_extra.
 
 (* FIXME: We should use the higher-level [eval_lsem] lemmas. *)
 Section FIXME.


### PR DESCRIPTION
Mathcomp now includes `onth` and related lemmas: https://github.com/math-comp/math-comp/pull/1318.

Fixes #1036.