### PR TITLE
Fix allocation of dead stack variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@
   ([PR#1028](https://github.com/jasmin-lang/jasmin/pull/1028);
   fixes [#18](https://github.com/jasmin-lang/jasmin/issues/18)).
 
+- Fix allocation of dead stack variables
+  ([PR #1044](https://github.com/jasmin-lang/jasmin/pull/1044);
+  fixes [#680](https://github.com/jasmin-lang/jasmin/issues/680)).
+
 ## Other changes
 
 - Adding an annotation to function (`'info` type). Useful to store result of analysis. (see [[#1016](https://github.com/jasmin-lang/jasmin/issues/1016)])

--- a/compiler/src/intervalGraphColoring.ml
+++ b/compiler/src/intervalGraphColoring.ml
@@ -40,6 +40,8 @@ let solve_aux sz todo =
 
 let events_of_graph g =
   Mv.fold (fun n (min, max) result ->
+      (* Support empty live-ranges by making them non-empty. *)
+      let max = if min = max then max + 1 else max in
       assert(min < max);
       (min, Start n) :: (max, End n) :: result
     )

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -3,7 +3,6 @@ open Wsize
 open Memory_model
 open Prog
 
-module Live = Liveness
 module G = IntervalGraphColoring
 
 let hierror = hierror ~kind:"compilation error" ~sub_kind:"variable allocation"
@@ -365,7 +364,7 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
   in
   Mv.iter (check_class fd.f_name.fn_name fd.f_loc ptr_classes ptr_args) classes;
 
-  let fd = Live.live_fd false fd in
+  let fd = Liveness.live_fd true fd in
   let (_, ranges), stack_pointers =
     live_ranges_stmt pd alias ptr_classes (0, Mint.empty) fd.f_body in
 

--- a/compiler/tests/fail/stack_allocation/x86-64/uninit_stack.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/uninit_stack.jazz
@@ -1,9 +1,0 @@
-export
-fn f () -> reg u64 {
-  stack u64 s1;
-  reg u64 res;
-
-  res = s1;
-
-  return res;
-}

--- a/compiler/tests/success/x86-64/bug_680.jazz
+++ b/compiler/tests/success/x86-64/bug_680.jazz
@@ -1,0 +1,28 @@
+/* Check that dead stack variables are properly allocated.
+ * See: https://github.com/jasmin-lang/jasmin/issues/680
+ */
+export
+fn adc_stack(reg u64 x) {
+  stack u64 s;
+  s = 0;
+  _, s += x;
+}
+
+export fn main () -> reg u64 {
+  reg u64 x;
+  stack u64 y;
+
+  x = 0;
+  y = #MOV(x);
+  return x;
+}
+
+/* Variable a must be allocated but its stack slot can be shared with b. */
+#[stacksize = 8] export
+fn share_stack(reg u64 x) -> reg u64 {
+  stack u64 a b;
+  a = #MOV(x);
+  b = #MOV(x);
+  x = b;
+  return x;
+}


### PR DESCRIPTION
Some variables are dead: they are written but never read back. This happens in particular when the source program uses “intrinsics” that are by design kept until assembly, even if they could be otherwise considered dead.

To properly compile programs with such dead stack variables, this makes two changes.

1. stack sharing (aka varalloc) uses weak liveness analysis that computes a singleton (e.g., [x; x]) live-range for dead variables.

2. graph-coloring extends these live ranges (e.g., to [x; x+1]) to be able to handle them properly.


Fixes #680 