### PR TITLE
Gimli proof: fix for latest EasyCrypt

### DIFF
--- a/compiler/examples/gimli/proofs/gimliv.ec
+++ b/compiler/examples/gimli/proofs/gimliv.ec
@@ -18,7 +18,7 @@ op eqstate (v: W128.t * W128.t * W128.t) (s: BArray48.t) =
 proof.
   proc; inline *; wp.
   while (={round} /\ eqstate (x{1}, y{1}, z{1}) state{2}); auto.
-  unroll for{2} ^while; wp; skip => />.
+  unroll for{2} ^while; wp; skip => &1 &2 />.
   rewrite !/VPSHUFD_128 !/VPSHUFD_128_B /= zeroextu128E.
   by rewrite /VPSLL_4u32 /VPSRL_4u32 /(`|<<|`) /(`<<`) !rol_xor.
 qed.


### PR DESCRIPTION
Recent changes (since yesterday, maybe https://github.com/EasyCrypt/easycrypt/pull/708) in EasyCrypt development branch made this proof fail. Bugfix or regression?