### PR TITLE
Use elpi.derive instead of "Scheme Equality"

### DIFF
--- a/compiler/safetylib/safetyAbsExpr.ml
+++ b/compiler/safetylib/safetyAbsExpr.ml
@@ -50,7 +50,7 @@ let msub_of_arr gv sc =
            
 (*-------------------------------------------------------------------------*)
 let get_wsize = function
-  | Type.Coq_sword sz -> sz
+  | Type.Coq_stype.Coq_sword sz -> sz
   | _ -> raise (Aint_error "Not a Coq_sword")
 
 (* Only for expressions that are not arrays *)

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -34,16 +34,16 @@ let z_unsigned_of_word sz z = z_of_cz (Word0.wunsigned sz z)
 (* ------------------------------------------------------------------------ *)
 
 let cty_of_ty = function
-  | Bty Bool      -> T.Coq_sbool
-  | Bty Int       -> T.Coq_sint
-  | Bty (U sz)   -> T.Coq_sword(sz)
-  | Arr (sz, len) -> T.Coq_sarr (pos_of_int (size_of_ws sz * len))
+  | Bty Bool      -> T.Coq_stype.Coq_sbool
+  | Bty Int       -> T.Coq_stype.Coq_sint
+  | Bty (U sz)   -> T.Coq_stype.Coq_sword(sz)
+  | Arr (sz, len) -> T.Coq_stype.Coq_sarr (pos_of_int (size_of_ws sz * len))
 
 let ty_of_cty = function
-  | T.Coq_sbool  ->  Bty Bool
-  | T.Coq_sint   ->  Bty Int
-  | T.Coq_sword sz -> Bty (U sz)
-  | T.Coq_sarr p -> Arr (U8, int_of_pos p)
+  | T.Coq_stype.Coq_sbool  ->  Bty Bool
+  | T.Coq_stype.Coq_sint   ->  Bty Int
+  | T.Coq_stype.Coq_sword sz -> Bty (U sz)
+  | T.Coq_stype.Coq_sarr p -> Arr (U8, int_of_pos p)
 
 (* ------------------------------------------------------------------------ *)
 

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -29,8 +29,8 @@ val z_of_word : wsize -> Obj.t -> Z.t
 val z_unsigned_of_word : wsize -> Obj.t -> Z.t
 
 (* -------------------------------------------------------------------- *)
-val cty_of_ty : Prog.ty -> Type.stype
-val ty_of_cty : Type.stype -> Prog.ty
+val cty_of_ty : Prog.ty -> Type.Coq_stype.stype
+val ty_of_cty : Type.Coq_stype.stype -> Prog.ty
 
 (* -------------------------------------------------------------------- *)
 val cvar_of_var :  var -> Var0.Var.var
@@ -64,4 +64,4 @@ val error_of_cerror :
    Compiler_util.pp_error_loc -> Utils.hierror
 
 (* ---------------------------------------------------- *)
-val fresh_var_ident : v_kind -> IInfo.t -> Uint63.t -> Name.t -> Type.stype -> var
+val fresh_var_ident : v_kind -> IInfo.t -> Uint63.t -> Name.t -> Type.Coq_stype.stype -> var

--- a/compiler/src/dune
+++ b/compiler/src/dune
@@ -10,7 +10,7 @@
 (library
  (name jasmin)
  (public_name jasmin.jasmin)
- (flags (:standard -w -9-27-32-33-34-37-50))
+ (flags (:standard -w -9-27-32-33-34-37-39-50))
  (modules :standard \ main_compiler x86_safety)
  (libraries angstrom batteries.unthreaded zarith menhirLib uint63))
 

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -982,11 +982,11 @@ let cast_int loc e ety =
   cast loc e ety P.tint 
 
 (* -------------------------------------------------------------------- *)
-let conv_ty : T.stype -> P.pty = function
-    | T.Coq_sbool    -> P.tbool
-    | T.Coq_sint     -> P.tint
-    | T.Coq_sword ws -> P.Bty (P.U ws)
-    | T.Coq_sarr p   -> P.Arr (U8, PE (P.icnst (Conv.int_of_pos p)))
+let conv_ty : T.Coq_stype.stype -> P.pty = function
+    | T.Coq_stype.Coq_sbool    -> P.tbool
+    | T.Coq_stype.Coq_sint     -> P.tint
+    | T.Coq_stype.Coq_sword ws -> P.Bty (P.U ws)
+    | T.Coq_stype.Coq_sarr p   -> P.Arr (U8, PE (P.icnst (Conv.int_of_pos p)))
 
 let type_of_op2 op = 
   let (ty1, ty2), tyo = E.type_of_op2 op in
@@ -1835,7 +1835,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
              (string_error "the swap primitive is not available at type %a" PrintCommon.pp_btype ty)
       in
       let es = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args [ty; ty] in
-      let p = Sopn.Opseudo_op (Oswap Type.Coq_sbool) in  (* The type is fixed latter *)
+      let p = Sopn.Opseudo_op (Oswap Type.Coq_stype.Coq_sbool) in  (* The type is fixed latter *)
       [mk_i (P.Copn(lvs, AT_keep, p, es))]
 
   | ls, `Raw, { pl_desc = PEPrim (f, args) }, None ->

--- a/compiler/src/printLinear.ml
+++ b/compiler/src/printLinear.ml
@@ -15,10 +15,10 @@ module F = Format
 (* ---------------------------------------------------------------- *)
 let pp_stype fmt =
   function
-  | T.Coq_sbool  -> F.fprintf fmt "bool"
-  | T.Coq_sint   -> F.fprintf fmt "int"
-  | T.Coq_sarr n -> F.fprintf fmt "u%a[%a]" pp_wsize U8 Z.pp_print (Conv.z_of_pos n)
-  | T.Coq_sword sz -> F.fprintf fmt "u%a" pp_wsize sz
+  | T.Coq_stype.Coq_sbool  -> F.fprintf fmt "bool"
+  | T.Coq_stype.Coq_sint   -> F.fprintf fmt "int"
+  | T.Coq_stype.Coq_sarr n -> F.fprintf fmt "u%a[%a]" pp_wsize U8 Z.pp_print (Conv.z_of_pos n)
+  | T.Coq_stype.Coq_sword sz -> F.fprintf fmt "u%a" pp_wsize sz
 
 (* ---------------------------------------------------------------- *)
 let pp_label fmt lbl =

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -15,6 +15,7 @@
 -arg "-w -deprecated-since-mathcomp-2.3.0"
 -arg "-w -deprecated-from-Coq"
 -arg "-w -deprecated-dirpath-Coq"
+-arg "-async-proofs off"
 
 -R 3rdparty Jasmin
 -R arch Jasmin

--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -1,4 +1,5 @@
 (* -------------------------------------------------------------------- *)
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype ssralg.
 From mathcomp Require Import word_ssrZ.
@@ -48,6 +49,7 @@ Definition rtype {t T} `{ToString t T} := t.
    But it definition can be done in the architecture itself
 *)
 
+#[only(eqbOK)] derive
 Inductive caimm_checker_s :=
   | CAimmC_none
   | CAimmC_arm_shift_amout of shift_kind
@@ -56,14 +58,7 @@ Inductive caimm_checker_s :=
   | CAimmC_riscv_12bits_signed
   | CAimmC_riscv_5bits_unsigned.
 
-Scheme Equality for caimm_checker_s.
-
-Lemma caimm_checker_s_eq_axiom : Equality.axiom caimm_checker_s_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_caimm_checker_s_dec_bl internal_caimm_checker_s_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build caimm_checker_s caimm_checker_s_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build caimm_checker_s caimm_checker_s_eqb_OK.
 
 (* -------------------------------------------------------------------- *)
 (* Basic architecture declaration.
@@ -217,18 +212,12 @@ HB.instance Definition _ := hasDecEq.Build asm_arg asm_arg_eq_axiom.
  * When writing to a register, depending on the instruction,
  * the most significant bits are either preserved or cleared.
  *)
+#[only(eqbOK)] derive
 Variant msb_flag : Type :=
 | MSB_CLEAR
 | MSB_MERGE.
 
-Scheme Equality for msb_flag.
-
-Lemma msb_flag_eq_axiom : Equality.axiom msb_flag_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_msb_flag_dec_bl internal_msb_flag_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build msb_flag msb_flag_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build msb_flag msb_flag_eqb_OK.
 
 (* -------------------------------------------------------------------- *)
 (* Implicit arguments.
@@ -239,6 +228,8 @@ Variant implicit_arg : Type :=
 | IArflag of rflag_t  (* Implicit flag. *)
 | IAreg   of reg_t.   (* Implicit register. *)
 
+(* TODO: can we get rid of this if we add the option to register equality to
+   elpi.derive? *)
 Definition implicit_arg_beq (i1 i2 : implicit_arg) :=
   match i1, i2 with
   | IArflag f1, IArflag f2 => f1 == f2 ::>
@@ -294,6 +285,7 @@ Definition check_oreg or ai :=
 (* Argument kinds.
  * Types for arguments of assembly instructions.
  *)
+#[only(eqbOK)] derive
 Variant arg_kind :=
 | CAcond
 | CAreg
@@ -302,15 +294,7 @@ Variant arg_kind :=
 | CAmem of bool (* true if Global is allowed *)
 | CAimm of caimm_checker_s & wsize.
 
-
-Scheme Equality for arg_kind.
-
-Lemma arg_kind_eq_axiom : Equality.axiom arg_kind_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_arg_kind_dec_bl internal_arg_kind_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build arg_kind arg_kind_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build arg_kind arg_kind_eqb_OK.
 
 (* An argument position where different argument kinds are allowed is
  * represented by a list of these kinds.
@@ -470,17 +454,17 @@ Fixpoint apply_lprod (A B : Type) (f : A -> B) (ts:list Type) : lprod ts A -> lp
   end.
 
 Lemma instr_desc_aux1 ws (id_in id_out : list arg_desc) (id_tin id_tout : list stype) :
-  is_true ((size id_in == size id_tin) && (size id_out == size id_tout)) ->
-  is_true ((size id_in == size id_tin) && (size id_out == size (map (extend_size ws) id_tout))).
+  ((size id_in == size id_tin) && (size id_out == size id_tout)) ->
+  ((size id_in == size id_tin) && (size id_out == size (map (extend_size ws) id_tout))).
 Proof. by rewrite size_map. Qed.
 
 Lemma instr_desc_aux2 ws (id_out : list arg_desc) (id_tout : list stype) :
-  is_true (all2 check_arg_dest id_out id_tout) ->
-  is_true (all2 check_arg_dest id_out (map (extend_size ws) id_tout)).
+  all2 check_arg_dest id_out id_tout ->
+  all2 check_arg_dest id_out (map (extend_size ws) id_tout).
 Proof.
-  rewrite /is_true => <-.
   elim: id_out id_tout => [ | a id_out hrec] [ | t id_tout] //=.
-  rewrite hrec; case: t => // ws'.
+  move=> /andP [+ /hrec ->]; rewrite andbT.
+  case: t => // ws'.
   by rewrite /extend_size /check_arg_dest; case: a => //; case: ifP.
 Qed.
 
@@ -704,15 +688,10 @@ End ENUM.
 
 (* -------------------------------------------------------------------- *)
 (* Flag values. *)
+#[only(eqbOK)] derive
 Variant rflagv := Def of bool | Undef.
-Scheme Equality for rflagv.
 
-Lemma rflagv_eq_axiom : Equality.axiom rflagv_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_rflagv_dec_bl internal_rflagv_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build rflagv rflagv_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build rflagv rflagv_eqb_OK.
 
 (* -------------------------------------------------------------------- *)
 (* Assembly declaration. *)

--- a/proofs/arch/arm_expand_imm.v
+++ b/proofs/arch/arm_expand_imm.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype.
 From mathcomp Require Import word_ssrZ.
@@ -8,20 +9,14 @@ Require Import utils word.
 (* -------------------------------------------------------------------- *)
 (* Valid immediates checks. *)
 
+#[only(eqbOK)] derive
 Variant expand_immediate_kind :=
 | EI_none
 | EI_byte
 | EI_pattern
 | EI_shift.
 
-Scheme Equality for expand_immediate_kind.
-
-Lemma expand_immediate_kind_eq_axiom : Equality.axiom expand_immediate_kind_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_expand_immediate_kind_dec_bl internal_expand_immediate_kind_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build expand_immediate_kind expand_immediate_kind_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build expand_immediate_kind expand_immediate_kind_eqb_OK.
 
 Definition z_to_bytes (n : Z) : Z * Z * Z * Z :=
   let '(n, b0) := Z.div_eucl n 256 in
@@ -55,32 +50,20 @@ Definition ei_kind (n : Z) : expand_immediate_kind :=
   else if is_ei_shift n then EI_shift
   else EI_none.
 
+#[only(eqbOK)] derive
 Variant wencoding :=
   | WE_allowed of bool (* false this encoding is not allowed *)
   | W12_encoding
   | W16_encoding.
 
-Scheme Equality for wencoding.
+HB.instance Definition _ := hasDecEq.Build wencoding wencoding_eqb_OK.
 
-Lemma wencoding_eq_axiom : Equality.axiom wencoding_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_wencoding_dec_bl internal_wencoding_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build wencoding wencoding_eq_axiom.
-
+#[only(eqbOK)] derive
 Record expected_wencoding :=
   { on_shift : wencoding;
     on_none  : wencoding; }.
 
-Scheme Equality for expected_wencoding.
-
-Lemma expected_wencoding_eq_axiom : Equality.axiom expected_wencoding_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_expected_wencoding_dec_bl internal_expected_wencoding_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build expected_wencoding expected_wencoding_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build expected_wencoding expected_wencoding_eqb_OK.
 
 Definition is_w12_encoding (z : Z) : bool := (z <? Z.pow 2 12)%Z.
 Definition is_w16_encoding (z : Z) : bool := (z <? Z.pow 2 16)%Z.

--- a/proofs/compiler/arm_decl.v
+++ b/proofs/compiler/arm_decl.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype fintype ssralg.
 From mathcomp Require Import word_ssrZ.
 
@@ -29,6 +30,7 @@ Definition arm_xreg_size := U64.
 (* -------------------------------------------------------------------- *)
 (* Registers. *)
 
+#[only(eqbOK)] derive
 Variant register : Type :=
 | R00 | R01 | R02 | R03         (* Lower general-purpose registers. *)
 | R04 | R05 | R06 | R07         (* Lower general-purpose registers. *)
@@ -36,16 +38,9 @@ Variant register : Type :=
 | LR                            (* Subroutine link register. *)
 | SP.                           (* Stack pointer. *)
 
-Scheme Equality for register.
-
-Lemma register_eq_axiom : Equality.axiom register_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_register_dec_bl internal_register_dec_lb).
-Qed.
-
 #[ export ]
 Instance eqTC_register : eqTypeC register :=
-  { ceqP := register_eq_axiom }.
+  { ceqP := register_eqb_OK }.
 
 Canonical arm_register_eqType := @ceqT_eqType _ eqTC_register.
 
@@ -92,22 +87,16 @@ Instance reg_toS : ToString (sword arm_reg_size) register :=
 (* -------------------------------------------------------------------- *)
 (* Flags. *)
 
+#[only(eqbOK)] derive
 Variant rflag : Type :=
 | NF    (* Negative condition flag. *)
 | ZF    (* Zero confition flag. *)
 | CF    (* Carry condition flag. *)
 | VF.   (* Overflow condition flag. *)
 
-Scheme Equality for rflag.
-
-Lemma rflag_eq_axiom : Equality.axiom rflag_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_rflag_dec_bl internal_rflag_dec_lb).
-Qed.
-
 #[ export ]
 Instance eqTC_rflag : eqTypeC rflag :=
-  { ceqP := rflag_eq_axiom }.
+  { ceqP := rflag_eqb_OK }.
 
 Canonical rflag_eqType := @ceqT_eqType _ eqTC_rflag.
 
@@ -142,6 +131,7 @@ Instance rflag_toS : ToString sbool rflag :=
 (* -------------------------------------------------------------------- *)
 (* Conditions. *)
 
+#[only(eqbOK)] derive
 Variant condt : Type :=
 | EQ_ct    (* Equal. *)
 | NE_ct    (* Not equal. *)
@@ -158,16 +148,9 @@ Variant condt : Type :=
 | GT_ct    (* Signed greater than. *)
 | LE_ct.   (* Signed less than or equal. *)
 
-Scheme Equality for condt.
-
-Lemma condt_eq_axiom : Equality.axiom condt_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_condt_dec_bl internal_condt_dec_lb).
-Qed.
-
 #[ export ]
 Instance eqTC_condt : eqTypeC condt :=
-  { ceqP := condt_eq_axiom }.
+  { ceqP := condt_eqb_OK }.
 
 Canonical condt_eqType := @ceqT_eqType _ eqTC_condt.
 
@@ -212,17 +195,9 @@ Definition string_of_condt (c : condt) : string :=
  * Some instructions can shift a register before performing an operation.
  *)
 
-Scheme Equality for shift_kind.
-
-Lemma shift_kind_eq_axiom : Equality.axiom shift_kind_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme internal_shift_kind_dec_bl internal_shift_kind_dec_lb).
-Qed.
-
 #[ export ]
 Instance eqTC_shift_kind : eqTypeC shift_kind :=
-  { ceqP := shift_kind_eq_axiom }.
+  { ceqP := shift_kind_eqb_OK }.
 
 Canonical shift_kind_eqType := @ceqT_eqType _ eqTC_shift_kind.
 

--- a/proofs/compiler/arm_extra.v
+++ b/proofs/compiler/arm_extra.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssralg.
 
@@ -17,6 +18,7 @@ Require Import
   arm.
 
 
+#[only(eqbOK)] derive
 Variant arm_extra_op : Type :=
   | Oarm_swap of wsize
   | Oarm_add_large_imm
@@ -24,21 +26,11 @@ Variant arm_extra_op : Type :=
   | Osmart_li_cc of wsize (* Conditional [Osmart_li]. *)
 .
 
-Scheme Equality for arm_extra_op.
-
-Lemma arm_extra_op_eq_axiom : Equality.axiom arm_extra_op_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_arm_extra_op_dec_bl
-       internal_arm_extra_op_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build arm_extra_op arm_extra_op_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build arm_extra_op arm_extra_op_eqb_OK.
 
 #[ export ]
 Instance eqTC_arm_extra_op : eqTypeC arm_extra_op :=
-  { ceqP := arm_extra_op_eq_axiom }.
+  { ceqP := arm_extra_op_eqb_OK }.
 
 (* Extra instructions descriptions. *)
 

--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -3,6 +3,7 @@
    These are the THUMB instructions of ARMv7-M, the instruction set of the M4
    processor. *)
 
+From elpi.apps Require Import derive.std.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq eqtype fintype.
 From mathcomp Require Import ssralg word_ssrZ.
 
@@ -29,6 +30,7 @@ End E.
 (* -------------------------------------------------------------------- *)
 (* ARM instruction options. *)
 
+#[only(eqbOK)] derive
 Record arm_options :=
   {
     set_flags : bool;
@@ -36,37 +38,11 @@ Record arm_options :=
     has_shift : option shift_kind;
   }.
 
-Definition arm_options_beq (ao0 ao1 : arm_options) : bool :=
-  [&& set_flags ao0 == set_flags ao1
-    , is_conditional ao0 == is_conditional ao1
-    & has_shift ao0 == has_shift ao1
-  ].
-
-Lemma arm_options_eq_axiom : Equality.axiom arm_options_beq.
-Proof.
-  move=> [? ? ?] [? ? ?].
-  apply: (iffP idP);
-    last move=> <-;
-    rewrite /arm_options_beq /=.
-  - move=> /and3P [].
-    repeat move=> /eqP ?.
-    by subst.
-  - by apply/and3P.
-Qed.
-
 #[ export ]
 Instance eqTC_arm_options : eqTypeC arm_options :=
-  { ceqP := arm_options_eq_axiom }.
+  { ceqP := arm_options_eqb_OK }.
 
 Canonical arm_options_eqType := @ceqT_eqType _ eqTC_arm_options.
-
-Lemma arm_options_dec_eq (ao0 ao1 : arm_options) :
-  { ao0 = ao1 } + { ao0 <> ao1 }.
-Proof.
-  case: (ao0 == ao1) /arm_options_eq_axiom.
-  - by left.
-  - by right.
-Qed.
 
 Definition default_opts : arm_options :=
   {|
@@ -93,11 +69,13 @@ Definition unset_is_conditional (ao : arm_options) : arm_options :=
 (* -------------------------------------------------------------------- *)
 (* ARM instruction mnemonics. *)
 
+#[only(eqbOK)] derive
 Variant halfword : Type :=
 | HWB
 | HWT
 .
 
+#[only(eqbOK)] derive
 Variant arm_mnemonic : Type :=
 (* Arithmetic *)
 | ADD                            (* Add without carry *)
@@ -171,19 +149,9 @@ Variant arm_mnemonic : Type :=
 | STRB                           (* Store a byte *)
 | STRH.                          (* Store a halfword *)
 
-Scheme Equality for arm_mnemonic.
-
-Lemma arm_mnemonic_eq_axiom : Equality.axiom arm_mnemonic_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_arm_mnemonic_dec_bl
-       internal_arm_mnemonic_dec_lb).
-Qed.
-
 #[ export ]
 Instance eqTC_arm_mnemonic : eqTypeC arm_mnemonic :=
-  { ceqP := arm_mnemonic_eq_axiom }.
+  { ceqP := arm_mnemonic_eqb_OK }.
 
 Canonical arm_mnemonic_eqType := @ceqT_eqType _ eqTC_arm_mnemonic.
 
@@ -331,41 +299,15 @@ Definition string_of_arm_mnemonic (mn : arm_mnemonic) : string :=
 (* -------------------------------------------------------------------- *)
 (* ARM operators are pairs of mnemonics and options. *)
 
+#[only(eqbOK)] derive
 Variant arm_op :=
 | ARM_op : arm_mnemonic -> arm_options -> arm_op.
 
-Definition arm_op_beq (op0 op1 : arm_op) : bool :=
-  let '(ARM_op mn0 ao0) := op0 in
-  let '(ARM_op mn1 ao1) := op1 in
-  (mn0 == mn1) && (ao0 == ao1).
-
-Lemma arm_op_eq_axiom : Equality.axiom arm_op_beq.
-Proof.
-  move=> [mn0 ao0] [mn1 ao1].
-  apply: (iffP idP);
-    last move=> <-;
-    rewrite /arm_op_beq /=.
-  - move=> /andP [].
-    move=> /arm_mnemonic_eq_axiom <-.
-    by move=> /arm_options_eq_axiom <-.
-  - apply/andP. split.
-    + by apply/arm_mnemonic_eq_axiom.
-    + by apply/arm_options_eq_axiom.
-Qed.
-
 #[ export ]
 Instance eqTC_arm_op : eqTypeC arm_op :=
-  { ceqP := arm_op_eq_axiom }.
+  { ceqP := arm_op_eqb_OK }.
 
 Canonical arm_op_eqType := @ceqT_eqType _ eqTC_arm_op.
-
-Lemma arm_op_dec_eq (op0 op1 : arm_op) :
-  { op0 = op1 } + { op0 <> op1 }.
-Proof.
-  case: (op0 == op1) /arm_op_eq_axiom.
-  - by left.
-  - by right.
-Qed.
 
 
 (* -------------------------------------------------------------------- *)

--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -550,13 +550,16 @@ Proof.
       by rewrite /exec_sopn /= truncate_word_le // /= zero_extend_u.
     done.
 
-  t_xrbindP=> wbase' vbase hgetx hbase woff' voff hseme hoff wres hread ? hw;
-    subst ws''.
+  apply: rbindP => wbase'.
+  apply: rbindP => vbase hgetx hbase.
+  apply: rbindP => woff'.
+  apply: rbindP => voff hseme hoff.
+  apply: rbindP => wres hread /= /ok_word_inj [? hw]; subst ws''.
   move: hbase => /to_wordI [ws0 [wbase [? /truncate_wordP [hws0 ?]]]];
     subst wbase' vbase.
   move: hoff => /to_wordI [ws1 [woff [? /truncate_wordP [hws1 ?]]]];
     subst woff' voff.
-  move: hw => [?]; subst wres.
+  move: hw => /= ?; subst wres.
 
   split; last done.
   clear hfve.
@@ -1121,13 +1124,17 @@ Proof.
   case: b hw hwrite12' => hw hwrite12'.
   - move: hexeces.
     rewrite /exec_sopn /=.
-    case: ves => [// | ? []]; t_xrbindP=> //= v _ -> /= [->] ?; subst ws''.
-    move=> [?]; subst v.
+    case: ves => [// | ? []]; last by t_xrbindP.
+    apply: rbindP => v /=.
+    apply: rbindP => _ -> [->] /ok_inj /(f_equal (head (Vbool true))) /= /Vword_inj [?]; subst ws''.
+    move=> /= ?; subst v.
     by rewrite truncate_word_le.
   move: hexeces.
   rewrite /exec_sopn /=.
-  case: ves => [// | ? []]; t_xrbindP=> //= v _ -> /= [->] ?; subst ws''.
-  move=> [?]; subst v.
+  case: ves => [// | ? []]; last by t_xrbindP.
+  apply: rbindP => v /=.
+  apply: rbindP => _ -> [->] /ok_inj /(f_equal (head (Vbool true))) /= /Vword_inj [?]; subst ws''.
+  move=> /= ?; subst v.
   by rewrite truncate_word_le.
 Qed.
 

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq eqtype fintype.
 From mathcomp Require Import ssralg.
@@ -76,6 +77,8 @@ End IS_MOVE_OP.
 
 Section COMPILER.
 
+(* To use [Finite.axiom], we need [compiler_step] to be [eqType]. *)
+#[only(eqbOK)] derive
 Variant compiler_step :=
   | Typing                      : compiler_step
   | ParamsExpansion             : compiler_step
@@ -142,16 +145,7 @@ Definition compiler_step_list := [::
   ; Assembly
 ].
 
-(* To use [Finite.axiom], we must first show that [compiler_step] is [eqType]. *)
-Scheme Equality for compiler_step.
-Lemma compiler_step_eq_axiom : Equality.axiom compiler_step_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_compiler_step_dec_bl
-       internal_compiler_step_dec_lb).
-Qed.
-HB.instance Definition _ := hasDecEq.Build compiler_step compiler_step_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build compiler_step compiler_step_eqb_OK.
 
 Lemma compiler_step_list_complete : Finite.axiom compiler_step_list.
 Proof. by case. Qed.

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -1266,7 +1266,7 @@ Proof.
     exists pr; split; first by reflexivity.
     move=> off w /[dup] /get_val_byte_bound hoff /hread ok_w.
     move: (va_wf i); rewrite /wf_arg ok_writable ok_pr.
-    move=> [_ [[<-] hargp]].
+    move=> [_ [/Vword_inj1 <- hargp]].
     rewrite -ok_w; apply (match_mem_read_incl_mem mi2).
     apply hargp.(wap_valid).
     by apply (between_byte hargp.(wap_no_overflow) (zbetween_refl _ _) hoff).

--- a/proofs/compiler/lea_proof.v
+++ b/proofs/compiler/lea_proof.v
@@ -128,24 +128,33 @@ Section PROOF.
       by rewrite lea_constP.
     move=> [] //= [] //= sz1 e1 He1 e2 He2 l sz' w hsz'.
     + case Heq1: mk_lea_rec => [l1|]//; case Heq2: mk_lea_rec => [l2|]// Hadd.
-      rewrite /sem_sop2 /=; t_xrbindP=> > + ? + ?
-        /to_wordI' [? [? [hsz1 ? ->]]] ?
-        /to_wordI' [? [? [hsz2 ? ->]]] ?.
-      subst=> h1 h2 [<-]; rewrite wadd_zero_extend // !zero_extend_idem //.
+      rewrite /sem_sop2 /=.
+      apply: rbindP => ? h1.
+      apply: rbindP => ? h2.
+      apply: rbindP => ? /to_wordI' [? [? [hsz1 ? ->]]].
+      apply: rbindP => ? /to_wordI' [? [? [hsz2 ? ->]]].
+      move=> /ok_word_inj [??]; subst=> /=.
+      rewrite wadd_zero_extend // !zero_extend_idem //.
       exact (lea_addP hsz (He1 _ _ _ (cmp_le_trans hsz' hsz1) Heq1 h1)
                            (He2 _ _ _ (cmp_le_trans hsz' hsz2) Heq2 h2) Hadd).
     + case Heq1: mk_lea_rec => [l1|]//;case Heq2: mk_lea_rec => [l2|]// Hmul.
-      rewrite /sem_sop2 /=; t_xrbindP=> > + ? + ?
-        /to_wordI' [? [? [hsz1 ? ->]]] ?
-        /to_wordI' [? [? [hsz2 ? ->]]] ?.
-      subst=> h1 h2 [<-]; rewrite wmul_zero_extend // !zero_extend_idem //.
+      rewrite /sem_sop2 /=.
+      apply: rbindP => ? h1.
+      apply: rbindP => ? h2.
+      apply: rbindP => ? /to_wordI' [? [? [hsz1 ? ->]]].
+      apply: rbindP => ? /to_wordI' [? [? [hsz2 ? ->]]].
+      move=> /ok_word_inj [??]; subst=> /=.
+      rewrite wmul_zero_extend // !zero_extend_idem //.
       exact (lea_mulP hsz (He1 _ _ _ (cmp_le_trans hsz' hsz1) Heq1 h1)
                            (He2 _ _ _ (cmp_le_trans hsz' hsz2) Heq2 h2) Hmul).
     case Heq1: mk_lea_rec => [l1|]//;case Heq2: mk_lea_rec => [l2|]// Hsub.
-    rewrite /sem_sop2 /=; t_xrbindP=> > + ? + ?
-        /to_wordI' [? [? [hsz1 ? ->]]] ?
-        /to_wordI' [? [? [hsz2 ? ->]]] ?.
-      subst=> h1 h2 [<-]; rewrite wsub_zero_extend // !zero_extend_idem //.
+    rewrite /sem_sop2 /=.
+    apply: rbindP => ? h1.
+    apply: rbindP => ? h2.
+    apply: rbindP => ? /to_wordI' [? [? [hsz1 ? ->]]].
+    apply: rbindP => ? /to_wordI' [? [? [hsz2 ? ->]]].
+    move=> /ok_word_inj [??]; subst=> /=.
+    rewrite wsub_zero_extend // !zero_extend_idem //.
     exact (lea_subP hsz (He1 _ _ _ (cmp_le_trans hsz' hsz1) Heq1 h1)
                            (He2 _ _ _ (cmp_le_trans hsz' hsz2) Heq2 h2) Hsub).
   Qed.

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -3091,7 +3091,7 @@ Section PROOF.
       rewrite /top_stack_aligned (negbTE ok_ra) /= => ok_stk_sz sp_aligned [??]; subst lbli li.
     have s1_rsp : (evm s1).[vrsp] = Vword (top_stack (emem s1)).
     + by move: T; rewrite /valid_RSP /kill_tmp_call /= kill_varsE; case: ifP.
-    move: (s1_rsp); rewrite hsp => -[?]; subst sp.
+    move: (s1_rsp); rewrite hsp => /Vword_inj1 ?; subst sp.
     set rastack_before := is_RAstack_None_call _.
     set rastack_after  := is_RAstack_None_return _.
     set sz := stack_frame_allocation_size _.
@@ -4447,7 +4447,7 @@ Section PROOF.
             by exists caller, lret, cbody, pc, retptr; split.
           move=> [ok_cbody ok_pc mem_lret [retptr ok_retptr ok_ra]].
           exists caller, lret, cbody, pc, retptr; split=> //.
-          move: ok_ra; rewrite ok_rsp => -[_ [<-] +].
+          move: ok_ra; rewrite ok_rsp => -[_ /Vword_inj1 <- +].
           by rewrite wrepr0 GRing.addr0.
 
       (* Initial code that stores the return address on top of the stack if it

--- a/proofs/compiler/riscv_decl.v
+++ b/proofs/compiler/riscv_decl.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype fintype ssralg.
 From mathcomp Require Import word_ssrZ.
 
@@ -22,22 +23,16 @@ Definition riscv_xreg_size := U64. (* Unused *)
 (* Registers. *)
 (* According to the RISC-V ABI, X3/GP and X4/TP are unallocatable, so we do not
    model them. *)
+#[only(eqbOK)] derive
 Variant register : Type :=
 | RA  | SP  | X5  | X6  | X7  | X8              (* General-purpose registers. *)
 | X9  | X10 | X11 | X12 | X13 | X14 | X15 | X16 (* General-purpose registers. *)
 | X17 | X18 | X19 | X20 | X21 | X22 | X23 | X24 (* General-purpose registers. *)
 | X25 | X26 | X27 | X28 | X29 | X30 | X31.      (* General-purpose registers. *)
 
-Scheme Equality for register.
-
-Lemma register_eq_axiom : Equality.axiom register_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_register_dec_bl internal_register_dec_lb).
-Qed.
-
 #[ export ]
 Instance eqTC_register : eqTypeC register :=
-  { ceqP := register_eq_axiom }.
+  { ceqP := register_eqb_OK }.
 
 Canonical riscv_register_eqType := @ceqT_eqType _ eqTC_register.
 
@@ -104,6 +99,7 @@ Instance reg_toS : ToString (sword riscv_reg_size) register :=
 (* -------------------------------------------------------------------- *)
 (* Conditions. *)
 
+#[only(eqbOK)] derive
 Variant condition_kind :=
 | EQ               (* Equal. *)
 | NE               (* Not equal. *)
@@ -111,34 +107,16 @@ Variant condition_kind :=
 | GE of signedness (* Signed / Unsigned greater than or equal to. *)
 .
 
+#[only(eqbOK)] derive
 Record condt := {
   cond_kind : condition_kind;
   cond_fst : option register;
   cond_snd : option register;
 }.
 
-Scheme Equality for condition_kind.
-
-Definition condt_beq c1 c2 : bool :=
-  (condition_kind_beq c1.(cond_kind) c2.(cond_kind)) &&
-  (c1.(cond_fst) == c2.(cond_fst)) && (c1.(cond_snd) == c2.(cond_snd))
-.
-
-Lemma condt_eq_axiom : Equality.axiom condt_beq.
-Proof.
-  move => c1 c2.
-  apply Bool.iff_reflect.
-  split.
-  + move => ->.
-    by rewrite /condt_beq internal_condition_kind_dec_lb// !eqxx.
-  case: c1 c2 => k1 f1 s1 [] k2 f2 s2.
-  rewrite /condt_beq/=.
-  move => /andP[]/andP[] /internal_condition_kind_dec_bl-> /eqP->/eqP->//.
-Qed.
-
 #[ export ]
 Instance eqTC_condt : eqTypeC condt :=
-  { ceqP := condt_eq_axiom }.
+  { ceqP := condt_eqb_OK }.
 
 Canonical condt_eqType := @ceqT_eqType _ eqTC_condt.
 
@@ -189,15 +167,13 @@ Instance riscv_decl : arch_decl register register_ext xregister rflag condt :=
   ; check_CAimm := riscv_check_CAimm
   }.
 
-  (* It looks like the program crashes if GP (global pointer) is not preserved.
-     To be on the safe side, GP and TP (thread pointer) are marked as callee-saved. *)
-  Definition riscv_linux_call_conv : calling_convention :=
-  {| callee_saved :=
-      map ARReg [:: SP; X8; X9; X18; X19; X20; X21; X22; X23; X24; X25; X26; X27 ]
-   ; callee_saved_not_bool := erefl true
-   ; call_reg_args  := [:: X10; X11; X12; X13; X14; X15; X16; X17 ]
-   ; call_xreg_args := [::]
-   ; call_reg_ret   := [:: X10; X11]
-   ; call_xreg_ret  := [::]
-   ; call_reg_ret_uniq := erefl true;
-  |}.
+Definition riscv_linux_call_conv : calling_convention :=
+{| callee_saved :=
+    map ARReg [:: SP; X8; X9; X18; X19; X20; X21; X22; X23; X24; X25; X26; X27 ]
+ ; callee_saved_not_bool := erefl true
+ ; call_reg_args  := [:: X10; X11; X12; X13; X14; X15; X16; X17 ]
+ ; call_xreg_args := [::]
+ ; call_reg_ret   := [:: X10; X11]
+ ; call_xreg_ret  := [::]
+ ; call_reg_ret_uniq := erefl true;
+|}.

--- a/proofs/compiler/riscv_extra.v
+++ b/proofs/compiler/riscv_extra.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssralg.
 
@@ -18,26 +19,16 @@ Require Import
 
 Local Notation E n := (sopn.ADExplicit n None).
 
-
+#[only(eqbOK)] derive
 Variant riscv_extra_op : Type :=  
   | SWAP of wsize
   | Oriscv_add_large_imm.
 
-Scheme Equality for riscv_extra_op.
-
-Lemma riscv_extra_op_eq_axiom : Equality.axiom riscv_extra_op_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_riscv_extra_op_dec_bl
-       internal_riscv_extra_op_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build riscv_extra_op riscv_extra_op_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build riscv_extra_op riscv_extra_op_eqb_OK.
 
 #[ export ]
 Instance eqTC_riscv_extra_op : eqTypeC riscv_extra_op :=
-  { ceqP := riscv_extra_op_eq_axiom }.
+  { ceqP := riscv_extra_op_eqb_OK }.
 
 (* [conflicts] ensures that the returned register is distinct from the first
    argument. *)

--- a/proofs/compiler/riscv_instr_decl.v
+++ b/proofs/compiler/riscv_instr_decl.v
@@ -1,5 +1,6 @@
 (* RISC-V 32I instruction set *)
 
+From elpi.apps Require Import derive.std.
 From mathcomp Require Import ssreflect ssrfun ssrbool seq eqtype ssralg.
 From mathcomp Require Import word_ssrZ.
 
@@ -95,6 +96,7 @@ Definition ITypeInstruction_5u  := ITypeInstruction CAimmC_riscv_5bits_unsigned.
 (* -------------------------------------------------------------------- *)
 (* RISC-V 32I Base Integer instructions (operators). *)
 
+#[only(eqbOK)] derive
 Variant riscv_op : Type :=
 (* Arithmetic *)
 | ADD                            (* Add register without carry *)
@@ -151,19 +153,9 @@ Variant riscv_op : Type :=
 | REMU                           (* Remainder for two unsigned registers *)
 .
 
-Scheme Equality for riscv_op.
-
-Lemma riscv_op_eq_axiom : Equality.axiom riscv_op_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_riscv_op_dec_bl
-       internal_riscv_op_dec_lb).
-Qed.
-
 #[ export ]
 Instance eqTC_riscv_op : eqTypeC riscv_op :=
-  { ceqP := riscv_op_eq_axiom }.
+  { ceqP := riscv_op_eqb_OK }.
 
 Canonical riscv_op_eqType := @ceqT_eqType _ eqTC_riscv_op.
 

--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -1,4 +1,5 @@
 (* ** Imports and settings *)
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq eqtype ssralg.
 From mathcomp Require Import word_ssrZ.
@@ -58,6 +59,7 @@ Definition slot := var.
 
 Notation size_slot s := (size_of s.(vtype)).
 
+(* elpi.derive not clever enough to unfold slot *)
 Record region :=
   { r_slot : slot;        (* the name of the region        *)
       (* the size of the region is encoded in the type of [r_slot] *)
@@ -105,19 +107,15 @@ End CmpR.
 Module Mr := Mmake CmpR.
 
 (* ------------------------------------------------------------------ *)
+#[only(eqbOK)] derive Z.
+
+#[only(eqbOK)] derive
 Record zone := {
   z_ofs : Z;
   z_len : Z;
 }.
 
-Scheme Equality for zone.
-
-Lemma zone_eq_axiom : Equality.axiom zone_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_zone_dec_bl internal_zone_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build zone zone_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build zone zone_eqb_OK.
 
 Definition disjoint_zones z1 z2 :=
   (((z1.(z_ofs) + z1.(z_len))%Z <= z2.(z_ofs)) ||

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -1224,7 +1224,7 @@ Section EXPR.
       exists (Vword wr); split=> //.
       have := hrec _ _ he1.
       rewrite /truncate_val /= hto /= => /(_ _ erefl) [] v' [] he1'.
-      t_xrbindP=> w hv' ?; subst w.
+      apply: rbindP => w hv' /ok_inj /Vword_inj1 ?; subst w.
       have := get_var_kindP hc hnnew hget; rewrite /get_gvar /= => -> /=.
       rewrite hto' /= he1' /= hv' /=.
       by rewrite -(eq_mem_source_word hvalid (readV hr)) hr.
@@ -1856,7 +1856,7 @@ Proof.
     have {}he1': sem_pexpr true [::] s2 e1' >>= to_pointer = ok w1.
     + have [ws1 [wv1 [? hwv1]]] := to_wordI hv1; subst.
       move: he1'; rewrite /truncate_val /= hwv1 /= => /(_ _ erefl) [] ve1' [] -> /=.
-      by t_xrbindP=> w1' -> ? /=; subst w1'.
+      by apply: rbindP => w1' -> /ok_inj /Vword_inj1 ->.
     rewrite he1' hxp /= hvw /=.
     have hvp1 := write_validw hmem1.
     have /valid_incl_word hvp2 := hvp1.
@@ -2741,7 +2741,8 @@ Lemma alloc_protect_ptrP m0 s1 s2 s1' rmap1 rmap2 ii r tag e msf vmsf v v' n i2 
   ∃ s2' : estate, sem_i P' rip s2 i2 s2' ∧ valid_state rmap2 m0 s1' s2'.
 Proof.
   move=> hvs he hmsf; rewrite /truncate_val /=.
-  t_xrbindP => w /to_wordI [sz' [wmsf [? htr]]] ? a' /to_arrI ? ? hw; subst v v' w vmsf.
+  apply: rbindP => w /to_wordI [sz' [wmsf [? htr]]] /ok_inj /Vword_inj1 ?; subst w vmsf.
+  t_xrbindP=> a' /to_arrI ? ? hw; subst v v'.
   rewrite /alloc_protect_ptr.
   t_xrbindP=> -[x ofsx] hgetr [y ofsy] hgete.
   case hkindy: (get_var_kind pmap y) => [vk|] //.
@@ -2826,7 +2827,7 @@ Proof.
   move: he1; t_xrbindP => ve1 h1 hve1 /=.
   have := alloc_eP hvs hmsf' hmsf.
   rewrite /truncate_val /= htr /= => /(_ _ erefl) [] vmsf' [] ok_vmsf'.
-  t_xrbindP=> z hto ?; subst z.
+  apply: rbindP => z hto /ok_inj /Vword_inj1 ?; subst z.
   move=> /(_ s2 s2' [::] [::ve1; vmsf'] [::Vword (w + wrepr Uptr ofs2)]) /= h.
   have ? : ofs2 = 0%Z; last subst ofs2.
   + by case: (vpky) hvpky hmk_addr => // -[] //= ? _ [] _ <-.
@@ -3929,9 +3930,9 @@ Proof.
   have := Forall3_nth haddr None (Vbool true) (Vbool true).
   move=> /[dup].
   move=> /(_ _ (nth_not_default hsri ltac:(discriminate)) _ _ hsri).
-  rewrite hpi hvai => -[[?] hwfi]; subst pi.
+  rewrite hpi hvai => -[/Vword_inj1 ? hwfi]; subst pi.
   move=> /(_ _ (nth_not_default hsrj ltac:(discriminate)) _ _ hsrj).
-  rewrite hpj hvaj => -[[?] hwfj]; subst pj.
+  rewrite hpj hvaj => -[/Vword_inj1 ? hwfj]; subst pj.
   apply (disj_sub_regions_disjoint_zrange hwfi hwfj) => //.
   by apply: hdisj hsri hsrj neq_ij.
 Qed.
@@ -4239,7 +4240,7 @@ Proof.
   have /is_sarrP [nx hty] := hlocal.(wfr_type).
   have :=
     Forall3_nth haddr None (Vbool true) (Vbool true) (nth_not_default hnth ltac:(discriminate)) _ _ hnth.
-  rewrite -hresp.(wrp_args) => -[[?] hwf]; subst w.
+  rewrite -hresp.(wrp_args) => -[/Vword_inj1 ? hwf]; subst w.
   set vp := Vword (sub_region_addr sr).
   exists (with_vm s2 (evm s2).[p <- vp]).
   have : type_of_val vp = vtype p by rewrite hlocal.(wfr_rtype).

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -2250,7 +2250,7 @@ Proof.
       have [sr hsr] := Forall2_nth (alloc_call_args_aux_not_None hcargsx) None None hi _ hpi.
       rewrite hw in hsr.
       have := Forall3_nth haddr None (Vbool true) (Vbool true) (nth_not_default hsr ltac:(discriminate)) _ _ hsr.
-      rewrite hp2 => -[[?] hwf']; subst p2.
+      rewrite hp2 => -[/Vword_inj1 ? hwf']; subst p2.
       have {}hw := Forall_nth (alloc_call_args_aux_writable hcargsx) None (nth_not_default hsr ltac:(discriminate)) _ hsr.
       have /List.Forall_forall -/(_ (sub_region_at_ofs sr (Some 0) (size_val (nth (Vbool true) vargs1 i)), type_of_val (nth (Vbool true) vargs1 i))) := hdisj'.
       rewrite -sub_region_addr_offset wrepr0 GRing.addr0.
@@ -2416,9 +2416,8 @@ Proof.
   move: ok_writablej; rewrite (nth_map None) //; apply: obindP=> _ -> _.
   rewrite ok_pj ok_pj'.
   rewrite /dc_truncate_val.
-  case: ifP.
-  + by move=> _ [<-].
-  by rewrite /truncate_val /= truncate_word_u => _ [<-].
+  rewrite /truncate_val /= truncate_word_u /= if_same.
+  by move=> /ok_inj.
 Qed.
 
 (* If the parameter is a reg ptr, [varg2] is a pointer, and is equal to [varg2']. *)
@@ -2633,7 +2632,7 @@ Proof.
   rewrite -hfss.(fss_read_old8); first by apply hread.
   move: (hargs j); rewrite /wf_arg (nth_map None) //.
   rewrite hpi /= -hresultp.(wrp_args).
-  move=> [_ [[<-] hargp]].
+  move=> [_ [/Vword_inj1 <- hargp]].
   rewrite -hvalideq.
   apply hargp.(wap_valid).
   have hsub := hresultp.(wrp_subtype).
@@ -2757,7 +2756,7 @@ Proof.
     move=> i hi pi hpi p hp hlt.
     move: (hargs' i); rewrite /wf_arg.
     rewrite (nth_map None) // hpi /=.
-    rewrite hp => -[_ [[<-] hargp]].
+    rewrite hp => -[_ [/Vword_inj1 <- hargp]].
     apply disjoint_zrange_U8 => //.
     + by apply size_of_gt0.
     + by apply hargp.(wap_no_overflow).

--- a/proofs/compiler/x86_decl.v
+++ b/proofs/compiler/x86_decl.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype choice fintype.
 From mathcomp Require Import word_ssrZ.
@@ -21,15 +22,18 @@ Definition x86_reg_size  := U64.
 Definition x86_xreg_size := U256.
 
 (* -------------------------------------------------------------------- *)
+#[only(eqbOK)] derive
 Variant register : Type :=
   | RAX | RCX | RDX | RBX | RSP | RBP | RSI | RDI
   | R8  | R9  | R10 | R11 | R12 | R13 | R14 | R15.
 
 (* -------------------------------------------------------------------- *)
+#[only(eqbOK)] derive
 Variant register_ext : Type :=
   | MM0 | MM1 | MM2 | MM3 | MM4 | MM5 | MM6 | MM7.
 
 (* -------------------------------------------------------------------- *)
+#[only(eqbOK)] derive
 Variant xmm_register : Type :=
   | XMM0 | XMM1 | XMM2 | XMM3
   | XMM4 | XMM5 | XMM6 | XMM7
@@ -37,10 +41,12 @@ Variant xmm_register : Type :=
   | XMM12 | XMM13 | XMM14 | XMM15.
 
 (* -------------------------------------------------------------------- *)
+#[only(eqbOK)] derive
 Variant rflag : Type :=
   | CF | PF | ZF | SF | OF.
 
 (* -------------------------------------------------------------------- *)
+#[only(eqbOK)] derive
 Variant condt : Type :=
 | O_ct                  (* overflow *)
 | NO_ct                 (* not overflow *)
@@ -62,64 +68,15 @@ Variant condt : Type :=
 
 (* -------------------------------------------------------------------- *)
 
-Scheme Equality for register.
+HB.instance Definition _ := hasDecEq.Build register register_eqb_OK.
 
-Lemma reg_eq_axiom : Equality.axiom register_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_register_dec_bl internal_register_dec_lb).
-Qed.
+HB.instance Definition _ := hasDecEq.Build register_ext register_ext_eqb_OK.
 
-HB.instance Definition _ := hasDecEq.Build register reg_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build xmm_register xmm_register_eqb_OK.
 
-(* -------------------------------------------------------------------- *)
+HB.instance Definition _ := hasDecEq.Build rflag rflag_eqb_OK.
 
-Scheme Equality for register_ext.
-
-Lemma regx_eq_axiom : Equality.axiom register_ext_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_register_ext_dec_bl
-       internal_register_ext_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build register_ext regx_eq_axiom.
-
-(* -------------------------------------------------------------------- *)
-
-Scheme Equality for xmm_register.
-
-Lemma xreg_eq_axiom : Equality.axiom xmm_register_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_xmm_register_dec_bl
-       internal_xmm_register_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build xmm_register xreg_eq_axiom.
-
-(* -------------------------------------------------------------------- *)
-
-Scheme Equality for rflag.
-
-Lemma rflag_eq_axiom : Equality.axiom rflag_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_rflag_dec_bl internal_rflag_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build rflag rflag_eq_axiom.
-
-(* -------------------------------------------------------------------- *)
-
-Scheme Equality for condt.
-
-Lemma condt_eq_axiom : Equality.axiom condt_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_condt_dec_bl internal_condt_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build condt condt_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build condt condt_eqb_OK.
 
 (* -------------------------------------------------------------------- *)
 Definition registers :=
@@ -180,7 +137,7 @@ HB.instance Definition _ := isFinite.Build rflag rflags_fin_axiom.
 
 #[global]
 Instance eqTC_register : eqTypeC register :=
-  { ceqP := reg_eq_axiom }.
+  { ceqP := register_eqb_OK }.
 
 #[global]
 Instance finC_register : finTypeC register :=
@@ -215,7 +172,7 @@ Instance x86_reg_toS : ToString (sword x86_reg_size) register :=
 (* -------------------------------------------------------------------- *)
 #[global]
 Instance eqTC_regx : eqTypeC register_ext :=
-  { ceqP := regx_eq_axiom }.
+  { ceqP := register_ext_eqb_OK }.
 
 #[global]
 Instance finC_regx : finTypeC register_ext :=
@@ -242,7 +199,7 @@ Instance x86_regx_toS : ToString (sword x86_reg_size) register_ext :=
 (* -------------------------------------------------------------------- *)
 #[global]
 Instance eqTC_xmm_register : eqTypeC xmm_register :=
-  { ceqP := xreg_eq_axiom }.
+  { ceqP := xmm_register_eqb_OK }.
 
 #[global]
 Instance finC_xmm_register : finTypeC xmm_register :=
@@ -278,7 +235,7 @@ Instance x86_xreg_toS : ToString (sword x86_xreg_size) xmm_register :=
 
 #[global]
 Instance eqTC_rflag : eqTypeC rflag :=
-  { ceqP := rflag_eq_axiom }.
+  { ceqP := rflag_eqb_OK }.
 
 #[global]
 Instance finC_rflag : finTypeC rflag :=
@@ -303,7 +260,7 @@ Instance x86_rflag_toS : ToString sbool rflag :=
 
 #[global]
 Instance eqC_condt : eqTypeC condt :=
-  { ceqP := condt_eq_axiom }.
+  { ceqP := condt_eqb_OK }.
 
 (* -------------------------------------------------------------------- *)
 

--- a/proofs/compiler/x86_extra.v
+++ b/proofs/compiler/x86_extra.v
@@ -1,4 +1,5 @@
 (* -------------------------------------------------------------------- *)
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssralg.
 From mathcomp Require Import word_ssrZ.
@@ -46,6 +47,7 @@ End E.
 
 (* -------------------------------------------------------------------- *)
 
+#[only(eqbOK)] derive
 Variant x86_extra_op : Type :=
 | Oset0     of wsize  (* set register + flags to 0 (implemented using XOR x x or VPXOR x x) *)
 | Oconcat128          (* concatenate 2 128 bits word into 1 256 word register *)
@@ -59,17 +61,7 @@ Variant x86_extra_op : Type :=
 | Ox86SLHprotect of reg_kind & wsize
 .
 
-Scheme Equality for x86_extra_op.
-
-Lemma x86_extra_op_eq_axiom : Equality.axiom x86_extra_op_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_x86_extra_op_dec_bl
-       internal_x86_extra_op_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build x86_extra_op x86_extra_op_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build x86_extra_op x86_extra_op_eqb_OK.
 
 Local Notation E n := (ADExplicit n None).
 
@@ -342,7 +334,7 @@ Definition assemble_extra ii o outx inx : cexec (seq (asm_op_msb_t * lexprs * re
 
 #[global]
 Instance eqC_x86_extra_op : eqTypeC x86_extra_op :=
-  { ceqP := x86_extra_op_eq_axiom }.
+  { ceqP := x86_extra_op_eqb_OK }.
 
 (* Without priority 1, this instance is selected when looking for an [asmOp],
    meaning that extra ops are the only possible ops. With that priority,

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype tuple.
 From mathcomp Require Import ssralg word word_ssrZ.
@@ -9,6 +10,7 @@ Require Import x86_decl.
 
 (* -------------------------------------------------------------------- *)
 
+#[only(eqbOK)] derive
 Variant x86_op : Type :=
   (* Data transfert *)
 | MOV    of wsize              (* copy *)
@@ -195,14 +197,7 @@ Variant x86_op : Type :=
 | VPCLMULQDQ of wsize
 .
 
-Scheme Equality for x86_op.
-
-Lemma x86_op_eq_axiom : Equality.axiom x86_op_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_x86_op_dec_bl internal_x86_op_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build x86_op x86_op_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build x86_op x86_op_eqb_OK.
 
 (* ----------------------------------------------------------------------------- *)
 Definition b_ty             := [:: sbool].
@@ -2399,7 +2394,7 @@ Definition x86_prim_string :=
 
 #[global]
 Instance eqC_x86_op : eqTypeC x86_op :=
-  { ceqP := x86_op_eq_axiom }.
+  { ceqP := x86_op_eqb_OK }.
 
 #[global]
 Instance x86_op_decl : asm_op_decl x86_op := {

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -176,6 +176,11 @@ Section PROOF.
     end.
   Qed.
 
+  Lemma cons_inj {A} {x1 x2 : A} (s1 s2 : seq A) :
+    x1 :: s1 = x2 :: s2 ->
+    x1 = x2 /\ s1 = s2.
+  Proof. by case. Qed.
+
   Lemma add_inc_dec_classifyP s sz (a b : pexpr) w1 (z1: word w1) w2 (z2 : word w2) :
     sem_pexprs true gd s [:: a; b] = ok [:: Vword z1; Vword z2] ->
     match add_inc_dec_classify sz a b with
@@ -186,12 +191,18 @@ Section PROOF.
   Proof.
     have := add_inc_dec_classifyP' sz a b.
     case: (add_inc_dec_classify sz a b)=> [y|y|//].
-    + case=> [[??]|[??]]; subst; rewrite /sem_pexprs /=; t_xrbindP.
-      + by move => z -> -> -> [<-]; exists w1, z1; do 2 (split; first by eauto); rewrite zero_extend_u /wrepr mathcomp.word.word.mkword1E.
-      by move => ? z -> <- -> [<-] [->]; exists w2, z2; do 2 (split; first by eauto); rewrite zero_extend_u /wrepr mathcomp.word.word.mkword1E GRing.addrC.
-    + case=> [[??]|[??]]; subst; rewrite /sem_pexprs /=; t_xrbindP.
-      + by move => z -> -> -> [<-]; exists w1, z1; do 2 (split; first by eauto); rewrite zero_extend_u /wrepr mathcomp.word.word.mkwordN1E.
-      by move => ? z -> <- -> [<-] [->]; exists w2, z2; do 2 (split; first by eauto); rewrite zero_extend_u /wrepr mathcomp.word.word.mkwordN1E GRing.addrC.
+    + case=> [[??]|[??]]; subst; rewrite /sem_pexprs /=.
+      + apply: rbindP => z -> /ok_inj /cons_inj [] -> /cons_inj [] /Vword_inj [??] _; subst w2 z2 => /=.
+        by exists w1, z1; do 2 (split; first by eauto); rewrite zero_extend_u /wrepr mathcomp.word.word.mkword1E.
+      apply: rbindP => ?.
+      apply: rbindP => z -> [<-] /ok_inj /cons_inj [] /Vword_inj [??] [->]; subst w1 z1 => /=.
+      by exists w2, z2; do 2 (split; first by eauto); rewrite zero_extend_u /wrepr mathcomp.word.word.mkword1E GRing.addrC.
+    case=> [[??]|[??]]; subst; rewrite /sem_pexprs /=.
+    + apply: rbindP => z -> /ok_inj /cons_inj [] -> /cons_inj [] /Vword_inj [??] _; subst w2 z2 => /=.
+      by exists w1, z1; do 2 (split; first by eauto); rewrite zero_extend_u /wrepr mathcomp.word.word.mkwordN1E.
+    apply: rbindP => ?.
+    apply: rbindP => z -> [<-] /ok_inj /cons_inj [] /Vword_inj [??] [->]; subst w1 z1 => /=.
+    by exists w2, z2; do 2 (split; first by eauto); rewrite zero_extend_u /wrepr mathcomp.word.word.mkwordN1E GRing.addrC.
   Qed.
 
   Lemma sub_inc_dec_classifyP sz e:

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -1,4 +1,5 @@
 (* ** Imports and settings *)
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype div ssralg.
 Require Import oseq.
@@ -20,14 +21,17 @@ Local Unset Elimination Schemes.
    - cpu-op: CPU instructions such as addition with carry
 *)
 
+#[only(eqbOK)] derive
 Variant cmp_kind :=
   | Cmp_int
   | Cmp_w of signedness & wsize.
 
+#[only(eqbOK)] derive
 Variant op_kind :=
   | Op_int
   | Op_w of wsize.
 
+#[only(eqbOK)] derive
 Variant sop1 :=
 | Oword_of_int of wsize     (* int → word *)
 | Oint_of_word of wsize     (* word → unsigned int *)
@@ -38,6 +42,7 @@ Variant sop1 :=
 | Oneg  of op_kind          (* Arithmetic negation *)
 .
 
+#[only(eqbOK)] derive
 Variant sop2 :=
 | Obeq                        (* const : sbool -> sbool -> sbool *)
 | Oand                        (* const : sbool -> sbool -> sbool *)
@@ -75,6 +80,7 @@ Variant sop2 :=
 .
 
 (* N-ary operators *)
+#[only(eqbOK)] derive
 Variant combine_flags :=
 | CF_LT    of signedness   (* Alias : signed => L  ; unsigned => B   *) 
 | CF_LE    of signedness   (* Alias : signed => LE ; unsigned => BE  *)
@@ -84,39 +90,17 @@ Variant combine_flags :=
 | CF_GT    of signedness   (* Alias : signed => !LE; unsigned => !BE *)
 .
 
+#[only(eqbOK)] derive
 Variant opN :=
 | Opack of wsize & pelem (* Pack words of size pelem into one word of wsize *)
 | Ocombine_flags of combine_flags
 .
 
-Scheme Equality for sop1.
-(* Definition sop1_beq : sop1 -> sop1 -> bool *)
+HB.instance Definition _ := hasDecEq.Build sop1 sop1_eqb_OK.
 
-Lemma sop1_eq_axiom : Equality.axiom sop1_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_sop1_dec_bl internal_sop1_dec_lb).
-Qed.
+HB.instance Definition _ := hasDecEq.Build sop2 sop2_eqb_OK.
 
-HB.instance Definition _ := hasDecEq.Build sop1 sop1_eq_axiom.
-
-Scheme Equality for sop2.
-(* Definition sop2_beq : sop2 -> sop2 -> bool *)
-
-Lemma sop2_eq_axiom : Equality.axiom sop2_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_sop2_dec_bl internal_sop2_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build sop2 sop2_eq_axiom.
-
-Scheme Equality for opN.
-
-Lemma opN_eq_axiom : Equality.axiom opN_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_opN_dec_bl internal_opN_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build opN opN_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build opN opN_eqb_OK.
 
 (* ----------------------------------------------------------------------------- *)
 
@@ -208,18 +192,12 @@ Definition mk_var_i (x : var) :=
 Notation vid ident :=
   (mk_var_i {| vtype := sword Uptr; vname := ident%string; |}).
 
+#[only(eqbOK)] derive
 Variant v_scope := 
   | Slocal 
   | Sglob.
 
-Scheme Equality for v_scope.
-
-Lemma v_scope_eq_axiom : Equality.axiom v_scope_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_v_scope_dec_bl internal_v_scope_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build v_scope v_scope_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build v_scope v_scope_eqb_OK.
 
 Record gvar := Gvar { gv : var_i; gs : v_scope }.
 
@@ -299,16 +277,10 @@ Definition var_info_of_lval (x: lval) : var_info :=
 (* ** Instructions
  * -------------------------------------------------------------------- *)
 
+#[only(eqbOK)] derive
 Variant dir := UpTo | DownTo.
 
-Scheme Equality for dir.
-
-Lemma dir_eq_axiom : Equality.axiom dir_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_dir_dec_bl internal_dir_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build dir dir_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build dir dir_eqb_OK.
 
 Definition range := (dir * pexpr * pexpr)%type.
 
@@ -341,6 +313,7 @@ Definition ii_with_location (ii : instr_info) : instr_info :=
 Definition ii_is_inline (ii : instr_info) : bool := InstrInfo.is_inline ii.
 Definition var_info_of_ii (ii : instr_info) : var_info := InstrInfo.var_info_of_ii ii.
 
+#[only(eqbOK)] derive
 Variant assgn_tag :=
   | AT_none       (* assignment introduced by the developer that can be removed *)
   | AT_keep       (* assignment that should be kept by the compiler *)
@@ -351,15 +324,7 @@ Variant assgn_tag :=
   | AT_phinode    (* renaming during SSA transformation *)
   .
 
-Scheme Equality for assgn_tag.
-
-Lemma assgn_tag_eq_axiom : Equality.axiom assgn_tag_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme internal_assgn_tag_dec_bl internal_assgn_tag_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build assgn_tag assgn_tag_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build assgn_tag assgn_tag_eqb_OK.
 
 (* -------------------------------------------------------------------- *)
 

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -18,7 +18,7 @@ Extraction Inline utils.assert.
 Extraction Inline utils.Result.bind.
 Extraction Inline Datatypes.implb.
 
-Extract Constant strings.ascii_beq => "Char.equal".
+Extract Constant strings.ascii_eqb => "Char.equal".
 Extract Constant strings.ascii_cmp =>
   "(fun x y -> let c = Char.compare x y in if c = 0 then Datatypes.Eq else if c < 0 then Datatypes.Lt else Datatypes.Gt)".
 

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -1,4 +1,5 @@
 (* ** Imports and settings *)
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq div eqtype.
 From mathcomp Require Import ssralg word_ssrZ.
@@ -112,16 +113,10 @@ End POINTER.
 (** This type describes whether a memory access must check for alignment.
   With Unaligned, there are no particular constraints.
   With Aligned, the pointer must be a multiple of the size of the access. *)
+#[only(eqbOK)] derive
 Variant aligned := Unaligned | Aligned.
 
-Scheme Equality for aligned.
-
-Lemma aligned_eq_axiom : Equality.axiom aligned_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_aligned_dec_bl internal_aligned_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build aligned aligned_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build aligned aligned_eqb_OK.
 
 Definition aligned_le (x y: aligned) : bool :=
   (x == Unaligned) || (y == Aligned).

--- a/proofs/lang/pseudo_operator.v
+++ b/proofs/lang/pseudo_operator.v
@@ -1,5 +1,6 @@
-From Coq Require Import ZArith.
+From elpi.apps Require Import derive.std.
 From mathcomp Require Import ssreflect ssrfun ssrbool seq eqtype.
+From Coq Require Import ZArith.
 
 Require Import
   strings
@@ -11,26 +12,18 @@ Require Import
 (* Pseudo operators. *)
 
 (* Instructions that must be present in all the architectures. *)
+#[only(eqbOK)] derive
 Variant spill_op := 
   | Spill 
   | Unspill.
 
-Scheme Equality for spill_op.
-
-Lemma spill_op_eq_axiom : Equality.axiom spill_op_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_spill_op_dec_bl
-       internal_spill_op_dec_lb).
-Qed.
-
 #[export]
 Instance eqTC_spill_op : eqTypeC spill_op :=
-  { ceqP := spill_op_eq_axiom }.
+  { ceqP := spill_op_eqb_OK }.
 
 Canonical spill_op_eqType := @ceqT_eqType _ eqTC_spill_op.
 
+#[only(eqbOK)] derive
 Variant pseudo_operator :=
 | Ospill    of spill_op & seq stype
 | Ocopy     of wsize & positive
@@ -41,33 +34,9 @@ Variant pseudo_operator :=
 | Oswap     of stype   (* [ty; ty] -> [ty; ty] *)
 .
 
-(* Scheme Equality for pseudo_operator. *)
-
-Definition pseudo_operator_beq (o1 o2 : pseudo_operator) : bool := 
-  match o1, o2 with
-  | Ospill o1 l1, Ospill o2 l2 => (o1 == o2) && (l1 == l2)
-  | Ocopy w1 p1, Ocopy w2 p2 => (w1 == w2) && (p1 == p2)
-  | Onop, Onop => true
-  | Omulu w1, Omulu w2 => w1 == w2
-  | Oaddcarry w1, Oaddcarry w2 => w1 == w2
-  | Osubcarry w1, Osubcarry w2 => w1 == w2
-  | Oswap t1, Oswap t2 => t1 == t2
-  | _, _ => false
-  end.
-
-Lemma pseudo_operator_eq_axiom : Equality.axiom pseudo_operator_beq.
-Proof.
-  case=> [o1 l1 | w1 p1 | | w1 | w1 | w1 | t1];
-    case=> [o2 l2 | w2 p2 | | w2 | w2 | w2 | t2] => /=;
-    by [ constructor
-       | apply (equivP andP); split => [[/eqP -> /eqP ->] | [-> ->]]
-       | apply (equivP eqP); split => [-> | [->]]
-       ].
-Qed.
-
 #[export]
 Instance eqTC_pseudo_operator : eqTypeC pseudo_operator :=
-  { ceqP := pseudo_operator_eq_axiom }.
+  { ceqP := pseudo_operator_eqb_OK }.
 
 Canonical pseudo_operator_eqType := @ceqT_eqType _ eqTC_pseudo_operator.
 

--- a/proofs/lang/shift_kind.v
+++ b/proofs/lang/shift_kind.v
@@ -1,22 +1,17 @@
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype.
 From Coq Require Import ZArith.
 Require Import utils.
 
- Variant shift_kind :=
- | SLSL
- | SLSR
- | SASR
- | SROR.
+#[only(eqbOK)] derive
+Variant shift_kind :=
+| SLSL
+| SLSR
+| SASR
+| SROR.
 
-Scheme Equality for shift_kind.
-
-Lemma shift_kind_eq_axiom : Equality.axiom shift_kind_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_shift_kind_dec_bl internal_shift_kind_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build shift_kind shift_kind_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build shift_kind shift_kind_eqb_OK.
 
 Definition shift_amount_bounds sk :=
   match sk with
@@ -25,5 +20,3 @@ Definition shift_amount_bounds sk :=
   | SASR => (1, 32)%Z
   | SROR => (1, 31)%Z
   end.
-
-

--- a/proofs/lang/slh_ops.v
+++ b/proofs/lang/slh_ops.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat div eqtype ssralg.
 
@@ -13,6 +14,7 @@ Require Import
    - as "toplevel" operators (to be used in [sopn]); and
    - as "pseudo-operators" of each architecture (to be used in [asm_op]).
 *)
+#[only(eqbOK)] derive
 Variant slh_op :=
   | SLHinit
   | SLHupdate
@@ -21,11 +23,4 @@ Variant slh_op :=
   | SLHprotect_ptr of positive
   | SLHprotect_ptr_fail of positive.  (* Not exported to the user *)
 
-Scheme Equality for slh_op.
-
-Lemma slh_op_eq_axiom : Equality.axiom slh_op_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_slh_op_dec_bl internal_slh_op_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build slh_op slh_op_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build slh_op slh_op_eqb_OK.

--- a/proofs/lang/stack_zero_strategy.v
+++ b/proofs/lang/stack_zero_strategy.v
@@ -10,11 +10,12 @@ Implemented in [compiler/stack_zeroization.v].
 The strategies are not defined in [compiler/stack_zeroization.v] to avoid a
 circular dependency. *)
 
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool seq eqtype fintype.
 Require Import utils.
 
-
+#[only(eqbOK)] derive
 Variant stack_zero_strategy :=
 | SZSloop
 | SZSloopSCT
@@ -30,17 +31,7 @@ Definition stack_zero_strategy_list := [::
 ].
 
 (* To use [Finite.axiom], we must first show that [stack_zero_strategy] is [eqType]. *)
-Scheme Equality for stack_zero_strategy.
-
-Lemma stack_zero_strategy_eq_axiom : Equality.axiom stack_zero_strategy_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme
-       internal_stack_zero_strategy_dec_bl
-       internal_stack_zero_strategy_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build stack_zero_strategy stack_zero_strategy_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build stack_zero_strategy stack_zero_strategy_eqb_OK.
 
 Lemma stack_zero_strategy_list_complete : Finite.axiom stack_zero_strategy_list.
 Proof. by case. Qed.

--- a/proofs/lang/strings.v
+++ b/proofs/lang/strings.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From Coq Require Import ZArith.
 From Coq Require Export String.
 From HB Require Import structures.
@@ -5,16 +6,11 @@ From mathcomp Require Import ssreflect ssrfun ssrbool eqtype choice.
 Require Import utils gen_map.
 
 (* -------------------------------------------------------------------- *)
-Scheme Equality for Ascii.ascii.
-(* ascii_beq :  Ascii.ascii ->  Ascii.ascii -> bool *)
-(* ascii_eq_dec *)
+#[only(eqbOK)] derive Ascii.ascii.
+(* ascii_eqb :  Ascii.ascii ->  Ascii.ascii -> bool *)
+(* ascii_eqb_OK *)
 
-Lemma ascii_eqP : Equality.axiom ascii_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_ascii_dec_bl internal_ascii_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build Ascii.ascii ascii_eqP.
+HB.instance Definition _ := hasDecEq.Build Ascii.ascii ascii_eqb_OK.
 HB.instance Definition _ := Countable.copy Ascii.ascii
   (can_type Ascii.ascii_nat_embedding).
 
@@ -43,16 +39,11 @@ Proof.
 Qed.
 
 (* -------------------------------------------------------------------- *)
-Scheme Equality for String.string.
-(* string_beq is defined
-   string_eq_dec is defined *)
+#[only(eqbOK)] derive string.
+(* string_eqb is defined
+   string_eqb_OK is defined *)
 
-Lemma string_eqP : Equality.axiom string_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_string_dec_bl internal_string_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build string string_eqP.
+HB.instance Definition _ := hasDecEq.Build string string_eqb_OK.
 
 Fixpoint string_cmp s1 s2 :=
   match s1, s2 with

--- a/proofs/lang/syscall.v
+++ b/proofs/lang/syscall.v
@@ -1,3 +1,4 @@
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool seq eqtype ssralg.
 From Coq Require Import PArith ZArith.
@@ -6,20 +7,11 @@ Require Import
   type
   utils.
 
-Local Unset Elimination Schemes.
-
+#[only(eqbOK)] derive
 Variant syscall_t : Type := 
   | RandomBytes of positive.
 
-Scheme Equality for syscall_t.
-
-Lemma syscall_t_eq_axiom : Equality.axiom syscall_t_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme internal_syscall_t_dec_bl internal_syscall_t_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build syscall_t syscall_t_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build syscall_t syscall_t_eqb_OK.
 
 (* -------------------------------------------------------------------- *)
 (* For typing                                                           *)

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -1,4 +1,5 @@
 (* ** Imports and settings *)
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice.
 From mathcomp Require Import fintype finfun.
@@ -1234,15 +1235,9 @@ Notation Lex u v :=
 
 (* -------------------------------------------------------------------- *)
 
-Scheme Equality for comparison.
+#[only(eqbOK)] derive comparison.
 
-Lemma comparison_beqP : Equality.axiom comparison_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme internal_comparison_dec_bl internal_comparison_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build comparison comparison_beqP.
+HB.instance Definition _ := hasDecEq.Build comparison comparison_eqb_OK.
 
 (* -------------------------------------------------------------------- *)
 
@@ -1502,10 +1497,10 @@ Lemma Pos_lt_leb_trans y x z:
   (x <? y)%positive -> (y <=? z)%positive -> (x <? z)%positive.
 Proof. move=> /P_ltP ? /P_leP ?;apply /P_ltP; Lia.lia. Qed.
 
-Lemma pos_eqP : Equality.axiom Pos.eqb.
-Proof. by move=> p1 p2;apply:(iffP idP);rewrite -Pos.eqb_eq. Qed.
+(* TODO: when elpi.derive supports it, register Pos.eqb_spec instead *)
+#[only(eqbOK)] derive positive.
 
-HB.instance Definition _ := hasDecEq.Build positive pos_eqP.
+HB.instance Definition _ := hasDecEq.Build positive positive_eqb_OK.
 
 #[global]
 Instance positiveO : Cmp Pos.compare.
@@ -1911,8 +1906,8 @@ Ltac t_do_rewrites tac :=
   repeat
     match goal with
     | [ h : ?lhs = ?rhs |- _ ] => tac h lhs rhs
-    | [ h : is_true (?lhs == ?rhs) |- _ ] => move: h => /eqP h; tac h lhs rhs
-    | [ h : is_true ?lhs |- _ ] => tac h lhs true
+    | [ h : Datatypes.is_true (?lhs == ?rhs) |- _ ] => move: h => /eqP h; tac h lhs rhs
+    | [ h : Datatypes.is_true ?lhs |- _ ] => tac h lhs true
     end.
 
 #[local]

--- a/proofs/lang/warray_.v
+++ b/proofs/lang/warray_.v
@@ -1,27 +1,21 @@
 (* * Syntax and semantics of the Jasmin source language *)
 
 (* ** Imports and settings *)
-From Coq Require Export ZArith Setoid Morphisms.
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype div ssralg.
 From mathcomp Require Import word_ssrZ.
+From Coq Require Export ZArith Setoid Morphisms.
 Require Import xseq.
 Require Export utils array gen_map type word memory_model.
 Import Utf8 ZArith Lia.
 
+#[only(eqbOK)] derive
 Variant arr_access := 
   | AAdirect
   | AAscale.
 
-Scheme Equality for arr_access.
-
-Lemma arr_access_eq_axiom : Equality.axiom arr_access_beq.
-Proof.
-  exact:
-    (eq_axiom_of_scheme internal_arr_access_dec_bl internal_arr_access_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build arr_access arr_access_eq_axiom.
+HB.instance Definition _ := hasDecEq.Build arr_access arr_access_eqb_OK.
 
 Local Open Scope Z_scope.
 

--- a/proofs/lang/wsize.v
+++ b/proofs/lang/wsize.v
@@ -2,6 +2,7 @@
 
 (* ** Imports and settings *)
 
+From elpi.apps Require Import derive.std.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool seq eqtype fintype.
 From Coq Require Import ZArith.
@@ -10,6 +11,7 @@ Import Utf8.
 Import word_ssrZ.
 
 (* -------------------------------------------------------------- *)
+#[only(eqbOK)] derive
 Variant wsize :=
   | U8
   | U16
@@ -19,6 +21,7 @@ Variant wsize :=
   | U256.
 
 (* Size in bits of the elements of a vector. *)
+#[only(eqbOK)] derive
 Variant velem := VE8 | VE16 | VE32 | VE64.
 
 Coercion wsize_of_velem (ve: velem) : wsize :=
@@ -30,22 +33,20 @@ Coercion wsize_of_velem (ve: velem) : wsize :=
   end.
 
 (* Size in bits of the elements of a pack. *)
+#[only(eqbOK)] derive
 Variant pelem :=
 | PE1 | PE2 | PE4 | PE8 | PE16 | PE32 | PE64 | PE128.
 
+#[only(eqbOK)] derive
 Variant signedness :=
   | Signed
   | Unsigned.
 
 (* -------------------------------------------------------------------- *)
-Scheme Equality for wsize.
+HB.instance Definition _ := hasDecEq.Build wsize wsize_eqb_OK.
 
-Lemma wsize_axiom : Equality.axiom wsize_beq.
-Proof.
-  exact: (eq_axiom_of_scheme internal_wsize_dec_bl internal_wsize_dec_lb).
-Qed.
-
-HB.instance Definition _ := hasDecEq.Build wsize wsize_axiom.
+(* We still need the sumbool version *)
+Definition wsize_eq_dec ws1 ws2 := Bool.reflect_dec _ _ (wsize_eqb_OK ws1 ws2).
 
 Definition wsizes :=
   [:: U8 ; U16 ; U32 ; U64 ; U128 ; U256 ].
@@ -152,6 +153,7 @@ Definition pp_sz_sz (s: string) (sign:bool) (sz sz': wsize) (_: unit) : string :
   s ++ "_u" ++ string_of_wsize sz ++ (if sign then "s" else "u")%string ++ string_of_wsize sz'.
 
 (* -------------------------------------------------------------------- *)
+#[only(eqbOK)] derive
 Variant reg_kind : Type :=
 | Normal
 | Extra.


### PR DESCRIPTION
elpi.derive is much faster on inductives with many constructors. This is particularly interesting for type x86_op which has more than 100 constructors.