### PR TITLE
x86: fix printing of CLFLUSH instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@
   ([PR #1044](https://github.com/jasmin-lang/jasmin/pull/1044);
   fixes [#680](https://github.com/jasmin-lang/jasmin/issues/680)).
 
+- Fix printing of x86 `CLFLUSH` instruction in “Intel” syntax
+  ([PR #1054](https://github.com/jasmin-lang/jasmin/pull/1054);
+  fixes [#438](https://github.com/jasmin-lang/jasmin/issues/438)).
+
 ## Other changes
 
 - Adding an annotation to function (`'info` type). Useful to store result of analysis. (see [[#1016](https://github.com/jasmin-lang/jasmin/issues/1016)])

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -1956,7 +1956,7 @@ Definition Ox86_RDTSCP_instr :=
 
 (* Fences & cache-related instructions *)
 Definition Ox86_CLFLUSH_instr :=
-  mk_instr_pp "CLFLUSH" [:: sword Uptr ] [::] [:: Ec 0 ] [::] MSB_CLEAR (λ _, tt) [:: [:: m true ] ] 1 (primM CLFLUSH) (pp_name "clflush" Uptr).
+  mk_instr_pp "CLFLUSH" [:: sword Uptr ] [::] [:: Ec 0 ] [::] MSB_CLEAR (λ _, tt) [:: [:: m true ] ] 1 (primM CLFLUSH) (pp_name "clflush" U8).
 
 Definition Ox86_PREFETCHT0_instr :=
   mk_instr_pp "PREFETCHT0" [:: sword Uptr ] [::] [:: Ec 0 ] [::] MSB_CLEAR (λ _, tt) [:: [:: m true ] ] 1 (primM PREFETCHT0) (pp_name "prefetcht0" Uptr).


### PR DESCRIPTION
Fixes #438.