### PR TITLE
LATEX: do not escape underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@
   [PR #1057](https://github.com/jasmin-lang/jasmin/pull/1057);
   fixes [#438](https://github.com/jasmin-lang/jasmin/issues/438)).
 
+- Fix LATEX printing of strings
+  ([PR #1063](https://github.com/jasmin-lang/jasmin/pull/1063),
+  [PR #1064](https://github.com/jasmin-lang/jasmin/pull/1064);
+  fixes [#1060](https://github.com/jasmin-lang/jasmin/issues/1060)).
+
 ## Other changes
 
 - Adding an annotation to function (`'info` type). Useful to store result of analysis. (see [[#1016](https://github.com/jasmin-lang/jasmin/issues/1016)])

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -28,7 +28,6 @@ let openbrace fmt () = F.fprintf fmt "\\{"
 let closebrace fmt () = F.fprintf fmt "\\}"
 let percent fmt () = F.fprintf fmt "\\%%"
 let dollar fmt () = F.fprintf fmt "\\$"
-let underscore fmt () = F.fprintf fmt "\\_"
 let tilde fmt () = F.fprintf fmt "\\textasciitilde{}"
 let caret fmt () = F.fprintf fmt "\\textasciicircum{}"
 let backslash fmt () = F.fprintf fmt "\\textbackslash{}"
@@ -56,7 +55,6 @@ let pp_string fmt s =
   | '}' -> closebrace fmt ()
   | '%' -> percent fmt ()
   | '$' -> dollar fmt ()
-  | '_' -> underscore fmt ()
   | '~' -> tilde fmt ()
   | '^' -> caret fmt ()
   | c -> F.fprintf fmt "%c" c


### PR DESCRIPTION
Follow-up on #1063.