### PR TITLE
Adding a check to verify that functions names do not conflict when translated to assembly labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 - Fix EC extraction in case on nested loops
   ([PR #971](https://github.com/jasmin-lang/jasmin/pull/971)).
 
+- Program with conflicting assembly labels print warning when compiled
+  ([PR #1067](https://github.com/jasmin-lang/jasmin/pull/1067);
+  fixes [#993](https://github.com/jasmin-lang/jasmin/issues/993)).
+
 ## Other changes
 
 - The deprecated legacy interface to the LATEX pretty-printer has been removed

--- a/compiler/src/label_check.ml
+++ b/compiler/src/label_check.ml
@@ -1,0 +1,42 @@
+open Prog 
+open Utils
+
+
+type function_label = {
+  loc : L.t;
+  fname : string;
+}
+
+type duplicate_label_warn = {
+  first_decl : function_label;
+  conflict_decl : function_label;
+}
+
+let pp_duplicate_label_warn fmt {first_decl={loc=first_loc; fname=first_fname}; conflict_decl={loc=_;fname=second_fname}} =
+  Format.fprintf fmt
+    "Function '%s' and function '%s' (declared at %s) have conflicting assembly label names."
+    second_fname
+    first_fname
+    (Location.tostring first_loc)
+
+
+let warn_duplicate_label warn = 
+  warning Always (L.i_loc0 warn.conflict_decl.loc) "%a" pp_duplicate_label_warn warn
+
+let check_labels_fun (f: ('len,'info,'asm) gfunc) ((errors, label_map): (((duplicate_label_warn list) * function_label Ms.t ))) : (duplicate_label_warn list) * function_label Ms.t = 
+  let fn_label = PrintCommon.escape f.f_name.fn_name in
+  if f.f_cc != Internal then 
+    match Ms.find_opt fn_label label_map with
+    | None -> errors, Ms.add fn_label {loc=f.f_loc;fname=f.f_name.fn_name} label_map
+    | Some (label) -> 
+      let conflict = {first_decl=label; conflict_decl={loc=f.f_loc; fname=f.f_name.fn_name}} in
+      conflict::errors, label_map
+  else errors,label_map
+
+let get_labels_errors (prog: ('len,'info,'asm) gprog) = 
+    fst (List.fold_left (
+      fun label_map f -> 
+        match f with 
+        | MIfun f -> check_labels_fun f label_map
+        | _ -> label_map
+    ) ([],Ms.empty) prog)

--- a/compiler/src/label_check.mli
+++ b/compiler/src/label_check.mli
@@ -1,0 +1,33 @@
+open Prog
+
+
+(**
+Record types describing data used to detect and print informations about function labels. Used for error (warning) printing
+*)
+type function_label = {
+  loc : L.t;
+  fname : string;
+}
+
+(**
+Duplicate label error (warning) containing informations about the two conflicting functions
+*)
+type duplicate_label_warn = {
+  first_decl : function_label;
+  conflict_decl : function_label;
+}
+
+(** 
+Function that print a duplicate_label_warn using Utils.warning
+@param error : duplicate_label_warn
+*)
+val warn_duplicate_label : duplicate_label_warn -> unit
+
+(**
+Check if functions have conflicting names when translated to their assembly label names.
+It return the list of conflict errors detected.
+The way error are handled is let to the calling function.
+@param prog : program to check
+@return : duplicate_label_warn list 
+*)
+val get_labels_errors : ('len,'info,'asm) gprog -> duplicate_label_warn list

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -134,6 +134,10 @@ let main () =
       exit 0
     end;
 
+    (* Check if generated assembly labels will generate conflicts*)
+    let label_errors = Label_check.get_labels_errors pprog in 
+    List.iter Label_check.warn_duplicate_label label_errors;
+    
     eprint Compiler.Typing (Printer.pp_pprog Arch.reg_size Arch.asmOp) pprog;
 
     let prog =

--- a/compiler/tests/success/common/inline_label_duplication.jazz
+++ b/compiler/tests/success/common/inline_label_duplication.jazz
@@ -1,0 +1,15 @@
+inline fn ble::e () -> reg u32 {
+    reg u32 x = 0;
+    return x;
+}
+
+inline fn ble__e () -> reg u32 {
+    reg u32 x = 1;
+    return x;
+}
+
+export fn out() -> reg u32 {
+    reg u32 x = ble::e();
+    reg u32 y = ble__e();
+    return y;
+} 


### PR DESCRIPTION
# Issue 

Assembly generation use `PrintCommon.escape` function to build labels which can creates names conflicts because of namespaces. see (#993).

# Solution 

We introduce a map in `pretyping.ml` environment that check if a label is already used by another function.