### PR TITLE
Wint2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 
 ## New features
 
+- Introduction of wint types siXX and uiXX (XX in [8,16,32,64,128, 256]). The
+  key feature of this new type are for the extraction to easycrypt. They are
+  extracted to int, removing the need to deal with modulus 2^XX operations.
+  Introduction of a new cast operators: `(sint)` and `(uint)` from words to
+  `int`. The previous cast operator `(int)` stands for one of them if its
+  argument is of wint type: applying it to usual machine words is deprecated.
+  Introduce zquot and zrem operators on int : `e1 /s e2` and `e1 %s e2`.
+  ([PR #1071](https://github.com/jasmin-lang/jasmin/pull/1071)).
+
 - Add support for x86 `SHA256MSG1`, `SHA256MSG2`, and `SHA256RNDS2` instructions
   ([PR #1116](https://github.com/jasmin-lang/jasmin/pull/1116);
   fixes [#1040](https://github.com/jasmin-lang/jasmin/issues/1040)).

--- a/compiler/entry/commonCLI.ml
+++ b/compiler/entry/commonCLI.ml
@@ -73,7 +73,7 @@ let parse_and_compile (type reg regx xreg rflag cond asm_op extra_op)
        and type rflag = rflag
        and type cond = cond
        and type asm_op = asm_op
-       and type extra_op = extra_op) pass file idirs =
+       and type extra_op = extra_op) ~wi2i pass file idirs =
   let _env, pprog, _ast =
     try Compile.parse_file Arch.arch_info ~idirs file with
     | Annot.AnnotationError (loc, code) ->
@@ -88,6 +88,10 @@ let parse_and_compile (type reg regx xreg rflag cond asm_op extra_op)
     try Compile.preprocess Arch.reg_size Arch.asmOp pprog
     with Typing.TyError (loc, code) ->
       hierror ~loc:(Lmore loc) ~kind:"typing error" "%s" code
+  in
+
+  let prog =
+    if not wi2i then prog else Compile.do_wint_int (module Arch) prog
   in
 
   let prog =

--- a/compiler/entry/commonCLI.mli
+++ b/compiler/entry/commonCLI.mli
@@ -17,6 +17,8 @@ val parse_and_compile :
       and type regx = 'regx
       and type rflag = 'rflag
       and type xreg = 'xreg) ->
+  wi2i:bool ->
+  (* true => start by replacing wint operation by int operation *)
   Compiler.compiler_step ->
   string ->
   (string * string) list ->

--- a/compiler/entry/jasmin2ec.ml
+++ b/compiler/entry/jasmin2ec.ml
@@ -36,8 +36,7 @@ let parse_and_extract arch call_conv idirs =
   let module A = (val get_arch_module arch call_conv) in
 
   let extract model amodel functions array_dir output pass file =
-    let prog = parse_and_compile (module A) pass file idirs in
-
+    let prog = parse_and_compile (module A) ~wi2i:true pass file idirs in
     extract_to_file prog arch A.reg_size A.asmOp model amodel functions
       array_dir output
   in

--- a/compiler/entry/jasmin_ct.ml
+++ b/compiler/entry/jasmin_ct.ml
@@ -6,7 +6,7 @@ open Utils
 let parse_and_check arch call_conv idirs =
   let module A = (val get_arch_module arch call_conv) in
   let check ~doit infer ct_list speculative pass file =
-    let prog = parse_and_compile (module A) pass file idirs in
+    let prog = parse_and_compile (module A) ~wi2i:false pass file idirs in
 
     if speculative then
       let prog =

--- a/compiler/examples/extraction-unit-tests/.gitignore
+++ b/compiler/examples/extraction-unit-tests/.gitignore
@@ -1,2 +1,3 @@
+gcd.ec
 loops.ec
 sdiv.ec

--- a/compiler/examples/extraction-unit-tests/Makefile
+++ b/compiler/examples/extraction-unit-tests/Makefile
@@ -4,7 +4,7 @@ JASMIN2EC := ../../jasmin2ec
 
 .SUFFIXES: .jazz .ec
 
-all: loops.ec proofs.ec sdiv.ec
+all: gcd.ec loops.ec proofs.ec sdiv.ec
 	easycrypt runtest $(ECARGS) ec.config $@
 
 clean:

--- a/compiler/examples/extraction-unit-tests/gcd.jazz
+++ b/compiler/examples/extraction-unit-tests/gcd.jazz
@@ -1,0 +1,17 @@
+inline
+fn euclid(reg ui64 a b) -> reg ui64 {
+  while (a != 0) {
+    reg ui64 r;
+    r = b % a;
+    b = a;
+    a = r;
+  }
+  return b;
+}
+
+export
+fn gcd(reg ui64 x y) -> reg ui64 {
+  y = y;
+  x = euclid(x, y);
+  return x;
+}

--- a/compiler/examples/extraction-unit-tests/proofs.ec
+++ b/compiler/examples/extraction-unit-tests/proofs.ec
@@ -1,6 +1,7 @@
-require import AllCore.
+require import AllCore IntDiv.
 from Jasmin require import JUtils JWord.
 
+require Gcd.
 require Loops.
 require Sdiv.
 
@@ -27,4 +28,15 @@ proof.
   rewrite sdivE smodE /slift2 /(\zquot) /(\zrem) /zsign.
   do 4! (rewrite to_sintK_small; first done).
   done.
+qed.
+
+hoare euclid_correct x y :
+  Gcd.M.euclid : x = a /\ y = b ==> `|res| = gcd x y.
+proof.
+  proc.
+  while (gcd a b = gcd x y).
+  - auto => &m /> ih a_nz.
+    by rewrite gcd_modl gcdC.
+  skip => &m [] /= <- <- _ g' ->.
+  by rewrite gcd0z.
 qed.

--- a/compiler/safety/fail/arr_init_fail.jazz
+++ b/compiler/safety/fail/arr_init_fail.jazz
@@ -13,7 +13,7 @@ fn main(reg u64 len, reg u32 x0 x1 x2 x3) {
   j = 0;
   while(j < len)
   {
-    c = tmp[(int)j];
+    c = tmp[j];
     j += 1;
   }
 }

--- a/compiler/safety/fail/bounded_while.jazz
+++ b/compiler/safety/fail/bounded_while.jazz
@@ -9,7 +9,7 @@ fn uninit(reg u64 bound) -> reg u64 {
   i = 0;
   #bounded
   while (i < max) {
-    t[(int) i] = i;
+    t[i] = i;
     i += 1;
   }
   max = t[N - 1];

--- a/compiler/safety/fail/load.jazz
+++ b/compiler/safety/fail/load.jazz
@@ -12,11 +12,11 @@ fn load_last(reg u64 ptr, reg u64 len) -> reg u64[2]
   j = 0;
   while(j < len)
   { c = (u8)[ptr + j];
-    s[u8 (int)j] = c;
+    s[u8 j] = c;
     j += 1;
   }
 
-  s[u8 (int)j] = 0x1;
+  s[u8 j] = 0x1;
 
   x[0] = s[0];
   x[1] = s[1];

--- a/compiler/safety/fail/wint_overflow.jazz
+++ b/compiler/safety/fail/wint_overflow.jazz
@@ -1,0 +1,3 @@
+param int big = 137;
+
+export fn wint_overflow() { reg si8 small = big; }

--- a/compiler/safety/success/array-direct.jazz
+++ b/compiler/safety/success/array-direct.jazz
@@ -15,13 +15,13 @@ fn array_direct() -> reg u256 {
   a.[u8 i] = b;
   a.[u64 0] = q;
   a.[u64 i] = q;
-  a.[u8 (int)q] = b;
+  a.[u8 q] = b;
   a.[u64 i + 8] = q;
   a.[u64 8 * (i + 1)] = q;
   a.[u64 (i + 1) * 8] = q;
   a.[u64 i * 8 + 8] = q;
-  a.[u8 (int)(q + 1)] = b;
-  a.[u8 (int)q + 1] = b;
+  a.[u8 q + 1] = b;
+  a.[u8 (uint)q + 1] = b;
 
   y = a.[u256 0];
   return y;

--- a/compiler/safety/success/array-len2.jazz
+++ b/compiler/safety/success/array-len2.jazz
@@ -3,7 +3,7 @@ fn fillhalf(stack u64[16] blk, reg u64 cond) -> stack u64[16] {
   inline int i;
 
   for i = 0 to 8 {
-    blk[2*i + (int)cond] = i;
+    blk[2*i + (uint)cond] = i;
   }
   
   return blk;

--- a/compiler/safety/success/array_init.jazz
+++ b/compiler/safety/success/array_init.jazz
@@ -14,7 +14,7 @@ fn main(reg u64 len, reg u32 x0 x1 x2 x3) {
 
   while(j < len)
   {
-    c = tmp[(int)j];
+    c = tmp[j];
     j += 1;
   }
 }

--- a/compiler/safety/success/bounded_while.jazz
+++ b/compiler/safety/success/bounded_while.jazz
@@ -7,7 +7,7 @@ fn test() -> reg u64 {
   i = 0;
   #bounded
   while (i < N) {
-    t[(int) i] = i;
+    t[i] = i;
     i += 1;
   }
   i = t[N/2];

--- a/compiler/safety/success/bug_386.jazz
+++ b/compiler/safety/success/bug_386.jazz
@@ -5,7 +5,7 @@ export fn main(){
   while (i < 3 * 3) {
     inline int k;
     for k = 0 to 4 {
-      a[(int) i] = 0;
+      a[i] = 0;
       i += 1;
     }
   }

--- a/compiler/safetylib/safetyAbsExpr.mli
+++ b/compiler/safetylib/safetyAbsExpr.mli
@@ -56,7 +56,7 @@ module AbsExpr (AbsDom : SafetyInterfaces.AbsNumBoolType) : sig
     Warray_.arr_access -> wsize -> int -> expr ->
     mvar list
 
-  val linearize_smpl_iexpr : AbsDom.t -> expr     -> Mtexpr.t option
+  val linearize_smpl_iexpr : AbsDom.t -> expr -> Mtexpr.t option
   val linearize_smpl_wexpr : AbsDom.t -> expr -> Mtexpr.t option
 
   val bexpr_to_btcons : expr -> AbsDom.t -> btcons option

--- a/compiler/safetylib/safetyAbsExpr.mli
+++ b/compiler/safetylib/safetyAbsExpr.mli
@@ -7,13 +7,13 @@ open SafetyVar
 open SafetyExpr
 open SafetyConstr
 open SafetyPreanalysis
-        
+
 
 (*---------------------------------------------------------------*)
 val pcast : wsize -> expr -> expr
 
 val wsize_of_ty : 'a gty -> int
-                
+
 val check_is_word : int ggvar -> unit
 
 (*---------------------------------------------------------------*)
@@ -24,8 +24,8 @@ type 'a gmsub = { ms_v      : var;
                   ms_offset : 'a; }
 
 (* - [{ms_v; ms_ws; ms_len; Some ms_offset}] is the slice
-     [8*ms_offset; 8*ms_offset + ms_ws * ms_len[ of ms_v. 
-     Note that the offset is not scaled on the word-size. 
+     [8*ms_offset; 8*ms_offset + ms_ws * ms_len[ of ms_v.
+     Note that the offset is not scaled on the word-size.
    - if [ms_offset] is not, the slices starts at an unknown offset. *)
 type msub = int gmsub
 
@@ -35,7 +35,7 @@ type mlvar =
   | MLvar  of minfo * mvar
   | MLvars of minfo * mvar list
   | MLasub of minfo * int option gmsub
-  
+
 val pp_mlvar : Format.formatter -> mlvar -> unit
 
 (*---------------------------------------------------------------*)
@@ -45,32 +45,32 @@ module ItMap : Map.S with type key = it_loc
 
 (*---------------------------------------------------------------*)
 module AbsExpr (AbsDom : SafetyInterfaces.AbsNumBoolType) : sig
-  val wrap_if_overflow : AbsDom.t -> Mtexpr.t -> signedness -> int -> Mtexpr.t 
+  val wrap_if_overflow : AbsDom.t -> Mtexpr.t -> signedness -> int -> Mtexpr.t
   val cast_if_overflows : AbsDom.t -> int -> int -> Mtexpr.t -> Mtexpr.t
-                                                                  
-  val aeval_cst_zint : AbsDom.t -> expr -> Z.t option      
+
+  val aeval_cst_zint : AbsDom.t -> expr -> Z.t option
   val aeval_cst_int : AbsDom.t -> expr  -> int option
 
   val abs_sub_arr_range :
     AbsDom.t -> (var * Expr.v_scope) ->
     Warray_.arr_access -> wsize -> int -> expr ->
     mvar list
-          
+
   val linearize_smpl_iexpr : AbsDom.t -> expr     -> Mtexpr.t option
   val linearize_smpl_wexpr : AbsDom.t -> expr -> Mtexpr.t option
-                                                  
+
   val bexpr_to_btcons : expr -> AbsDom.t -> btcons option
-      
+
   val set_zeros : mvar list -> AbsDom.t -> AbsDom.t
-                                             
+
   val set_bounds :
     mvar list -> mvar list -> AbsDom.t ->
     AbsDom.t * (Format.formatter -> unit) list
-                                            
+
   val apply_glob : global_decl list -> AbsDom.t -> AbsDom.t
 
   val mvar_of_lvar : AbsDom.t -> minfo -> lval -> mlvar
- 
+
   val aeval_offset :
     AbsDom.t -> 'a gty -> mvar -> minfo option -> expr -> AbsDom.t
 
@@ -79,7 +79,7 @@ module AbsExpr (AbsDom : SafetyInterfaces.AbsNumBoolType) : sig
   val abs_forget_array_contents : AbsDom.t -> minfo -> lval -> AbsDom.t
 
   val abs_assign : AbsDom.t -> ty -> mlvar -> expr -> AbsDom.t
- 
+
   val abs_assign_opn :
     AbsDom.t -> minfo -> lval list -> expr option list -> AbsDom.t
 end

--- a/compiler/safetylib/safetyInterpreter.ml
+++ b/compiler/safetylib/safetyInterpreter.ml
@@ -108,8 +108,10 @@ type safe_cond =
   | AlignedPtr  of wsize * var * expr (* aligned pointer *)
   | AlignedExpr of wsize * expr       (* aligned expression *)
 
-  | NotZero of wsize * expr
+  | NotEqual of E.op_kind * expr * expr
   | Termination of bool (* the boolean signals whether this is a severe violation *)
+
+let notZero(ws, e) = NotEqual(Op_w ws, e, pcast ws (Pconst (Z.of_int 0)))
 
 let severe_violation =
   function
@@ -124,6 +126,10 @@ let alignment_violation =
 let pp_var = Printer.pp_var ~debug:false
 let pp_expr = Printer.pp_expr ~debug:false
 let pp_ws fmt ws = Format.fprintf fmt "%i" (int_of_ws ws)
+let pp_ows fmt ws =
+  match ws with
+  | E.Op_int -> ()
+  | E.Op_w ws -> pp_ws fmt ws
 
 let pp_access fmt = function
   | Warray_.AAdirect -> Format.fprintf fmt "direct"
@@ -146,7 +152,7 @@ let pp_safety_cond fmt = function
     Format.fprintf fmt "is_init %a"
       pp_arr_slice slice
 
-  | NotZero(sz,e) -> Format.fprintf fmt "%a <>%a zero" pp_expr e pp_ws sz
+  | NotEqual(sz, e1, e2) -> Format.fprintf fmt "%a <>%a %a" pp_expr e1 pp_ows sz pp_expr e2
   | InRange(lo, hi, e) -> Format.fprintf fmt "%a ∈ [%a; %a]" pp_expr e pp_expr lo pp_expr hi
   | InBound(n,slice)  ->
     Format.fprintf fmt "in_bound: %a (length %i U8)"
@@ -250,25 +256,71 @@ let arr_aligned access ws e = match access with
   | Warray_.AAscale  -> []
   | Warray_.AAdirect ->
      begin match e with
-     | Papp1 (Oint_of_word U64, e) -> [AlignedExpr (ws, e)]
+     | Papp1 (E.Oint_of_word(_, U64), e) -> [AlignedExpr (ws, e)]
      | _ -> [AlignedExpr (ws, Papp1 (Oword_of_int U64, e))]
      end
 
 (*------------------------------------------------------------*)
-let safe_op2 e2 = function
+let pow2 = Z.pow (Z.of_int 2)
+let half_modulus ws = pow2 (int_of_ws ws - 1)
+let modulus ws = pow2 (int_of_ws ws)
+
+let in_wint_range sg sz e =
+  match sg with
+  | Unsigned ->
+    InRange(Pconst Z.zero, Pconst (Z.pred (modulus sz)), e)
+  | Signed ->
+    InRange(Pconst (Z.neg (half_modulus sz)), Pconst (Z.pred (half_modulus sz)), e)
+
+let wint_to_int sg sz e =
+  Papp1(E.Oint_of_word(sg, sz), e)
+
+let safe_op1 o e1 =
+  match o with
+  | E.Owi1(sg, o) ->
+    begin match o with
+    | E.WIwint_of_int sz -> [in_wint_range sg sz e1]
+    | E.WIint_of_wint sz -> []
+    | E.WIword_of_wint _ -> []
+    | E.WIwint_of_word _ -> []
+    | E.WIwint_ext(szo, szi) -> [] (* Check this ! *)
+    | E.WIneg sz ->
+      if sg = Signed then [NotEqual(Op_int, wint_to_int sg sz e1, Pconst (Z.neg (half_modulus sz)))]
+      else [InRange(Pconst Z.zero, Pconst Z.zero, wint_to_int sg sz e1)]
+    end
+  | _ -> []
+
+let to_int_op2 sg sz op e1 e2 =
+  Papp2 (op, wint_to_int sg sz e1, wint_to_int sg sz e2)
+
+let safe_op2 o e1 e2 =
+  match o with
   | E.Obeq | E.Oand | E.Oor | E.Oadd _ | E.Omul _ | E.Osub _
   | E.Oland _ | E.Olor _ | E.Olxor _
   | E.Olsr _ | E.Olsl _ | E.Oasr _
   | E.Oror _ | E.Orol _
   | E.Oeq _ | E.Oneq _ | E.Olt _ | E.Ole _ | E.Ogt _ | E.Oge _ -> []
 
-  | E.Odiv E.Cmp_int -> []
-  | E.Omod Cmp_int  -> []
-  | E.Odiv (E.Cmp_w(_, s)) -> [NotZero (s, e2)]
-  | E.Omod (E.Cmp_w(_, s)) -> [NotZero (s, e2)]
+  | E.Odiv (_, E.Op_int) -> []
+  | E.Omod (_, E.Op_int)  -> []
+  | E.Odiv (_, E.Op_w s) -> [notZero (s, e2) (* FIXME this is not sufficiant case Signed *) ]
+  | E.Omod (_, E.Op_w s) -> [notZero (s, e2) (* FIXME this is not sufficiant case Signed *) ]
 
   | E.Ovadd _ | E.Ovsub _ | E.Ovmul _
   | E.Ovlsr _ | E.Ovlsl _ | E.Ovasr _ -> []
+  | E.Owi2(sg, sz, o) ->
+    match o with
+    | WIadd -> [in_wint_range sg sz (to_int_op2 sg sz (E.Oadd Op_int) e1 e2)]
+    | WImul -> [in_wint_range sg sz (to_int_op2 sg sz (E.Omul Op_int) e1 e2)]
+    | WIsub -> [in_wint_range sg sz (to_int_op2 sg sz (E.Osub Op_int) e1 e2)]
+    | WIdiv -> [notZero (sz, e2) (* FIXME this is not sufficiant case Signed *) ]
+    | WImod -> [notZero (sz, e2) (* FIXME this is not sufficiant case Signed *) ]
+    | WIshl ->
+        let e = Papp2 (E.Olsl (Op_w sz), e1, e2) in
+        [in_wint_range sg sz (wint_to_int sg sz e)]
+    | WIshr -> [] (* shift rigth is allways in the range *)
+    | WIeq | WIneq | WIlt | WIle | WIgt | WIge -> []
+
 
 let safe_var x = match (L.unloc x).v_ty with
     | Arr _ -> []
@@ -307,8 +359,8 @@ let rec safe_e_rec safe = function
     arr_aligned (* x.gv *) access ws e @
     safe
 
-  | Papp1 (_, e) -> safe_e_rec safe e
-  | Papp2 (op, e1, e2) -> safe_op2 e2 op @ safe_e_rec (safe_e_rec safe e1) e2
+  | Papp1 (op, e) -> safe_op1 op e @ safe_e_rec safe e
+  | Papp2 (op, e1, e2) -> safe_op2 op e1 e2 @ safe_e_rec (safe_e_rec safe e1) e2
   | PappN (_,es) -> List.fold_left safe_e_rec safe es
 
   | Pif  (_,e1, e2, e3) ->
@@ -341,17 +393,13 @@ let safe_lval = function
 
 let safe_lvals = List.fold_left (fun safe x -> safe_lval x @ safe) []
 
-let pow2 = Z.pow (Z.of_int 2)
-let half_modulus ws = pow2 (int_of_ws ws - 1)
-let modulus ws = pow2 (int_of_ws ws)
-
 let int_of_word sg ws e =
   match sg with
-  | Unsigned -> Papp1 (E.Oint_of_word ws, e)
+  | Unsigned -> Papp1 (E.uint_of_word ws, e)
   | Signed ->
      let m = Pconst (half_modulus ws) in
      Papp2 (E.Osub Op_int,
-            Papp1 (E.Oint_of_word ws, Papp2 (E.Oadd (E.Op_w ws), e, Papp1 (E.Oword_of_int ws, m))),
+            Papp1 (E.uint_of_word ws, Papp2 (E.Oadd (E.Op_w ws), e, Papp1 (E.Oword_of_int ws, m))),
             m)
 
 let int_of_words sg ws hi lo =
@@ -373,17 +421,17 @@ let safe_opn safe opn es =
       match c with
       | Wsize.X86Division(sz, sg) ->
          let n, d = split_div sg sz es in
-         [ NotZero(sz, List.nth es 2)
+         [ notZero(sz, List.nth es 2)
          ; match sg with
            | Unsigned ->
              InRange(Pconst Z.zero, Papp2 (E.Osub E.Op_int, Papp2 (E.Omul E.Op_int, Pconst (modulus sz), d), Pconst Z.one), n)
           | Signed ->
-             InRange (Pconst (Z.neg (half_modulus sz)), Pconst (Z.pred (half_modulus sz)), Papp2 (E.Odiv E.Cmp_int, n, d))
+             InRange (Pconst (Z.neg (half_modulus sz)), Pconst (Z.pred (half_modulus sz)), Papp2 (E.Odiv(Unsigned, E.Op_int), n, d))
         ]
       | Wsize.InRangeMod32(sz, lo, hi, n) ->
          let n = List.nth es (Conv.int_of_nat n) in
-         let n = Papp1 (Oint_of_word sz, n) in
-         let n = Papp2 (Omod Cmp_int, n, Pconst (Z.of_int 32)) in
+         let n = Papp1 (E.uint_of_word sz, n) in
+         let n = Papp2 (E.Omod (Unsigned, Op_int), n, Pconst (Z.of_int 32)) in
          [ InRange(Pconst (Conv.z_of_cz lo), Pconst (Conv.z_of_cz hi), n) ]
       | Wsize.AllInit(ws, p, i) ->
         let e = List.nth es (Conv.int_of_nat i) in
@@ -391,25 +439,25 @@ let safe_opn safe opn es =
         List.flatten
           (List.init (Conv.int_of_pos p) (fun i -> init_get y Warray_.AAscale ws (Pconst (Z.of_int i)) 1))
       | NotZero (sz, n) ->
-        [ NotZero(sz, List.nth es (Conv.int_of_nat n)) ]
+        [ notZero(sz, List.nth es (Conv.int_of_nat n)) ]
 
       | ULt (sz, n, z) ->
         let n = List.nth es (Conv.int_of_nat n) in
-        let n = Papp1 (Oint_of_word sz, n) in
+        let n = Papp1 (E.uint_of_word sz, n) in
         [ InRange(Pconst Z.zero, Pconst (Z.pred (Conv.z_of_cz z)), n)] (* n ∈ [0; z-1] *)
 
       | UGe (sz, z, n) ->
         let n = List.nth es (Conv.int_of_nat n) in
-        let n = Papp1 (Oint_of_word sz, n) in
+        let n = Papp1 (E.uint_of_word sz, n) in
         let z = Pconst (Conv.z_of_cz z) in
         [ InRange(Pconst Z.zero, n, z) ] (* z ∈ [0; n] *)
 
       | UaddLe(sz, n1, n2, z) ->
         let n1 = List.nth es (Conv.int_of_nat n1) in
-        let n1 = Papp1 (Oint_of_word sz, n1) in
+        let n1 = Papp1 (E.uint_of_word sz, n1) in
         let n2 = List.nth es (Conv.int_of_nat n2) in
-        let n2 = Papp1 (Oint_of_word sz, n2) in
-        let n12 = Papp2 (Oadd Op_int, n1, n2) in
+        let n2 = Papp1 (E.uint_of_word sz, n2) in
+        let n12 = Papp2 (E.Oadd Op_int, n1, n2) in
         let z = Pconst (Conv.z_of_cz z) in
         [ InRange(Pconst Z.zero, z, n12) ] (* n1 + n2 ∈ [0; z] *)
 
@@ -708,17 +756,16 @@ end = struct
     | InRange(lo, hi, e) ->
        begin
          let out_of_range =
-           Papp2(Oor,
-                 Papp2 (Olt E.Cmp_int, e, lo),
-                 Papp2 (Olt E.Cmp_int, hi, e)) in
+           Papp2(E.Oor,
+                 Papp2 (E.Olt E.Cmp_int, e, lo),
+                 Papp2 (E.Olt E.Cmp_int, hi, e)) in
          let s = state.abs in
          match AbsExpr.bexpr_to_btcons out_of_range s with
          | None -> false
          | Some c -> AbsDom.is_bottom (AbsDom.meet_btcons s c) end
 
-    | NotZero (ws,e) ->
-      (* We check that e is never 0 *)
-      let be = Papp2 (E.Oeq (E.Op_w ws), e, pcast ws (Pconst (Z.of_int 0))) in
+    | NotEqual(k, e1, e2) ->
+      let be = Papp2 (E.Oeq k, e1, e2) in
       begin match AbsExpr.bexpr_to_btcons be state.abs with
         | None -> false
         | Some c ->
@@ -1009,7 +1056,7 @@ end = struct
   (* Carry flag is true if [w] and [vu] are not equal. *)
   let cf_of_word sz w vu =
     Some (Papp2 (E.Oneq (E.Op_int),
-                 Papp1(E.Oint_of_word sz,w),
+                 Papp1(E.uint_of_word sz,w),
                  vu))
 
   (* FIXME *)
@@ -1093,8 +1140,8 @@ end = struct
     let el,er = as_seq2 es in
     let w = Papp2 (op, el, er) in
     let vu = Papp2 (op_int,
-                    Papp1(E.Oint_of_word ws,el),
-                    Papp1(E.Oint_of_word ws,er)) in
+                    Papp1(E.uint_of_word ws,el),
+                    Papp1(E.uint_of_word ws,er)) in
     let vs = () in              (* FIXME *)
     let rflags = f_flags ws w vu vs in
     rflags @ [Some w]
@@ -1116,8 +1163,8 @@ end = struct
                          w_no_carry,
                          pcast ws (Pconst (Z.of_int 1))) in
 
-    let eli = Papp1 (E.Oint_of_word ws, el)    (* (int)el *)
-    and eri = Papp1 (E.Oint_of_word ws, er) in (* (int)er *)
+    let eli = Papp1 (E.uint_of_word ws, el)    (* (int)el *)
+    and eri = Papp1 (E.uint_of_word ws, er) in (* (int)er *)
     let w_i =
       Papp2 (E.Oadd E.Op_int, eli, eri) in (* (int)el + (int)er *)
     let pow_ws = Pconst (Z.pow (Z.of_int 2) (int_of_ws ws)) in (* 2^ws *)
@@ -1154,8 +1201,8 @@ end = struct
                          w_no_carry,
                          pcast ws (Pconst (Z.of_int 1))) in
 
-    let eli = Papp1 (E.Oint_of_word ws, el)    (* (int)el *)
-    and eri = Papp1 (E.Oint_of_word ws, er) in (* (int)er *)
+    let eli = Papp1 (E.uint_of_word ws, el)    (* (int)el *)
+    and eri = Papp1 (E.uint_of_word ws, er) in (* (int)er *)
 
     (* cf_no_carry is true <=> el < er *)
     let cf_no_carry = Papp2 (E.Olt E.Cmp_int, eli, eri ) in
@@ -1203,14 +1250,14 @@ end = struct
     | Sopn.Oasm (Arch_extra.ExtOp X86_extra.Ox86MOVZX32) ->
       let e = as_seq1 es in
       (* Cast [e], seen as an U32, to an integer, and then back to an U64. *)
-      [Some (Papp1(E.Oword_of_int U64, Papp1(E.Oint_of_word U32, e)))]
+      [Some (Papp1(E.Oword_of_int U64, Papp1(E.uint_of_word U32, e)))]
 
     (* Idem than Ox86MOVZX32, but with different sizes. *)
     | Sopn.Oasm (Arch_extra.BaseOp (x, X86_instr_decl.MOVZX (sz_o, sz_i))) ->
       assert (x = None); (* FIXME *)
       assert (int_of_ws sz_o >= int_of_ws sz_i);
       let e = as_seq1 es in
-      [Some (Papp1(E.Oword_of_int sz_o, Papp1(E.Oint_of_word sz_i, e)))]
+      [Some (Papp1(E.Oword_of_int sz_o, Papp1(E.uint_of_word sz_i, e)))]
 
     (* CMP flags are identical to SUB flags. *)
     | Sopn.Oasm (Arch_extra.BaseOp (_, X86_instr_decl.CMP ws)) ->
@@ -1262,7 +1309,7 @@ end = struct
     | Sopn.Oasm (Arch_extra.BaseOp (x, X86_instr_decl.DIV ws)) ->
       assert (x = None);
       let n, d = split_div Unsigned ws es in
-      let w = Papp1 (E.Oword_of_int ws, Papp2 (E.Odiv E.Cmp_int, n, d)) in
+      let w = Papp1 (E.Oword_of_int ws, Papp2 (E.Odiv(Unsigned, E.Op_int), n, d)) in
       let rflags = rflags_of_div in
       rflags @ [None; Some w]
 
@@ -1270,7 +1317,7 @@ end = struct
     | Sopn.Oasm (Arch_extra.BaseOp (x, X86_instr_decl.IDIV ws)) ->
        assert (x = None);
        let n, d = split_div Signed ws es in
-      let w = Papp1 (E.Oword_of_int ws, Papp2 (E.Odiv E.Cmp_int, n, d)) in
+      let w = Papp1 (E.Oword_of_int ws, Papp2 (E.Odiv(Unsigned, E.Op_int), n, d)) in
       let rflags = rflags_of_div in
       rflags @ [None; Some w]
 
@@ -1281,7 +1328,7 @@ end = struct
       let w = Papp2 (E.Oadd (E.Op_w ws), e,
                      Papp1(E.Oword_of_int ws, Pconst (Z.of_int 1))) in
       let vu = Papp2 (E.Oadd E.Op_int,
-                      Papp1(E.Oint_of_word ws,e),
+                      Papp1(E.uint_of_word ws,e),
                       Pconst (Z.of_int 1)) in
       let vs = () in
       let rflags = nocf (rflags_of_aluop ws w vu vs) in
@@ -1294,7 +1341,7 @@ end = struct
       let w = Papp2 (E.Osub (E.Op_w ws), e,
                      Papp1(E.Oword_of_int ws,Pconst (Z.of_int 1))) in
       let vu = Papp2 (E.Osub E.Op_int,
-                      Papp1(E.Oint_of_word ws,e),
+                      Papp1(E.uint_of_word ws,e),
                       Pconst (Z.of_int 1)) in
       let vs = () in
       let rflags = nocf (rflags_of_aluop ws w vu vs) in
@@ -1454,7 +1501,9 @@ end = struct
           check_is_word x;
           Mtexpr.var (mvar_of_var x)
         | Papp1 (E.Oword_of_int _, e) -> to_mvar e
-        | Papp1 (E.Oint_of_word _, e) -> to_mvar e
+        | Papp1 (E.Oint_of_word (s, _), e) ->
+            assert (s = Signed); (* FIXME wint2 *)
+            to_mvar e
         | _ -> raise Opn_heur_failed in
       let el, er = as_seq2 es in
       begin try

--- a/compiler/scripts/update-cast-int
+++ b/compiler/scripts/update-cast-int
@@ -1,0 +1,5 @@
+#!/bin/sh
+for f in $(find . -name "*.jazz" -o -name "*.jinc")
+do
+  sed -i 's/(int)/(uint)/g' "$f"
+done

--- a/compiler/src/annotations.ml
+++ b/compiler/src/annotations.ml
@@ -3,7 +3,7 @@ type symbol = string
 type pident = symbol Location.located
 
 (* -------------------------------------------------------------------- *)
-type wsize = Wsize.wsize 
+type wsize = Wsize.wsize
 
 let int_of_ws = function
   | Wsize.U8 -> 8
@@ -43,3 +43,23 @@ let add_symbol ~loc s annot =
   if has_symbol s annot
   then annot
   else (Location.mk_loc loc s, None) :: annot
+
+(* -------------------------------------------------------------------- *)
+let sint = "Internal::sint"
+let uint = "Internal::uint"
+
+let has_sint annot = has_symbol sint annot
+let has_uint annot = has_symbol uint annot
+
+let is_wint (k, _) =
+  let s = Location.unloc k in
+  String.equal s sint || String.equal s uint
+
+let remove_wint annot = List.filter (fun x -> not (is_wint x)) annot
+
+let has_wint annot =
+  BatList.find_map_opt (fun (k, _) ->
+    let s = Location.unloc k in
+    if String.equal s sint then Some Wsize.Signed
+    else if String.equal s uint then Some Unsigned
+    else None) annot

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -66,6 +66,59 @@ let do_spill_unspill asmop ?(debug = false) cp =
   | Utils0.Error msg -> Error (Conv.error_of_cerror (Printer.pp_err ~debug) msg)
   | Utils0.Ok p -> Ok (Conv.prog_of_cuprog p)
 
+let do_wint_int
+   (type reg regx xreg rflag cond asm_op extra_op)
+    (module Arch : Arch_full.Arch
+      with type reg = reg
+       and type regx = regx
+       and type xreg = xreg
+       and type rflag = rflag
+       and type cond = cond
+       and type asm_op = asm_op
+       and type extra_op = extra_op) prog =
+  let fdsi = snd prog in
+  let fv = List.fold_left (fun fv fd -> Sv.union fv (vars_fc fd)) Sv.empty fdsi in
+  let m =
+    Sv.fold (fun x m ->
+          match x.v_ty with
+          | Bty (U _) ->
+            begin match Annotations.has_wint x.v_annot with
+            | None -> m
+            | Some sg ->
+              let annot = Annotations.remove_wint x.v_annot in
+              let xi = V.mk x.v_name x.v_kind tint x.v_dloc annot in
+              Mv.add x (sg, Conv.cvar_of_var xi) m
+            end
+          | _ -> m)
+      fv Mv.empty in
+  let cp = Conv.cuprog_of_prog prog in
+  let info x =
+    let x = Conv.var_of_cvar x in
+     Mv.find_opt x m in
+  let cp = Wint_int.wi2i_prog Arch.asmOp Arch.msf_size info cp in
+  let cp =
+    match cp with
+    | Utils0.Ok cp -> cp
+    | Utils0.Error e ->
+      let e = Conv.error_of_cerror (Printer.pp_err ~debug:false) e in
+      raise (HiError e) in
+  let (gd, fdso) = Conv.prog_of_cuprog cp in
+  (* Restore type of array in the functions signature *)
+  let restore_ty tyi tyo =
+    match tyi, tyo with
+    | Arr(ws1, l1), Arr(ws2, l2) -> assert (arr_size ws1 l1 = arr_size ws2 l2); tyi
+    | Bty (U _), Bty Int -> tyo
+    | _, _ -> assert (tyi = tyo); tyo
+  in
+  let restore_sig fdi fdo =
+    { fdo with
+      f_tyin = List.map2 restore_ty fdi.f_tyin fdo.f_tyin;
+      f_tyout = List.map2 restore_ty fdi.f_tyout fdo.f_tyout;
+    } in
+  let fds = List.map2 restore_sig fdsi fdso in
+  (gd, fds)
+
+
 (*--------------------------------------------------------------------- *)
 
 let compile (type reg regx xreg rflag cond asm_op extra_op)
@@ -227,6 +280,19 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     tokeep
   in
 
+  let remove_wint_annot fd =
+    let vars = Prog.vars_fc fd in
+    let subst =
+      Sv.fold (fun x s ->
+          if Annotations.has_wint x.v_annot = None then s
+          else
+            let annot = Annotations.remove_wint x.v_annot in
+            let x' = V.mk x.v_name x.v_kind x.v_ty x.v_dloc annot in
+            Mv.add x x' s)
+        vars Mv.empty in
+    Subst.vsubst_func subst fd
+  in
+
   let warn_extra s p =
     if s = Compiler.DeadCode_RegAllocation then
       let fds, _ = Conv.prog_of_csprog p in
@@ -319,6 +385,8 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
         Var0.Var.vname (Conv.cvar_of_var Arch.rip);
       Compiler.stackalloc = memory_analysis;
       Compiler.removereturn;
+      Compiler.remove_wint_annot =
+        apply "remove wint annot" remove_wint_annot;
       Compiler.regalloc = global_regalloc;
       Compiler.print_uprog =
         (fun s p ->

--- a/compiler/src/compile.mli
+++ b/compiler/src/compile.mli
@@ -43,6 +43,22 @@ val do_spill_unspill :
   ((unit, 'asm) prog, Utils.hierror) result
 (** Removes (aka implements) #spill and #unspill instructions. *)
 
+val do_wint_int :
+  (module Arch_full.Arch
+     with type reg = 'reg
+      and type regx = 'regx
+      and type xreg = 'xreg
+      and type rflag = 'rflag
+      and type cond = 'cond
+      and type asm_op = 'asm_op
+      and type extra_op = 'extra_op) ->
+  (unit,
+    ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op Sopn.asm_op_t)
+   prog ->
+  (unit,
+    ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op Sopn.asm_op_t)
+   prog
+
 val compile :
   (module Arch_full.Arch
      with type reg = 'reg

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -33,28 +33,28 @@ val cty_of_ty : Prog.ty -> Type.stype
 val ty_of_cty : Type.stype -> Prog.ty
 
 (* -------------------------------------------------------------------- *)
-val cvar_of_var :  var -> Var0.Var.var
-val var_of_cvar :  Var0.Var.var -> var
-val vari_of_cvari :  Expr.var_i -> var L.located
+val cvar_of_var : var -> Var0.Var.var
+val var_of_cvar : Var0.Var.var -> var
+val vari_of_cvari : Expr.var_i -> var L.located
 
 val csv_of_sv : Sv.t -> Var0.SvExtra.Sv.t
 val sv_of_csv : Var0.SvExtra.Sv.t -> Sv.t
 
-val lval_of_clval :  Expr.lval -> Prog.lval
+val lval_of_clval : Expr.lval -> Prog.lval
 
-val cexpr_of_expr :  expr -> Expr.pexpr
-val expr_of_cexpr :  Expr.pexpr -> expr
+val cexpr_of_expr : Prog.expr -> Expr.pexpr
+val expr_of_cexpr : Expr.pexpr -> expr
 
-val cufdef_of_fdef :  (unit, 'asm) func -> Var0.funname * 'asm Expr._ufundef
-val fdef_of_cufdef :  Var0.funname * 'asm Expr._ufundef -> (unit, 'asm) func
+val cufdef_of_fdef : (unit, 'asm) func -> Var0.funname * 'asm Expr._ufundef
+val fdef_of_cufdef : Var0.funname * 'asm Expr._ufundef -> (unit, 'asm) func
 
 val cuprog_of_prog : (unit, 'asm) prog -> 'asm Expr._uprog
-val prog_of_cuprog :  'asm Expr._uprog -> (unit, 'asm) prog
+val prog_of_cuprog : 'asm Expr._uprog -> (unit, 'asm) prog
 
-val csfdef_of_fdef :  (unit, 'asm) sfundef -> Var0.funname * 'asm Expr._sfundef
-val fdef_of_csfdef :  Var0.funname * 'asm Expr._sfundef -> (unit, 'asm) sfundef
+val csfdef_of_fdef : (unit, 'asm) sfundef -> Var0.funname * 'asm Expr._sfundef
+val fdef_of_csfdef : Var0.funname * 'asm Expr._sfundef -> (unit, 'asm) sfundef
 
-val prog_of_csprog :  'asm Expr._sprog -> (unit, 'asm) sprog
+val prog_of_csprog : 'asm Expr._sprog -> (unit, 'asm) sprog
 
 val to_array : 
   Prog.ty -> BinNums.positive -> Warray_.WArray.array -> wsize * Z.t array

--- a/compiler/src/coreIdent.ml
+++ b/compiler/src/coreIdent.ml
@@ -24,6 +24,15 @@ type 'len gty =
            (* invariant only Const variable can be used in expression *)
            (* the type of the expression is [Int] *)
 
+
+type 'len gety =
+  | ETbool
+  | ETint
+  | ETword of signedness option * wsize
+  | ETarr  of wsize * 'len (* Arr(n,de): array of n-bit integers with dim. *)
+           (* invariant only Const variable can be used in expression *)
+           (* the type of the expression is [Int] *)
+
 let u8   = Bty (U U8)
 let u16  = Bty (U U16)
 let u32  = Bty (U U32)
@@ -33,6 +42,28 @@ let u256 = Bty (U U256)
 let tu ws = Bty (U ws)
 let tbool = Bty Bool
 let tint  = Bty Int
+
+let etw ws = ETword (None, ws)
+let etwi s ws = ETword(Some s, ws)
+let etbool = ETbool
+let etint = ETint
+
+let gty_of_gety (t: 'len gety) : 'len gty =
+  match t with
+  | ETbool -> tbool
+  | ETint  -> tint
+  | ETword(_, ws) -> tu ws
+  | ETarr(ws, len) -> Arr(ws, len)
+
+let gety_of_gty (t : 'len gty) : 'len gety =
+  match t with
+  | Arr(ws, len) -> ETarr(ws, len)
+  | Bty t ->
+    match t with
+    | Bool -> etbool
+    | Int  -> etint
+    | U ws -> etw ws
+
 
 (* ------------------------------------------------------------------------ *)
 

--- a/compiler/src/coreIdent.mli
+++ b/compiler/src/coreIdent.mli
@@ -25,6 +25,14 @@ type 'len gty =
            (* invariant only Const variable can be used in expression *)
            (* the type of the expression is [Int] *)
 
+type 'len gety =
+  | ETbool
+  | ETint
+  | ETword of signedness option * wsize
+  | ETarr  of wsize * 'len (* Arr(n,de): array of n-bit integers with dim. *)
+           (* invariant only Const variable can be used in expression *)
+           (* the type of the expression is [Int] *)
+
 val u8    : 'len gty
 val u16   : 'len gty
 val u32   : 'len gty
@@ -34,6 +42,14 @@ val u256  : 'len gty
 val tu    : wsize -> 'len gty
 val tbool : 'len gty
 val tint  : 'len gty
+
+val etw    : wsize -> 'len gety
+val etwi   : signedness -> wsize -> 'len gety
+val etbool : 'len gety
+val etint  : 'len gety
+
+val gty_of_gety : 'len gety -> 'len gty
+val gety_of_gty : 'len gty -> 'len gety
 
 (* ------------------------------------------------------------------------ *)
 

--- a/compiler/src/ct_checker_forward.ml
+++ b/compiler/src/ct_checker_forward.ml
@@ -311,7 +311,8 @@ let is_ct_op1 (_: Expr.sop1) = true
 
 let is_ct_op2 (o: Expr.sop2) =
   match o with
-  | Omod (Cmp_w _) | Odiv (Cmp_w _) -> false
+  | Omod (_, Op_w _) | Odiv (_, Op_w _) -> false
+  | Owi2(_, _, (WImod | WIdiv)) -> false
   | _ -> true
 
 let is_ct_opN (_ : Expr.opN) = true

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -117,6 +117,7 @@ let set_cc cc =
 let print_strings = function
   | Compiler.Typing                      -> "typing"   , "typing"
   | Compiler.ParamsExpansion             -> "cstexp"   , "param expansion"
+  | Compiler.WintWord                    -> "wintword" , "replace wint by word"
   | Compiler.ArrayCopy                   -> "arraycopy", "array copy"
   | Compiler.AddArrInit                  -> "addarrinit", "add array initialisation"
   | Compiler.LowerSpill                  -> "lowerspill", "lower spill/unspill instructions"

--- a/compiler/src/insert_copy_and_fix_length.ml
+++ b/compiler/src/insert_copy_and_fix_length.ml
@@ -37,11 +37,11 @@ and iac_instr pd i = { i with i_desc = iac_instr_r pd i.i_loc i.i_desc }
 and iac_instr_r pd loc ir =
   match ir with
   | Cassgn (x, t, _, e) ->
-    if !Glob_options.introduce_array_copy then 
+    if !Glob_options.introduce_array_copy then
       match is_array_copy x e with
       | None -> ir
-      | Some (ws, n) -> 
-          warning IntroduceArrayCopy 
+      | Some (ws, n) ->
+          warning IntroduceArrayCopy
             loc "an array copy is introduced";
           let op = Pseudo_operator.Ocopy(ws, Conv.pos_of_int n) in
           Copn([x], t, Sopn.Opseudo_op op, [e])
@@ -53,14 +53,14 @@ and iac_instr_r pd loc ir =
 
     begin match o, xs with
     | Sopn.Opseudo_op(Pseudo_operator.Ospill(o,_)), _ ->
-      let tys = List.map (fun e -> Conv.cty_of_ty (Typing.ty_expr pd loc e)) es in  
+      let tys = List.map (fun e -> Conv.cty_of_ty (Typing.ty_expr pd loc e)) es in
       Copn(xs,t, Sopn.Opseudo_op(Pseudo_operator.Ospill(o, tys)), es)
-                 
+
     | Sopn.Opseudo_op(Pseudo_operator.Ocopy(ws, _)), [x] ->
       (* Fix the size it is dummy for the moment *)
       let xn = size_of_lval x in
       let wsn = size_of_ws ws in
-      if xn mod wsn <> 0 then 
+      if xn mod wsn <> 0 then
         Typing.error loc
           "the destination %a has size %i: it should be a multiple of %i"
           (Printer.pp_lval ~debug:false) x
@@ -71,7 +71,7 @@ and iac_instr_r pd loc ir =
     | Sopn.Opseudo_op(Pseudo_operator.Oswap _), x::_ ->
       (* Fix the type it is dummy for the moment *)
       let ty = Conv.cty_of_ty (Typing.ty_lval pd loc x) in
-      Copn(xs, t, Sopn.Opseudo_op(Pseudo_operator.Oswap ty), es)  
+      Copn(xs, t, Sopn.Opseudo_op(Pseudo_operator.Oswap ty), es)
     | Sopn.Oslh (SLHprotect_ptr _), [Lvar x] ->
       (* Fix the size it is dummy for the moment *)
       let xn = size_of (L.unloc x).v_ty in

--- a/compiler/src/insert_copy_and_fix_length.ml
+++ b/compiler/src/insert_copy_and_fix_length.ml
@@ -98,5 +98,6 @@ and iac_instr_r pd loc ir =
 let iac_func pd f =
   { f with f_body = iac_stmt pd f.f_body }
 
-let doit pd (p:(unit, 'asm) Prog.prog) = (fst p, List.map (iac_func pd) (snd p))
+let doit pd (p:(unit, 'asm) Prog.prog) : (unit, 'asm) Prog.prog =
+  (fst p, List.map (iac_func pd) (snd p))
 

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -139,7 +139,7 @@ let optparent fmt ctxt prio p =
 
 let string_of_wsize w = Format.sprintf "u%d" (bits_of_wsize w)
 
-let pp_svsize fmt (vs,s,ve) = 
+let pp_svsize fmt (vs,s,ve) =
   Format.fprintf fmt "%d%s%d"
     (int_of_vsize vs) (suffix_of_sign s) (bits_of_vesize ve)
 
@@ -203,7 +203,7 @@ let rec pp_expr_rec prio fmt pe =
   | PEBool b -> F.fprintf fmt "%s" (if b then "true" else "false")
   | PEInt i -> F.fprintf fmt "%s" i
   | PECall (f, args) -> F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args
-  | PECombF (f, args) -> 
+  | PECombF (f, args) ->
     F.fprintf fmt "%a(%a)" pp_var f (pp_list ", " pp_expr) args
   | PEPrim (f, args) -> F.fprintf fmt "%a%a(%a)" sharp () pprim (L.unloc f) (pp_list ", " pp_expr) args
   | PEOp1 (op, e) ->
@@ -223,10 +223,10 @@ let rec pp_expr_rec prio fmt pe =
     optparent fmt prio p ")"
 
 and pp_mem_access fmt (al, ty,x,e) =
-  let pp_e fmt e = 
+  let pp_e fmt e =
     match e with
     | None -> ()
-    | Some (`Add, e) -> Format.fprintf fmt " + %a" pp_expr e 
+    | Some (`Add, e) -> Format.fprintf fmt " + %a" pp_expr e
     | Some (`Sub, e) -> Format.fprintf fmt " - %a" pp_expr e in
   F.fprintf fmt "%a[%a%a%a]" (pp_opt (pp_paren pp_ws)) ty pp_aligned al pp_var x pp_e e
 
@@ -244,7 +244,7 @@ and pp_ws fmt w = F.fprintf fmt "%a" ptype (string_of_wsize w)
 and pp_expr fmt e = pp_expr_rec Pmin fmt e
 
 and pp_arr_access fmt al aa ws x e len=
- let pp_olen fmt len = 
+ let pp_olen fmt len =
    match len with
    | None -> ()
    | Some len -> Format.fprintf fmt " : %a" pp_expr len in
@@ -305,7 +305,7 @@ let pp_lv fmt x =
   | PLIgnore -> F.fprintf fmt "_"
   | PLVar x -> pp_var fmt x
   | PLArray (al, aa, ws, x, e, len) -> pp_arr_access fmt al aa ws x e len
-  | PLMem me -> pp_mem_access fmt me 
+  | PLMem me -> pp_mem_access fmt me
 
 let pp_eqop fmt op =
   F.fprintf fmt "%a=" pp_op2 op
@@ -320,7 +320,7 @@ let rec pp_instr depth fmt (annot, p) =
   if annot <> [] then F.fprintf fmt "%a%a" indent depth pp_top_annotations annot;
   indent fmt depth;
   match L.unloc p with
-  | PIdecl d -> pp_vardecls fmt d 
+  | PIdecl d -> pp_vardecls fmt d
   | PIArrayInit x -> F.fprintf fmt "%a (%a);" kw "arrayinit" pp_var x
   | PIAssign ((pimp,lvs), op, e, cnd) ->
     begin match pimp, lvs with
@@ -332,15 +332,15 @@ let rec pp_instr depth fmt (annot, p) =
          | PEPrim _ -> F.fprintf fmt "() %a" pp_eqop op
          | _ -> ()
        end
-    | None, _ -> F.fprintf fmt "%a %a " (pp_list ", " pp_lv) lvs pp_eqop op 
+    | None, _ -> F.fprintf fmt "%a %a " (pp_list ", " pp_lv) lvs pp_eqop op
     | Some pimp, _ ->
       F.fprintf fmt "?%a%a%a, %a %a "
         openbrace ()
         pp_struct_attribute (L.unloc pimp)
         closebrace ()
-        (pp_list ", " pp_lv) lvs 
+        (pp_list ", " pp_lv) lvs
         pp_eqop op
-      
+
     end;
     F.fprintf fmt "%a%a;"
       pp_expr e
@@ -409,7 +409,7 @@ let pp_param fmt { ppa_ty ; ppa_name ; ppa_init } =
     pp_expr ppa_init
 
 let pp_pgexpr fmt = function
-  | GEword e -> pp_expr fmt e 
+  | GEword e -> pp_expr fmt e
   | GEarray es ->
     F.fprintf fmt "%a @[%a@] %a"
       openbrace ()

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -26,15 +26,32 @@
 
   let _keywords = [
     "type"  , TYPE   ;
-    "u8"    , T_U8   ;
-    "u16"   , T_U16  ;
-    "u32"   , T_U32  ;
-    "u64"   , T_U64  ;
-    "u128"  , T_U128 ;
-    "u256"  , T_U256 ;
 
     "bool"  , T_BOOL ;
     "int"   , T_INT  ;
+    "sint"  , T_INT_CAST `Signed;
+    "uint"  , T_INT_CAST `Unsigned;
+
+    "u8"  , T_W (U8  , `Word (Some `Unsigned));
+    "u16" , T_W (U16 , `Word (Some `Unsigned));
+    "u32" , T_W (U32 , `Word (Some `Unsigned));
+    "u64" , T_W (U64 , `Word (Some `Unsigned));
+    "u128", T_W (U128, `Word (Some `Unsigned));
+    "u256", T_W (U256, `Word (Some `Unsigned));
+
+    "ui8"  , T_W (U8  , `WInt `Unsigned);
+    "ui16" , T_W (U16 , `WInt `Unsigned);
+    "ui32" , T_W (U32 , `WInt `Unsigned);
+    "ui64" , T_W (U64 , `WInt `Unsigned);
+    "ui128", T_W (U128, `WInt `Unsigned);
+    "ui256", T_W (U256, `WInt `Unsigned);
+
+    "si8"  , T_W (U8  , `WInt `Signed);
+    "si16" , T_W (U16 , `WInt `Signed);
+    "si32" , T_W (U32 , `WInt `Signed);
+    "si64" , T_W (U64 , `WInt `Signed);
+    "si128", T_W (U128, `WInt `Signed);
+    "si256", T_W (U256, `WInt `Signed);
 
     "const" , CONSTANT;
     "downto", DOWNTO ;
@@ -71,10 +88,7 @@
   | 's' -> `Signed
   | _ -> assert false
 
-  let mk_sign : char option -> S.sign =
-  function
-  | Some c -> sign_of_char c
-  | None   -> `Unsigned
+  let mk_sign : char option -> S.sign option = Option.map sign_of_char
 
   let size_of_string =
   function
@@ -86,7 +100,6 @@
   | "256" -> Wsize.U256
   | _ -> assert false
 
-  let mksizesign sw s = size_of_string sw, sign_of_char s
 
   let mk_gensize = function
     | "1"   -> `W1
@@ -110,6 +123,13 @@
 
   let mkvsizesign r s g = mk_vsize r, sign_of_char s, mk_gensize g
 
+  let mkwsign = function
+   | "w"  -> `Word None
+   | "s"  -> `Word (Some `Signed)
+   | "u"  -> `Word (Some `Unsigned)
+   | "si" -> `WInt `Signed
+   | "ui" -> `WInt `Unsigned
+   | _    -> assert false
 }
 
 (* -------------------------------------------------------------------- *)
@@ -129,6 +149,8 @@ let size = "8" | "16" | "32" | "64" | "128" | "256"
 let signletter = ['s' 'u']
 let gensize = "1" | "2" | "4" | "8" | "16" | "32" | "64" | "128"
 let vsize   = "2" | "4" | "8" | "16" | "32"
+
+let wsign = "s" | "u" | "si" | "ui"
 
 
 (* -------------------------------------------------------------------- *)
@@ -155,8 +177,12 @@ rule main = parse
   | ident as s
       { Option.default (NID s) (Hash.find_option keywords s) }
 
-  | (size as sw) (signletter as s)                { SWSIZE(mksizesign sw s)  }
-  | (vsize as r) (signletter as s) (gensize as g) { SVSIZE(mkvsizesign r s g)}
+  | (size as sw) (wsign as s)
+      { SWSIZE(size_of_string sw, mkwsign s)  }
+
+  | (vsize as r) (signletter as s) (gensize as g)
+      { SVSIZE(mkvsizesign r s g)}
+
   | "#"     { SHARP      }
   | "["     { LBRACKET   }
   | "]"     { RBRACKET   }
@@ -185,8 +211,8 @@ rule main = parse
   | "+"  { PLUS     }
   | "-"  { MINUS    }
   | "*"  { STAR     }
-  | "/"  { SLASH    }
-  | "%"  { PERCENT  }
+  | "/"  (signletter as s)? { SLASH   (mk_sign s) }
+  | "%"  (signletter as s)? { PERCENT (mk_sign s) }
   | "|"  { PIPE     }
   | "&"  { AMP      }
   | "^"  { HAT      }

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -128,7 +128,7 @@ let main () =
     in
 
     if !print_dependencies then begin
-      Format.printf "%a" 
+      Format.printf "%a"
         (pp_list " " (fun fmt p -> Format.fprintf fmt "%s" (BatPathGen.OfString.to_string p)))
         (List.tl (List.rev (Pretyping.Env.dependencies env)));
       exit 0
@@ -171,9 +171,8 @@ let main () =
           source_prog
         |> fun () -> exit 0
       else
-      (
         eprint s (Printer.pp_prog ~debug Arch.reg_size Arch.asmOp) p
-      ) in
+    in
 
     visit_prog_after_pass ~debug:true Compiler.ParamsExpansion prog;
 

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -20,9 +20,9 @@ type sop = [ `Op2 of S.peop2 | `Op1 of S.peop1]
 type tyerror =
   | UnknownVar          of A.symbol
   | UnknownFun          of A.symbol
-  | InvalidArrayType    of P.pty
-  | TypeMismatch        of P.pty pair
-  | NoOperator          of sop * P.pty list
+  | InvalidArrayType    of P.epty
+  | TypeMismatch        of P.epty pair
+  | NoOperator          of sop * P.epty list
   | InvalidOperator     of sop
   | NoReturnStatement   of P.funname * int
   | InvalidReturnStatement of P.funname * int * int
@@ -30,11 +30,11 @@ type tyerror =
   | InvalidArgCount     of int * int
   | InvalidLvalCount    of int * int
   | DuplicateFun        of A.symbol * L.t
-  | DuplicateAlias      of A.symbol * P.pty L.located * P.pty L.located
+  | DuplicateAlias      of A.symbol * P.epty L.located * P.epty L.located
   | TypeNotFound        of A.symbol
-  | InvalidTypeAlias    of A.symbol * P.pty
-  | InvalidCast         of P.pty pair
-  | InvalidTypeForGlobal of P.pty
+  | InvalidTypeAlias    of A.symbol L.located option * P.epty
+  | InvalidCast         of P.epty pair
+  | InvalidTypeForGlobal of P.epty
   | GlobArrayNotWord
   | GlobWordNotArray
   | EqOpWithNoLValue
@@ -91,20 +91,20 @@ let pp_tyerror fmt (code : tyerror) =
 
   | InvalidArrayType ty ->
     F.fprintf fmt "the expression has type %a instead of array"
-       Printer.pp_ptype ty
+       Printer.pp_eptype ty
 
   | TypeMismatch (t1,t2) ->
     F.fprintf fmt
       "the expression has type %a instead of %a"
-      Printer.pp_ptype t1 Printer.pp_ptype t2
+      Printer.pp_eptype t1 Printer.pp_eptype t2
 
   | InvalidCast (t1,t2) ->
     F.fprintf fmt "can not implicitly cast %a into %a"
-      Printer.pp_ptype t1 Printer.pp_ptype t2
+      Printer.pp_eptype t1 Printer.pp_eptype t2
 
   | InvalidTypeForGlobal ty ->
       F.fprintf fmt "globals should have type word; found: ‘%a’"
-        Printer.pp_ptype ty
+        Printer.pp_eptype ty
 
   | GlobArrayNotWord ->
     F.fprintf fmt "the definition is an array and not a word"
@@ -122,13 +122,13 @@ let pp_tyerror fmt (code : tyerror) =
       F.fprintf fmt
         "no operator %s for these types %a"
         (S.string_of_peop2 o)
-        (pp_list " * " Printer.pp_ptype) ts
+        (pp_list " * " Printer.pp_eptype) ts
 
   | NoOperator (`Op1 o, ts) ->
       F.fprintf fmt
         "no operator %s for these type %a"
         (S.string_of_peop1 o)
-        (pp_list " * " Printer.pp_ptype) ts
+        (pp_list " * " Printer.pp_eptype) ts
 
   | NoReturnStatement (name, expected) ->
      F.fprintf fmt "function “%s” has no return statement (but its signature claims that %d values should be returned)" name.P.fn_name expected
@@ -160,9 +160,9 @@ let pp_tyerror fmt (code : tyerror) =
       F.fprintf fmt
         "Type '%s' (ie: '%a') is already declared at %s (with type : '%a')"
         id
-        Printer.pp_ptype (L.unloc newtype)
+        Printer.pp_eptype (L.unloc newtype)
         (L.tostring (L.loc oldtype))
-        Printer.pp_ptype (L.unloc oldtype)
+        Printer.pp_eptype (L.unloc oldtype)
 
   | TypeNotFound (id) ->
       F.fprintf fmt
@@ -170,9 +170,15 @@ let pp_tyerror fmt (code : tyerror) =
       id
 
   | InvalidTypeAlias (id,typ) ->
+      let pp_id fmt (id, typ) =
+        match id with
+        | None -> F.fprintf fmt "'%a'" Printer.pp_eptype typ
+        | Some id ->
+            F.fprintf fmt "'%s' (ie: '%a'), defined at %s," (L.unloc id) Printer.pp_eptype typ
+               (L.tostring (L.loc id)) in
       F.fprintf fmt
-      "Type '%s' (ie: '%a') is not allowed as array element. Only machine words (u8, u16 ...) allowed"
-      id Printer.pp_ptype typ
+      "Type %a is not allowed as array element. Only machine words (w8, w16 ...) allowed"
+      pp_id (id, typ)
 
   | EqOpWithNoLValue ->
       F.fprintf fmt
@@ -230,6 +236,9 @@ let fully_qualified (stack: (A.symbol * 'a) list) n =
   List.fold_left (fun n (ns, _) -> qualify ns n) n stack
 
 (* -------------------------------------------------------------------- *)
+
+type fun_sig = { fs_tin : P.epty list ; fs_tout : P.epty list }
+
 module Env : sig
   type 'asm env
 
@@ -254,25 +263,25 @@ module Env : sig
   val exit_namespace : 'asm env -> 'asm env
 
   module Vars : sig
-    val push_global   : 'asm env -> (P.pvar * P.pexpr_ P.ggexpr) -> 'asm env
-    val push_param    : 'asm env -> (P.pvar * P.pexpr) -> 'asm env
-    val push_local    : 'asm env -> P.pvar -> 'asm env
-    val push_implicit : 'asm env -> P.pvar -> 'asm env
+    val push_global   : 'asm env -> (P.pvar * P.epty * P.pexpr_ P.ggexpr ) -> 'asm env
+    val push_param    : 'asm env -> (P.pvar * P.epty * P.pexpr) -> 'asm env
+    val push_local    : 'asm env -> P.pvar * P.epty -> 'asm env
+    val push_implicit : 'asm env -> P.pvar * P.epty -> 'asm env
 
-    val find : A.symbol -> 'asm env -> (P.pvar * E.v_scope) option
+    val find : A.symbol -> 'asm env -> (P.pvar * P.epty * E.v_scope) option
 
     val iter_locals  : (P.pvar -> unit) -> 'asm env -> unit
     val clear_locals : 'asm env -> 'asm env
   end
 
   module TypeAlias : sig
-    val push : 'asm env -> A.pident -> P.pty -> 'asm env
-    val get : 'asm env -> A.pident -> P.pty L.located
+    val push : 'asm env -> A.pident -> P.epty -> 'asm env
+    val get : 'asm env -> A.pident -> P.epty L.located
   end
 
   module Funs : sig
-    val push : 'asm env -> (unit, 'asm) P.pfunc -> P.pty list -> 'asm env
-    val find : A.symbol -> 'asm env -> ((unit, 'asm) P.pfunc * P.pty list) option
+    val push : 'asm env -> (unit, 'asm) P.pfunc -> fun_sig -> 'asm env
+    val find : A.symbol -> 'asm env -> ((unit, 'asm) P.pfunc * fun_sig) option
   end
 
   module Exec : sig
@@ -290,9 +299,9 @@ end  = struct
     }
 
   type 'asm global_bindings = {
-      gb_types : (A.symbol, P.pty L.located) Map.t;
-      gb_vars : (A.symbol, P.pvar * E.v_scope) Map.t;
-      gb_funs : (A.symbol, (unit, 'asm) P.pfunc * P.pty list) Map.t;
+      gb_types : (A.symbol, P.epty L.located) Map.t;
+      gb_vars : (A.symbol, P.pvar * P.epty * E.v_scope) Map.t;
+      gb_funs : (A.symbol, (unit, 'asm) P.pfunc * fun_sig) Map.t;
     }
 
   type 'asm env = {
@@ -347,7 +356,7 @@ end  = struct
         | k -> on_duplicate n v k end;
         Map.add n v dst)
 
-  let warn_duplicate_var name (v, _) (v', _) =
+  let warn_duplicate_var name (v, _, _) (v', _, _) =
     warning DuplicateVar (L.i_loc0 v.P.v_dloc)
       "the variable %s is already declared at %a"
       name L.pp_loc v'.P.v_dloc
@@ -454,12 +463,12 @@ end  = struct
       let name = v.P.v_name in
       match Map.find name map with
       | exception Not_found -> ()
-      | v' -> warn_duplicate_var name (v, ()) v'
+      | v' -> warn_duplicate_var name (v, (), ()) v'
 
-    let push_core (env : 'asm env) (name: P.Name.t) (v : P.pvar) (s : E.v_scope) =
+    let push_core (env : 'asm env) (name: P.Name.t) (v : P.pvar) (ty: P.epty) (s : E.v_scope)  =
       let doit m =
         warn_double_decl v m.gb_vars;
-        { m with gb_vars = Map.add name (v, s) m.gb_vars }
+        { m with gb_vars = Map.add name (v, ty, s) m.gb_vars }
       in
       let e_bindings =
         match env.e_bindings with
@@ -472,27 +481,26 @@ end  = struct
     let rename_var name x =
       P.GV.mk name x.P.v_kind x.P.v_ty x.P.v_dloc x.P.v_annot
 
-    let push_global env (x, e) =
+    let push_global env (x, ty, e) =
       let name = x.P.v_name in
       let x = rename_var (fully_qualified (fst env.e_bindings) name) x in
-      let env = push_core env name x Sglob in
+      let env = push_core env name x ty Sglob in
       { env with e_decls = P.MIglobal (x, e) :: env.e_decls }
 
-    let push_param env (x, e) =
+    let push_param env (x, ty, e) =
       let name = x.P.v_name in
       let x = rename_var (fully_qualified (fst env.e_bindings) name) x in
-      let env = push_core env name x Slocal in
+      let env = push_core env name x ty Slocal in
       { env with e_decls = P.MIparam (x, e) :: env.e_decls }
 
-    let push_local (env : 'asm env) (v : P.pvar) =
+    let push_local (env : 'asm env) ((v,ty) : P.pvar * P.epty) =
       env.e_declared := P.Spv.add v !(env.e_declared);
-      push_core env v.P.v_name v Slocal
+      push_core env v.P.v_name v ty Slocal
 
-    let push_implicit (env : 'asm env) (v : P.pvar) =
+    let push_implicit (env : 'asm env) ((v,ty) : P.pvar * P.epty) =
       let vars = match env.e_bindings with (_, b) :: _, _ | [], b -> b.gb_vars in
       assert (not (Map.mem v.P.v_name vars));
-      push_core env v.P.v_name v Slocal
-
+      push_core env v.P.v_name v ty Slocal
 
     let iter_locals f (env : 'asm env) =
       P.Spv.iter f !(env.e_declared)
@@ -504,7 +512,7 @@ end  = struct
 
   module TypeAlias = struct
 
-    let push (env: 'asm env) (id: A.pident) (ty: P.pty) : 'asm env =
+    let push (env: 'asm env) (id: A.pident) (ty: P.epty) : 'asm env =
       match find (fun x -> x.gb_types) (L.unloc id) env with
       | Some alias ->
          rs_tyerror  ~loc:(L.loc id)  (DuplicateAlias (L.unloc id, (L.mk_loc (L.loc id) ty) ,alias) )
@@ -518,7 +526,7 @@ end  = struct
           in
           {env with e_bindings = binds}
 
-    let get (env: 'asm env) (id: A.pident) : P.pty L.located =
+    let get (env: 'asm env) (id: A.pident) : P.epty L.located =
       let typea = find (fun b -> b.gb_types) (L.unloc id) env in
       match typea with
       | None ->
@@ -588,7 +596,7 @@ type tt_mode = [
 (* -------------------------------------------------------------------- *)
 
 let tt_var_core (mode:tt_mode) (env : 'asm Env.env) { L.pl_desc = x; L.pl_loc = lc; } =
-  let v, _ as vs =
+  let v, _, _ as vs =
     match Env.Vars.find x env with
     | Some vs -> vs
     | None -> rs_tyerror ~loc:lc (UnknownVar x) in
@@ -604,35 +612,35 @@ let tt_var_core (mode:tt_mode) (env : 'asm Env.env) { L.pl_desc = x; L.pl_loc = 
   vs
 
 let tt_var (mode:tt_mode) (env : 'asm Env.env) x =
-  let v, s = tt_var_core mode env x in
+  let v, ty, s = tt_var_core mode env x in
   if s = Sglob then
     rs_tyerror ~loc:(L.loc x) (StringError "global variables are not allowed here");
-  v
+  v, ty
 
 let tt_var_global (mode:tt_mode) (env : 'asm Env.env) v =
   let lc = v.L.pl_loc in
-  let x, s = tt_var_core mode env v in
-  { P.gv = L.mk_loc lc x; P.gs = s }, x.P.v_ty
+  let x, ty, s = tt_var_core mode env v in
+  { P.gv = L.mk_loc lc x; P.gs = s }, ty
 
 (* -------------------------------------------------------------------- *)
 let tt_fun (env : 'asm Env.env) { L.pl_desc = x; L.pl_loc = loc; } =
   Env.Funs.find x env |> oget ~exn:(tyerror ~loc (UnknownFun x))
 
 (* -------------------------------------------------------------------- *)
-let check_ty_eq ~loc ~(from : P.pty) ~(to_ : P.pty) =
-  if not (P.pty_equal from to_) then
+let check_ty_eq ~loc ~(from : P.epty) ~(to_ : P.epty) =
+  if not (P.epty_equal from to_) then
     match from, to_ with
-    | P.Arr _, P.Arr _ -> () (* we delay typechecking until we know the lengths *)
+    | ETarr _, ETarr _ -> () (* we delay typechecking until we know the lengths *)
     | _, _ -> rs_tyerror ~loc (TypeMismatch (from, to_))
 
 let check_ty_ptr pd ~loc ty =
-  check_ty_eq ~loc ~from:ty ~to_:(P.tu pd)
+  check_ty_eq ~loc ~from:ty ~to_:(P.etw pd)
 
 let check_ty_bool ~loc ty =
-  check_ty_eq ~loc ~from:ty ~to_:P.tbool
+  check_ty_eq ~loc ~from:ty ~to_:P.etbool
 
 (* -------------------------------------------------------------------- *)
-let check_return_statement ~loc name (declared : P.pty list) (given : (L.t * P.pty) list) : unit =
+let check_return_statement ~loc name (declared : P.epty list) (given : (L.t * P.epty) list) : unit =
   let given_size = List.length given in
   let declared_size = List.length declared in
   if Stdlib.Int.equal 0 given_size
@@ -701,28 +709,27 @@ let tt_sign = function
   | `Unsigned -> W.Unsigned
 
 (* -------------------------------------------------------------------- *)
-let tt_as_array ((loc, ty) : L.t * P.pty) : P.pty * P.pexpr_ =
+let tt_as_array ((loc, ty) : L.t * P.epty) : P.epty * P.pexpr_ =
   match ty with
-  | P.Arr (ws, n) -> P.Bty (P.U ws), n
+  | ETarr (ws, n) -> P.etw ws, n
   | _ -> rs_tyerror ~loc (InvalidArrayType ty)
 
 (* -------------------------------------------------------------------- *)
-
-type ty_op_kind =
-  | OpKE of E.cmp_kind
-  | OpKV of W.signedness * W.velem * W.wsize
 
 let wsize_le = Utils0.cmp_le W.wsize_cmp
 let wsize_min = Utils0.cmp_min W.wsize_cmp
 let wsize_max s1 s2 = if wsize_le s1 s2 then s2 else s1
 
 let max_ty ty1 ty2 =
-  if P.pty_equal ty1 ty2 then Some ty1 else
+  if P.epty_equal ty1 ty2 then Some ty1 else
   match ty1, ty2 with
-  | P.Bty P.Int, P.Bty (P.U _) -> Some ty2
-  | P.Bty (P.U _), P.Bty P.Int -> Some ty1
-  | P.Bty (P.U w1), P.Bty (P.U w2) -> Some (P.Bty (P.U (Utils0.cmp_min W.wsize_cmp w1 w2)))
-  | _    , _     -> None
+  | ETint, ETword _ -> Some ty2
+  | ETword _, ETint -> Some ty1
+  | ETword(None, w1), ETword(None, w2) ->
+      Some(ETword(None, Utils0.cmp_min W.wsize_cmp w1 w2))
+  (* Do not allow implicite cast on wint, this is important for the pass wint_int *)
+  | ETword(Some _b, w1), ETword(Some _b2, _w2) -> None
+  | _, _ -> None
 
 let tt_vsize_op loc op (vs:S.vsize) (ve:S.vesize)  =
   match vs, ve with
@@ -738,210 +745,262 @@ let tt_vsize_op loc op (vs:S.vsize) (ve:S.vesize)  =
   | `V4 , `W64 -> W.VE64, W.U256
   | _   ,  _   -> rs_tyerror ~loc (InvalidOperator op)
 
-let op_info_dfl exn ty s (intok, (minws, maxws)) =
+type word_kind =
+  | Word
+  | WInt
+
+type eop_kind =
+  | EOp_int
+  | EOp_w of word_kind * W.wsize
+
+type ty_op_kind =
+  | OpKE of W.signedness * eop_kind
+  | OpKV of W.signedness * W.velem * W.wsize
+
+let check_osign exn os (s:W.signedness) =
+  match os with
+  | None -> ()
+  | Some s' -> if s <> s' then raise exn
+
+type op_ok_on = {
+  intok  : bool;
+  wintok : bool;
+}
+
+let op_info_dfl exn ty s ((o_ok : op_ok_on), (minws, maxws)) =
   match ty with
-  | P.Bty (P.U ws) ->
+  | P.ETword (None, ws) ->
     let ws = wsize_max minws ws in
     let ws = wsize_min ws maxws in
-    OpKE (E.Cmp_w(s, ws))
-  | _          ->
-    if not intok then raise exn;
-    OpKE (E.Cmp_int)
+    let s = Option.default W.Unsigned s in
+    OpKE (s, EOp_w (Word, ws))
 
-let check_op loc op cmp sz =
+  | P.ETword (Some s', ws) ->
+    if not (o_ok.wintok) then raise exn;
+    let ws = wsize_max minws ws in
+    let ws = wsize_min ws maxws in
+    check_osign exn s s';
+    OpKE (s', EOp_w (WInt, ws))
+
+  | _          ->
+    if not (o_ok.intok) then raise exn;
+    let s = Option.default W.Unsigned s in
+    OpKE (s, EOp_int)
+
+let check_size_op loc op sz (min, max) =
+  if not (wsize_le min sz && wsize_le sz max) then
+    rs_tyerror ~loc (InvalidOperator op)
+
+let check_op_w loc op ty s (o_ok, cmp) =
+  match ty with
+  | None, ws ->
+    check_size_op loc op ws cmp;
+    let s =  Option.default W.Unsigned s in
+    OpKE (s, EOp_w (Word, ws))
+  | Some s', ws ->
+     if not (o_ok.wintok) then rs_tyerror ~loc (InvalidOperator op);
+     check_osign  (tyerror ~loc (InvalidOperator op)) s s';
+     OpKE (s', EOp_w (WInt, ws))
+
+let check_op_vec loc op cmp sz =
   match cmp with
   | None -> rs_tyerror ~loc (InvalidOperator op)
   | Some (min, max) ->
     if not (wsize_le min sz && wsize_le sz max) then
       rs_tyerror ~loc (InvalidOperator op)
 
-let op_info exn op (castop:S.castop) ty ws_cmp vs_cmp =
+let tt_osign = Option.map tt_sign
+
+let tt_swsize (sz, sg) =
+  match sg with
+  | `Word _ -> P.etw sz
+  | `WInt s -> P.etwi (tt_sign s) sz
+
+let tt_swsize_op (swz:S.swsize) =
+  let (ws, s) = swz in
+  match s with
+  | `Word s -> tt_osign s, (None, ws)
+  | `WInt s -> let s = tt_sign s in Some s, (Some s, ws)
+
+let op_info exn op (s : W.signedness option) (castop:S.castop) ty ws_cmp vs_cmp =
   match castop with
   | None                ->
-    let s = W.Unsigned in
     op_info_dfl exn ty s ws_cmp
 
   | Some c ->
     let loc = L.loc c in
     match L.unloc c with
-    | CSS(None, s) ->
-      let s = tt_sign s in
-      op_info_dfl exn ty s ws_cmp
-
-    | CSS(Some sz, s) ->
-      let s = tt_sign s in
-      check_op loc op (Some (snd ws_cmp)) sz;
-      OpKE(E.Cmp_w(s, sz))
+    | CSS swz ->
+      let s1, ty = tt_swsize_op swz in
+      let s =
+        match s, s1 with
+        | Some s, Some s1 -> if s = s1 then Some s else rs_tyerror ~loc (InvalidOperator op)
+        | Some _, None -> s
+        | None, Some _ -> s1
+        | None, None -> None
+      in
+      check_op_w loc op ty s ws_cmp
 
     | CVS(vs,s,ve) ->
       let s = tt_sign s in
       let ve, ws = tt_vsize_op loc op vs ve in
-      check_op loc op vs_cmp (W.wsize_of_velem ve);
+      check_op_vec loc op vs_cmp (W.wsize_of_velem ve);
       OpKV(s, ve, ws)
 
 
 
 (* -------------------------------------------------------------------- *)
-let op_kind_of_cmp = function
-  | E.Cmp_int     -> E.Op_int
-  | E.Cmp_w(_,ws) -> E.Op_w ws
-
 type 'o op_info = {
     opi_op   : ty_op_kind -> 'o;
-    opi_wcmp : bool * (W.wsize * W.wsize);
+    opi_wcmp : op_ok_on * (W.wsize * W.wsize);
     opi_vcmp : (W.wsize * W.wsize) option;
   }
 
 let cmp_8_64 = (W.U8, W.U64)
 let cmp_8_256 = (W.U8, W.U256)
 
-let mk_cmp_kind eop vop = function
-  | OpKE c        -> eop c
-  | OpKV(s,ve,ws) -> vop s ve ws
+let mk_op_kind eop vop = function
+    | OpKE(s, k) -> eop s k
+    | OpKV(s, ve, ws) -> vop s ve ws
 
-let mk_cmp_info eop vop = {
-    opi_op   = mk_cmp_kind eop vop;
-    opi_wcmp = true, cmp_8_256;
-    opi_vcmp = Some cmp_8_64;
-  }
+let mk_op_s_k_info eop =
+  { opi_op = mk_op_kind eop (fun _ _ _ -> assert false)
+  ; opi_wcmp =  {intok = true; wintok = true}, cmp_8_256
+  ; opi_vcmp = None }
 
-let mk_op_of_c op c = op (op_kind_of_cmp c)
 
-let mk_op_info eop vop = mk_cmp_info (mk_op_of_c eop) vop
+let mk_op_k_info eop vop =
+  { opi_op = mk_op_kind (fun s k -> eop s k) vop
+  ; opi_wcmp =  {intok = true; wintok = true}, cmp_8_256
+  ; opi_vcmp = Some cmp_8_64 }
 
-let mk_cmp_info_nvec eop = {
-    opi_op   = mk_cmp_kind eop (fun _ _ _ -> assert false);
-    opi_wcmp = true, cmp_8_256;
-    opi_vcmp = None;
-  }
+let mk_op_k_info_no_vec eop =
+  { opi_op = mk_op_kind (fun s k -> eop s k) (fun _ _ _ -> assert false)
+  ; opi_wcmp = {intok = true; wintok = true}, cmp_8_256
+  ; opi_vcmp = None }
 
-let mk_op64_info_nvec eop = mk_cmp_info_nvec (mk_op_of_c eop)
+let mk_logic_ws eop = function
+  | OpKE (_, EOp_w (Word, ws))
+  | OpKV (_,_, ws) -> eop ws
+  | _ -> assert false
 
 let mk_logic_info eop =
-  let mk = function
-    | OpKE (Cmp_int)     -> assert false
-    | OpKE (Cmp_w(_,ws)) -> eop ws
-    | OpKV (_s,_ve,ws)   -> eop ws in
-  { opi_op = mk;
-    opi_wcmp = false, cmp_8_256;
+  { opi_op = mk_logic_ws eop;
+    opi_wcmp = {intok = false; wintok = false}, cmp_8_256;
     opi_vcmp = Some (cmp_8_64); }
+
+let mk_rot_info eop =
+  { opi_op = mk_logic_ws eop;
+    opi_wcmp = {intok = false; wintok = false}, cmp_8_64;
+    opi_vcmp = None; }
 
 (* -------------------------------------------------------------------- *)
 
 let op1_of_ty exn op castop ty (info:E.sop1 op_info) =
-  let tok = op_info exn (`Op1 op) castop ty info.opi_wcmp info.opi_vcmp in
+  let tok = op_info exn (`Op1 op) None castop ty info.opi_wcmp info.opi_vcmp in
   info.opi_op tok
 
-let lnot_info = mk_logic_info (fun s -> E.Olnot s)
-let  neg_info = mk_op64_info_nvec (fun s -> E.Oneg s)
+let lnot_info = mk_logic_info (fun ws -> E.Olnot ws)
+
+let mk_op1 op_k op_wi s = function
+  | EOp_int -> op_k E.Op_int
+  | EOp_w (Word, sz) -> op_k (E.Op_w sz)
+  | EOp_w (WInt, sz) -> E.Owi1 (s, op_wi sz)
+
+let  neg_info =
+  mk_op_k_info_no_vec (mk_op1 (fun k -> E.Oneg k) (fun sz -> E.WIneg sz))
 
 (* -------------------------------------------------------------------- *)
 
-let add_info =
-  mk_op_info (fun k -> E.Oadd k) (fun _s ve ws -> E.Ovadd(ve,ws))
+let mk_op2 op_k op_wi s = function
+  | EOp_int -> op_k s E.Op_int
+  | EOp_w (Word, sz) -> op_k s (E.Op_w sz)
+  | EOp_w (WInt, sz) -> E.Owi2 (s, sz, op_wi)
+
+let add_info : E.sop2 op_info =
+  mk_op_k_info (mk_op2 (fun _ k -> E.Oadd k) E.WIadd) (fun _s ve ws -> E.Ovadd(ve,ws))
 
 let sub_info =
-  mk_op_info (fun k -> E.Osub k) (fun _s ve ws -> E.Ovsub(ve,ws))
+  mk_op_k_info (mk_op2 (fun _ k -> E.Osub k) E.WIsub) (fun _s ve ws -> E.Ovsub(ve,ws))
 
 let mul_info =
-  mk_op_info (fun k -> E.Omul k) (fun _s ve ws -> E.Ovmul(ve,ws))
+  mk_op_k_info (mk_op2 (fun _ k -> E.Omul k) E.WImul) (fun _s ve ws -> E.Ovmul(ve,ws))
 
-let div_info = mk_cmp_info_nvec (fun k -> E.Odiv k)
-let mod_info = mk_cmp_info_nvec (fun k -> E.Omod k)
+let div_info = mk_op_s_k_info (mk_op2 (fun s k -> E.Odiv(s, k)) E.WIdiv)
+let mod_info = mk_op_s_k_info (mk_op2 (fun s k -> E.Omod(s, k)) E.WImod)
 
 let land_info = mk_logic_info (fun k -> E.Oland k)
 let lor_info  = mk_logic_info (fun k -> E.Olor  k)
 let lxor_info = mk_logic_info (fun k -> E.Olxor k)
 
 let shr_info =
-  let mk = function
-    | OpKE (Cmp_int)     -> E.Oasr E.Op_int
-    | OpKE (Cmp_w(s,ws)) ->
-      if s = W.Unsigned then E.Olsr ws else E.Oasr (E.Op_w ws)
-    | OpKV (s,ve,ws)   ->
-      if s = W.Unsigned then E.Ovlsr(ve,ws) else E.Ovasr(ve,ws) in
-  { opi_op   = mk;
-    opi_wcmp = true, cmp_8_256;
-    opi_vcmp = Some cmp_8_64;
-  }
-
-let rot_info exn op =
-  let mk opk =
-    match opk with
-    | OpKE Cmp_int -> raise exn
-    | OpKE (Cmp_w (_, ws)) -> op ws
-    | OpKV _ -> raise exn
-  in
-  {
-    opi_op = mk;
-    opi_wcmp = true, cmp_8_64;
-    opi_vcmp = None;
-  }
+  mk_op_k_info
+   (mk_op2
+     (fun s k ->
+       match k with
+       | E.Op_int -> E.Oasr k
+       | E.Op_w ws -> if s = W.Unsigned then E.Olsr ws else E.Oasr k) E.WIshr)
+     (fun s ve ws -> if s = W.Unsigned then E.Ovlsr(ve,ws) else E.Ovasr(ve,ws))
 
 let shl_info =
-  let mk = function
-    | OpKE (Cmp_int)      -> E.Olsl E.Op_int
-    | OpKE (Cmp_w(_s,ws)) -> E.Olsl (E.Op_w ws)
-    | OpKV (_s,ve,ws)     -> E.Ovlsl(ve,ws) in
-  { opi_op   = mk;
-    opi_wcmp = true, cmp_8_256;
-    opi_vcmp = Some cmp_8_64;
-  }
+  mk_op_k_info (mk_op2 (fun _ k -> E.Olsl k) E.WIshl)  (fun _s ve ws -> E.Ovlsl(ve,ws))
 
-let mk_test_info eop2 =
-  let mk = function
-    | OpKE k          -> eop2 k
-    | OpKV (s,_ve,ws) -> eop2 (E.Cmp_w(s,ws)) in
-  { opi_op = mk;
-    opi_wcmp = true, cmp_8_256;
-    opi_vcmp = Some (cmp_8_64); }
+let ror_info = mk_rot_info (fun ws -> E.Oror ws)
+let rol_info = mk_rot_info (fun ws -> E.Orol ws)
 
-let eq_info  = mk_test_info (fun c -> E.Oeq (op_kind_of_cmp c))
-let neq_info = mk_test_info (fun c -> E.Oneq (op_kind_of_cmp c))
-let lt_info  = mk_test_info (fun c -> E.Olt c)
-let le_info  = mk_test_info (fun c -> E.Ole c)
-let gt_info  = mk_test_info (fun c -> E.Ogt c)
-let ge_info  = mk_test_info (fun c -> E.Oge c)
+let eq_info  =  mk_op_k_info_no_vec (mk_op2 (fun _s k -> E.Oeq k) E.WIeq)
+let neq_info =  mk_op_k_info_no_vec (mk_op2 (fun _s k -> E.Oneq k) E.WIneq)
 
-let op2_of_ty exn op castop ty (info:E.sop2 op_info) =
-  let tok = op_info exn (`Op2 op) castop ty info.opi_wcmp info.opi_vcmp in
+let cmp_of_op_k s = function
+  | E.Op_int -> E.Cmp_int
+  | E.Op_w sz -> E.Cmp_w(s, sz)
+
+let lt_info  =  mk_op_k_info_no_vec (mk_op2 (fun s k -> E.Olt (cmp_of_op_k s k)) E.WIlt)
+let le_info  =  mk_op_k_info_no_vec (mk_op2 (fun s k -> E.Ole (cmp_of_op_k s k)) E.WIle)
+let gt_info  =  mk_op_k_info_no_vec (mk_op2 (fun s k -> E.Ogt (cmp_of_op_k s k)) E.WIgt)
+let ge_info  =  mk_op_k_info_no_vec (mk_op2 (fun s k -> E.Oge (cmp_of_op_k s k)) E.WIge)
+
+let op2_of_ty exn op s castop ty (info:E.sop2 op_info) =
+  let tok = op_info exn (`Op2 op) s castop ty info.opi_wcmp info.opi_vcmp in
   info.opi_op tok
+
+let ensure_word exn ty = (max_ty ty (P.etw U256) |> oget ~exn)
 
 let op2_of_pop2 exn ty (op : S.peop2) =
   match op with
   | `And    -> E.Oand
   | `Or     -> E.Oor
 
-  | `Add  c -> op2_of_ty exn op c ty add_info
-  | `Sub  c -> op2_of_ty exn op c ty sub_info
-  | `Mul  c -> op2_of_ty exn op c ty mul_info
-  | `Div  c -> op2_of_ty exn op c ty div_info
-  | `Mod  c -> op2_of_ty exn op c ty mod_info
+  | `Add  c -> op2_of_ty exn op None c ty add_info
+  | `Sub  c -> op2_of_ty exn op None c ty sub_info
+  | `Mul  c -> op2_of_ty exn op None c ty mul_info
+  | `Div(s, c) -> op2_of_ty exn op (tt_osign s) c ty div_info
+  | `Mod(s, c) -> op2_of_ty exn op (tt_osign s) c ty mod_info
 
-  | `BAnd c -> op2_of_ty exn op c (max_ty ty P.u256 |> oget ~exn) land_info
-  | `BOr  c -> op2_of_ty exn op c (max_ty ty P.u256 |> oget ~exn) lor_info
-  | `BXOr c -> op2_of_ty exn op c (max_ty ty P.u256 |> oget ~exn) lxor_info
-  | `ShR  c -> op2_of_ty exn op c ty shr_info
-  | `ShL  c -> op2_of_ty exn op c ty shl_info
-  | `ROR  c -> op2_of_ty exn op c ty (rot_info exn (fun x -> E.Oror x))
-  | `ROL  c -> op2_of_ty exn op c ty (rot_info exn (fun x -> E.Orol x))
+  | `BAnd c -> op2_of_ty exn op None c (ensure_word exn ty) land_info
+  | `BOr  c -> op2_of_ty exn op None c (ensure_word exn ty) lor_info
+  | `BXOr c -> op2_of_ty exn op None c (ensure_word exn ty) lxor_info
+  | `ShR(s, c) -> op2_of_ty exn op (tt_osign s) c ty shr_info
+  | `ShL  c -> op2_of_ty exn op None c ty shl_info
+  | `ROR  c -> op2_of_ty exn op None c ty ror_info
+  | `ROL  c -> op2_of_ty exn op None c ty rol_info
 
-  | `Eq   c -> op2_of_ty exn op c ty eq_info
-  | `Neq  c -> op2_of_ty exn op c ty neq_info
-  | `Lt   c -> op2_of_ty exn op c ty lt_info
-  | `Le   c -> op2_of_ty exn op c ty le_info
-  | `Gt   c -> op2_of_ty exn op c ty gt_info
-  | `Ge   c -> op2_of_ty exn op c ty ge_info
+  | `Eq   c -> op2_of_ty exn op None c ty eq_info
+  | `Neq  c -> op2_of_ty exn op None c ty neq_info
+  | `Lt(s, c) -> op2_of_ty exn op (tt_osign s) c ty lt_info
+  | `Le(s, c) -> op2_of_ty exn op (tt_osign s) c ty le_info
+  | `Gt(s, c) -> op2_of_ty exn op (tt_osign s) c ty gt_info
+  | `Ge(s, c) -> op2_of_ty exn op (tt_osign s) c ty ge_info
 
 let op1_of_pop1 exn ty (op: S.peop1) =
   match op with
   | `Cast _ -> assert false
   | `Not c ->
-    if ty = P.tbool then
+    if ty = P.etbool then
       if c <> None then raise exn
       else E.Onot
     else
-      op1_of_ty exn op c  (max_ty ty P.u256 |> oget ~exn) lnot_info
+      op1_of_ty exn op c (ensure_word exn ty) lnot_info
 
   | `Neg c -> op1_of_ty exn op c ty neg_info
 
@@ -963,48 +1022,103 @@ let peop2_of_eqop (eqop : S.peqop) =
   | `BOr  s -> Some (`BOr s)
 
 (* -------------------------------------------------------------------- *)
+
+let wk_s_ws (s: W.signedness option) (ws: W.wsize) =
+  let wk = if s = None then Word else WInt in
+  let s = Option.default W.Unsigned s in
+  (wk, s, ws)
+
+let op_word_of_int (wk, s, ws) =
+  match wk with
+  | Word -> E.Oword_of_int ws
+  | WInt -> E.Owi1(s, E.WIwint_of_int ws)
+
+let op_int_of_word (wk, s, ws) =
+  match wk with
+  | Word -> E.Oint_of_word (s, ws)
+  | WInt -> E.Owi1(s, E.WIint_of_wint ws)
+
 let cast loc e ety ty =
   match ety, ty with
-  | P.Bty P.Int , P.Bty (P.U w) -> P.Papp1 (E.Oword_of_int w, e)
-  | P.Bty (P.U w), P.Bty P.Int -> P.Papp1 (E.Oint_of_word w, e)
-  | P.Bty (P.U w1), P.Bty (P.U w2) when W.wsize_cmp w1 w2 <> Datatypes.Lt -> e
-  | _, _ when P.pty_equal ety ty -> e
-  | P.Arr _, P.Arr _ -> e (* we delay typechecking until we know the lengths *)
+  | P.ETint, P.ETword(s,ws) ->
+    let op = op_word_of_int (wk_s_ws s ws) in
+    P.Papp1(op, e)
+
+  | P.ETword(s, ws), P.ETint ->
+    (* FIXME do we really want to keep this cast word -> int implicit?
+       Since we can use to_uint or to_sint ... *)
+    let op = op_int_of_word (wk_s_ws s ws) in
+    P.Papp1(op, e)
+
+  | P.ETword(None, w1), P.ETword(None, w2) when W.wsize_cmp w1 w2 <> Datatypes.Lt -> e
+  | P.ETword(Some W.Unsigned, w1),  P.ETword(Some W.Unsigned, w2) when W.wsize_cmp w1 w2 <> Datatypes.Lt -> e
+
+  | _, _ when P.epty_equal ety ty -> e
+  | P.ETarr _, P.ETarr _ -> e (* we delay typechecking until we know the lengths *)
   | _  ->  rs_tyerror ~loc (InvalidCast(ety,ty))
 
+(*
 let cast_word loc ws e ety =
   match ety with
-  | P.Bty P.Int   -> P.Papp1 (Oword_of_int ws, e), ws
+  | P.Bty P.Int   -> P.Papp1 (E.Oword_of_int ws, e), ws
   | P.Bty (P.U ws1) -> e, ws1
   | _             ->  rs_tyerror ~loc (InvalidCast(ety,P.Bty (P.U ws)))
+*)
 
-let cast_int loc e ety =
-  cast loc e ety P.tint
+let cast_int loc os e ety =
+  match ety with
+  | P.ETint -> e
+  | P.ETword (s, ws) ->
+    let wk, s, ws = wk_s_ws s ws in
+    let s =
+      match wk, os with
+      | _, None ->
+       if wk = Word then
+          Utils.warning Deprecated (L.i_loc0 loc)
+            "Syntax (int)e when e has type %a is deprecated. Use (uint)e of (sint)e instead"
+            (fun fmt -> PrintCommon.pp_btype fmt) (P.U ws);
+        s
+      | Word, Some s -> tt_sign s
+      | WInt, Some s' ->
+        (* FIXME: Should we do a better error message ? *)
+        if tt_sign s' <> s then rs_tyerror ~loc (InvalidCast(ety,P.etint));
+        s
+    in
+    let op = op_int_of_word(wk, s, ws) in
+    P.Papp1(op, e)
+  | _ -> rs_tyerror ~loc (InvalidCast(ety,P.etint))
+
 
 (* -------------------------------------------------------------------- *)
-let conv_ty : T.stype -> P.pty = function
-    | T.Coq_sbool    -> P.tbool
-    | T.Coq_sint     -> P.tint
-    | T.Coq_sword ws -> P.Bty (P.U ws)
-    | T.Coq_sarr p   -> P.Arr (U8, PE (P.icnst (Conv.int_of_pos p)))
+let conv_ty : BinNums.positive T.extended_type -> P.epty = function
+    | T.ETbool       -> P.etbool
+    | T.ETint        -> P.etint
+    | T.ETword(s,ws) -> P.ETword(s,ws)
+    | T.ETarr p      -> P.ETarr (U8, PE (P.icnst (Conv.int_of_pos p)))
+
+let conv_cty : T.stype -> P.epty = function
+    | T.Coq_sbool    -> P.etbool
+    | T.Coq_sint     -> P.etint
+    | T.Coq_sword ws -> P.etw ws
+    | T.Coq_sarr p   -> P.ETarr (U8, PE (P.icnst (Conv.int_of_pos p)))
 
 let type_of_op2 op =
-  let (ty1, ty2), tyo = E.type_of_op2 op in
+  let (ty1, ty2), tyo = E.etype_of_op2 op in
   conv_ty ty1, conv_ty ty2, conv_ty tyo
 
 let tt_op2 (loc1, (e1, ety1)) (loc2, (e2, ety2))
            { L.pl_desc = pop; L.pl_loc = loc } =
 
   match pop with
-  | `Eq None when ety1 = P.tbool && ety2 = P.tbool ->
-    P.Papp2(E.Obeq, e1, e2), P.tbool
-  | `Neq None when ety1 = P.tbool && ety1 = P.tbool ->
-    P.Papp1 (E.Onot, P.Papp2(E.Obeq, e1, e2)), P.tbool
+  | `Eq None when ety1 = P.etbool && ety2 = P.etbool ->
+     P.Papp2(E.Obeq, e1, e2), P.etbool
+  | `Neq None when ety1 = P.etbool && ety1 = P.etbool ->
+    P.Papp1 (E.Onot, P.Papp2(E.Obeq, e1, e2)), P.etbool
   | _ ->
     let exn = tyerror ~loc (NoOperator (`Op2 pop, [ety1; ety2])) in
     let ty =
       match pop with
-      | `And   | `Or    -> P.tbool
+      | `And   | `Or    -> P.etbool
       | `ShR _ | `ShL _ | `ROR _ | `ROL _ -> ety1
       | `Add _ | `Sub _ | `Mul _ | `Div _ | `Mod _
         | `BAnd _ | `BOr _ | `BXOr _
@@ -1017,7 +1131,7 @@ let tt_op2 (loc1, (e1, ety1)) (loc2, (e2, ety2))
     P.Papp2(op, e1, e2), tyo
 
 let type_of_op1 op =
-  let ty, tyo = E.type_of_op1 op in
+  let ty, tyo = E.etype_of_op1 op in
   conv_ty ty, conv_ty tyo
 
 let tt_op1 (loc1, (e1, ety1)) { L.pl_desc = pop; L.pl_loc = loc } =
@@ -1070,12 +1184,6 @@ let combine_flags =
 let is_combine_flags id =
   List.mem_assoc (L.unloc id) combine_flags
 
-let ensure_int loc i ty =
-  match ty with
-  | P.Bty Int -> i
-  | P.Bty (P.U ws) -> P.Papp1(E.Oint_of_word ws,i)
-  | _ -> rs_tyerror ~loc (TypeMismatch (ty, P.tint))
-
 (* -------------------------------------------------------------------- *)
 let tt_al aa =
   let open Memory_model in
@@ -1090,6 +1198,37 @@ let ignore_align ~loc =
   | Some _al ->
      warning Always (L.i_loc0 loc) "ignored alignment annotation in array slice"
 
+
+(* -------------------------------------------------------------------- *)
+
+let tt_mem_wsize dfl (ct : S.swsize L.located option) =
+  match ct with
+  | None -> dfl
+  | Some ct ->
+      match L.unloc ct with
+      | (_, `WInt _) as a->
+        rs_tyerror ~loc:(L.loc ct)
+          (StringError ("invalid cast annotation "^(S.string_of_swsize_ty a)))
+      | (ws, `Word _) -> ws
+
+(* Precondition e : P.etw ws *)
+(*
+let wint_of_word ws (cast : W.signedness option) e =
+  match cast with
+  | None -> e, P.etw ws
+  | Some s ->
+    let e = P.Papp1 (E.EO.Owint_of_word(s, ws), e) in
+    e, P.etwi s ws
+*)
+(*
+let word_of_wint wint_of_word ws (cast : W.signedness option) e =
+  match cast with
+  | None -> e, P.etw ws
+  | Some s ->
+    let e = P.Papp1 (E.EO.Owint_of_word(s, ws), e) in
+    e, P.etwi s ws
+*)
+
 (* -------------------------------------------------------------------- *)
 let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
   match L.unloc pe with
@@ -1097,10 +1236,10 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     tt_expr ~mode pd env pe
 
   | S.PEBool b ->
-    P.Pbool b, P.tbool
+    P.Pbool b, P.etbool
 
   | S.PEInt i ->
-    P.Pconst (S.parse_int i), P.tint
+    P.Pconst (S.parse_int i), P.etint
 
   | S.PEVar x ->
     let x, ty = tt_var_global mode env x in
@@ -1108,15 +1247,15 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
 
   | S.PEFetch me ->
     let ct, x, e, al = tt_mem_access ~mode pd env me in
-    P.Pload (al, ct, x, e), P.Bty (P.U ct)
+    P.Pload (al, ct, x, e), P.etw ct
 
   | S.PEGet (al, aa, ws, ({ L.pl_loc = xlc } as x), pi, olen) ->
     let x, ty = tt_var_global mode env x in
     let ty, _ = tt_as_array (xlc, ty) in
-    let ws = Option.default (P.ws_of_ty ty) ws in
-    let ty = P.tu ws in
+    let ws = tt_mem_wsize (P.ws_of_ety ty) ws in
+    let ty = P.etw ws in
     let i,ity  = tt_expr ~mode pd env pi in
-    let i = ensure_int (L.loc pi) i ity in
+    let i = cast_int (L.loc pi) (Some `Unsigned) i ity in
     begin match olen with
     | None ->
        let al = tt_al aa al in
@@ -1124,8 +1263,8 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     | Some plen ->
        ignore_align ~loc:(L.loc pe) al;
       let len,ity  = tt_expr ~mode:`OnlyParam pd env plen in
-      check_ty_eq ~loc:(L.loc plen) ~from:ity ~to_:P.tint;
-      let ty = P.Arr (ws, P.PE len) in
+      check_ty_eq ~loc:(L.loc plen) ~from:ity ~to_:P.etint;
+      let ty = P.ETarr (ws, P.PE len) in
       P.Psub (aa, ws, P.PE len, x, i), ty
     end
 
@@ -1133,22 +1272,50 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     let e, ety = tt_expr ~mode pd env pe in
 
     begin match op with
-    | `Cast (`ToInt) ->
-      let e = cast_int (L.loc pe) e ety in
-      e, P.tint
+    | `Cast (`ToInt s) ->
+      let e = cast_int (L.loc pe) s e ety in
+      e, P.etint
 
     | `Cast (`ToWord (sz, sg)) ->
-      let e, ws = cast_word (L.loc pe) sz e ety in
-      let e =
-        if W.wsize_cmp ws sz = Datatypes.Lt then
-          let op =
-            match sg with
-            | `Unsigned -> E.Ozeroext (sz, ws)
-            | `Signed   -> E.Osignext (sz, ws)
-          in
-          P.Papp1(op,e)
-        else e in
-      e, P.Bty (P.U sz)
+       let rty = tt_swsize (sz, sg) in
+       (* We allow either to change the kind (i.e. ui/si/w) or the size but
+          not both at the same time *)
+       let e =
+         match sg, ety with
+         | `Word s, P.ETword(None, ws) ->
+            if W.wsize_cmp ws sz <> Datatypes.Lt then e (* implicit truncation *)
+            else
+              let s = Option.default W.Unsigned (tt_osign s) in
+              let op = if s = W.Unsigned then E.Ozeroext(sz, ws) else E.Osignext(sz, ws) in
+              P.Papp1(op, e)
+
+         | `Word s, P.ETword(Some s', ws) ->
+            if W.wsize_cmp ws sz <> Datatypes.Eq then
+              rs_tyerror ~loc:(L.loc pe) (InvalidCast(ety,rty));
+            Papp1(E.Owi1(s', E.WIword_of_wint ws), e)
+
+         | `Word s, P.ETint ->
+            Papp1(E.Oword_of_int sz, e)
+
+         | `WInt s, P.ETword(None, ws) ->
+            let s = tt_sign s in
+            Papp1(E.Owi1 (s, E.WIwint_of_word ws), e)
+
+         | `WInt s, P.ETword (Some s', ws) ->
+            let s = tt_sign s in
+            if s = s' then
+              if s = W.Unsigned && W.wsize_cmp ws sz <> Datatypes.Lt then e (* implicit truncation *)
+              else P.Papp1(E.Owi1(s, E.WIwint_ext(sz, ws)), e)
+            else
+              rs_tyerror ~loc:(L.loc pe) (InvalidCast(ety,rty))
+
+         | `WInt s, P.ETint ->
+             let s = tt_sign s in
+             Papp1(E.Owi1(s, E.WIwint_of_int sz), e)
+
+         | _ -> rs_tyerror ~loc:(L.loc pe) (InvalidCast(ety,rty))
+       in
+       e, rty
     | _  ->
       let et1 = tt_expr ~mode pd env pe in
       tt_op1 (L.loc pe, et1) (L.mk_loc (L.loc pe) op)
@@ -1168,10 +1335,10 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
         rs_tyerror ~loc:(L.loc pe) (InvalidArgCount(nargs, nexp));
       let tt_expr pe =
         let e, ety = tt_expr ~mode pd env pe in
-        check_ty_eq ~loc:(L.loc pe) ~from:ety ~to_:P.tbool;
+        check_ty_eq ~loc:(L.loc pe) ~from:ety ~to_:P.etbool;
         e in
       let args = List.map tt_expr args in
-      P.PappN (E.Ocombine_flags c, args), P.tbool
+      P.PappN (E.Ocombine_flags c, args), P.etbool
     | exception Not_found -> assert false
     end
 
@@ -1189,10 +1356,10 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     if sg <> `Unsigned then rs_tyerror ~loc PackSigned;
     let sz, pz, len = tt_pack ~loc nb es in
     let args = List.map (tt_expr ~mode pd env) args in
-    let args = List.map (fun (a, ty) -> cast loc a ty (P.Bty P.Int)) args in
+    let args = List.map (fun (a, ty) -> cast_int loc (Some sg) a ty) args in
     let alen = List.length args in
     if alen <> len then rs_tyerror ~loc (PackWrongLength (len, alen));
-    P.PappN (E.Opack (sz, pz), args), P.Bty (P.U sz)
+    P.PappN (E.Opack (sz, pz), args), P.etw sz
 
   | S.PEIf (pe1, pe2, pe3) ->
     let e1, ty1 = tt_expr ~mode pd env pe1 in
@@ -1201,7 +1368,7 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
 
     check_ty_bool ~loc:(L.loc pe1) ty1;
     let ty = max_ty ty2 ty3 |> oget ~exn:(tyerror ~loc:(L.loc pe) (TypeMismatch (ty2, ty3))) in
-    P.Pif(ty, e1, e2, e3), ty
+    P.Pif(P.gty_of_gety ty, e1, e2, e3), ty
 
 and tt_expr_cast pd ?(mode=`AllVar) (env : 'asm Env.env) pe ty =
   let e, ety = tt_expr ~mode pd env pe in
@@ -1209,52 +1376,67 @@ and tt_expr_cast pd ?(mode=`AllVar) (env : 'asm Env.env) pe ty =
 
 and tt_mem_access pd ?(mode=`AllVar) (env : 'asm Env.env)
            (al, ct, ({ L.pl_loc = xlc } as x), e) =
-  let x = tt_var `NoParam env x in
-  check_ty_ptr pd ~loc:xlc x.P.v_ty;
+  let x, ty = tt_var `NoParam env x in
+  check_ty_ptr pd ~loc:xlc ty;
   let e =
     match e with
-    | None -> P.Papp1 (Oword_of_int pd, P.Pconst (Z.zero))
+    | None -> P.Papp1 (op_word_of_int (Word, W.Unsigned, pd), P.Pconst (Z.zero))
     | Some(k, e) ->
-      let e = tt_expr_cast ~mode pd env e (P.tu pd) in
+      let e = tt_expr_cast ~mode pd env e (P.etw pd) in
       match k with
       | `Add -> e
       | `Sub -> Papp1(E.Oneg (E.Op_w pd), e) in
-  let ct = ct |> Option.default pd in
+  let ct = tt_mem_wsize pd ct in
   let al = tt_al AAdirect al in
-  (ct,L.mk_loc xlc x,e, al)
+  (ct, L.mk_loc xlc x, e, al)
 
 (* -------------------------------------------------------------------- *)
-and tt_type pd (env : 'asm Env.env) (pty : S.ptype) : P.pty =
+and tt_type pd (env : 'asm Env.env) (pty : S.ptype) : P.epty =
   match L.unloc pty with
-  | S.TBool     -> P.tbool
-  | S.TInt      -> P.tint
-  | S.TWord  ws -> P.Bty (P.U ws)
+  | S.TBool     -> P.etbool
+  | S.TInt      -> P.etint
+  | S.TWord  ws -> tt_swsize ws
   | S.TArray (ws, e) ->
-     let ws = match ws with
-       | TypeWsize ws -> ws
+     let loc, id, ety =
+       match ws with
+       | TypeWsize ws -> L.loc pty, None, tt_swsize ws
        | TypeSizeAlias id ->
-          let extern_type = Env.TypeAlias.get env id in
-          match L.unloc extern_type with
-          | P.Bty (P.U ws) -> ws
-          | ty -> rs_tyerror  ~loc:(L.loc id) (InvalidTypeAlias ((L.unloc id),ty))
-     in P.Arr (ws, P.PE (fst (tt_expr ~mode:`OnlyParam pd env e)))
+          let ty = Env.TypeAlias.get env id in
+          L.loc id, Some (L.mk_loc (L.loc ty) (L.unloc id)), L.unloc ty in
+     let ws =
+       match ety with
+       | P.ETword(None, ws) -> ws (* wint array are not allowed this is require by wint_int *)
+       | ty -> rs_tyerror ~loc (InvalidTypeAlias (id,ty))
+     in P.ETarr (ws, P.PE (fst (tt_expr ~mode:`OnlyParam pd env e)))
   | S.TAlias id -> L.unloc (Env.TypeAlias.get env id)
 
 (* -------------------------------------------------------------------- *)
 let tt_exprs pd (env : 'asm Env.env) es = List.map (tt_expr ~mode:`AllVar pd env) es
 
 (* -------------------------------------------------------------------- *)
-let tt_expr_bool pd env pe = tt_expr_cast pd env pe P.tbool
-let tt_expr_int  pd env pe = tt_expr_cast pd env pe P.tint
+let tt_expr_bool pd env pe = tt_expr_cast pd env pe P.etbool
+let tt_expr_int  pd env pe = tt_expr_cast pd env pe P.etint
 
 (* -------------------------------------------------------------------- *)
+
+let mk_var x sto xety xlc annot =
+  let annot =
+    match xety with
+    | P.ETword(Some s, ws) ->
+      let s = if s = W.Signed then Annotations.sint else Annotations.uint in
+      Annotations.add_symbol ~loc:xlc s annot
+    | _ -> annot
+  in
+  P.PV.mk x sto (P.gty_of_gety xety) xlc annot
+
 let tt_vardecl dfl_writable pd (env : 'asm Env.env) ((annot, (sto, xty)), x) =
   let { L.pl_desc = x; L.pl_loc = xlc; } = x in
   let regkind = tt_reg_kind annot in
-  let (sto, xty) = (tt_sto regkind (dfl_writable x) sto, tt_type pd env xty) in
-  if P.is_ptr sto && not (P.is_ty_arr xty) then
+  let (sto, xety) = (tt_sto regkind (dfl_writable x) sto, tt_type pd env xty) in
+  let x = mk_var x sto xety xlc annot in
+  if P.is_ptr sto && not (P.is_ty_arr x.v_ty) then
     rs_tyerror ~loc:xlc PtrOnlyForArray;
-  L.mk_loc xlc (P.PV.mk x sto xty xlc annot)
+  L.mk_loc xlc (x, xety)
 
 (* -------------------------------------------------------------------- *)
 let tt_vardecls_push dfl_writable pd (env : 'asm Env.env) pxs =
@@ -1270,8 +1452,8 @@ let tt_param pd (env : 'asm Env.env) _loc (pp : S.pparam) : 'asm Env.env =
 
   check_ty_eq ~loc:(L.loc pp.ppa_init) ~from:ty ~to_:ety;
 
-  let x = P.PV.mk (L.unloc pp.ppa_name) W.Const ty (L.loc pp.ppa_name) [] in
-  let env = Env.Vars.push_param env (x,pe) in
+  let x = mk_var (L.unloc pp.ppa_name) W.Const ty (L.loc pp.ppa_name) [] in
+  let env = Env.Vars.push_param env (x,ety, pe) in
   env
 
 
@@ -1287,20 +1469,20 @@ let tt_lvalue pd (env : 'asm Env.env) { L.pl_desc = pl; L.pl_loc = loc; } =
 
   match pl with
   | S.PLIgnore ->
-    loc, (fun ty -> P.Lnone(loc,ty)) , None
+    loc, (fun ety -> P.Lnone(loc, P.gty_of_gety ety)) , None
 
   | S.PLVar x ->
-    let x = tt_var `NoParam env x in
-    loc, (fun _ -> P.Lvar (L.mk_loc loc x)), Some x.P.v_ty
+    let x, xty = tt_var `NoParam env x in
+    loc, (fun _ -> P.Lvar (L.mk_loc loc x)), Some xty
 
   | S.PLArray (al, aa, ws, ({ pl_loc = xlc } as x), pi, olen) ->
-    let x  = tt_var `NoParam env x in
+    let x, xty  = tt_var `NoParam env x in
     reject_constant_pointers xlc x ;
-    let ty,_ = tt_as_array (xlc, x.P.v_ty) in
-    let ws = Option.default (P.ws_of_ty ty) ws in
-    let ty = P.tu ws in
+    let ty,_ = tt_as_array (xlc, xty) in
+    let ws = tt_mem_wsize (P.ws_of_ety ty) ws in
+    let ty = P.etw ws in
     let i,ity  = tt_expr ~mode:`AllVar pd env pi in
-    let i = ensure_int (L.loc pi) i ity in
+    let i = cast_int (L.loc pi) (Some `Unsigned) i ity in
     begin match olen with
     | None ->
       let al = tt_al aa al in
@@ -1308,22 +1490,19 @@ let tt_lvalue pd (env : 'asm Env.env) { L.pl_desc = pl; L.pl_loc = loc; } =
     | Some plen ->
       ignore_align ~loc al;
       let len,ity  = tt_expr ~mode:`OnlyParam pd env plen in
-      check_ty_eq ~loc:(L.loc plen) ~from:ity ~to_:P.tint;
-      let ty = P.Arr(ws, P.PE len) in
+      check_ty_eq ~loc:(L.loc plen) ~from:ity ~to_:P.etint;
+      let ty = P.ETarr(ws, P.PE len) in
       loc, (fun _ -> P.Lasub (aa, ws, P.PE len, L.mk_loc xlc x, i)), Some ty
     end
 
   | S.PLMem me ->
     let ct, x, e, al = tt_mem_access ~mode:`AllVar pd env me in
-    loc, (fun _ -> P.Lmem (al, ct, x, e)), Some (P.Bty (P.U ct))
+    loc, (fun _ -> P.Lmem (al, ct, x, e)), Some (P.etw ct)
 
 (* -------------------------------------------------------------------- *)
 
-let f_sig f =
-  List.map P.ty_i f.P.f_ret, List.map (fun v -> v.P.v_ty) f.P.f_args
-
-let prim_sig asmOp p : 'a P.gty list * 'a P.gty list * Sopn.arg_desc list =
-  let f = conv_ty in
+let prim_sig asmOp p : 'a P.gety list * 'a P.gety list * Sopn.arg_desc list =
+  let f t = conv_cty t in
   let o = Sopn.asm_op_instr asmOp p in
   List.map f o.tout,
   List.map f o.tin,
@@ -1432,8 +1611,8 @@ let default_suffix =
 (**
 Deprecated intrinsic operators map (old name -> new name)
 *)
-let deprecated_intrinsic = 
-  let m = Ms.empty in 
+let deprecated_intrinsic =
+  let m = Ms.empty in
   let m = Ms.add "VPBLENDVB" "BLENDV" m in
   Ms.add "VPMOVMSKB" "MOVEMASK" m
 
@@ -1447,7 +1626,7 @@ let check_deprecated_intrinsic (old_name: string) (loc:L.t) =
     warning Deprecated (L.i_loc0 loc) "Intrinsic operator '%s' is deprecated. Please use '%s' instead." old_name new_name
 
 
-let tt_prim asmOp id = 
+let tt_prim asmOp id =
   let { L.pl_loc = loc ; L.pl_desc = s } = id in
   let name, sz = extract_size s in
   check_deprecated_intrinsic name loc;
@@ -1477,8 +1656,8 @@ let prim_of_op exn loc o =
     function
     | None -> None
     | Some({L.pl_desc = S.CVS _} ) -> raise exn
-    | Some({L.pl_desc = S.CSS(None, _)}) -> None
-    | Some({L.pl_desc = S.CSS(Some sz, _)}) ->
+    | Some({L.pl_desc = S.CSS(sz, `WInt _)}) -> raise exn
+    | Some({L.pl_desc = S.CSS(sz, _)}) ->
       Some (Annotations.int_of_ws sz)
   in
   let p =
@@ -1678,7 +1857,7 @@ let tt_lvalues arch_info env loc (pimp, pls) implicit tys =
             ~on_id:(fun loc _nid s -> L.mk_loc loc (S.PLVar (L.mk_loc loc s)))
             error (c,s) in
         let _, flv, vty = tt_lvalue arch_info.pd env a in
-        let e, ety = P.PappN (E.Ocombine_flags (List.assoc (L.unloc c) combines), args), P.tbool in
+        let e, ety = P.PappN (E.Ocombine_flags (List.assoc (L.unloc c) combines), args), P.etbool in
         let e = vty |> Option.map_default (cast (L.loc a) e ety) e in
         let ety =
           match vty with
@@ -1706,19 +1885,18 @@ let tt_exprs_cast pd env loc les tys =
     let e, ety = tt_expr ~mode:`AllVar pd env le in
     cast (L.loc le) e ety ty) les tys
 
-let arr_init xi =
+let arr_init (xi, ty) =
   let open P in
-  let x = L.unloc xi in
-  match x.v_ty with
-  | Arr(ws, PE e) as ty ->
+  match ty with
+  | P.ETarr(ws, PE e) as ty ->
     let size = PE (icnst (size_of_ws ws) ** e) in
-    Cassgn (Lvar xi, E.AT_inline, ty, P.Parr_init size)
+    Cassgn (Lvar xi, E.AT_inline, P.gty_of_gety ty, P.Parr_init size)
   | _           ->
-    rs_tyerror ~loc:(L.loc xi) (InvalidArrayType x.v_ty)
+    rs_tyerror ~loc:(L.loc xi) (InvalidArrayType ty)
 
-let cassgn_for (x: P.plval) (tg: E.assgn_tag) (ty: P.pty) (e: P.pexpr) :
-  (P.pexpr_, unit, 'asm) P.ginstr_r =
-  Cassgn (x, tg, ty, e)
+let cassgn_for (x: P.plval) (tg: E.assgn_tag) (ty: P.epty) (e: P.pexpr) :
+  (unit, 'asm) P.pinstr_r =
+  Cassgn (x, tg, P.gty_of_gety ty, e)
 
 let mk_call loc inline lvs f es =
   let open P in
@@ -1780,11 +1958,10 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       tt_assign env_lhs env_rhs ls `Raw (L.mk_loc el (S.PECombF(f, args))) None
 
     | ls, `Raw, { L.pl_desc = S.PECall (f, args); pl_loc = el }, None ->
-      let (f,tlvs) = tt_fun env_rhs f in
-      let _tlvs, tes = f_sig f in
-      let lvs, is = tt_lvalues arch_info env_lhs (L.loc pi) ls None tlvs in
+      let (f,fsig) = tt_fun env_rhs f in
+      let lvs, is = tt_lvalues arch_info env_lhs (L.loc pi) ls None fsig.fs_tout in
       assert (is = []);
-      let es  = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args tes in
+      let es  = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args fsig.fs_tin in
       let is_inline = P.is_inline annot f.P.f_cc in
       let annot =
         if is_inline || FInfo.is_export f.P.f_cc
@@ -1845,13 +2022,18 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
           [x ty; y ty], ty
         | _ ->
           rs_tyerror ~loc:(L.loc pi)
-            (string_error "a pair of destination is expected for swap") in
+            (string_error "a pair of destination is expected for swap")
+      in
       let () = match ty with
-        | Arr _ -> ()
-        | Bty (U ws) when ws <= U64 -> ()
-        | Bty ty ->
-           rs_tyerror ~loc:(L.loc pi)
-             (string_error "the swap primitive is not available at type %a" PrintCommon.pp_btype ty)
+        | P.ETarr _ -> ()
+        | P.ETword(None, ws) when ws <= U64 -> ()
+        | _ ->
+          let w = match ty with P.ETword(w, ws) -> w | _ -> None in
+          let ty = match P.gty_of_gety ty with P.Bty ty -> ty | _ -> assert false in
+            rs_tyerror ~loc:(L.loc pi)
+              (string_error "the swap primitive is not available at type %a"
+                 (PrintCommon.pp_btype ?w) ty)
+
       in
       let es = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args [ty; ty] in
       let p = Sopn.Opseudo_op (Oswap Type.Coq_sbool) in  (* The type is fixed latter *)
@@ -1864,10 +2046,13 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       let es  = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args tes in
       mk_i (P.Copn(lvs, AT_keep, p, es)) :: einstr
 
-  | ls, `Raw, { pl_desc = PEOp1 (`Cast(`ToWord ct), {pl_desc = PEPrim (f, args) })} , None
+  | ls, `Raw, { pl_desc = PEOp1 (`Cast(`ToWord ct), {pl_desc = PEPrim (f, args) }); pl_loc = loc} , None
       ->
-      let ws, s = ct in
-      assert (s = `Unsigned); (* FIXME *)
+      let ws =
+        match ct with
+        | (ws, `Word _) -> ws
+        | (ws, `WInt _) -> rs_tyerror ~loc (string_error "invalid cast for asm operator")
+        in
       let p = tt_prim arch_info.asmOp f in
       let id = Sopn.asm_op_instr arch_info.asmOp p in
       let p = cast_opn ~loc:(L.loc pi) id ws p in
@@ -1938,9 +2123,9 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       vds
 
   | S.PIArrayInit ({ L.pl_loc = lc; } as x) ->
-    let x = tt_var `AllVar env x in
+    let x, xty = tt_var `AllVar env x in
     let xi = (L.mk_loc lc x) in
-    env, [mk_i (arr_init xi)]
+    env, [mk_i (arr_init (xi, xty))]
 
   | S.PIAssign (ls, eqop, pe, ocp) -> env, tt_assign env env ls eqop pe ocp
 
@@ -1953,8 +2138,8 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
   | PIFor ({ pl_loc = lx } as x, (d, i1, i2), s) ->
       let i1   = tt_expr_int arch_info.pd env i1 in
       let i2   = tt_expr_int arch_info.pd env i2 in
-      let vx   = tt_var `AllVar env x in
-      check_ty_eq ~loc:lx ~from:vx.P.v_ty ~to_:P.tint;
+      let vx, xty = tt_var `AllVar env x in
+      check_ty_eq ~loc:lx ~from:xty ~to_:P.etint;
       let s    = tt_block arch_info env s in
       let d    = match d with `Down -> E.DownTo | `Up -> E.UpTo in
       env, [mk_i (P.Cfor (L.mk_loc lx vx, (d, i1, i2), s))]
@@ -2138,7 +2323,7 @@ let add_known_implicits arch_info env c =
   let env, known_implicits =
     List.map_fold (fun env (s1, s2) ->
         let s2 = create env s2 in
-        let env = Env.Vars.push_implicit env (P.PV.mk s2 (Reg(Normal, Direct)) P.tbool L._dummy []) in
+        let env = Env.Vars.push_implicit env (mk_var s2 (Reg(Normal, Direct)) P.etbool L._dummy [], P.etbool) in
         env, (s1, s2)) env arch_info.known_implicits in
   Env.set_known_implicits env known_implicits
 
@@ -2163,11 +2348,13 @@ let tt_fundef arch_info (env0 : 'asm Env.env) loc (pf : S.pfundef) : 'asm Env.en
     let env, args = List.map_fold (tt_annot_paramdecls dfl_mut arch_info.pd) env pf.pdf_args in
     let env = add_known_implicits arch_info env pf.pdf_body.pdb_instr in
     env, List.flatten args in
-  let rty  = Option.map_default (List.map (tt_type arch_info.pd env |- snd |- snd)) [] pf.pdf_rty in
+  let fs_tout = Option.map_default (List.map (tt_type arch_info.pd env |- snd |- snd)) [] pf.pdf_rty in
   let ret_annot = Option.map_default (List.map fst) [] pf.pdf_rty in
   let body, ret_loc, xret = tt_funbody arch_info envb pf.pdf_body in
-  let f_cc = tt_call_conv loc args xret pf.pdf_cc in
-  let args = List.map L.unloc args in
+  let f_args = List.map (fun x -> L.mk_loc (L.loc x) (fst (L.unloc x))) args in
+  let fs_tin = List.map (fun x -> snd (L.unloc x)) args in
+  let f_ret = List.map (fun x -> L.mk_loc (L.loc x) (fst (L.unloc x))) xret in
+  let f_cc = tt_call_conv loc f_args f_ret pf.pdf_cc in
   let name = L.unloc pf.pdf_name in
   let fdef =
     { P.f_loc   = loc;
@@ -2175,22 +2362,22 @@ let tt_fundef arch_info (env0 : 'asm Env.env) loc (pf : S.pfundef) : 'asm Env.en
       P.f_cc    = f_cc;
       P.f_info  = ();
       P.f_name  = P.F.mk name;
-      P.f_tyin  = List.map (fun { P.v_ty } -> v_ty) args;
-      P.f_args  = args;
+      P.f_tyin  = List.map P.gty_of_gety fs_tin;
+      P.f_args  = List.map L.unloc f_args;
       P.f_body  = body;
-      P.f_tyout = rty;
+      P.f_tyout = List.map P.gty_of_gety fs_tout;
       P.f_ret_info = { ret_annot; ret_loc };
-      P.f_ret   = xret; } in
+      P.f_ret   = f_ret; } in
 
-  check_return_statement ~loc fdef.P.f_name rty
-    (List.map (fun x -> (L.loc x, (L.unloc x).P.v_ty)) xret);
+  check_return_statement ~loc fdef.P.f_name fs_tout
+    (List.map (fun x -> L.loc x, snd (L.unloc x)) xret);
 
   warn_unused_variables envb fdef;
 
   let return_storage = Option.map_default (List.map (fst |- snd)) [] pf.pdf_rty in
-  check_return_storage ~loc fdef.P.f_name return_storage xret;
+  check_return_storage ~loc fdef.P.f_name return_storage f_ret;
 
-  Env.Funs.push env0 fdef rty
+  Env.Funs.push env0 fdef {fs_tin; fs_tout}
 
 (* -------------------------------------------------------------------- *)
 let tt_global_def pd env (gd:S.gpexpr) =
@@ -2200,7 +2387,7 @@ let tt_global_def pd env (gd:S.gpexpr) =
   let array_of_string s =
     L.unloc s |> String.to_list |> List.map @@ fun c ->
     c |> Char.code |> Z.of_int |> fun z ->
-    P.(L.mk_loc (L.loc s) (Papp1 (E.Oword_of_int W.U8, Pconst z)), u8) in
+    P.(L.mk_loc (L.loc s) (Papp1 (op_word_of_int(Word, W.Unsigned, W.U8), Pconst z)), P.etw U8) in
   match gd with
   | S.GEword e ->
     `Word (f e)
@@ -2214,29 +2401,30 @@ let tt_global pd (env : 'asm Env.env) _loc (gd: S.pglobal) : 'asm Env.env =
   let open P in
   let mk_pe ws (pe,ety) =
     match ety with
-    | Bty (U ews) when Utils0.cmp_le Wsize.wsize_cmp ws ews -> L.unloc pe
-    | Bty Int -> Papp1 (Oword_of_int ws, L.unloc pe)
-    | _ -> rs_tyerror ~loc:(L.loc pe) (TypeMismatch (ety, Bty (U ws)))
+    | P.ETword(wk, ews) when wk = None && Utils0.cmp_le Wsize.wsize_cmp ws ews ->
+      L.unloc pe
+    | P.ETint -> Papp1 (op_word_of_int(Word, W.Unsigned, ws), L.unloc pe)
+    | _ -> rs_tyerror ~loc:(L.loc pe) (TypeMismatch (ety, P.etw ws))
     in
 
   let ty, d =
     match tt_type pd env gd.S.pgd_type, tt_global_def pd env gd.S.pgd_val with
-    | (Bty (U ws)) as ty, `Word (pe,ety) ->
+    | P.ETword(None, ws) as ty, `Word (pe,ety) ->
       let pe = mk_pe ws (pe,ety) in
       ty, P.GEword pe
-    | Bty _, `Array _ ->
+    | (P.ETint | P.ETbool | P.ETword _), `Array _ ->
       rs_tyerror ~loc:(L.loc gd.S.pgd_type) GlobArrayNotWord
-    | Arr(ws, _n) as ty, `Array es ->
+    | P.ETarr(ws, _n) as ty, `Array es ->
       let pes = List.map (mk_pe ws) es in
       ty, P.GEarray pes
-    | Arr _, `Word _ ->
+    | P.ETarr _, `Word _ ->
       rs_tyerror ~loc:(L.loc gd.S.pgd_type) GlobWordNotArray
     | ty,_ -> rs_tyerror ~loc:(L.loc gd.S.pgd_type) (InvalidTypeForGlobal ty)
   in
 
-  let x = P.PV.mk (L.unloc gd.S.pgd_name) W.Global ty (L.loc gd.S.pgd_name) [] in
+  let x = mk_var (L.unloc gd.S.pgd_name) W.Global ty (L.loc gd.S.pgd_name) [] in
 
-  Env.Vars.push_global env (x,d)
+  Env.Vars.push_global env (x,ty,d)
 
 
 let tt_typealias arch_info env id ty =

--- a/compiler/src/pretyping.mli
+++ b/compiler/src/pretyping.mli
@@ -4,6 +4,8 @@ exception TyError of Location.t * tyerror
 
 val pp_tyerror : Format.formatter -> tyerror -> unit
 
+type fun_sig = { fs_tin : Prog.epty list ; fs_tout : Prog.epty list }
+
 module Env : sig
   type 'asm env
 
@@ -22,12 +24,12 @@ module Env : sig
   val exit_file : 'asm env -> 'asm env
 
   module Funs : sig
-    val push : 'asm env -> (unit, 'asm) Prog.pfunc -> Prog.pty list -> 'asm env
+    val push : 'asm env -> (unit, 'asm) Prog.pfunc -> fun_sig -> 'asm env
 
     val find :
       Annotations.symbol ->
       'asm env ->
-      ((unit, 'asm) Prog.pfunc * Prog.pty list) option
+      ((unit, 'asm) Prog.pfunc * fun_sig) option
   end
 
   module Exec : sig
@@ -71,7 +73,7 @@ val tt_global :
 val tt_fun :
   'asm Env.env ->
   Annotations.symbol Location.located ->
-  (unit, 'asm) Prog.pfunc * Prog.pty list
+  (unit, 'asm) Prog.pfunc * fun_sig
 
 val tt_program :
   ('a, 'b, 'c, 'd, 'e, 'f, 'g) arch_info ->

--- a/compiler/src/printCommon.ml
+++ b/compiler/src/printCommon.ml
@@ -38,22 +38,72 @@ let string_of_cmp_kind = function
   | E.Cmp_w (sg, sz) -> asprintf " %d%s" (int_of_ws sz) (string_of_signess sg)
   | E.Cmp_int -> ""
 
+let string_of_w_cast sz =
+  asprintf "%du" (int_of_ws sz)
+
 let string_of_op_kind = function
-  | E.Op_w ws -> asprintf "%du" (int_of_ws ws)
+  | E.Op_w ws -> string_of_w_cast ws
   | E.Op_int -> ""
+
+let string_of_div_kind sg = function
+  | E.Op_w ws -> asprintf "%d%s" (int_of_ws ws) (string_of_signess sg)
+  | E.Op_int -> if sg = Signed then (string_of_signess sg) else ""
 
 (* -------------------------------------------------------------------- *)
 
-let string_of_op_w s ws =
-  asprintf "%s %du" s (int_of_ws ws)
+let string_of_w_ty ws = asprintf "u%d" (int_of_ws ws)
+
+let string_of_wi sg = asprintf "%si" (string_of_signess sg)
+let string_of_wi_ty sg ws = asprintf "%si%d" (string_of_signess sg) (int_of_ws ws)
+
+let string_of_int_cast sg =
+  asprintf "%sint" (string_of_signess sg)
+
+let string_of_wi_cast sg sz =
+  asprintf "%d%s" (int_of_ws sz) (string_of_wi sg)
+
+let string_of_wiop1 sg = function
+  | E.WIwint_of_int sz ->
+      asprintf "(%s /* of int */)" (string_of_wi_cast sg sz)
+  | WIint_of_wint sz ->
+      asprintf "(%s /* of %s */)" (string_of_int_cast sg) (string_of_wi_ty sg sz)
+  | WIword_of_wint sz ->
+      asprintf "(%s /* of %s */)" (string_of_w_cast sz) (string_of_wi_ty sg sz)
+  | WIwint_of_word sz ->
+      asprintf "(%s /* of %s */)" (string_of_wi_cast sg sz) (string_of_w_ty sz)
+  | WIwint_ext(szo, _) ->
+      asprintf "(%s)" (string_of_wi_cast sg szo)
+  | WIneg sz ->
+      asprintf "-%s" (string_of_wi_cast sg sz)
 
 let string_of_op1 = function
-  | E.Oint_of_word sz -> asprintf "(int /* of u%d */)" (int_of_ws sz)
+  | E.Oint_of_word (s, sz) ->
+      asprintf "(%s /* of %s */)" (string_of_int_cast s) (string_of_w_ty sz)
+  | E.Oword_of_int szo  -> asprintf "(%du)" (int_of_ws szo)
   | E.Osignext (szo, _) -> asprintf "(%ds)" (int_of_ws szo)
-  | E.Oword_of_int szo | E.Ozeroext (szo, _) -> asprintf "(%du)" (int_of_ws szo)
-  | E.Olnot w -> string_of_op_w "!" w
+  | E.Ozeroext (szo, _) -> asprintf "(%du)" (int_of_ws szo)
+  | E.Olnot sz ->
+      asprintf "!%s" (string_of_w_cast sz)
   | E.Onot -> "!"
   | E.Oneg k -> "-" ^ string_of_op_kind k
+  | E.Owi1(sg, o) -> string_of_wiop1 sg o
+
+let string_of_wiop2 sg sz = function
+  | E.WIadd -> "+" ^ string_of_wi_cast sg sz
+  | E.WImul -> "*" ^ string_of_wi_cast sg sz
+  | E.WIsub -> "-" ^ string_of_wi_cast sg sz
+  | E.WIdiv -> "/" ^ string_of_wi_cast sg sz
+  | E.WImod -> "%" ^ string_of_wi_cast sg sz
+
+  | E.WIshr -> ">>" ^ string_of_wi_cast sg sz
+  | E.WIshl -> "<<" ^ string_of_wi_cast sg sz
+
+  | E.WIeq  -> "==" ^ string_of_wi_cast sg sz
+  | E.WIneq -> "!=" ^ string_of_wi_cast sg sz
+  | E.WIlt  -> "<"  ^ string_of_wi_cast sg sz
+  | E.WIle  -> "<=" ^ string_of_wi_cast sg sz
+  | E.WIgt  -> ">"  ^ string_of_wi_cast sg sz
+  | E.WIge  -> ">=" ^ string_of_wi_cast sg sz
 
 let string_of_op2 = function
   | E.Obeq -> "=="
@@ -62,17 +112,17 @@ let string_of_op2 = function
   | E.Oadd k -> "+" ^ string_of_op_kind k
   | E.Omul k -> "*" ^ string_of_op_kind k
   | E.Osub k -> "-" ^ string_of_op_kind k
-  | E.Odiv k -> "/" ^ string_of_cmp_kind k
-  | E.Omod k -> "%" ^ string_of_cmp_kind k
-  | E.Oland w -> string_of_op_w "&" w
-  | E.Olor w -> string_of_op_w "|" w
-  | E.Olxor w -> string_of_op_w "^" w
-  | E.Olsr w -> string_of_op_w ">>" w
+  | E.Odiv(s, k) -> "/" ^ string_of_div_kind s k
+  | E.Omod(s, k) -> "%" ^ string_of_div_kind s k
+  | E.Oland w -> "&"  ^ string_of_w_cast w
+  | E.Olor  w -> "|"  ^ string_of_w_cast w
+  | E.Olxor w -> "^"  ^ string_of_w_cast w
+  | E.Olsr  w -> ">>" ^ string_of_w_cast w
   | E.Olsl k -> "<<" ^ string_of_op_kind k
   | E.Oasr E.Op_int -> ">>s"
   | E.Oasr (E.Op_w w) -> asprintf ">>%ds" (int_of_ws w)
-  | E.Oror w -> string_of_op_w ">>r" w
-  | E.Orol w -> string_of_op_w "<<r" w
+  | E.Oror w -> ">>r " ^ string_of_w_cast w
+  | E.Orol w -> "<<r " ^ string_of_w_cast w
   | E.Oeq k -> "==" ^ string_of_op_kind k
   | E.Oneq k -> "!=" ^ string_of_op_kind k
   | E.Olt k -> "<" ^ string_of_cmp_ty k
@@ -85,6 +135,7 @@ let string_of_op2 = function
   | Ovlsr (ve, ws) -> asprintf ">>%s" (string_of_velem Unsigned ws ve)
   | Ovasr (ve, ws) -> asprintf ">>%s" (string_of_velem Unsigned ws ve)
   | Ovlsl (ve, ws) -> asprintf "<<%s" (string_of_velem Signed ws ve)
+  | Owi2(sg, ws, o) -> string_of_wiop2 sg ws o
 
 (* -------------------------------------------------------------------- *)
 let pp_opn pd asmOp fmt o = pp_string fmt (Sopn.string_of_sopn pd asmOp o)
@@ -114,15 +165,20 @@ let pp_kind fmt = function
   | Global -> fprintf fmt "global"
 
 (* -------------------------------------------------------------------- *)
-let pp_btype fmt = function
+let w_of_signedess = function
+  | None                -> "u"
+  | Some Wsize.Signed   -> "si"
+  | Some Wsize.Unsigned -> "ui"
+
+let pp_btype ?w fmt = function
   | Bool -> fprintf fmt "bool"
-  | U i -> fprintf fmt "u%i" (int_of_ws i)
+  | U i -> fprintf fmt "%s%i" (w_of_signedess w) (int_of_ws i)
   | Int -> fprintf fmt "int"
 
 (* -------------------------------------------------------------------- *)
-let pp_gtype (pp_size : formatter -> 'size -> unit) fmt = function
-  | Bty ty -> pp_btype fmt ty
-  | Arr (ws, e) -> fprintf fmt "%a[%a]" pp_btype (U ws) pp_size e
+let pp_gtype ?w (pp_size : formatter -> 'size -> unit) fmt = function
+  | Bty ty -> pp_btype ?w fmt ty
+  | Arr (ws, e) -> fprintf fmt "%a[%a]" (pp_btype ?w:None) (U ws) pp_size e
 
 (* -------------------------------------------------------------------- *)
 let pp_arr_access pp_gvar pp_expr fmt al aa ws x e =
@@ -130,12 +186,12 @@ let pp_arr_access pp_gvar pp_expr fmt al aa ws x e =
     pp_gvar x
     (if aa = Warray_.AAdirect then "." else "")
     pp_aligned al
-    pp_btype (U ws) pp_expr e
+    (pp_btype ?w:None) (U ws) pp_expr e
 
 let pp_arr_slice pp_gvar pp_expr pp_len fmt aa ws x e len =
   fprintf fmt "%a%s[%a %a : %a]" pp_gvar x
     (if aa = Warray_.AAdirect then "." else "")
-    pp_btype (U ws) pp_expr e pp_len len
+    (pp_btype ?w:None) (U ws) pp_expr e pp_len len
 
 (* -------------------------------------------------------------------- *)
 let pp_len fmt len = fprintf fmt "%i" len

--- a/compiler/src/printCommon.mli
+++ b/compiler/src/printCommon.mli
@@ -7,14 +7,16 @@ val string_of_signess : Wsize.signedness -> string
 val string_of_velem : Wsize.signedness -> Wsize.wsize -> Wsize.velem -> string
 val string_of_op1 : Expr.sop1 -> string
 val string_of_op2 : Expr.sop2 -> string
+
 val pp_opn :
   Wsize.wsize -> 'asm Sopn.asmOp -> Format.formatter -> 'asm Sopn.sopn -> unit
 val pp_syscall : BinNums.positive Syscall_t.syscall_t -> string
 val pp_bool : Format.formatter -> bool -> unit
 val pp_kind : Format.formatter -> Wsize.v_kind -> unit
-val pp_btype : Format.formatter -> Prog.base_ty -> unit
+val pp_btype : ?w:Wsize.signedness -> Format.formatter -> Prog.base_ty -> unit
 
 val pp_gtype :
+  ?w:Wsize.signedness ->
   (Format.formatter -> 'size -> unit) ->
   Format.formatter ->
   'size Prog.gty ->

--- a/compiler/src/printer.mli
+++ b/compiler/src/printer.mli
@@ -7,13 +7,14 @@ val pp_print_X : Format.formatter -> Z.t -> unit
 
 val pp_pvar  : Format.formatter -> pvar -> unit
 val pp_ptype : Format.formatter -> pty -> unit
+val pp_eptype : Format.formatter -> epty -> unit
 val pp_plval : Format.formatter -> plval -> unit
 val pp_pexpr : Format.formatter -> pexpr -> unit
 val pp_pprog : Wsize.wsize -> ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op Sopn.asmOp ->
                Format.formatter -> ('info, ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op) pprog -> unit
 
 val pp_var   : debug:bool -> Format.formatter -> var -> unit
-val pp_dvar   : debug:bool -> Format.formatter -> var -> unit
+val pp_dvar  : debug:bool -> Format.formatter -> var -> unit
 
 val string_of_combine_flags : Expr.combine_flags -> string
 

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -56,27 +56,29 @@ type 'len grange = E.dir * 'len gexpr * 'len gexpr
 (* Warning E.sopn (E.Ocopy) contain a 'len without being polymorphic.
    Before instr this information is dummy ...
    This is durty ...
-*)   
-type ('len,'info,'asm) ginstr_r =
+*)
+
+type ('len, 'info, 'asm) ginstr_r =
   | Cassgn of 'len glval * E.assgn_tag * 'len gty * 'len gexpr
+  (* turn 'asm Sopn.sopn into 'sopn? could be useful to ensure that we remove things statically *)
   | Copn   of 'len glvals * E.assgn_tag * 'asm Sopn.sopn * 'len gexprs
   | Csyscall of 'len glvals * BinNums.positive Syscall_t.syscall_t * 'len gexprs
-  | Cif    of 'len gexpr * ('len,'info,'asm) gstmt * ('len,'info,'asm) gstmt
-  | Cfor   of 'len gvar_i * 'len grange * ('len,'info,'asm) gstmt
-  | Cwhile of E.align * ('len,'info,'asm) gstmt * 'len gexpr * (IInfo.t * 'info) * ('len,'info,'asm) gstmt
+  | Cif    of 'len gexpr * ('len, 'info, 'asm) gstmt * ('len, 'info, 'asm) gstmt
+  | Cfor   of 'len gvar_i * 'len grange * ('len, 'info, 'asm) gstmt
+  | Cwhile of E.align * ('len, 'info, 'asm) gstmt * 'len gexpr * (IInfo.t * 'info) * ('len, 'info, 'asm) gstmt
   | Ccall  of 'len glvals * funname * 'len gexprs
 
-and ('len,'info,'asm) ginstr = {
-  i_desc : ('len,'info,'asm) ginstr_r;
-  i_loc  : L.i_loc;
-  i_info : 'info;
-  i_annot : Annotations.annotations;
-}
+and ('len, 'info, 'asm) ginstr = {
+    i_desc : ('len, 'info, 'asm) ginstr_r;
+    i_loc  : L.i_loc;
+    i_info : 'info;
+    i_annot : Annotations.annotations;
+  }
 
-and ('len,'info,'asm) gstmt = ('len,'info,'asm) ginstr list
+and ('len, 'info, 'asm) gstmt = ('len, 'info, 'asm) ginstr list
 
 (* ------------------------------------------------------------------------ *)
-type ('len,'info,'asm) gfunc = {
+type ('len, 'info, 'asm) gfunc = {
     f_loc  : L.t;
     f_annot: FInfo.f_annot;
     f_info : 'info;
@@ -84,41 +86,43 @@ type ('len,'info,'asm) gfunc = {
     f_name : funname;
     f_tyin : 'len gty list;
     f_args : 'len gvar list;
-    f_body : ('len,'info,'asm) gstmt;
+    f_body : ('len, 'info, 'asm) gstmt;
     f_tyout : 'len gty list;
     f_ret_info : FInfo.return_info;
     f_ret  : 'len gvar_i list
   }
 
-type 'len ggexpr = 
+type 'len ggexpr =
   | GEword of 'len gexpr
   | GEarray of 'len gexprs
 
-type ('len,'info,'asm) gmod_item =
-  | MIfun   of ('len,'info,'asm) gfunc
+type ('len, 'info, 'asm) gmod_item =
+  | MIfun   of ('len, 'info, 'asm) gfunc
   | MIparam of ('len gvar * 'len gexpr)
   | MIglobal of ('len gvar * 'len ggexpr)
 
-type ('len,'info,'asm) gprog = ('len,'info,'asm) gmod_item list
+type ('len, 'info, 'asm) gprog = ('len, 'info, 'asm) gmod_item list
    (* first declaration occur at the end (i.e reverse order) *)
 
 (* ------------------------------------------------------------------------ *)
-(* Parametrized expression *)
+(* Parametrized expression, this is the result after prettyping             *)
+type  pty    = pexpr_ gty
+and   pvar   = pexpr_ gvar
+and   pvar_i = pexpr_ gvar_i
+and   plval  = pexpr_ glval
+and   plvals = pexpr_ glvals
+and   pexpr  = pexpr_ gexpr
+and   pexpr_ = PE of pexpr [@@unboxed]
 
-type pty    = pexpr_ gty
-and  pvar   = pexpr_ gvar
-and  pvar_i = pexpr_ gvar_i
-and  plval  = pexpr_ glval
-and  plvals = pexpr_ glvals
-and  pexpr  = pexpr_ gexpr
-and  pexpr_ = PE of pexpr [@@unboxed]
+type epty   = pexpr_ gety
 
-type ('info,'asm) pinstr = (pexpr_,'info,'asm) ginstr
-type ('info,'asm) pstmt  = (pexpr_,'info,'asm) gstmt
+type ('info, 'asm) pinstr_r = (pexpr_, 'info, 'asm) ginstr_r
+type ('info, 'asm) pinstr = (pexpr_, 'info, 'asm) ginstr
+type ('info, 'asm) pstmt  = (pexpr_, 'info, 'asm) gstmt
 
-type ('info,'asm) pfunc     = (pexpr_,'info,'asm) gfunc
-type ('info,'asm) pmod_item = (pexpr_,'info,'asm) gmod_item
-type ('info,'asm) pprog     = (pexpr_,'info,'asm) gprog
+type ('info, 'asm) pfunc     = (pexpr_, 'info, 'asm) gfunc
+type ('info, 'asm) pmod_item = (pexpr_, 'info, 'asm) gmod_item
+type ('info, 'asm) pprog     = (pexpr_, 'info, 'asm) gprog
 
 (* -------------------------------------------------------------------- *)
 module PV : sig
@@ -145,6 +149,10 @@ module Spv : Set.S  with type elt = pvar
 val pty_equal : pty -> pty -> bool
 val pexpr_equal : pexpr -> pexpr -> bool
 
+val epty_equal : epty -> epty -> bool
+
+val ws_of_ety : epty -> wsize
+
 (* ------------------------------------------------------------------------ *)
 (* Non parametrized expression                                              *)
 
@@ -156,17 +164,17 @@ type lvals = int glval list
 type expr  = int gexpr
 type exprs = int gexpr list
 
+
 type range = int grange
 
-type ('info,'asm) instr = (int,'info,'asm) ginstr
-type ('info,'asm) instr_r = (int,'info,'asm) ginstr_r
-type ('info,'asm) stmt  = (int,'info,'asm) gstmt
+type ('info, 'asm) instr = (int, 'info, 'asm) ginstr
+type ('info, 'asm) instr_r = (int,'info,'asm) ginstr_r
+type ('info, 'asm) stmt  = (int, 'info, 'asm) gstmt
 
-type ('info,'asm) func     = (int,'info,'asm) gfunc
-type ('info,'asm) mod_item = (int,'info,'asm) gmod_item
+type ('info, 'asm) func     = (int, 'info, 'asm) gfunc
+type ('info, 'asm) mod_item = (int, 'info, 'asm) gmod_item
 type global_decl           = var * Global.glob_value
-type ('info,'asm) prog     = global_decl list *('info,'asm) func list
-
+type ('info, 'asm) prog     = global_decl list * ('info, 'asm) func list
 
 (* -------------------------------------------------------------------- *)
 val var_of_ident : CoreIdent.var -> var
@@ -196,7 +204,7 @@ val is_regx : var -> bool
 
 (* -------------------------------------------------------------------- *)
 val kind_i : 'len gvar_i -> v_kind
-val ty_i   : 'len gvar_i -> 'len gty 
+val ty_i   : 'len gvar_i -> 'len gty
 
 (* -------------------------------------------------------------------- *)
 (* used variables                                                       *)
@@ -205,14 +213,14 @@ val fold_vars_fc : ('ty gvar -> 'acc -> 'acc) -> 'acc -> ('ty, 'info, 'asm) gfun
 val vars_lv : Sv.t -> lval -> Sv.t
 val vars_e  : expr -> Sv.t
 val vars_es : expr list -> Sv.t
-val vars_i  : ('info,'asm) instr -> Sv.t
-val vars_c  : ('info,'asm) stmt  -> Sv.t
-val pvars_c  : ('info,'asm) pstmt  -> Spv.t
-val vars_fc : ('info,'asm) func  -> Sv.t
+val vars_i  : ('info, 'asm) instr -> Sv.t
+val vars_c  : ('info, 'asm) stmt  -> Sv.t
+val pvars_c : ('info, 'asm) pstmt  -> Spv.t
+val vars_fc : ('info, 'asm) func  -> Sv.t
 
-val locals  : ('info,'asm) func -> Sv.t
+val locals  : ('info, 'asm) func -> Sv.t
 
-val spilled :  ('info,'asm) func -> Sv.t
+val spilled :  ('info, 'asm) func -> Sv.t
 
 (* -------------------------------------------------------------------- *)
 (** [written_lv s x] inserts [x] into [s] if [x] is a variable *)
@@ -220,15 +228,15 @@ val written_lv : Sv.t -> lval -> Sv.t
 
 (* -------------------------------------------------------------------- *)
 (* Written variables & called functions *)
-val written_vars_fc : ('info,'asm) func -> Sv.t * L.i_loc list Mf.t
+val written_vars_fc : ('info, 'asm) func -> Sv.t * L.i_loc list Mf.t
 
 (* -------------------------------------------------------------------- *)
 (* Refresh i_loc, ensure that locations are uniq                        *)
 
-val refresh_i_loc_i : ('info,'asm) instr -> ('info,'asm) instr 
-val refresh_i_loc_c : ('info,'asm) stmt  -> ('info,'asm) stmt 
-val refresh_i_loc_f : ('info,'asm) func  -> ('info,'asm) func 
-val refresh_i_loc_p : ('info,'asm) prog  -> ('info,'asm) prog 
+val refresh_i_loc_i : ('info, 'asm) instr -> ('info, 'asm) instr
+val refresh_i_loc_c : ('info, 'asm) stmt  -> ('info, 'asm) stmt
+val refresh_i_loc_f : ('info, 'asm) func  -> ('info, 'asm) func
+val refresh_i_loc_p : ('info, 'asm) prog  -> ('info, 'asm) prog
 
 (* -------------------------------------------------------------------- *)
 (* Functions on types                                                   *)
@@ -242,7 +250,7 @@ val wsize_le : wsize -> wsize -> bool
 
 val int_of_pe  : pelem -> int
 
-val int_of_velem : velem -> int 
+val int_of_velem : velem -> int
 
 val is_ty_arr : 'e gty -> bool
 val array_kind : ty -> wsize * int
@@ -271,7 +279,7 @@ val get_ofs : Warray_.arr_access -> Wsize.wsize -> 'len gexpr -> int option
 (* -------------------------------------------------------------------- *)
 (* Functions over lvalue                                                *)
 
-val expr_of_lval : 'len glval -> 'len gexpr option
+val expr_of_lval :  'len glval -> 'len gexpr option
 
 (* -------------------------------------------------------------------- *)
 (* Functions over instruction                                           *)
@@ -287,5 +295,5 @@ val is_inline : Annotations.annotations -> FInfo.call_conv -> bool
 val clamp : wsize -> Z.t -> Z.t
 
 (* -------------------------------------------------------------------- *)
-type ('info,'asm) sfundef = Expr.stk_fun_extra * ('info,'asm) func 
-type ('info,'asm) sprog   = ('info,'asm) sfundef list * Expr.sprog_extra
+type ('info, 'asm) sfundef = Expr.stk_fun_extra * ('info, 'asm) func
+type ('info, 'asm) sprog   = ('info, 'asm) sfundef list * Expr.sprog_extra

--- a/compiler/src/slicing.mli
+++ b/compiler/src/slicing.mli
@@ -1,2 +1,2 @@
 open Prog
-val slice : string list -> ('a, 'b) prog -> ('a, 'b) prog
+val slice : string list -> ('info, 'asm) prog -> ('info, 'asm) prog

--- a/compiler/src/typing.ml
+++ b/compiler/src/typing.ml
@@ -17,11 +17,11 @@ let error loc fmt =
     bfmt fmt
 
 (* -------------------------------------------------------------------- *)
-let ty_var (x:var_i) = 
+let ty_var (x:var_i) =
   let ty = (L.unloc x).v_ty in
   begin match ty with
-  | Arr(_, n) -> 
-      if (n < 1) then 
+  | Arr(_, n) ->
+      if (n < 1) then
         error (L.i_loc0 (L.unloc x).v_dloc)
           "the variable %a has type %a, its array size should be positive"
           (Printer.pp_var ~debug:false) (L.unloc x) PrintCommon.pp_ty ty
@@ -37,22 +37,22 @@ let ty_gvar (x:int ggvar) = ty_var x.gv
 let check_array loc e te =
   match te with
   | Arr _ -> ()
-  | _     -> 
-    error loc 
+  | _     ->
+    error loc
       "the expression %a has type %a while an array is expected"
       (Printer.pp_expr ~debug:false) e PrintCommon.pp_ty te
 
-let subtype t1 t2 = 
+let subtype t1 t2 =
   match t1, t2 with
   | Bty (U ws1), Bty (U ws2) -> wsize_le ws1 ws2
   | Bty bty1, Bty bty2 -> bty1 = bty2
   | Arr(ws1,len1), Arr(ws2,len2) -> arr_size ws1 len1 == arr_size ws2 len2
-  | _, _ -> false 
+  | _, _ -> false
 
-let check_type loc e te ty = 
-  if not (subtype ty te) then 
+let check_type loc e te ty =
+  if not (subtype ty te) then
     error loc "the expression %a has type %a while %a is expected"
-        (Printer.pp_expr ~debug:false) e 
+        (Printer.pp_expr ~debug:false) e
         PrintCommon.pp_ty te PrintCommon.pp_ty ty
 
 let check_int loc e te = check_type loc e te tint
@@ -61,15 +61,15 @@ let check_ptr pd loc e te = check_type loc e te (tu pd)
 
 (* -------------------------------------------------------------------- *)
 
-let type_of_op1 op = 
+let type_of_op1 op =
   let tin,tout = E.type_of_op1 op in
   Conv.ty_of_cty tin, Conv.ty_of_cty tout
 
-let type_of_op2 op = 
+let type_of_op2 op =
   let (tin1,tin2),tout = E.type_of_op2 op in
   (Conv.ty_of_cty tin1, Conv.ty_of_cty tin2), Conv.ty_of_cty tout
 
-let type_of_opN op = 
+let type_of_opN op =
   let tins, tout = E.type_of_opN op in
   List.map Conv.ty_of_cty tins, Conv.ty_of_cty tout
 
@@ -81,20 +81,20 @@ let type_of_sopn loc pd asmOp op =
 
 (* -------------------------------------------------------------------- *)
 
-let rec ty_expr pd loc (e:expr) = 
+let rec ty_expr pd loc (e:expr) =
   match e with
   | Pconst _    -> tint
   | Pbool _     -> tbool
   | Parr_init len -> Arr (U8, len)
-  | Pvar x      -> ty_gvar x 
+  | Pvar x      -> ty_gvar x
   | Pget(_al, _aa,ws,x,e) ->
     ty_get_set pd loc ws x e
-    
-  | Psub(_aa, ws, len, x, e) -> 
+
+  | Psub(_aa, ws, len, x, e) ->
     ty_get_set_sub pd loc ws len x e
   | Pload(_, ws,x,e) ->
     ty_load_store pd loc ws x e
-  | Papp1(op,e) -> 
+  | Papp1(op,e) ->
     let tin, tout = type_of_op1 op in
     check_expr pd loc e tin;
     tout
@@ -103,7 +103,7 @@ let rec ty_expr pd loc (e:expr) =
     check_expr pd loc e1 tin1;
     check_expr pd loc e2 tin2;
     tout
-  | PappN(op,es) -> 
+  | PappN(op,es) ->
     let tins, tout = type_of_opN op in
     check_exprs pd loc es tins;
     tout
@@ -113,37 +113,37 @@ let rec ty_expr pd loc (e:expr) =
     check_expr pd loc e2 ty;
     ty
 
-and check_expr pd loc e ty = 
+and check_expr pd loc e ty =
   let te = ty_expr pd loc e in
   check_type loc e te ty
 
-and check_exprs pd loc es tys = 
+and check_exprs pd loc es tys =
   let len = List.length tys in
   if List.length es <> len then
     error loc "invalid number of expressions %i expected" len;
   List.iter2 (check_expr pd loc) es tys
 
-and ty_load_store pd loc ws x e = 
+and ty_load_store pd loc ws x e =
   let tx = ty_var x in
-  let te = ty_expr pd loc e in 
+  let te = ty_expr pd loc e in
   check_ptr pd loc (Pvar (gkvar x)) tx;
   check_ptr pd loc e te;
   tu ws
 
-and ty_get_set pd loc ws x e = 
+and ty_get_set pd loc ws x e =
   let tx = ty_gvar x in
-  let te = ty_expr pd loc e in 
-  check_array loc (Pvar x) tx; 
-  check_int loc e te; 
+  let te = ty_expr pd loc e in
+  check_array loc (Pvar x) tx;
+  check_int loc e te;
   tu ws
 
 and ty_get_set_sub pd loc ws len x e =
   let tx = ty_gvar x in
-  let te = ty_expr pd loc e in 
-  check_array loc (Pvar x) tx; 
+  let te = ty_expr pd loc e in
+  check_array loc (Pvar x) tx;
   check_int loc e te;
   Arr(ws, len)
-  
+
 (* -------------------------------------------------------------------- *)
 
 let ty_lval pd loc = function
@@ -153,13 +153,13 @@ let ty_lval pd loc = function
   | Laset(_al,_aa,ws,x,e) -> ty_get_set pd loc ws (gkvar x) e
   | Lasub(_aa,ws,len,x,e) -> ty_get_set_sub pd loc ws len (gkvar x) e
 
-let check_lval pd loc x ty = 
+let check_lval pd loc x ty =
   let tx = ty_lval pd loc x in
-  if not (subtype tx ty) then 
+  if not (subtype tx ty) then
     error loc "the left value %a has type %a while %a is expected"
         (Printer.pp_lval ~debug:false) x
         PrintCommon.pp_ty tx PrintCommon.pp_ty ty
-  
+
 let check_lvals pd loc xs tys =
   let len = List.length tys in
   if List.length xs <> len then
@@ -168,12 +168,12 @@ let check_lvals pd loc xs tys =
 
 (* -------------------------------------------------------------------- *)
 
-let getfun env fn = 
-  try Hf.find env fn with Not_found -> assert false 
+let getfun env fn =
+  try Hf.find env fn with Not_found -> assert false
 
 (* -------------------------------------------------------------------- *)
 
-let rec check_instr pd asmOp env i = 
+let rec check_instr pd asmOp env i =
   let loc = i.i_loc in
   match i.i_desc with
   | Cassgn(x,_,ty,e) ->
@@ -192,11 +192,11 @@ let rec check_instr pd asmOp env i =
     check_exprs pd loc es tins;
     check_lvals pd loc xs tout
 
-  | Cif(e,c1,c2) -> 
+  | Cif(e,c1,c2) ->
     check_expr pd loc e tbool;
     check_cmd pd asmOp env c1;
     check_cmd pd asmOp env c2
-    
+
   | Cfor(i,(_,e1,e2),c) ->
     check_expr pd loc (Pvar (gkvar i)) tint;
     check_expr pd loc e1 tint;
@@ -213,12 +213,12 @@ let rec check_instr pd asmOp env i =
     check_exprs pd loc es fd.f_tyin;
     check_lvals pd loc xs fd.f_tyout
 
-and check_cmd pd asmOp env c = 
+and check_cmd pd asmOp env c =
   List.iter (check_instr pd asmOp env) c
 
 (* -------------------------------------------------------------------- *)
 
-let check_fun pd asmOp env fd = 
+let check_fun pd asmOp env fd =
   let args = List.map (fun x -> Pvar (gkvar (L.mk_loc x.v_dloc x))) fd.f_args in
   let res = List.map (fun x -> Pvar (gkvar x)) fd.f_ret in
   let i_loc = L.i_loc0 fd.f_loc in
@@ -229,10 +229,6 @@ let check_fun pd asmOp env fd =
 
 (* -------------------------------------------------------------------- *)
 
-let check_prog pd asmOp (_,funcs) = 
+let check_prog pd asmOp (_,funcs) =
   let env = Hf.create 107 in
   List.iter (check_fun pd asmOp env) (List.rev funcs)
-
-
-
-

--- a/compiler/tests/fail/dead_code/x86-64/for_loop_iterator.jazz
+++ b/compiler/tests/fail/dead_code/x86-64/for_loop_iterator.jazz
@@ -102,7 +102,7 @@ export fn main (reg u64 counter) -> reg u64 {
   reg u64 x98;
   reg u64 x99;
 
-  for i = 0 to (int)counter {
+  for i = 0 to (uint)counter {
     res = x99;
     x99 = x98;
     x98 = x97;

--- a/compiler/tests/fail/dead_code/x86-64/while_loop_iterator.jazz
+++ b/compiler/tests/fail/dead_code/x86-64/while_loop_iterator.jazz
@@ -106,7 +106,7 @@ export fn main (reg u64 counter) -> reg u64 {
 
 
 
-  while (i < (int)counter) {
+  while (i < (uint)counter) {
     res = x99;
     x99 = x98;
     x98 = x97;

--- a/compiler/tests/fail/param_expansion/x86-64/expression_arg.jazz
+++ b/compiler/tests/fail/param_expansion/x86-64/expression_arg.jazz
@@ -1,3 +1,3 @@
-param int N = (int)(64u) 3;
+param int N = (uint)(64u) 3;
 
 inline fn f (reg u64[N] a) { }

--- a/compiler/tests/fail/param_expansion/x86-64/expression_global.jazz
+++ b/compiler/tests/fail/param_expansion/x86-64/expression_global.jazz
@@ -1,2 +1,2 @@
-param int N = (int)(64u) 3;
+param int N = (uint)(64u) 3;
 u64[N] a = {1,2};

--- a/compiler/tests/fail/param_expansion/x86-64/expression_global2.jazz
+++ b/compiler/tests/fail/param_expansion/x86-64/expression_global2.jazz
@@ -1,2 +1,2 @@
 param int N = 2;
-u64[(int)(64u)N] g = {1};
+u64[(uint)(64u)N] g = {1};

--- a/compiler/tests/fail/param_expansion/x86-64/expression_res.jazz
+++ b/compiler/tests/fail/param_expansion/x86-64/expression_res.jazz
@@ -1,4 +1,4 @@
-param int N = (int)(64u) 3;
+param int N = (uint)(64u) 3;
 
 inline fn f () -> reg u64[N] {
   reg u64[N] a;

--- a/compiler/tests/fail/stack_allocation/x86-64/non_constant_index.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/non_constant_index.jazz
@@ -4,7 +4,7 @@ fn f (reg u64 i) -> reg u64 {
   stack u64[2] a;
   stack u64[2] b;
   a[0]=0;
-  b[(int)i:2] = a[0:2];
+  b[(uint)i:2] = a[0:2];
   res = b[0];
   return res;
 }

--- a/compiler/tests/fail/unroll/x86-64/bug_29.jazz
+++ b/compiler/tests/fail/unroll/x86-64/bug_29.jazz
@@ -1,7 +1,7 @@
 export fn main (reg u64 io) -> reg u64 {
   inline int i;
   reg u64 res;
-  for i = 0 to (int)io {
+  for i = 0 to (uint)io {
     res = i;
   }
   return res;

--- a/compiler/tests/pending/x86-64/even.jazz
+++ b/compiler/tests/pending/x86-64/even.jazz
@@ -6,7 +6,7 @@ fn even() -> reg u64 {
   reg u64 i;
   i = 0;
   while (i <u 4) {
-    a.[u8 (int)i] = i;
+    a.[u8 i] = i;
     i += 4;
   }
   return i;

--- a/compiler/tests/pending/x86-64/two-counters.jazz
+++ b/compiler/tests/pending/x86-64/two-counters.jazz
@@ -13,7 +13,7 @@ fn sum() -> reg u64 {
   j = N;
   for k = 0 to N { a[k] = k; }
   while (j >u 0) {
-    result += a.[u64 (int)i];
+    result += a.[u64 (uint)i];
     i += 8;
     j -= 1;
   }

--- a/compiler/tests/sct-checker/fail/basic.jazz
+++ b/compiler/tests/sct-checker/fail/basic.jazz
@@ -19,7 +19,7 @@ fn missing_else(#transient reg u64 a){
     a = m;
     m = #update_msf(b, m);
   }
-  a = not[(int) a];
+  a = not[a];
   a = #protect(a, m);
 }
 
@@ -33,7 +33,7 @@ fn missing_then(#transient reg u64 a){
   } else {
     m = #update_msf(!b, m);
   }
-  a = not[(int) a];
+  a = not[a];
   a = #protect(a, m);
 }
 

--- a/compiler/tests/sct-checker/fail/functions.jazz
+++ b/compiler/tests/sct-checker/fail/functions.jazz
@@ -5,7 +5,7 @@ u8[6] g = "jasmin";
 fn call_kills_msf(#transient reg u64 c) -> #public reg u64 {
   reg u64 m x;
   m = #init_msf();
-  x = g[u64 (int) c];
+  x = g[u64 c];
   leak(0);
   x = #protect(x, m);
   return x;

--- a/compiler/tests/sct-checker/success/basic.jazz
+++ b/compiler/tests/sct-checker/success/basic.jazz
@@ -43,7 +43,7 @@ export fn whileloop(#transient reg u64 a) -> #public reg u64 {
   ?{}, i = #set0();
   while (i < 2) {
     msf = #update_msf(i < 2, msf);
-    t = not[(int) i];
+    t = not[i];
     t = #protect(t, msf);
     a ^= t;
     i += 1;
@@ -57,9 +57,9 @@ export fn archetype(#transient reg u64 i) -> #transient reg u64 {
   r = 0;
   if i < 2 {
     msf = #update_msf(i < 2, msf);
-    t = not[(int) i];
+    t = not[i];
     t = #protect(t, msf);
-    r = not[(int) t];
+    r = not[t];
   }
   return r;
 }

--- a/compiler/tests/sct-checker/success/paper.jazz
+++ b/compiler/tests/sct-checker/success/paper.jazz
@@ -66,10 +66,10 @@ fn fig4a(
   reg u64 i t1 t2;
   i = 0;
   while (i < N) {
-    t1 = msg[(int) i];
-    t2 = key[(int) i];
+    t1 = msg[i];
+    t2 = key[i];
     t1 ^= t2;
-    msg[(int) i] = t1;
+    msg[i] = t1;
     i += 1;
   }
   return msg;
@@ -87,12 +87,12 @@ fn fig4b(
   i = 0;
   while (i < N) {
     ms = #update_msf(i < N, ms);
-    t1 = msg[(int) i];
+    t1 = msg[i];
     t1 = #protect(t1, ms);
-    t2 = key[(int) i];
+    t2 = key[i];
     t2 = #protect(t2, ms);
     t1 ^= t2;
-    msg[(int) i] = t1;
+    msg[i] = t1;
     i += 1;
   }
   ms = #update_msf(!(i < N), ms);
@@ -111,10 +111,10 @@ fn fig4c(
   i = 0;
   while (i < N) {
     ms = #update_msf(i < N, ms);
-    t1 = msg[(int) i];
-    t2 = key[(int) i];
+    t1 = msg[i];
+    t2 = key[i];
     t1 ^= t2;
-    msg[(int) i] = t1;
+    msg[i] = t1;
     i += 1;
   }
   ms = #update_msf(!(i < N), ms);
@@ -148,7 +148,7 @@ fn fig5b(reg const ptr u64[N] p) -> reg u64 {
   i = 0;
   while (i < N) {
     ms = #update_msf(i < N, ms);
-    t = p[(int) i];
+    t = p[i];
     t = #protect(t, ms);
     s += t;
     i += 1;
@@ -167,7 +167,7 @@ fn fig5c(reg const ptr u64[N] p) -> reg u64 {
   i = 0;
   while (i < N) {
     ms = #update_msf(i < N, ms);
-    t = p[(int) i];
+    t = p[i];
     s += t;
     i += 1;
   }
@@ -185,7 +185,7 @@ fn fig5d(
   s = 0;
   i = 0;
   while (i < N) {
-    t = p[(int) i];
+    t = p[i];
     s += t;
     i += 1;
   }
@@ -209,7 +209,7 @@ fn fig6a(
   b = i < N;
   if b {
     ms = #update_msf(b, ms);
-    s[(int) i] = pub_v;
+    s[i] = pub_v;
   } else {
     ms = #update_msf(!b, ms);
   }

--- a/compiler/tests/success/arm-m4/global.jazz
+++ b/compiler/tests/success/arm-m4/global.jazz
@@ -22,6 +22,6 @@ fn mod4p1(reg u32 i) -> reg u32 {
   reg ptr u8[4] p;
   p = t;
   i &= 3;
-  r = (32u)p[(int) i];
+  r = (32u)p[i];
   return r;
 }

--- a/compiler/tests/success/common/wint.jazz
+++ b/compiler/tests/success/common/wint.jazz
@@ -1,0 +1,30 @@
+export fn syntax() -> reg u32 {
+  reg ui32 a = 42; // immediate
+  reg si32 b = -5;
+  reg si32 c = -b; // negation
+  c *= c; // multiplication
+  reg u32 x = (32u)c; // safe conversion to machine-word
+  x |= (32u)a;
+  return x;
+}
+
+export fn conv(reg u32 x) -> reg u32 {
+  reg ui32 u = (32ui)x;
+  reg si32 s = (32si)x;
+  x = (32u)u;
+  x |= (32u)s;
+  return x;
+}
+
+export fn safe_uint_to_sint() -> reg si32 {
+  reg ui32 u = 1 << 31;
+  reg si32 s = (32si)(32u)u;
+  return s;
+}
+
+fn conv_with_int() -> reg int {
+  reg int i = 127;
+  reg si8 s = (8si)i;
+  i = (int)s;
+  return i;
+}

--- a/compiler/tests/success/common/wint_div.jazz
+++ b/compiler/tests/success/common/wint_div.jazz
@@ -1,0 +1,52 @@
+fn sdiv (reg si32 x, reg si32 y) -> reg si32 {
+   reg si32 z;
+   z = x /s y;
+   return z;
+}
+
+fn sdiv1 (reg si32 x, reg si32 y) -> reg si32 {
+   reg si32 z;
+   z = x / y;
+   return z;
+}
+
+fn udiv (reg ui32 x, reg ui32 y) -> reg ui32 {
+   reg ui32 z;
+   z = x /u y;
+   return z;
+}
+
+fn udiv1 (reg ui32 x, reg ui32 y) -> reg ui32 {
+   reg ui32 z;
+   z = x / y;
+   return z;
+}
+
+inline fn isdiv (inline int x, inline int y) -> inline int {
+   inline int z;
+   z = x /s y;
+   return z;
+}
+
+inline fn iudiv (inline int x, inline int y) -> inline int {
+   inline int z;
+   z = x /u y;
+   return z;
+}
+
+
+fn wsdiv (reg u32 x, reg u32 y) -> reg u32 {
+   reg u32 z;
+   z = x /s y;
+   return z;
+}
+
+fn wudiv (reg u32 x, reg u32 y) -> reg u32 {
+   reg u32 z;
+   z = x /u y;
+   return z;
+}
+
+
+
+

--- a/compiler/tests/success/subroutines/x86-64/auto-reg-ptr.jazz
+++ b/compiler/tests/success/subroutines/x86-64/auto-reg-ptr.jazz
@@ -2,7 +2,7 @@ u64[2] g = { 1, 0 };
 
 fn load(reg const ptr u64[2] p, reg u64 i) -> reg u64 {
   reg u64 r;
-  r = p[(int)i];
+  r = p[i];
   return r;
 }
 

--- a/compiler/tests/success/x86-64/array_add.jazz
+++ b/compiler/tests/success/x86-64/array_add.jazz
@@ -4,6 +4,6 @@ export fn test (reg u64 x) -> reg u64 {
   t[0] = 0;
   t[1] = 1;
   p = 0;
-  r = t[(int)p + 1];
+  r = t[(uint)p + 1];
   return r;
 }

--- a/compiler/tests/success/x86-64/bug_175.jazz
+++ b/compiler/tests/success/x86-64/bug_175.jazz
@@ -14,9 +14,9 @@ inline fn add(reg ptr u64[N] a b) -> reg ptr u64[N]
   reg u64 i t;
   i = 0;
   while(i < N)
-  { t = a[(int)i];
-    t += b[(int)i];
-    a[(int) i] = t;
+  { t = a[i];
+    t += b[i];
+    a[i] = t;
     i += 1;
   }
   return a;
@@ -27,7 +27,7 @@ inline fn store(reg u64 p, reg ptr u64[N] x)
   reg u64 i t;
   i = 0;
   while(i < N)
-  { t = x[(int)i];
+  { t = x[i];
     (u64)[p + 8*i] = t;
     i += 1;
   }

--- a/compiler/tests/success/x86-64/stack_array.jazz
+++ b/compiler/tests/success/x86-64/stack_array.jazz
@@ -9,16 +9,16 @@ fn fill(reg u64 in, reg u64 out, reg u64 len) -> reg u64 {
    i = 0;
    #bounded
    while (i < max) {
-     // t[(int)i] = [in + 8 * i];  // works but not in the spirit
+     // t[i] = [in + 8 * i];  // works but not in the spirit
      aux = [in + 8 * i];
-     t[(int)i] = aux;
+     t[i] = aux;
      i += 1;
    }
 
    i = 0;
    while (i < max) {
-     // [out + 8 * i] = t[(int)i];
-     aux = t[(int)i];
+     // [out + 8 * i] = t[i];
+     aux = t[i];
      [in + 8 * i] = aux;
      i += 1; 
    }  

--- a/compiler/tests/success/x86-64/test_glob_array_256.jazz
+++ b/compiler/tests/success/x86-64/test_glob_array_256.jazz
@@ -13,7 +13,7 @@ export fn sum (reg u64 x) -> reg u64 {
   
   while (i <= 3 * 32) {
     
-    aux ^= gt1.[(int)i];
+    aux ^= gt1.[i];
     i += 32;
   }
 
@@ -21,7 +21,7 @@ export fn sum (reg u64 x) -> reg u64 {
   
   while (i <= 3 * 4) {
     
-    aux ^= gt1.[(int)(8 * i)];
+    aux ^= gt1.[8 * i];
     i += 4;
   }
 
@@ -43,7 +43,7 @@ export fn sum1 (reg u64 x) -> reg u64 {
   
   while (i <= 7 * 16) {
     
-    aux ^= gt1.[u128 (int)i];
+    aux ^= gt1.[u128 i];
     i += 16;
   }
 
@@ -51,7 +51,7 @@ export fn sum1 (reg u64 x) -> reg u64 {
   
   while (i <= 3 * 4) {
     
-    aux ^= gt1.[u128 (int)(8 * i)];
+    aux ^= gt1.[u128 8 * i];
     i += 4;
   }
 

--- a/compiler/tests/success/x86-64/test_glob_array_while.jazz
+++ b/compiler/tests/success/x86-64/test_glob_array_while.jazz
@@ -9,12 +9,12 @@ export fn sum (reg u64 x) -> reg u64 {
   r = 0; 
   i = 0;
   while (i < 4) {
-    r += gt1[(int)i];
+    r += gt1[i];
     i += 1;
   }
   i = 0;
   while (i < 4) {
-    r += gt2[(int)i];
+    r += gt2[i];
     i += 1;
   }   
   return r;

--- a/compiler/tests/success/x86-64/test_glob_array_while1.jazz
+++ b/compiler/tests/success/x86-64/test_glob_array_while1.jazz
@@ -14,12 +14,12 @@ export fn sum (reg u64 x) -> reg u64 {
   r = 0; 
   i = 0;
   while (i < 4) {
-    r += gt1[(int)i];
+    r += gt1[i];
     i += 1;
   }
   i = 0;
   while (i < 4) {
-    r += gt2[(int)i];
+    r += gt2[i];
     i += 1;
   }   
   return r;

--- a/compiler/tests/success/x86-64/test_glob_array_while2.jazz
+++ b/compiler/tests/success/x86-64/test_glob_array_while2.jazz
@@ -10,7 +10,7 @@ export fn sum (reg u64 x) -> reg u64 {
   i = 0;
   gt1 = glob_t;
   while (i < 4) {
-    r += gt1[(int)i];
+    r += gt1[i];
     i += 1;
   }
   return r;

--- a/compiler/tests/success/x86-64/test_printer_intel.jazz
+++ b/compiler/tests/success/x86-64/test_printer_intel.jazz
@@ -16,7 +16,7 @@ export fn foo(reg u64 plain, reg u64 output) {
   while(j < 80)
   {
     pi = (u8)[plain + j];
-    pi ^= s_k[u8 (int)j];
+    pi ^= s_k[u8 j];
     pi ^= s_0[u8 0];
     (u8)[output + j] = pi;
     j += 1;

--- a/eclib/JUtils.ec
+++ b/eclib/JUtils.ec
@@ -77,7 +77,7 @@ lemma exp_abs (x n:int) : x ^ `|n| = x ^ n.
 proof. by smt (exprV). qed.
 
 lemma modz_mod_pow2 i n k : i %% 2^n %% 2^k = i %% 2^(min `|n| `|k|).
-proof. 
+proof.
   rewrite -(exp_abs 2 n) -(exp_abs 2 k).
   move: `|n| `|k| (IntOrder.normr_ge0 n) (IntOrder.normr_ge0 k) => {n k} n k hn hk.
   rewrite /min;case (n < k) => hnk.
@@ -344,7 +344,7 @@ rewrite bs2int_cat /=; congr.
 by rewrite /bs2int /= big_int1.
 qed.
 
-lemma bs2int_nseq b k: 
+lemma bs2int_nseq b k:
   bs2int (nseq k b) = if b /\ 0 <= k then 2^k - 1 else 0.
 proof.
 case: (0 <= k) => /= hk; last by rewrite nseq0_le 1:/# /bs2int /= big_geq //.

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -120,6 +120,10 @@ compiler/unionfind.v
 compiler/unionfind_proof.v
 compiler/unrolling.v
 compiler/unrolling_proof.v
+compiler/wint_int.v
+compiler/wint_int_proof.v
+compiler/wint_word.v
+compiler/wint_word_proof.v
 compiler/x86_decl.v
 compiler/x86_extra.v
 compiler/x86_instr_decl.v

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -169,20 +169,6 @@ Definition lower_load (ws: wsize) (e: pexpr) : low_expr :=
   let%opt _ := chk_ws_reg ws in
   le_issue LDR [:: e ].
 
-Definition is_load (e: pexpr) : bool :=
-  match e with
-  | Pconst _ | Pbool _ | Parr_init _
-  | Psub _ _ _ _ _
-  | Papp1 _ _ | Papp2 _ _ _ | PappN _ _ | Pif _ _ _ _
-    => false
-  | Pvar {| gs := Sglob |}
-  | Pget _ _ _ _ _
-  | Pload _ _ _ _
-    => true
-  | Pvar {| gs := Slocal ; gv := x |}
-    => is_var_in_memory x
-  end.
-
 Definition mov_imm_op (e : pexpr) : sopn :=
   if isSome (is_const e)
   then Oasm (ExtOp (Osmart_li U32))
@@ -244,9 +230,9 @@ Definition lower_Papp2_op
       then Some (RSB, e1, [:: e0])
       else
         Some (SUB, e0, [:: e1 ])
-  | Odiv (Cmp_w Signed U32) =>
+  | Odiv Signed (Op_w U32) =>
       Some (SDIV, e0, [:: e1 ])
-  | Odiv (Cmp_w Unsigned U32) =>
+  | Odiv Unsigned (Op_w U32) =>
       Some (UDIV, e0, [:: e1 ])
   | Oland _ =>
       Some (AND, e0, [:: e1 ])

--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -257,11 +257,11 @@ Proof.
     move: hw0' => /Vword_inj [?]; subst ws0.
     move=> /= ?; subst w0'.
 
-    move: hseme1 => /sem_sop1I /= [w1 [?] hw1']; subst w1.
+    move: hseme1 => /sem_sop1I /= [w1 [?]] [[?] [?] hw1']; subst w1.
     move: hw1' => /Vword_inj [?]; subst ws1.
     move=> /= ?; subst w1'.
 
-    move=> [?]; subst es'.
+    move=> [?]; subst.
     rewrite /=.
 
     rewrite hseme00 hseme01 {hseme00 hseme01} /=.
@@ -417,7 +417,7 @@ Proof.
   case: e hseme hfve h => // op.
   move=> [] //= gx.
   move=> [] //.
-  move=> [[]||||||] //.
+  move=> [[]|||||||] //.
   move=> [] // z.
 
   rewrite /=.
@@ -585,17 +585,17 @@ Proof.
   move: h.
   rewrite /lower_pexpr_aux /lower_Papp1.
   move=> /chk_ws_regP [?]; subst ws.
-  case: op hw hfve => [ ws'' || [] ws'' | [] ws'' || [] |] // hw hfve.
+  case: op hw hfve => [ ws'' || [] ws'' | [] ws'' || [] ||] // hw hfve.
 
   (* Case: [Oword_of_int]. *)
-  - move: hw => /sem_sop1I /= [w' hw' hw].
-    move: hw => /Vword_inj [?]; subst ws'.
+  - move: hw => /sem_sop1I /= [w' [?] [hw' [?] hw]].
+    move: hw => /Vword_inj [?]; subst ws'; subst.
     move=> /= ?; subst w.
     rewrite hws /= /mov_imm_op.
     {
       case: isSome => -[??]; subst op' es.
       all: split; last done.
-      all: eexists; first by [|rewrite /= hseme /= /sem_sop1 /= hw'].
+      all: eexists; first by rewrite /= hseme /= /sem_sop1 /= hw'.
       all: by rewrite /exec_sopn /= truncate_word_u zero_extend_wrepr.
     }
 
@@ -603,9 +603,9 @@ Proof.
 
   (* Case: [Osignext]. *)
   - case: is_load; last by [].
-    move: hw => /sem_sop1I /= [w' hw' hw].
+    move: hw => /sem_sop1I /= [w' [?] [hw' [?] hw]].
     move: hw => /Vword_inj [?]; subst ws'.
-    move=> /= ?; subst w.
+    move=> /= ?; subst.
     {
       case: ws'' hfve w' hw' => //= hfve w' hw'.
       all: move=> [? ?]; subst op' es.
@@ -621,9 +621,9 @@ Proof.
 
   (* Case: [Ozeroext]. *)
   - case: is_load; last by [].
-    move: hw => /sem_sop1I /= [w' hw' hw].
+    move: hw => /sem_sop1I /= [w' [?] [hw' [?] hw]].
     move: hw => /Vword_inj [?]; subst ws'.
-    move=> /= ?; subst w.
+    move=> /= ?; subst.
     {
       case: ws'' hfve w' hw' => //= hfve w' hw'.
       all: move=> [? ?]; subst op' es.
@@ -638,9 +638,9 @@ Proof.
     }
 
   (* Case: [Olnot]. *)
-  move: hw => /sem_sop1I /= [w' hw' hw].
+  move: hw => /sem_sop1I /= [w' [?] [hw' [?] hw]].
   move: hw hws => /Vword_inj [?]; subst ws'.
-  move=> /= ? _; subst w.
+  move=> /= ? _; subst.
 
   rewrite /arg_shift.
   case hshift: get_arg_shift => [[[e' sh] sham]|] /=.
@@ -740,6 +740,7 @@ Proof.
         match goal with
         | [ |- forall (_ : op_kind), _ -> _ ] => move=> [|ws''] //
         | [ |- forall (_ : cmp_kind), _ -> _ ] => move=> [|[] ws''] //
+        | [ |- forall (_ : signedness) (_ : op_kind), _ -> _ ] => move=> [] [|ws''] //
         | [ |- forall (_ : wsize), _ -> _ ] => move=> ws'' //
         end.
 
@@ -832,6 +833,7 @@ Proof.
     match goal with
     | [ |- forall _ : op_kind, _ -> _ ] => move=> [|ws''] //
     | [ |- forall (_ : cmp_kind), _ -> _ ] => move=> [|[] ws''] //
+    | [ |- forall (_ : signedness) (_ : op_kind), _ -> _ ] => move=> [] [|ws''] //
     | [ |- forall _ : wsize, _ -> _ ] => move=> ws'' //
     end.
 
@@ -887,7 +889,7 @@ Proof.
 
   all: rewrite /=.
   all: match goal with
-       | [ h : mk_sem_divmod _ _ _ _ = _ |- _ ] =>
+       | [ hop : mk_sem_divmod _ _ _ _ = _ |- _ ] =>
            move: hop => /mk_sem_divmodP [hdiv0 hdiv1 ?]; subst w2
        end
        || (move: hop => [?]; subst w2).

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -30,9 +30,6 @@ Context {atoI : arch_toIdent}.
 (* ------------------------------------------------------------------------ *)
 (* Stack alloc parameters. *)
 
-Definition is_load e :=
-  if e is Pload _ _ _ _ then true else false.
-
 Definition arm_mov_ofs
   (x : lval) (tag : assgn_tag) (vpk : vptr_kind) (y : pexpr) (ofs : Z) :
   option instr_r :=
@@ -44,7 +41,7 @@ Definition arm_mov_ofs
   | MK_MOV =>
     match x with
     | Lvar x_ =>
-      if is_load y then
+      if is_Pload y then
         if ofs == Z0 then mk (LDR, [:: y]) else None
       else
         if ofs == Z0 then mk (MOV, [:: y])

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -470,7 +470,7 @@ Lemma eval_assemble_cond_Onot rf c v v0 v1 :
        & value_uincl v v'.
 Proof.
   move=> hv1 hincl.
-  move=> /sem_sop1I /= [b hb ?]; subst v.
+  move=> /sem_sop1I /= [b [b'] [hb [?] ? ]]; subst v b'.
 
   have hc := value_uincl_to_bool_value_of_bool hincl hb hv1.
   clear v0 v1 hincl hb hv1.

--- a/proofs/compiler/compiler_proof.v
+++ b/proofs/compiler/compiler_proof.v
@@ -32,7 +32,8 @@ Require Import
   psem_of_sem_proof
   slh_lowering_proof
   direct_call_proof
-  stack_zeroization_proof.
+  stack_zeroization_proof
+  wint_word_proof.
 
 Require Import
   arch_decl
@@ -182,10 +183,9 @@ Lemma compiler_first_partP entries (p: prog) (p': uprog) scs m fn va scs' m' vr 
     List.Forall2 value_uincl vr vr' &
     sem_call (dc:=direct_c) p' tt scs m fn va scs' m' vr'.
 Proof.
-  rewrite /compiler_first_part; t_xrbindP => pa0.
-  rewrite print_uprogP => ok_pa0 pb.
-  rewrite print_uprogP => ok_pb pa.
-  rewrite print_uprogP => ok_pa pc ok_pc ok_puc ok_puc'.
+  rewrite /compiler_first_part; t_xrbindP => paw ok_paw pa0.
+  rewrite !print_uprogP => ok_pa0 pb.
+  rewrite print_uprogP => ok_pb pa ok_pa pc ok_pc ok_puc ok_puc'.
   rewrite !print_uprogP => pd ok_pd.
   rewrite !print_uprogP => pe ok_pe.
   rewrite !print_uprogP => pf ok_pf.
@@ -235,7 +235,11 @@ Proof.
   - by move=> vr'; apply: (lower_spill_fdP (sip := sip_of_asm_e) (sCP := sCP_unit) ok_pb).
   apply: compose_pass; first by move => vr'; apply: (add_init_fdP).
   apply: compose_pass_uincl.
-  - by move=> vr'; apply:(array_copy_fdP (sCP := sCP_unit) ok_pa0 va_refl).
+  - move=> vr'.
+    have := [elaborate array_copy_fdP (dc := indirect_c) (sCP := sCP_unit)].
+    by move=> /(_ _ _ _ tt ok_pa0); apply; apply va_refl.
+  apply: compose_pass_uincl'.
+  + by move=> vr'; apply: wi2w_progP; apply ok_paw.
   apply: compose_pass; first by move => vr'; exact: psem_call_u.
   exists vr => //.
   exact: (List_Forall2_refl _ value_uincl_refl).

--- a/proofs/compiler/compiler_util.v
+++ b/proofs/compiler/compiler_util.v
@@ -175,7 +175,7 @@ Section ASM_OP.
 Context `{asmop:asmOp}.
 Context {pT: progT}.
 
-Definition map_prog_name (F: funname -> fundef -> fundef) (p:prog) :prog :=
+Definition map_prog_name (F: funname -> fundef -> fundef) (p:prog) : prog :=
   {| p_funcs := map (fun f => (f.1, F f.1 f.2)) (p_funcs p);
      p_globs := p_globs p;
      p_extra := p_extra p|}.

--- a/proofs/compiler/compiler_util.v
+++ b/proofs/compiler/compiler_util.v
@@ -13,7 +13,7 @@ Variant warning_msg : Set :=
 (* ** Compiler error
  * -------------------------------------------------------------------------- *)
 
-Variant box := 
+Variant box :=
   | Vbox
   | Hbox
   | HoVbox
@@ -101,9 +101,9 @@ Definition pp_at_ii ii (e : pp_error_loc) := {|
   pel_pass := e.(pel_pass);
   pel_internal := e.(pel_internal) |}.
 
-Definition add_iinfo {T} (ii:instr_info) (x : cexec T) := 
+Definition add_iinfo {T} (ii:instr_info) (x : cexec T) :=
   match x with
-  | Ok a => ok a 
+  | Ok a => ok a
   | Error e => Error (pp_at_ii ii e)
   end.
 
@@ -149,17 +149,17 @@ Definition with_pel_msg (e : pp_error_loc) (msg : pp_error) : pp_error_loc :=
   |}.
 
 Lemma add_iinfoP {A a} ii (e:cexec A):
-  add_iinfo ii e = ok a -> 
+  add_iinfo ii e = ok a ->
   e = ok a.
 Proof. by case: e. Qed.
 
 Lemma add_finfoP {A a} fi (e:cexec A):
-  add_finfo fi e = ok a -> 
+  add_finfo fi e = ok a ->
   e = ok a.
 Proof. by case: e. Qed.
 
 Lemma add_funnameP {A a} fn (e:cexec A):
-  add_funname fn e = ok a -> 
+  add_funname fn e = ok a ->
   e = ok a.
 Proof. by case: e. Qed.
 
@@ -297,13 +297,13 @@ Ltac t_xrbindP :=
   | [ |- unit -> _ ] =>
       case; t_xrbindP
 
-  | [ |- add_finfo _ _ = ok _ -> _] => 
+  | [ |- add_finfo _ _ = ok _ -> _] =>
       move=> /add_finfoP; t_xrbindP
 
-  | [ |- add_funname _ _ = ok _ -> _] => 
+  | [ |- add_funname _ _ = ok _ -> _] =>
       move=> /add_funnameP; t_xrbindP
 
-  | [ |- add_iinfo _ _ = ok _ -> _] => 
+  | [ |- add_iinfo _ _ = ok _ -> _] =>
       move=> /add_iinfoP; t_xrbindP
 
   | [ |- ok _ = ok _ -> _ ] =>
@@ -327,10 +327,10 @@ Definition gen_loop_iterator pass_name (ii:option instr_info) :=
    ; pel_internal := true
   |}.
 
-Definition loop_iterator pass_name := 
+Definition loop_iterator pass_name :=
   gen_loop_iterator pass_name None.
 
-Definition ii_loop_iterator pass_name ii := 
+Definition ii_loop_iterator pass_name ii :=
   gen_loop_iterator pass_name (Some ii).
 
 Definition error_copy_remain := "array copy remain"%string.

--- a/proofs/compiler/constant_prop.v
+++ b/proofs/compiler/constant_prop.v
@@ -53,7 +53,8 @@ Definition to_expr (t:stype) : sem_t t -> exec pexpr :=
 Definition ssem_sop1 (o: sop1) (e: pexpr) : pexpr := 
   let r := 
     Let x := of_expr _ e in
-    to_expr (sem_sop1_typed o x) in
+    Let v := sem_sop1_typed o x in
+    to_expr v in
   match r with 
   | Ok e => e
   | _ => Papp1 o e

--- a/proofs/compiler/jasmin_compiler.v
+++ b/proofs/compiler/jasmin_compiler.v
@@ -5,3 +5,4 @@ Require arm_params.
 Require x86_params.
 Require riscv_params.
 Require sem_params_of_arch_extra.
+Require wint_int.

--- a/proofs/compiler/riscv_lowering_proof.v
+++ b/proofs/compiler/riscv_lowering_proof.v
@@ -281,11 +281,11 @@ Let x := sem_pexpr true (p_globs p) s0 e2 in to_word ws x = ok (- w)%R.
 Proof.
   case : e1 => // -[] // sz [] // n /= [<-] /=.
   move => /truncate_wordP [hcmp ->].
-  rewrite truncate_word_le //.  
+  rewrite truncate_word_le //.
   rewrite wrepr_opp.
   by rewrite wopp_zero_extend.
 Qed.
-  
+
 #[ local ]
 Lemma Hassgn : sem_Ind_assgn p Pi_r.
 Proof.
@@ -364,7 +364,7 @@ Proof.
     case: eqP => //= ?; subst.
     case: s hseme => //.
     + move => w /= hseme.
-      case: is_constP hseme => a //= hseme. 
+      case: is_constP hseme => a //= hseme.
       move=> [] <- <- <-.
       rewrite /sem_sopn /= /exec_sopn /= truncate_word_u /=.
       move: hseme htrunc.
@@ -474,9 +474,9 @@ Proof.
       case h_insert: insert_minus => [e1' | //].
       set op2' := Oasm _.
       have [hcmp [w1 [w2] [ok_w1 ok_w2 sem_correct]]] := Hassgn_op2_generic ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
-      move=> [<- <- <-].  
+      move=> [<- <- <-].
       apply :(sem_correct _ _ w1 (- w2)%R) => //.
-      + by rewrite ok_v1. 
+      + by rewrite ok_v1.
       + apply (minus_insertP h_insert).
         by rewrite ok_v2.
       by rewrite /= wadd_zero_extend.
@@ -537,8 +537,8 @@ Proof.
     apply: (decide_op_reg_immP ok_v1 ok_v2 h erefl).
     set op2' := Oasm _.
     have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
-    Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.  
-    by apply sem_correct; rewrite /= -wand_zero_extend.        
+    Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
+    by apply sem_correct; rewrite /= -wand_zero_extend.
   + case h: decide_op_reg_imm => [[ol esi] | ] //= [<- <- <-].
     apply: (decide_op_reg_immP ok_v1 ok_v2 h erefl).
     set op2' := Oasm _.
@@ -566,12 +566,12 @@ Proof.
     move=> [<- <- <-].
     rewrite !fun_if if_same.
     set op2' := Oasm _.
-    have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] := 
+    have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
       Hassgn_op2_shift ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
     have [_ [wa ok_wa eq_shift]] := check_shift_amountP good_shift ok_v2 ok_w2.
     apply (sem_correct _ _ ok_wa).
     rewrite /= zero_extend_wshl //; last by have [? _] := wunsigned_range w2.
-    by rewrite -/(sem_shift _ _ _) eq_shift.  
+    by rewrite -/(sem_shift _ _ _) eq_shift.
   case: o ok_v => // -[] // ok_v.
   case good_shift: check_shift_amount => [ sa | ] //.
   move=> [<- <- <-].
@@ -591,7 +591,7 @@ Proof.
   move=> ii.
 
   rewrite /Pi /=.
-  
+
   case h : lower_copn => [l | ];
   last by apply: sem_seq_ir; apply: Eopn.
   move: h.
@@ -604,7 +604,7 @@ Proof.
     case: ifP => // /Bool.orb_false_elim [] /negbT h_neqx /negbT h_neqy.
     move => [] <-.
     move: hsem01.
-    rewrite /sem_sopn /=. 
+    rewrite /sem_sopn /=.
     t_xrbindP.
     move => vs _ v1 ok_v1 _ v2 ok_v2 <- <-.
     rewrite /exec_sopn /= /sopn_sem /= /sopn_sem_ /=.
@@ -641,7 +641,7 @@ Qed.
 Lemma Hsyscall : sem_Ind_syscall p Pi_r.
 Proof.
   move=> s1 scs m s2 o xs es ves vs hes ho hw ii.
-  apply: sem_seq_ir. 
+  apply: sem_seq_ir.
   by apply: Esyscall; eassumption.
 Qed.
 
@@ -649,7 +649,7 @@ Qed.
 Lemma Hif_true : sem_Ind_if_true p ev Pc Pi_r.
 Proof.
   move=> s0 s1 e c0 c1 hseme _ hc ii.
-  apply: sem_seq_ir. 
+  apply: sem_seq_ir.
   by apply: Eif_true; eassumption.
 Qed.
 
@@ -657,7 +657,7 @@ Qed.
 Lemma Hif_false : sem_Ind_if_false p ev Pc Pi_r.
 Proof.
   move=> s0 s1 e c0 c1 hseme _ hc ii.
-  apply: sem_seq_ir. 
+  apply: sem_seq_ir.
   by apply: Eif_false; eassumption.
 Qed.
 

--- a/proofs/compiler/riscv_lowering_proof.v
+++ b/proofs/compiler/riscv_lowering_proof.v
@@ -171,7 +171,7 @@ Lemma Hassgn_op2_generic s e1 e2 v1 v2 op2 v ws v' lv s1 (op2' : sopn) :
 Proof.
   move=> ok_v1 ok_v2 ok_v htrunc hwrite hvalid ws1 ws2 ws3 ws1' ws2' eq1 eq2 eq3.
   move: ok_v.
-  rewrite /sem_sop2; move: (sem_sop2_typed op2).
+  rewrite /sem_sop2 /=; move: (sem_sop2_typed op2).
   rewrite -> eq1 => /= sem_sop2_typed ok_v.
   rewrite /sem_sopn /= /exec_sopn /= /sopn_sem /sopn_sem_ hvalid /=.
   move: (semi (sopn.get_instr_desc op2')).
@@ -442,8 +442,8 @@ Proof.
   t_xrbindP=> s e1 e2 v1 ok_v1 v2 ok_v2 ok_v.
   rewrite /lower_Papp2 /chk_ws_reg.
   case: eqP => //= ?; subst.
-  case: s ok_v => //= o ok_v.
-  + case: o ok_v => //= ws ok_v.
+  case: s ok_v => //=.
+  + case => //= ws ok_v.
     rewrite /riscv_lowering.decide_op_reg_imm.
     - case en : is_wconst => [ n | ].
       - case : ifP => //.
@@ -459,13 +459,13 @@ Proof.
       Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
       move=> [<- <- <-].
       by apply sem_correct; rewrite /= wadd_zero_extend.
-  + case: o ok_v => //= ws ok_v.
+  + case => //= ws ok_v.
     move=> [<- <- <-].
     set op2' := Oasm _.
     have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
       Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
     by apply sem_correct; rewrite /= wmul_zero_extend.
-  + case: o ok_v => //= ws ok_v.
+  + case => //= ws ok_v.
     rewrite /riscv_lowering.decide_op_reg_imm_neg.
     case en : is_wconst => [ n | ].
     - case : ifP => //.
@@ -485,7 +485,7 @@ Proof.
     have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
       Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
     by apply sem_correct; rewrite /= wsub_zero_extend.
-  + case: o ok_v => // -[] [] //=.
+  + case => // -[] // [] //=.
     + rewrite /sem_sop2 /=.
       t_xrbindP=> w1 ok_w1 w2 ok_w2.
       rewrite /mk_sem_divmod /=.
@@ -509,7 +509,7 @@ Proof.
     rewrite /riscv_divu_semi w2_nzero.
     rewrite (truncate_val_subtype_eq htrunc) //.
     by rewrite hwrite.
-  + case: o ok_v => // -[] [] //=.
+  + case => // -[] // [] //=.
     + rewrite /sem_sop2 /=.
       t_xrbindP=> w1 ok_w1 w2 ok_w2.
       rewrite /mk_sem_divmod /=.
@@ -533,25 +533,25 @@ Proof.
     rewrite /riscv_div_semi.
     rewrite (truncate_val_subtype_eq htrunc) //.
     by rewrite hwrite.
-  + case h: decide_op_reg_imm => [[ol esi] | ] //= [<- <- <-].
+  + move=> o ok_v; case h: decide_op_reg_imm => [[ol esi] | ] //= [<- <- <-].
     apply: (decide_op_reg_immP ok_v1 ok_v2 h erefl).
     set op2' := Oasm _.
     have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
     Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
     by apply sem_correct; rewrite /= -wand_zero_extend.
-  + case h: decide_op_reg_imm => [[ol esi] | ] //= [<- <- <-].
+  + move=> o ok_v; case h: decide_op_reg_imm => [[ol esi] | ] //= [<- <- <-].
     apply: (decide_op_reg_immP ok_v1 ok_v2 h erefl).
     set op2' := Oasm _.
     have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
       Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
     by apply sem_correct; rewrite /= -wor_zero_extend.
-  + case h: decide_op_reg_imm => [[ol esi] | ] //= [<- <- <-].
+  + move=> o ok_v; case h: decide_op_reg_imm => [[ol esi] | ] //= [<- <- <-].
     apply: (decide_op_reg_immP ok_v1 ok_v2 h erefl).
     set op2' := Oasm _.
     have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
       Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
     by apply sem_correct; rewrite /= -wxor_zero_extend.
-  + case: o ok_v => // ok_v.
+  + case => // ok_v.
     case good_shift: check_shift_amount => [ sa | ] //.
     move=> [<- <- <-].
     rewrite !fun_if if_same.
@@ -561,7 +561,7 @@ Proof.
     have [_ [wa ok_wa eq_shift]] := check_shift_amountP good_shift ok_v2 ok_w2.
     apply (sem_correct _ _ ok_wa).
     by rewrite /= !zero_extend_u /sem_shr eq_shift.
-  + case: o ok_v => // ws ok_v.
+  + case => // ws ok_v.
     case good_shift: check_shift_amount => [ sa | ] //.
     move=> [<- <- <-].
     rewrite !fun_if if_same.
@@ -572,7 +572,7 @@ Proof.
     apply (sem_correct _ _ ok_wa).
     rewrite /= zero_extend_wshl //; last by have [? _] := wunsigned_range w2.
     by rewrite -/(sem_shift _ _ _) eq_shift.
-  case: o ok_v => // -[] // ok_v.
+  case => // -[] // ok_v.
   case good_shift: check_shift_amount => [ sa | ] //.
   move=> [<- <- <-].
   rewrite !fun_if if_same.

--- a/proofs/compiler/riscv_params.v
+++ b/proofs/compiler/riscv_params.v
@@ -33,9 +33,6 @@ Context {atoI : arch_toIdent}.
 (* ------------------------------------------------------------------------ *)
 (* Stack alloc parameters. *)
 
-Definition is_load e :=
-  if e is Pload _ _ _ _ then true else false.
-
 Definition riscv_mov_ofs
   (x : lval) (tag : assgn_tag) (vpk : vptr_kind) (y : pexpr) (ofs : Z) :
   option instr_r :=
@@ -47,7 +44,7 @@ Definition riscv_mov_ofs
   | MK_MOV =>
     match x with
     | Lvar x_ =>
-      if is_load y then
+      if is_Pload y then
         if ofs == Z0 then mk (LOAD Signed U32, [:: y]) else None
       else
         if ofs == Z0 then mk (MV, [:: y])

--- a/proofs/compiler/riscv_params_proof.v
+++ b/proofs/compiler/riscv_params_proof.v
@@ -385,7 +385,7 @@ Lemma eval_assemble_cond_Onot get c v v0 v1 :
 Proof.
   Opaque riscv_eval_cond.
   move=> hv1 hincl.
-  move=> /sem_sop1I /= [b hb ?]; subst v.
+  move=> /sem_sop1I /= [b [b'] [hb [?] ?]]; subst v b'.
 
   have hc := value_uincl_to_bool_value_of_bool hincl hb hv1.
   clear v0 v1 hincl hb hv1.
@@ -418,7 +418,7 @@ Lemma assemble_cond_app2P_aux ck v1 v2 op2 v w1 w2 :
 Proof.
   move=> ok_v hincl1 hincl2 eq1.
   move: ok_v.
-  rewrite /sem_sop2; move: (sem_sop2_typed op2).
+  rewrite /sem_sop2 /=; move: (sem_sop2_typed op2).
   rewrite -> eq1 => /= sem_sop2_typed ok_v.
 
   move: ok_v.

--- a/proofs/compiler/slh_lowering_proof.v
+++ b/proofs/compiler/slh_lowering_proof.v
@@ -38,6 +38,7 @@ Section CONST_PROP.
   Proof.
     rewrite /ssem_sop1.
     case h0: of_expr => [v|//] /=.
+    case: sem_sop1_typed => [v'|//] /=.
     case h1: to_expr => //.
     move: h0 => /use_mem_of_expr ->.
     exact: (use_mem_to_expr h1).
@@ -57,7 +58,7 @@ Section CONST_PROP.
   Lemma use_mem_s_op1 op1 e :
     use_mem (s_op1 op1 e) = use_mem e.
   Proof.
-    case: op1 => [||||||[]] * /=.
+    case: op1 => [||||||[]|] * /=.
     all: by rewrite (use_mem_ssem_sop1, use_mem_snot, use_mem_sneg_int).
   Qed.
 

--- a/proofs/compiler/wint_int.v
+++ b/proofs/compiler/wint_int.v
@@ -1,0 +1,376 @@
+(* ** Imports and settings *)
+From HB Require Import structures.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssralg.
+From mathcomp Require Import word_ssrZ.
+From Coq Require Import ZArith.
+Require Import expr sem_op_typed compiler_util.
+Import Utf8.
+Import oseq.
+Require Import flag_combination.
+
+Local Open Scope seq_scope.
+Local Open Scope Z_scope.
+
+
+Module Import E.
+
+  Definition pass : string := "wint_to_int".
+
+  Definition ierror_s := pp_internal_error_s pass.
+
+  Definition ierror := pp_internal_error pass.
+
+  Definition ierror_e e :=
+    ierror (pp_nobox [:: pp_s "ill typed expression"; pp_e e]).
+
+  Definition ierror_lv lv :=
+    ierror (pp_nobox [:: pp_s "ill typed left value"; pp_lv lv]).
+
+End E.
+
+Section WITH_PARAMS.
+
+Context `{asmop:asmOp} {msfsz : MSFsize}.
+
+#[local]
+Existing Instance progUnit.
+
+Definition is_wi1 (o: sop1) :=
+  if o is Owi1 s op then Some (s, op) else None.
+
+Definition is_wi2 (o: sop2) :=
+  if o is Owi2 s _ op then Some (s, op) else None.
+
+Definition wi2i_op2 (o : sop2) : sop2 :=
+  match is_wi2 o with
+  | Some (s, op) =>
+    match op with
+    | WIadd => Oadd Op_int
+    | WImul => Omul Op_int
+    | WIsub => Osub Op_int
+    | WIdiv => Odiv s Op_int
+    | WImod => Omod s Op_int
+    | WIshl => Olsl Op_int
+    | WIshr => Oasr Op_int
+    | WIeq  => Oeq  Op_int
+    | WIneq => Oneq Op_int
+    | WIlt  => Olt  Cmp_int
+    | WIle  => Ole  Cmp_int
+    | WIgt  => Ogt  Cmp_int
+    | WIge  => Oge  Cmp_int
+    end
+  | None => o
+  end.
+
+Definition esubtype (ty1 ty2 : extended_type positive) :=
+ match ty1, ty2 with
+ | ETword None w, ETword None w' => (w ≤ w')%CMP
+ | ETword (Some sg) w, ETword (Some sg') w' => (sg == sg') && (w == w')
+ | ETint, ETint => true
+ | ETbool, ETbool => true
+ | ETarr l, ETarr l' => l == l'
+ | _, _ => false
+ end.
+
+Definition wi2i_op1_e (o : sop1) (e : pexpr) :=
+  match is_wi1 o with
+  | Some (s, o) =>
+    match o with
+    | WIwint_of_int ws => e
+    | WIint_of_wint ws => e
+    | WIword_of_wint ws => Papp1 (Oword_of_int ws) e
+    | WIwint_of_word ws => Papp1 (Oint_of_word s ws) e
+    | WIwint_ext szo szi =>
+      if (szi <= szo)%CMP then e
+      else
+      Papp1 (Oint_of_word s szo)
+       (Papp1 (signed (Ozeroext szo szi) (Osignext szo szi) s)
+         (Papp1 (Oword_of_int szi) e))
+
+    | WIneg ws => Papp1 (Oneg Op_int) e
+    end
+  | None => Papp1 o e
+  end.
+
+Definition wi2i_op2_e (o : sop2) (e1 e2 : pexpr) :=
+  let o := wi2i_op2 o in
+  Papp2 o e1 e2.
+
+Section Section.
+
+Context (m: var -> option (signedness * var)).
+Context (FV: Sv.t).
+
+Definition to_etype sg (t:stype) : extended_type positive:=
+  match t with
+  | sbool    => tbool
+  | sint     => tint
+  | sarr l   => tarr l
+  | sword ws => ETword _ sg ws
+  end.
+
+Definition sign_of_var x := Option.map fst (m x).
+
+Definition etype_of_var x : extended_type positive :=
+  to_etype (sign_of_var x) (vtype x).
+
+Definition sign_of_gvar (x : gvar) :=
+  if is_lvar x then sign_of_var (gv x)
+  else None.
+
+Definition etype_of_gvar x := to_etype (sign_of_gvar x) (vtype (gv x)).
+
+Definition sign_of_etype (ty: extended_type positive) : option signedness :=
+  match ty with
+  | ETword (Some s) _ => Some s
+  | _ => None
+  end.
+
+Fixpoint etype_of_expr (e:pexpr) : extended_type positive :=
+  match e with
+  | Pconst _ => tint
+  | Pbool _ => tbool
+  | Parr_init len => tarr len
+  | Pvar x => etype_of_gvar x
+  | Pget al aa ws x e => tword ws
+  | Psub al ws len x e => tarr (Z.to_pos (arr_size ws len))
+  | Pload al ws x e => tword ws
+  | Papp1 o e => (etype_of_op1 o).2
+  | Papp2 o e1 e2 => (etype_of_op2 o).2
+  | PappN o es => to_etype None (type_of_opN o).2
+  | Pif ty e1 e2 e3 => to_etype (sign_of_etype (etype_of_expr e2)) ty
+  end.
+
+Definition sign_of_expr (e:pexpr) : option signedness :=
+  sign_of_etype (etype_of_expr e).
+
+Definition wi2i_var (x:var) :=
+  match m x with
+  | Some (_, xi) => xi
+  | None => x
+  end.
+
+Definition in_FV_var (x:var) :=
+ Sv.mem x FV.
+
+Definition wi2i_vari (x:var_i) :=
+  Let _ := assert (in_FV_var x) (E.ierror_e (Plvar x)) in
+  ok {|v_var := wi2i_var x; v_info := v_info x |}.
+
+Definition wi2i_gvar (x: gvar) :=
+  if is_lvar x then
+    Let xi := wi2i_vari (gv x) in
+    ok (mk_lvar xi)
+  else ok x.
+
+Definition wi2i_type (sg : option signedness) ty :=
+  if sg == None then ty else sint.
+
+Fixpoint wi2i_e (e0:pexpr) : cexec pexpr :=
+  match e0 with
+  | Pconst _ | Pbool _ | Parr_init _ => ok e0
+  | Pvar x =>
+    Let x := wi2i_gvar x in
+    ok (Pvar x)
+  | Pget al aa ws x e =>
+    Let x := wi2i_gvar x in
+    Let e := wi2i_e e in
+    ok (Pget al aa ws x e)
+  | Psub al ws len x e =>
+    Let x := wi2i_gvar x in
+    Let e := wi2i_e e in
+    ok (Psub al ws len x e)
+  | Pload al ws x e =>
+    Let _ := assert [&& m x == None & sign_of_expr e == None]
+                    (E.ierror_e e0) in
+    Let x := wi2i_vari x in
+    Let e := wi2i_e e in
+    ok (Pload al ws x e)
+  | Papp1 o e =>
+    Let _ := assert (esubtype (etype_of_op1 o).1 (etype_of_expr e))
+                    (E.ierror_e e0) in
+    Let e := wi2i_e e in
+    ok (wi2i_op1_e o e)
+  | Papp2 o e1 e2 =>
+    let ty := etype_of_op2 o in
+    Let _ := assert [&& esubtype ty.1.1 (etype_of_expr e1) &
+                        esubtype ty.1.2 (etype_of_expr e2)]
+                    (E.ierror_e e0) in
+    Let e1 := wi2i_e e1 in
+    Let e2 := wi2i_e e2 in
+    ok (wi2i_op2_e o e1 e2)
+
+  | PappN o es =>
+    Let _ := assert (all (fun e => sign_of_expr e == None) es)
+                    (E.ierror_e e0) in
+    Let es := mapM wi2i_e es in
+    ok (PappN o es)
+
+  | Pif ty e1 e2 e3 =>
+    let ety := etype_of_expr e0 in
+    Let _ := assert [&& esubtype ety (etype_of_expr e2) &
+                        esubtype ety (etype_of_expr e3)]
+                    (E.ierror_e e0) in
+    let ty := wi2i_type (sign_of_expr e2) ty in
+    Let e1 := wi2i_e e1 in
+    Let e2 := wi2i_e e2 in
+    Let e3 := wi2i_e e3 in
+    ok (Pif ty e1 e2 e3)
+  end.
+
+Definition wi2i_lvar (ety : extended_type positive) (x : var_i) : cexec var_i :=
+  Let _ := assert (esubtype (etype_of_var x) ety)
+                  (E.ierror_lv (Lvar x)) in
+  wi2i_vari x.
+
+Definition wi2i_lv (ety : extended_type positive) (lv : lval) : cexec lval :=
+  let s := sign_of_etype ety in
+  match lv with
+  | Lnone vi ty =>
+    ok (Lnone vi (wi2i_type s ty))
+
+  | Lvar x =>
+    Let x := wi2i_lvar ety x in
+    ok (Lvar x)
+
+  | Lmem al ws x e =>
+    Let _ := assert [&& in_FV_var x, m x == None, sign_of_expr e == None & s == None]
+                    (E.ierror_lv lv) in
+    Let e := wi2i_e e in
+    ok (Lmem al ws x e)
+
+  | Laset al aa ws x e =>
+    Let _ := assert [&& in_FV_var x, sign_of_expr e == None & s == None]
+                     (E.ierror_lv lv) in
+    Let e := wi2i_e e in
+    ok (Laset al aa ws x e)
+
+  | Lasub aa ws len x e =>
+    Let _ := assert [&& in_FV_var x, sign_of_expr e == None & s == None]
+                     (E.ierror_lv lv) in
+    Let e := wi2i_e e in
+    ok (Lasub aa ws len x e)
+  end.
+
+Context (sigs : funname -> option (list (extended_type positive) * list (extended_type positive))).
+
+Definition get_sig f :=
+  match sigs f with
+  | Some sig => ok sig
+  | None => Error (E.ierror_s "unknown function")
+  end.
+
+Fixpoint wi2i_ir (ir:instr_r) : cexec instr_r :=
+  match ir with
+  | Cassgn x tag ty e =>
+    let ety := etype_of_expr e in
+    let sg  := sign_of_etype ety in
+    let tyr := to_etype sg ty in
+    Let _ := assert (esubtype tyr ety)
+                    (E.ierror_s "invalid type in assigned") in
+    Let x := wi2i_lv tyr x in
+    Let e := wi2i_e e in
+    let ty := wi2i_type sg ty in
+    ok (Cassgn x tag ty e)
+
+  | Copn xs t o es =>
+    Let _ := assert (all (fun e => sign_of_expr e == None) es)
+                    (E.ierror_s "invalid expr in Copn") in
+
+    Let es := mapM wi2i_e es in
+    let xtys := map (to_etype None) (sopn_tout o) in
+    Let xs := mapM2 (E.ierror_s "invalid dest in Copn") wi2i_lv xtys xs in
+    ok (Copn xs t o es)
+
+  | Csyscall xs o es =>
+    Let _ := assert (all (fun e => sign_of_expr e == None) es)
+                    (E.ierror_s "invalid args in Csyscall") in
+    Let es := mapM wi2i_e es in
+    let xtys := map (to_etype None) (syscall_sig_u o).(scs_tout) in
+    Let xs := mapM2 (E.ierror_s "invalid dest in Copn") wi2i_lv xtys xs in
+    ok (Csyscall xs o es)
+
+  | Cif b c1 c2 =>
+    Let b := wi2i_e b in
+    Let c1 := mapM wi2i_i c1 in
+    Let c2 := mapM wi2i_i c2 in
+    ok (Cif b c1 c2)
+
+  | Cfor x (dir, e1, e2) c =>
+    Let _ := assert (in_FV_var x) (E.ierror_s "invalid loop counter") in
+    Let e1 := wi2i_e e1 in
+    Let e2 := wi2i_e e2 in
+    Let c := mapM wi2i_i c in
+    ok (Cfor x (dir, e1, e2) c)
+
+  | Cwhile a c e info c' =>
+    Let e := wi2i_e e in
+    Let c := mapM wi2i_i c in
+    Let c' := mapM wi2i_i c' in
+    ok (Cwhile a c e info c')
+
+  | Ccall xs f es =>
+    Let sig := get_sig f in
+    Let _ := assert (all2 (fun ety e => esubtype ety (etype_of_expr e)) sig.1 es)
+                    (E.ierror_s "invalid args in Ccall") in
+    Let xs := mapM2 (E.ierror_s "bad xs length in Ccall") wi2i_lv sig.2 xs in
+    Let es := mapM wi2i_e es in
+    ok (Ccall xs f es)
+  end
+
+with wi2i_i (i:instr) : cexec instr :=
+  let (ii,ir) := i in
+  Let ir := add_iinfo ii (wi2i_ir ir) in
+  ok (MkI ii ir).
+
+
+Definition wi2i_fun (fn:funname) (f: fundef) :=
+  add_funname fn (
+  Let sig := get_sig fn in
+  let 'MkFun ii si p c so r ev := f in
+  Let p := mapM2 (E.ierror_s "bad params in fun") wi2i_lvar sig.1 p in
+  Let c := mapM wi2i_i c in
+  Let r := mapM2 (E.ierror_s "bad return in fun") (fun ety x =>
+                    Let _ := assert (esubtype ety (etype_of_var x))
+                                    (E.ierror_e (Plvar x)) in
+                    wi2i_vari x) sig.2 r in
+  let mk := map (fun ety => wi2i_type (sign_of_etype ety) (to_stype ety)) in
+  let tin := mk sig.1 in
+  let tout := mk sig.2 in
+  ok (MkFun ii tin p c tout r ev)).
+
+Definition build_sig (fd : funname * fundef) :=
+ let 'MkFun ii si p c so r ev := fd.2 in
+ let mk := map2 (fun (x:var_i) ty => to_etype (sign_of_var x) ty) in
+ (fd.1, (mk p si, mk r so)).
+
+End Section.
+
+Context (info : var -> option (signedness * var)).
+
+Definition build_info (fv : Sv.t) :=
+  Let fvm :=
+    foldM (fun x (fvm: Sv.t * Mvar.t (signedness * var)) =>
+      match info x with
+      | None => ok fvm
+      | Some (s, xi) =>
+        Let w :=
+          match is_word_type (vtype x) with
+          | Some w => ok w
+          | None => Error (E.ierror_s "invalid info")
+          end in
+        Let _ := assert ((vtype xi == sint) && ~~Sv.mem xi fvm.1) (E.ierror_s "invalid info") in
+        ok (Sv.add xi fvm.1, Mvar.set fvm.2 x (s, xi))
+      end)
+      (fv, Mvar.empty _)
+      (Sv.elements fv) in
+   ok (Mvar.get fvm.2).
+
+Definition wi2i_prog (p:_uprog) : cexec _uprog :=
+  let FV := vars_p (p_funcs p) in
+  Let m := build_info FV in
+  let sigs := map (build_sig info) (p_funcs p) in
+  Let funcs := map_cfprog_name (wi2i_fun m FV (get_fundef sigs)) (p_funcs p) in
+  ok {| p_extra := p_extra p; p_globs := p_globs p; p_funcs := funcs |}.
+
+End WITH_PARAMS.

--- a/proofs/compiler/wint_int_proof.v
+++ b/proofs/compiler/wint_int_proof.v
@@ -1,0 +1,1004 @@
+Require Import compiler_util psem psem_facts.
+Require Import wint_int.
+Import Utf8.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssralg.
+
+Section PROOF.
+
+#[local] Existing Instance progUnit.
+
+Context
+  {asm_op syscall_state : Type}
+  {ep : EstateParams syscall_state}
+  {spp : SemPexprParams}
+  {sip : SemInstrParams asm_op syscall_state}.
+
+#[local] Existing Instance sCP_unit.
+#[local] Existing Instance nosubword.
+#[local] Existing Instance indirect_c.
+
+Variable (p:uprog) (ev:extra_val_t).
+
+Notation gd := (p_globs p).
+
+#[local]Open Scope vm_scope.
+
+Section M.
+
+Context (m: var -> option (signedness * var)).
+Context (FV : Sv.t).
+
+Definition wf_m :=
+ forall x,
+    match m x with
+    | None => true
+    | Some (s, xi) =>
+      [/\ is_sword (vtype x), vtype xi = sint &
+          forall y, x <> y -> in_FV_var FV y ->
+             match m y with
+             | None => xi <> y
+             | Some (_, yi) => xi <> yi
+             end]
+    end.
+
+Hypothesis (hwf_m : wf_m).
+
+Definition val_to_int (s:option signedness) v :=
+  match v with
+  | Vword _ w =>
+    match s with
+    | None => v
+    | Some sg => Vint (int_of_word sg w)
+    end
+  | Vundef (sword _) _ =>
+    match s with
+    | None => v
+    | Some sg => undef_i
+    end
+  | _  => v
+  end.
+
+Definition eqvm (vm vmi : Vm.t) :=
+  forall x, in_FV_var FV x -> vmi.[wi2i_var m x] = val_to_int (sign_of_var m x) vm.[x].
+
+Definition eqst (s si : estate) :=
+  [/\ escs s = escs si, emem s = emem si & eqvm (evm s) (evm si)].
+
+Lemma is_defined_val_to_int sg v : is_defined (val_to_int sg v) = is_defined v.
+Proof.
+  case: v => //=.
+  + by case: sg.
+  by move=> [] // >; case: sg.
+Qed.
+
+Lemma val_to_int_None v : val_to_int None v = v.
+Proof. by case: v => //= -[]. Qed.
+
+Lemma is_wi1P o :
+  match is_wi1 o with
+  | Some(s, oi) => o = Owi1 s oi
+  | None =>
+     let t := etype_of_op1 o in
+     sign_of_etype t.1 = None /\ sign_of_etype t.2 = None
+  end.
+Proof. by case: o => // -[]. Qed.
+
+Lemma is_wi2P o :
+  match is_wi2 o with
+  | Some(s, oi) => ∃ sz, o = Owi2 s sz oi
+  | None =>
+     let t := etype_of_op2 o in
+     [/\ sign_of_etype t.1.1 = None
+       , sign_of_etype t.1.2 = None
+       & sign_of_etype t.2 = None]
+  end.
+Proof.
+  case: o => //;
+  match goal with
+  | |- signedness -> _ => move=> ?
+  | |- _ => idtac
+  end; case => //= ?;
+  eexists; reflexivity.
+Qed.
+
+Lemma int_of_word_wrepr sg sz z :
+  in_wint_range sg sz z = ok tt ->
+  int_of_word sg (wrepr sz z) = z.
+Proof.
+  case: sg => /assertP /andP[] /ZleP ? /ZleP; rewrite /wmax_unsigned => ?.
+  + exact: wsigned_repr.
+  apply wunsigned_repr_small; Lia.lia.
+Qed.
+
+Lemma esubtype_sign_of t1 t2 : esubtype t1 t2 -> sign_of_etype t2 = sign_of_etype t1.
+Proof. by case: t1 t2 => [||l1|[[]|] sz1] [||l2|[[]|] sz2]. Qed.
+
+Lemma sign_of_etype_expr e : sign_of_etype (etype_of_expr m e) = sign_of_expr m e.
+Proof. done. Qed.
+
+Lemma sign_of_to_etype_None ty : sign_of_etype (to_etype None ty) = None.
+Proof. by case: ty. Qed.
+
+Lemma sign_of_etype_var x : sign_of_etype (etype_of_var m x) = sign_of_var m x.
+Proof.
+  rewrite /etype_of_var /sign_of_var.
+  have := hwf_m x; case: m => /= [ | _]; last by apply sign_of_to_etype_None.
+  by move=> [sg xi [] + _ _]; case: vtype.
+Qed.
+
+Lemma sign_of_etype_gvar x : sign_of_etype (etype_of_gvar m x) = sign_of_gvar m x.
+Proof.
+  rewrite /etype_of_gvar /sign_of_gvar; case: ifP => _.
+  + by apply sign_of_etype_var.
+  by apply sign_of_to_etype_None.
+Qed.
+
+Lemma to_stypeK sg t : to_stype (to_etype sg t) = t.
+Proof. by case: t. Qed.
+
+Lemma get_var_type_of vm (x : var) (v : value) :
+  get_var true vm x = ok v → type_of_val v = to_stype (etype_of_var m x).
+Proof.
+  rewrite /get_var /etype_of_var; t_xrbindP => /= hdef <-.
+  have := Vm.getP vm x; rewrite /compat_val hdef /= => /eqP ->.
+  by rewrite to_stypeK.
+Qed.
+
+Lemma get_gvar_type_of vm (x : gvar) (v : value) :
+  get_gvar true gd vm x = ok v → type_of_val v = to_stype (etype_of_gvar m x).
+Proof.
+  rewrite /get_gvar /etype_of_gvar /sign_of_gvar; case: ifP => _.
+  + by apply get_var_type_of.
+  by move=> /type_of_get_global <-; rewrite to_stypeK.
+Qed.
+
+Lemma sem_pexpr_type_of s e v :
+  sem_pexpr true gd s e = ok v ->
+  type_of_val v = to_stype (etype_of_expr m e).
+Proof.
+  case: e => //=; t_xrbindP.
+  1-3: by move=> > <-.
+  + by move=> ?; apply get_gvar_type_of.
+  1-2: by move=> >; apply: on_arr_gvarP; t_xrbindP => *; subst.
+  + by move=> *; subst.
+  + move=> o; rewrite /sem_sop1; t_xrbindP => *; subst.
+    by rewrite type_of_to_val; clear; case: o => // [ [] | sg []].
+  + move=> o; rewrite /sem_sop2; t_xrbindP => *; subst.
+    rewrite type_of_to_val; clear.
+    by case: o => //;
+    match goal with
+    | |- signedness -> wsize -> _ => move=> ??
+    | |- signedness -> _ => move=> ?
+    | _ => idtac
+    end; case.
+  + by rewrite /sem_opN; t_xrbindP => *; subst; rewrite to_stypeK type_of_to_val.
+  move=> > _ _ > _ htr1 > _ htr2 <-.
+  rewrite to_stypeK; case: ifP => _; eauto using truncate_val_has_type.
+Qed.
+
+Lemma wrepr_int_of_word sz sg (w:word sz) :
+  wrepr sz (int_of_word sg w) = w.
+Proof. by case: sg => /=; rewrite ?wrepr_signed ? wrepr_unsigned. Qed.
+
+Section E.
+
+Context (s si: estate) (heqs : eqst s si).
+
+Let P e :=
+  forall ei, wi2i_e m FV e = ok ei ->
+  forall v,
+    sem_pexpr true gd s e = ok v ->
+    sem_pexpr true gd si ei = ok (val_to_int (sign_of_expr m e) v).
+
+Let Q es :=
+  forall eis, mapM (wi2i_e m FV) es = ok eis ->
+  forall vs,
+    sem_pexprs true gd s es = ok vs ->
+    sem_pexprs true gd si eis = ok (map2 (fun e v => val_to_int (sign_of_expr m e) v) es vs).
+
+Lemma wi2i_varP (x: var) v :
+   in_FV_var FV x ->
+   get_var true (evm s) x = ok v ->
+   get_var true (evm si) (wi2i_var m x) = ok (val_to_int (sign_of_var m x) v).
+Proof.
+  move=> hin; case heqs => _ _ /(_ x hin); rewrite /wi2i_var /sign_of_var.
+  case hm : m (hwf_m x) => [ [sg xi] | ]; last first.
+  + by rewrite !val_to_int_None /get_var => _ ->.
+  move=> [] hty htyi _ hto.
+  move=> /get_varP [/= -> hdb hcomp]; rewrite /get_var /=.
+  by rewrite hto is_defined_val_to_int hdb.
+Qed.
+
+Lemma wi2i_variP x xi v:
+  wi2i_vari m FV x = ok xi ->
+  get_var true (evm s) x = ok v ->
+  get_var true (evm si) xi = ok (val_to_int (sign_of_var m x) v).
+Proof. rewrite /wi2i_vari; t_xrbindP => + <-; apply wi2i_varP. Qed.
+
+Lemma wi2i_gvarP x xi v :
+  wi2i_gvar m FV x = ok xi ->
+  get_gvar true gd (evm s) x = ok v ->
+  get_gvar true gd (evm si) xi = ok (val_to_int (sign_of_gvar m x) v).
+Proof.
+  rewrite /wi2i_gvar /get_gvar /sign_of_gvar; case: ifP.
+  + by move=> /= _; t_xrbindP => ? + <- /=; apply wi2i_variP.
+  by move=> h [<-]; rewrite h val_to_int_None.
+Qed.
+
+Lemma wi2i_gvar_nw x xi v :
+  ~is_sword (vtype (gv x)) ->
+  wi2i_gvar m FV x = ok xi ->
+  get_gvar true gd (evm s) x = ok v ->
+  get_gvar true gd (evm si) xi = ok v.
+Proof.
+  move=> hty hto hget; have := wi2i_gvarP hto hget.
+  have -> : sign_of_gvar m x = None; last by rewrite val_to_int_None.
+  rewrite /sign_of_gvar  /sign_of_var; case: ifP => _ //.
+  by case: m (hwf_m (gv x)) => // -[sg ?] []?; elim hty.
+Qed.
+
+Lemma esubtype_to_word sg sz ty v w :
+  esubtype (twint sg sz) ty ->
+  type_of_val v = to_stype ty->
+  to_word sz v = ok w ->
+  v = Vword w.
+Proof.
+  rewrite /=; case: ty => // -[] // _ _ /andP [/eqP <- /eqP <-] /=.
+  move=> /type_of_valI [-> | [w' ->]] //=.
+  by rewrite truncate_word_u => -[->].
+Qed.
+
+Lemma wi2i_eP_ : (forall e, P e) /\ (forall es, Q es).
+Proof.
+  apply: pexprs_ind_pair; subst P Q; split => //=; t_xrbindP.
+  + by move=> _ <- _ _ /=.
+  + move=> e he es hes ?? /he{}he ? /hes{}hes <- ?? /he{}he ? /hes{}hes <- /=.
+    by rewrite he /= hes.
+  1-3: by move=> ?? <- ? <-.
+  + move=> x ei xi + <- v /=.
+    have -> : sign_of_expr m x = sign_of_gvar m x; last by apply wi2i_gvarP.
+    by rewrite /sign_of_expr /= sign_of_etype_gvar.
+  + move=> al aa sz x e he _ xi hxi ei /he{}he <- v.
+    apply: on_arr_gvarP => len t htyx hx.
+    t_xrbindP => i ve /he {}he /to_intI ? w hget ?; subst ve v.
+    by rewrite /= /on_arr_var (wi2i_gvar_nw _ hxi hx) ?htyx //= he //= hget.
+  + move=> aa sz len x e he _ xi hxi ei /he{}he <- v.
+    apply: on_arr_gvarP => len' t htyx hx.
+    t_xrbindP => i ve /he {}he /to_intI ? w hget ?; subst ve v.
+    by rewrite /= /on_arr_var (wi2i_gvar_nw _ hxi hx) ?htyx //= he //= hget.
+  + move=> al sz x e he ? /andP [/eqP hmx /eqP hte] xi hxi ei /he{}he <- v.
+    move=> wx vx gx hptrx we ve /he{}he hptre w hr <- /=.
+    rewrite /= (wi2i_variP hxi gx) /sign_of_var hmx /= val_to_int_None.
+    rewrite hptrx /= he hte val_to_int_None /= hptre /=.
+    by case: heqs => _ <- _; rewrite hr.
+  + move=> o e hrec _ hte ei /hrec{}hrec <- v ve he.
+    rewrite /wi2i_op1_e; have hse := esubtype_sign_of hte.
+    have htve := sem_pexpr_type_of he; apply hrec in he => {hrec}.
+    case: is_wi1 (is_wi1P o).
+    + move=> [sg [sz|sz|sz|sz|szo szi|sz]] ?; subst o => /=; rewrite /= in hse, hte.
+      + rewrite he /sign_of_expr /= hse /sem_sop1 /=; t_xrbindP.
+        move=> ? /to_intI -> ?.
+        rewrite /wint_of_int; t_xrbindP => hrange <- <- /=.
+        by rewrite int_of_word_wrepr.
+      + rewrite he /sign_of_expr /= hse /sem_sop1 /=; t_xrbindP.
+        move => w /to_wordI [?[?] [? htr ?]]; subst.
+        move: htve; rewrite /sign_of_expr => /=.
+        case: (sg) hte hse;
+          case: etype_of_expr => // -[[] | ] //= ? /eqP ? _ [?]; subst;
+          by move: htr; rewrite truncate_word_u => -[->].
+      + move: he; rewrite /sign_of_expr hse.
+        case: etype_of_expr hte htve hse => //= -[_ | ] // _ /andP[/eqP <- /eqP <-].
+        move=> hty _ -> /=.
+        rewrite /sem_sop1 /=; t_xrbindP.
+        move=> w hw <-.
+        have [ ? | [w' ?]] := type_of_valI hty; subst ve => //=.
+        move: hw => /=; rewrite truncate_word_u => -[->].
+        by rewrite wrepr_int_of_word.
+      + rewrite he /sign_of_expr hse /=.
+        rewrite val_to_int_None /sem_sop1 /=; t_xrbindP.
+        by move=> w hw <-; rewrite hw /=.
+      + case:ifP => hsz;
+          rewrite /= he /sign_of_expr hse /sem_sop1 /=; t_xrbindP;
+          case: (etype_of_expr m e) hte hse htve => //=;
+          move=> [sg' | ] // sz' /andP[] /eqP ? /eqP ? _; subst sg' sz';
+          move=> /type_of_valI [-> // | [w ->]] /= w';
+          rewrite truncate_word_u => -[?] ?; subst w' v => /=.
+        + rewrite /sem_word_extend; case: sg => /=.
+          + rewrite /sign_extend wsigned_repr //.
+            by move: (wsigned_range_m hsz) (wsigned_range w); Lia.lia.
+          rewrite /zero_extend wunsigned_repr_small //.
+          by move: (wbase_m hsz) (wunsigned_range w); Lia.lia.
+        by case: sg => /=; rewrite truncate_word_u /= truncate_word_u /=
+           ?wrepr_signed ?wrepr_unsigned.
+      rewrite he /sign_of_expr hse /=.
+      rewrite /sem_sop1 /=; t_xrbindP.
+      case: (etype_of_expr m e) hte hse htve => //=.
+      move=> [sg' | ] // sz' /andP[] /eqP ? /eqP ? _; subst sg' sz'.
+      move=> /type_of_valI [-> // | [w ->]] /= w'.
+      rewrite truncate_word_u => -[<-] w1.
+      rewrite /wint_of_int; t_xrbindP => + <- <- /=.
+      by move=> h; rewrite int_of_word_wrepr.
+    rewrite /= he /sign_of_expr hse => -[-> ->].
+    by rewrite !val_to_int_None.
+  + move=> o e1 hrec1 e2 hrec2 ei /andP [hte1 hte2].
+    move=> ei1 /hrec1{}hrec1 ei2 /hrec2{}hrec2 <- v v1 he1 v2 he2.
+    have htve1 := sem_pexpr_type_of he1.
+    have htve2 := sem_pexpr_type_of he2.
+    have hse1 := esubtype_sign_of hte1.
+    have hse2 := esubtype_sign_of hte2.
+    have hei1 := hrec1 _ he1; have hei2 := hrec2 _ he2 => {hrec1 hrec2}.
+    rewrite /wi2i_op2_e /wi2i_op2.
+    case: is_wi2 (is_wi2P o).
+    + case => sg [] [] sz ?; subst o;
+      rewrite /= hei1 hei2 /= /sem_sop2 /= /mk_sem_wiop2 /wint_of_int; t_xrbindP.
+      1-3: by move=> w1 hw1 w2 hw2 w hinr <- <-;
+        have ? := esubtype_to_word hte1 htve1 hw1;
+        have ? := esubtype_to_word hte2 htve2 hw2; subst v1 v2 => /=;
+        rewrite /sign_of_expr hse1 hse2 /= int_of_word_wrepr.
+      + move=> w1 hw1 w2 hw2 w; rewrite /mk_sem_divmod.
+        case: eqP => //= hw2_0; case: ifPn => // /and3P.
+        move=> h [?] ?; subst w v.
+        have ? := esubtype_to_word hte1 htve1 hw1.
+        have ? := esubtype_to_word hte2 htve2 hw2; subst v1 v2 => /=;
+        rewrite /sign_of_expr hse1 hse2 /=.
+        move=> {hte2 hte1 hse1 hse2 hei1 hei2 htve1 htve2 he1 he2 hw1 hw2}.
+        case: sg h => /=; rewrite /wdiv /wdivi => h.
+        + rewrite wsigned_repr //.
+          have ? : wsigned w2 <> 0%Z.
+          + by move=> heq; apply hw2_0; rewrite -(wrepr_signed w2) heq wrepr0.
+          apply: (Z_quot_bound (half_modulues_pos sz) (wsigned_range w1) (wsigned_range w2)) => //.
+          move=> [h1 h2]; apply h; split; apply/eqP => //.
+          by rewrite -(wrepr_signed w2) h2.
+        rewrite wunsigned_repr_small //.
+        have ? := wunsigned_range w1; have ? := wunsigned_range w2.
+        have ? : wunsigned w2 <> 0%Z.
+        + by move=> heq; apply hw2_0; rewrite -(wrepr_unsigned w2) heq wrepr0.
+        split; first by apply Z.div_pos; Lia.lia.
+        apply Z.div_lt_upper_bound; Lia.nia.
+      + move=> w1 hw1 w2 hw2 w; rewrite /mk_sem_divmod.
+        case: eqP => //= hw2_0; case: ifPn => // /and3P.
+        move=> h [?] ?; subst w v.
+        have ? := esubtype_to_word hte1 htve1 hw1.
+        have ? := esubtype_to_word hte2 htve2 hw2; subst v1 v2 => /=;
+        rewrite /sign_of_expr hse1 hse2 /=.
+        move=> {hte2 hte1 hse1 hse2 hei1 hei2 htve1 htve2 he1 he2 hw1 hw2}.
+        case: sg h => /=; rewrite /wmod /wmodi => h.
+        + rewrite wsigned_repr //.
+          have /(Z_rem_bound (wsigned w1)) : (wsigned w2 <> 0)%Z.
+          + by move=> heq; apply hw2_0; rewrite -(wrepr_signed w2) heq wrepr0.
+          move: (wsigned_range w1) (wsigned_range w2).
+          rewrite /wmin_signed /wmax_signed; Lia.lia.
+        rewrite wunsigned_repr_small //.
+        have ? : wunsigned w2 <> 0%Z.
+        + by move=> heq; apply hw2_0; rewrite -(wrepr_unsigned w2) heq wrepr0.
+        move: (wunsigned_range w1) (wunsigned_range w2) (Z.mod_pos_bound (wunsigned w1) (wunsigned w2)).
+        Lia.lia.
+      1-2:
+        by move=> w1 hw1 w2 hw2 w; rewrite /mk_sem_wishift /wint_of_int; t_xrbindP;
+         move=> hinr <- <-;
+         have ? := esubtype_to_word hte1 htve1 hw1;
+         have ? := esubtype_to_word hte2 htve2 hw2; subst v1 v2 => /=;
+         rewrite /sign_of_expr hse1 hse2 /= int_of_word_wrepr.
+      1-6:
+        by move=> w1 hw1 w2 hw2 <-;
+         have ? := esubtype_to_word hte1 htve1 hw1;
+         have ? := esubtype_to_word hte2 htve2 hw2; subst v1 v2 => /=;
+         rewrite /sign_of_expr hse1 hse2 /=.
+    rewrite /= hei1 hei2 /= /sign_of_expr /= hse1 hse2 => -[-> -> ->].
+    by rewrite !val_to_int_None.
+  + move=> o es hes ei hall esi /hes{}hes <- /= v vs hsem hvs.
+    have hsz := size_mapM hsem.
+    have {hes hsem} := hes _ hsem; rewrite /sem_pexprs => -> /=.
+    have -> : map2 (λ (e : pexpr) (v0 : value), val_to_int (sign_of_expr m e) v0) es vs = vs.
+    + move=> {hvs}; elim: es vs hall hsz => [ | e es hrec] [ | v' vs] //=.
+      by move=> /andP[]/eqP -> /hrec h [] /h ->; rewrite val_to_int_None.
+    by rewrite hvs /sign_of_expr /= sign_of_to_etype_None val_to_int_None.
+  move=> t e he e1 he1 e2 he2 ei_ /andP[] hs1 hs2.
+  move=> ei /he{}he ei1 /he1{}he1 ei2 /he2{}he2 <-.
+  move=> vr b v hv hb v1' v1 hv1 htr1 v2' v2 hv2 htr2 <-.
+  have htve := sem_pexpr_type_of hv.
+  have htve1 := sem_pexpr_type_of hv1.
+  have htve2 := sem_pexpr_type_of hv2.
+  have hse1 := esubtype_sign_of hs1.
+  have hse2 := esubtype_sign_of hs2.
+  have hei := he _ hv; have hei1 := he1 _ hv1; have hei2 := he2 _ hv2.
+  move=> {he he1 he2} /=.
+  rewrite hei hei1 hei2 (to_boolI hb) /=.
+  rewrite /sign_of_expr hse1 hse2 /wi2i_type.
+  case: eqP => hsig.
+  + by rewrite hsig !val_to_int_None htr1 htr2.
+  have : exists ws sg, [/\ t = sword ws , etype_of_expr m e1 = ETword _ (Some sg) ws &
+                                          etype_of_expr m e2 = ETword _ (Some sg) ws ].
+  + case: (etype_of_expr m e1) hsig hs1 hs2 => //=;
+      try by rewrite sign_of_to_etype_None.
+    move=> [sg |] ws; last by rewrite sign_of_to_etype_None.
+    case: (t) => //= _ _ /andP [_ /eqP ->].
+    case: (etype_of_expr m e2) => // -[] // _ _ /andP[] /eqP <- /eqP <-.
+    by exists ws, sg.
+  move=> [ws [sg [? heq1 heq2]]]; subst t; rewrite heq1 /=.
+  move: htve1 htve2; rewrite heq1 heq2 /=.
+  move=> /type_of_valI [? | [w1 ?]]; subst v1 => //.
+  move=> /type_of_valI [? | [w2 ?]]; subst v2 => //.
+  move: htr1 htr2; rewrite /truncate_val /= !truncate_word_u /=.
+  by move=> [] ? [] ?; subst v1' v2'; case: (b).
+Qed.
+
+Lemma wi2i_eP e : P e.
+Proof. by case wi2i_eP_. Qed.
+
+Lemma wi2i_esP es : Q es.
+Proof. by case wi2i_eP_. Qed.
+
+End E.
+
+Lemma sign_to_etype_type_of sg sg' v :
+  sign_of_etype (to_etype sg (type_of_val v)) = Some sg' ->
+  sg = Some sg' /\
+  exists ws, v = undef_w \/ exists (w:word ws), v = Vword w.
+Proof.
+  have := (@type_of_valI v _ erefl); case: type_of_val => //=.
+  move=> ws h; case: sg => // ? [->]; eauto.
+Qed.
+
+
+Lemma is_swordP ty : is_sword ty -> exists ws, ty = sword ws.
+Proof. case: ty => //; eauto. Qed.
+
+Lemma wi2i_lvarP_None (x : var_i) s s' si v :
+  eqst s si ->
+  in_FV_var FV x -> m x = None ->
+  write_var true x v s = ok s' ->
+  exists2 si', write_var true x v si = ok si' & eqst s' si'.
+Proof.
+  move=> [?? hvm] hin hmx /write_varP [-> hdb htr].
+  exists (with_vm si (evm si).[x <- v]); first by apply/write_varP.
+  split => // z hinz.
+  case: (v_var x =P z) => [ ? | /eqP hne].
+  + by subst z; rewrite /wi2i_var /sign_of_var hmx val_to_int_None !Vm.setP_eq.
+  rewrite !Vm.setP_neq //; first by apply hvm.
+  rewrite /wi2i_var; case : (m z) (hwf_m z) => [[sg zi] | ] // [_ _ h].
+  apply /eqP => ?;  subst zi.
+  have:= h x _ hin; rewrite hmx; apply => //.
+  by apply/eqP; rewrite eq_sym.
+Qed.
+
+Lemma wi2i_lvarP x xi ety s s' si v :
+  eqst s si ->
+  wi2i_lvar m FV (to_etype (sign_of_etype ety) (type_of_val v)) x = ok xi ->
+  write_var true x v s = ok s' ->
+  exists2 si' : estate,
+      write_var true xi (val_to_int (sign_of_etype (to_etype (sign_of_etype ety) (type_of_val v))) v) si = ok si' &
+      eqst s' si'.
+Proof.
+  rewrite /wi2i_lvar /wi2i_vari; t_xrbindP => heqs hsub hin ? hw; subst xi.
+  move: hsub; rewrite /wi2i_vari /wi2i_var /etype_of_var /sign_of_var.
+  case heqm: m (hwf_m x) => [[sg xi]| ] /=.
+  + move=> [/is_swordP [sw hxty] htxi hdiff] hsub.
+    have := (esubtype_sign_of hsub); rewrite hxty /=.
+    move/write_varP: hw => [-> hdb htr].
+    move=> /(sign_to_etype_type_of) [heq [ws [? | [w ?]]]]; subst.
+    + by move: hdb; rewrite /DB.
+    move: hsub; rewrite /esubtype hxty heq => /andP[_ /eqP?]; subst sw.
+    rewrite /val_to_int /=.
+    exists (with_vm si (evm si).[xi <- int_of_word sg w]).
+    + by apply/write_varP; split => //=; rewrite htxi.
+    case: heqs => ?? hvm.
+    split => //= z hz.
+    rewrite (Vm.setP _ x); case: eqP => heqx.
+    + subst z; rewrite /wi2i_var heqm Vm.setP_eq.
+      by rewrite hxty /= cmp_le_refl htxi /sign_of_var heqm.
+    rewrite Vm.setP_neq; first by apply hvm.
+    by apply/eqP; have := hdiff _ heqx hz; rewrite /wi2i_var; case: m => [[]|].
+  move=> _ hsub.
+  have := (esubtype_sign_of hsub); rewrite sign_of_to_etype_None => ->.
+  by rewrite val_to_int_None; apply: wi2i_lvarP_None hw.
+Qed.
+
+Lemma wi2i_lvP ety lv lvi s si s' v:
+  eqst s si ->
+  let ety := to_etype (sign_of_etype ety) (type_of_val v) in
+  wi2i_lv m FV ety lv = ok lvi ->
+  write_lval true gd lv v s = ok s' ->
+  exists2 si',  write_lval true gd lvi (val_to_int (sign_of_etype ety) v) si = ok si' & eqst s' si'.
+Proof.
+  move=> heqs; case: lv => /=.
+  + move=> i ty [<-] /write_noneP [-> htr hdb]; exists si => //=.
+    rewrite /write_none.
+    case heq: sign_of_etype => [sg | ] /=.
+    + have [_ [ws [ ? | [w ?]]]] := sign_to_etype_type_of heq; subst v.
+      + by move: hdb; rewrite /DB.
+      by rewrite /val_to_int.
+    by rewrite val_to_int_None htr hdb.
+  + by move=> x; t_xrbindP => xi /= + <-; apply: wi2i_lvarP.
+  + t_xrbindP => a ws x e /and4P [hinx /eqP hmx /eqP hse /eqP hsty].
+    move=> ei /(wi2i_eP heqs) he <- wx vx /(wi2i_varP heqs hinx).
+    rewrite /sign_of_var /wi2i_var hmx val_to_int_None=> hx htox we ve /he{}he htoe ? htov m' hw <-.
+    case heqs => ? hmem ?.
+    exists (with_mem si m') => //.
+    by rewrite /write_lval hx he /= htox /= hsty hse !val_to_int_None htoe /= htov /= -hmem hw.
+  + t_xrbindP => a aa ws x e /and3P[hinx /eqP hse /eqP hsety].
+    move=> ei /(wi2i_eP heqs) he <-; apply: on_arr_varP.
+    move=> len t htx /(wi2i_varP heqs hinx).
+    have hmx : m x = None.
+    + by have := hwf_m x; case: m => // -[sg ?] []; rewrite htx.
+    rewrite /sign_of_var /wi2i_var hmx val_to_int_None=> hx.
+    t_xrbindP => we ve /he{}he htoe ? htov m' hset.
+    move=> /(wi2i_lvarP_None heqs hinx hmx) [si' hw heqs']; exists si' => //.
+    rewrite /write_lval hx /= he hse hsety !val_to_int_None /=.
+    by rewrite htoe /= htov /= hset /= hw.
+  t_xrbindP => a aa ws x e /and3P[hinx /eqP hse /eqP hsty].
+  move=> ei /(wi2i_eP heqs) he <-; apply: on_arr_varP.
+  move=> len t htx /(wi2i_varP heqs hinx).
+  have hmx : m x = None.
+  + by have := hwf_m x; case: m => // -[sg ?] []; rewrite htx.
+  rewrite /sign_of_var /wi2i_var hmx val_to_int_None=> hx.
+  t_xrbindP => we ve /he{}he htoe ? htov m' hset.
+  move=> /(wi2i_lvarP_None heqs hinx hmx) [si' hw heqs']; exists si' => //.
+  by rewrite /write_lval hx /= he hse hsty !val_to_int_None /= htoe htov /= hset /= hw.
+Qed.
+
+Lemma wi2i_lvsP E ety lvs lvis s si s' vs:
+  eqst s si ->
+  mapM2 E (wi2i_lv m FV) ety lvs = ok lvis ->
+  write_lvals true gd s lvs vs = ok s' ->
+  all2 (fun ety v => ety == (to_etype (sign_of_etype ety) (type_of_val v))) ety vs ->
+  exists2 si',
+    write_lvals true gd si lvis (map2 (fun ety v => val_to_int (sign_of_etype ety) v) ety vs) = ok si' &
+    eqst s' si'.
+Proof.
+  elim: ety lvs vs lvis s si => [|ety etys hrec] [|lv lvs] //= [|v vs] // ? s si heqs; t_xrbindP.
+  + by move=> <- <- _; exists si.
+  move=> lvi hlvi lvis hlvis <- s1 hw hws /andP[ /eqP heq hall] /=.
+  rewrite heq in hlvi.
+  have := wi2i_lvP heqs hlvi hw.
+  rewrite -heq => -[si1 -> heqs1 /=].
+  have [si' -> heqs2 /=] := hrec _ _ _ _ _ heqs1 hlvis hws hall; eauto.
+Qed.
+
+Context (p_funcsi : ufun_decls)
+        (sigs : funname → option (seq (extended_type positive) * seq (extended_type positive)))
+        (hsig : forall fn fd, get_fundef (p_funcs p) fn = Some fd ->
+                  sigs fn = Some
+                    (map2 (fun (x:var_i) ty => to_etype (sign_of_var m x) ty) fd.(f_params) fd.(f_tyin),
+                     map2 (fun (x:var_i) ty => to_etype (sign_of_var m x) ty) fd.(f_res) fd.(f_tyout)))
+        (hp' : forall fn fd, get_fundef (p_funcs p) fn = Some fd ->
+               exists2 fdi, wi2i_fun m FV sigs fn fd = ok fdi & get_fundef p_funcsi fn = Some fdi).
+
+Let pi : uprog := {| p_funcs := p_funcsi; p_globs := gd; p_extra := p_extra p |}.
+
+Let Pi_r s (i:instr_r) s' :=
+  forall ii, wi2i_ir m FV sigs i = ok ii ->
+  forall si, eqst s si ->
+  exists2 si', sem_i pi ev si ii si' & eqst s' si'.
+
+Let Pi s (i:instr) s' :=
+  forall ii, wi2i_i m FV sigs i = ok ii ->
+  forall si, eqst s si ->
+  exists2 si', sem_I pi ev si ii si' & eqst s' si'.
+
+Let Pc s (c:cmd) s' :=
+  forall ci, mapM (wi2i_i m FV sigs) c = ok ci ->
+  forall si, eqst s si ->
+  exists2 si', sem pi ev si ci si' & eqst s' si'.
+
+Let Pfor (i:var_i) vs s c s' :=
+  in_FV_var FV i ->
+  forall ci, mapM (wi2i_i m FV sigs) c = ok ci ->
+  forall si, eqst s si ->
+  exists2 si', sem_for pi ev i vs si ci si' & eqst s' si'.
+
+Let Pfun scs1 m1 fn vargs scs2 m2 vres :=
+  forall fsig, sigs fn = Some fsig ->
+  all2 (fun ety v => esubtype ety (to_etype (sign_of_etype ety) (type_of_val v))) fsig.1 vargs ->
+  let vargsi := map2 (fun ety v => val_to_int (sign_of_etype ety) v) fsig.1 vargs  in
+  let vresi  := map2 (fun ety v => val_to_int (sign_of_etype ety) v) fsig.2 vres in
+  sem_call pi ev scs1 m1 fn vargsi scs2 m2 vresi /\
+  all2 (fun ety v => ety == (to_etype (sign_of_etype ety) (type_of_val v))) fsig.2 vres.
+
+Local Lemma Hskip : sem_Ind_nil Pc.
+Proof. by move=> s ? [<-] si; exists si => //; constructor. Qed.
+
+Local Lemma Hcons : sem_Ind_cons p ev Pc Pi.
+Proof.
+  move=> s1 s2 s3 i c _ hi _ hc ? /=; t_xrbindP.
+  move=> ii /hi{}hi ci /hc{}hc <- si1 /hi [si2 h1] /hc [si3 h2 heqs2].
+  exists si3 => //; apply: Eseq h1 h2.
+Qed.
+
+Local Lemma HmkI : sem_Ind_mkI p ev Pi_r Pi.
+Proof.
+  move=> i_i i s1 s2 _ hi ? /=; t_xrbindP => ii /add_iinfoP /hi{}hi <- si /hi [si' ??].
+  exists si' => //; constructor.
+Qed.
+
+Lemma esubtype_truncate v v' ty ety :
+  let sg := sign_of_etype ety in
+  type_of_val v = to_stype ety ->
+  esubtype (to_etype sg ty) ety ->
+  truncate_val ty v = ok v' ->
+  truncate_val (wi2i_type sg ty) (val_to_int sg v) = ok (val_to_int (sign_of_etype (to_etype sg ty)) v').
+Proof.
+  move=> /= hty.
+  case heq: sign_of_etype => [sg | ]; last by rewrite /wi2i_type eqxx sign_of_to_etype_None !val_to_int_None.
+  case: ety {hty} heq (type_of_valI hty) => // -[_|] //= ws [->] h.
+  case: ty => //= _ /andP[_ /eqP->] /=.
+  case: h => [-> | [w ->]] //.
+  by rewrite /truncate_val /= truncate_word_u /= => -[<-].
+Qed.
+
+Local Lemma Hassgn : sem_Ind_assgn p Pi_r.
+Proof.
+  move=> s1 s2 x t ty e v v' he htr hw ii /=.
+  t_xrbindP => hsub xi hxi ei hei <- si heqs.
+  have hsem := wi2i_eP heqs hei he.
+  have hty := sem_pexpr_type_of he.
+  have ? := truncate_val_has_type htr. subst ty.
+  have [si' hw' ?] := wi2i_lvP heqs hxi hw.
+  exists si' => //; econstructor; eauto; apply: esubtype_truncate hty hsub htr.
+Qed.
+
+Lemma all_None_val_to_int s1 es ve :
+  sem_pexprs true gd s1 es = ok ve ->
+  all (λ e : pexpr, sign_of_expr m e == None) es ->
+  (map2 (λ (e : pexpr) (v : value), val_to_int (sign_of_expr m e) v) es ve) = ve.
+Proof.
+  move=> /size_mapM.
+  elim: es ve => [| e es hes] [| ve ves] //= [] hsz /andP [/eqP -> /(hes _ hsz)] ->.
+  by rewrite val_to_int_None.
+Qed.
+
+Lemma all2_esubtype_None vs :
+  all2
+    (λ ety v, ety == to_etype (sign_of_etype ety) (type_of_val v))
+      [seq to_etype None ty | ty <- (List.map type_of_val vs)]
+      vs.
+Proof. by elim: vs => //= v vs ->; rewrite sign_of_to_etype_None eqxx. Qed.
+
+Lemma map2_None_val_to_int vs:
+  map2 (λ (ety : extended_type positive) (v : value), val_to_int (sign_of_etype ety) v)
+       [seq to_etype None i | i <- List.map type_of_val vs] vs = vs.
+Proof. by elim: vs => //= v vs ->; rewrite sign_of_to_etype_None val_to_int_None. Qed.
+
+Local Lemma Hopn : sem_Ind_opn p Pi_r.
+Proof.
+  move => s1 s2 t o xs es; rewrite /sem_sopn; t_xrbindP => vr ve hes hex hws ii /=.
+  t_xrbindP => hall eis heis xis hxis <- si heqs.
+  have := wi2i_esP heqs heis hes.
+  have -> := all_None_val_to_int hes hall.
+  move=> hsem.
+  have := wi2i_lvsP heqs hxis hws.
+  rewrite -(sopn_toutP hex).
+  move=> /(_ (all2_esubtype_None _)); rewrite map2_None_val_to_int => -[si' hws' ?].
+  exists si' => //.
+  econstructor; eauto.
+  by rewrite /sem_sopn hsem /= hex /= hws'.
+Qed.
+
+Lemma exec_syscall_toutP scs1 scs2 m1 m2 o vs vs' :
+  exec_syscall scs1 m1 o vs = ok (scs2, m2, vs') →
+  List.map type_of_val vs' =  scs_tout (syscall_sig_u o).
+Proof.
+  case: o => len /=.
+  rewrite /exec_getrandom_u; case: vs => // v [] //; t_xrbindP.
+  by move=> ?? _ ? _ <- /= _ _ <-.
+Qed.
+
+Local Lemma Hsyscall : sem_Ind_syscall p Pi_r.
+Proof.
+  move=> s1 scs m1 s2 o xs es ves vs hes hex hws ii /=.
+  t_xrbindP => hall eis heis xis hxis <- si heqs.
+  have := wi2i_esP heqs heis hes.
+  have -> := all_None_val_to_int hes hall.
+  move=> hsem.
+  pose s1' := with_scs (with_mem s1 m1) scs.
+  pose si1' := with_scs (with_mem si m1) scs.
+  have heqs1 : eqst s1' si1' by case: heqs.
+  have := wi2i_lvsP heqs1 hxis hws.
+  rewrite -(exec_syscall_toutP hex).
+  move=> /(_ (all2_esubtype_None _)); rewrite map2_None_val_to_int => -[si' hws' ?].
+  exists si' => //.
+  econstructor; eauto.
+  by case: heqs => <- <-.
+Qed.
+
+Local Lemma Hif_true : sem_Ind_if_true p ev Pc Pi_r.
+Proof.
+  move=> s1 s2 e c1 c2 he _ hc ii /=; t_xrbindP.
+  move=> ei hei ci1 hci1 ci2 hci2 <- si heqs.
+  have /= {}hei := wi2i_eP heqs hei he.
+  have [si' h ?] := hc _ hci1 _ heqs.
+  by exists si' => //; apply: Eif_true h.
+Qed.
+
+Local Lemma Hif_false : sem_Ind_if_false p ev Pc Pi_r.
+Proof.
+  move=> s1 s2 e c1 c2 he _ hc ii /=; t_xrbindP.
+  move=> ei hei ci1 hci1 ci2 hci2 <- si heqs.
+  have /= {}hei := wi2i_eP heqs hei he.
+  have [si' h ?] := hc _ hci2 _ heqs.
+  by exists si' => //; apply: Eif_false h.
+Qed.
+
+Local Lemma Hwhile_true : sem_Ind_while_true p ev Pc Pi_r.
+Proof.
+  move=> s1 s2 s3 s4 a c e i_i c' _ hc he _ hc' _ hwh ii hwhi.
+  move: (hwhi) => /=; t_xrbindP.
+  move=> ei hei ci hci ci' hci' ? si heqs; subst ii.
+  have [si2 hc1 heqs2]:= hc _ hci _ heqs.
+  have /= {}hei := wi2i_eP heqs2 hei he.
+  have [si3 hc2 heqs3] := hc' _ hci' _ heqs2.
+  have [si4 hwh' ?] := hwh _ hwhi _ heqs3.
+  by exists si4 => //; apply: Ewhile_true hc2 hwh'.
+Qed.
+
+Local Lemma Hwhile_false : sem_Ind_while_false p ev Pc Pi_r.
+Proof.
+  move=> s1 s2 a c e i_i c' _ hc he ii hwhi si heqs.
+  move: (hwhi) => /=; t_xrbindP.
+  move=> ei hei ci hci ci' hci' ?; subst ii.
+  have [si2 hc1 heqs2]:= hc _ hci _ heqs.
+  have /= {}hei := wi2i_eP heqs2 hei he.
+  by exists si2 => //; apply: Ewhile_false.
+Qed.
+
+Local Lemma Hfor : sem_Ind_for p ev Pi_r Pfor.
+Proof.
+  move=> s1 s2 i d lo hi c vlo vhi hlo hhi _ hfor ii /=; t_xrbindP.
+  move=> hin loi hloi hii hhii ci hci <- si heqs.
+  have /= {}hlo:= wi2i_eP heqs hloi hlo.
+  have /= {}hhi:= wi2i_eP heqs hhii hhi.
+  have [si' h ?] := hfor hin _ hci _ heqs.
+  exists si' => //; econstructor; eauto.
+Qed.
+
+Local Lemma Hfor_nil : sem_Ind_for_nil Pfor.
+Proof. move=> s i c _ ci _ si heqs; exists si => //; apply EForDone. Qed.
+
+Local Lemma Hfor_cons : sem_Ind_for_cons p ev Pc Pfor.
+Proof.
+  move=> s1 s1' s2 s3 i w ws c hw _ hc _ hfor hin ci hci si heqs.
+  have hmi : m i = None.
+  + case: m (hwf_m i) => // -[sg ii].
+    move/write_varP: hw => [] _ _ /vm_truncate_valE [->] _ [] //.
+  have [si1 {}hw {}heqs]:= wi2i_lvarP_None heqs hin hmi hw.
+  have [si2 {}hc {}heqs]:= hc _ hci _ heqs.
+  have [si3 ??]:= hfor hin _ hci _ heqs.
+  exists si3 => //; econstructor; eauto.
+Qed.
+
+Lemma esubtype_to_etype_eq ety ety' :
+  esubtype ety ety' ->
+  ety' = to_etype (sign_of_etype ety) (to_stype ety').
+Proof.
+  by case: ety ety' => [||len|[sg|] ws] [||len'|[sg'|] ws'] //= /andP[/eqP <- /eqP <-].
+Qed.
+
+Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
+Proof.
+  move=> s1 scs2 m2 s2 xs fn args vargs vs hes _ hf hws ii /=; rewrite /get_sig; t_xrbindP.
+  move=> fsig; case hgetsig : sigs => [fsig'| ] // [?]; subst fsig'.
+  move=> hsub xis hxis eis heis <- si heqs.
+  have hes' := wi2i_esP heqs heis hes.
+  have /= := hf _ hgetsig.
+  have -> : map2 (λ ety v, val_to_int (sign_of_etype ety) v) fsig.1 vargs  =
+            map2 (λ e v, val_to_int (sign_of_expr m e) v) args vargs.
+  + move=> {hf hes' heis hws hxis}.
+    elim: fsig.1 args vargs hsub hes=> [|ety tin hrec] [|e es] //=.
+    move=> vargs' /andP[] hsub hall; t_xrbindP => va hva vargs hvargs ?; subst vargs' => /=.
+    by rewrite (hrec _ _ hall hvargs) -(esubtype_sign_of hsub).
+  move=> [|hsem hsubr].
+  + move=> {hf hes' heis hws hxis}.
+    elim: fsig.1 args vargs hsub hes => [|ety tin hrec] [|e es] //=.
+    + by move=> _ _ [<-].
+    move=> vargs' /andP[] hsub hall; t_xrbindP => va hva vargs hvargs ?; subst vargs' => /=.
+    by rewrite (sem_pexpr_type_of hva) (hrec _ _ hall hvargs) -(esubtype_to_etype_eq hsub) hsub.
+  have heqs2 : eqst (with_scs (with_mem s1 m2) scs2) (with_scs (with_mem si m2) scs2) by case heqs.
+  have [si' {}hws ?]:= wi2i_lvsP heqs2 hxis hws hsubr.
+  exists si' => //; econstructor; eauto.
+  by case: heqs => <- <-.
+Qed.
+
+Local Lemma Hproc : sem_Ind_proc p ev Pc Pfun.
+Proof.
+  move=> scs1 m1 scs2 m2 fn [fi ftin fparams fbody ftout fres fextra].
+  move=> vargs vargs' s0 s1 s2 vres vres' hfun htra [hi] hw _ hc hres hfull hscs hfi.
+  rewrite /= in htra hi hw hc hres hfull hfi; subst s0 m2.
+  move=> fsig; have [fdi + hfuni] := hp' hfun.
+  rewrite /wi2i_fun => /add_funnameP; t_xrbindP.
+  rewrite /get_sig (hsig hfun) /= => ? [?]; subst => /=.
+  set etyin := map2 _ fparams ftin.
+  set etyout := map2 _ fres ftout.
+  set ftini := map _ etyin.
+  set ftouti := map _ etyout.
+  set vargsi' := (map2 (λ ety v, val_to_int (sign_of_etype ety) v) fsig.1 vargs').
+  set vargsi := (map2 (λ ety v, val_to_int (sign_of_etype ety) v) fsig.1 vargs).
+  set vresi' := (map2 (λ ety v, val_to_int (sign_of_etype ety) v) fsig.2 vres').
+  set vresi := (map2 (λ ety v, val_to_int (sign_of_etype ety) v) fsig.2 vres).
+  move=> fparamsi hparamsi ci hci fresi hresi ? [?] hsub; subst fdi fsig.
+  have : mapM2 ErrType dc_truncate_val ftini vargsi' = ok vargsi /\
+         forall s si, eqst s si ->
+           write_vars true fparams vargs s = ok s1 ->
+           exists2 si1,
+             write_vars true fparamsi vargsi si = ok si1 &
+             eqst s1 si1.
+  + move: htra hsub hparamsi.
+    rewrite /ftini /vargsi /vargsi' /ftini /etyin.
+    move=> {hw hfuni vresi vresi' vargsi vargsi' hfun ftini etyin hresi}.
+    elim: ftin vargs' fparams fparamsi vargs => [|ty tys hrec] [|va vas] [| a params] //= .
+    + by move=> _ _ [<-] _ [<-]; split => // s si ? [<-]; exists si.
+    t_xrbindP.
+    move=> _ _ tva hva tvas hvas <- /andP[hsub hall] ai hai paramsi hparamsi <-.
+    rewrite {2}/dc_truncate_val /= to_stypeK.
+    have /= := esubtype_truncate _ _ hva.
+    move /(_ (to_etype (sign_of_etype (to_etype (sign_of_var m a) ty)) (type_of_val va))).
+    rewrite to_stypeK => /(_ erefl).
+    have heq : to_etype (sign_of_etype (to_etype (sign_of_var m a) ty)) ty =
+               to_etype (sign_of_var m a) ty.
+    + by case ty => //= ws; case: sign_of_var.
+    have -> := esubtype_sign_of hsub => ->; last by rewrite heq.
+    rewrite /=; have [-> hwrec /=] := hrec _ _ _ _ hvas hall hparamsi.
+    split; first by rewrite heq.
+    t_xrbindP=> s si heqs s' hw hws.
+    have := wi2i_lvarP heqs _ hw; rewrite (truncate_val_has_type hva).
+    rewrite -sign_of_etype_var in hai => /(_ _ _ hai).
+    rewrite sign_of_etype_var.
+    by move=> [si' -> heqs'] /=; apply: hwrec heqs' hws.
+  have heqs : eqst {| escs := scs1; emem := m1; evm := Vm.init |} {| escs := scs1; emem := m1; evm := Vm.init |}.
+  + split => //= z hin.
+    rewrite !Vm.initP /wi2i_var /sign_of_var.
+    case: m (hwf_m z) => [[sg zi] | ] //=; last by rewrite val_to_int_None.
+    by move=> [] /is_swordP [ws ->] -> _ /=; apply undef_x_vundef.
+  move=> [hvargsi /(_ _ _ heqs hw) [si1 {}hw heqs1]].
+  have [si2 hsemc heqs2] := hc _ hci _ heqs1.
+  have [???] : [/\ get_var_is true (evm si2) fresi = ok vresi
+                 , mapM2 ErrType dc_truncate_val ftouti vresi = ok vresi'
+                 & all2 (λ ety v, ety == to_etype (sign_of_etype ety) (type_of_val v)) etyout vres'].
+  + move: hres hfull hresi.
+    rewrite /vresi /vresi' /ftouti /etyout.
+    move=> {vresi' vresi ftouti etyout hfuni hfun vargsi vargsi' hsub hvargsi hw heqs}.
+    elim: fres vres fresi ftout vres' => [|r rs hrec] /=.
+    + move=> ? ? ftout ? [<-] + [<-].
+      by case: ftout => //= -[<-].
+    t_xrbindP => vres fresi ftout vres' v hr vs hrs <-.
+    case: ftout => //= ty tys; t_xrbindP.
+    move=> tv htv tvs htvs <- ri hsub hri ris hris <- /=.
+    have -> := wi2i_variP heqs2 hri hr.
+    have [-> -> -> /=]:= hrec _ _ _ _ hrs htvs hris.
+    rewrite -(esubtype_sign_of hsub) sign_of_etype_var.
+    have -> := truncate_val_has_type htv; rewrite eqxx; split => //.
+    have /= := esubtype_truncate _ _ htv.
+    rewrite -sign_of_etype_var in hsub.
+    move=> /(_ _ (get_var_type_of hr) hsub).
+    by rewrite -(esubtype_sign_of hsub) sign_of_etype_var to_stypeK /dc_truncate_val /= => -> /=.
+  by case: heqs2 => *; split => //; econstructor; eauto.
+Qed.
+
+Definition wi2w_callP_aux :=
+    (sem_call_Ind
+       Hskip
+       Hcons
+       HmkI
+       Hassgn
+       Hopn
+       Hsyscall
+       Hif_true
+       Hif_false
+       Hwhile_true
+       Hwhile_false
+       Hfor
+       Hfor_nil
+       Hfor_cons
+       Hcall
+       Hproc).
+
+End M.
+
+Section FINAL.
+
+Context (info : var → option (signedness * var)).
+
+Lemma build_infoP FV m :
+  build_info info FV = ok m ->
+  wf_m m FV /\ forall x, Sv.In x FV -> m x = info x.
+Proof.
+  rewrite /build_info; t_xrbindP => -[FV' m'] /= + <-.
+  set f := (f in foldM f _ _).
+  have :
+    forall xs (xs':seq var) FV1 FV2 m1 m2,
+      Sv.Subset FV FV1 →
+      (forall x, x \in xs → Sv.In x FV) →
+      (forall x, Sv.In x FV → (x \in xs') || (x \in xs)) →
+      (forall x, x \in xs' → Mvar.get m1 x = info x) →
+      (forall x xi, Mvar.get m1 x = Some xi -> x \in xs' /\ Sv.In xi.2 FV1) →
+      wf_m (Mvar.get m1) FV →
+      foldM f (FV1, m1) xs = ok (FV2, m2) →
+      wf_m (Mvar.get m2) FV ∧ ∀ x : Sv.elt, Sv.In x FV → Mvar.get m2 x = info x.
+  + elim => [| x xs hrec] xs' FV1 FV2 m1 m2 hsub hin hor hget hget' hwf /=.
+    + by move=> [_ <-]; split => // x /hor; rewrite orbC => /hget.
+    t_xrbindP => -[FV1' m1']; rewrite {1}/f.
+    case heq: info => [[sg xi] | ]; last first.
+    + move=> [<- <-] /(hrec (x::xs')) [] //.
+      + by move=> z hz; apply hin; rewrite in_cons hz orbT.
+      + by move=> z /hor; rewrite !in_cons; case: eqP.
+      + move=> z; rewrite in_cons => /orP [/eqP |] ?; last by apply hget.
+        subst z; case h : Mvar.get => [ xi| //].
+        by rewrite -h; apply hget; case: (hget' _ _ h).
+      by move=> z xi /hget' []; rewrite in_cons => ->; rewrite orbT.
+    case hw: is_word_type => [ws|] //=; t_xrbindP => /andP[/eqP htxi /Sv_memP hxi].
+    have htx := is_word_typeP hw.
+    move=> <- <- /(hrec (x::xs')) [] //.
+    + by SvD.fsetdec.
+    + by move=> z hz; apply hin; rewrite in_cons hz orbT.
+    + by move=> z /hor; rewrite !in_cons; case: eqP.
+    + move=> z; rewrite in_cons Mvar.setP eq_sym.
+      case: eqP => /=; first by move=> <-; rewrite heq.
+      by move=> _; apply hget.
+    + move=> z sz; rewrite Mvar.setP; case: eqP.
+      + by move=> <- [<-]; rewrite in_cons eqxx; split => //=; SvD.fsetdec.
+      by rewrite in_cons => _ /hget' [] ->; rewrite orbT; split => //; SvD.fsetdec.
+    move=> z; rewrite Mvar.setP; case: eqP => [<- | hne].
+    + rewrite htx; split => //.
+      move=> y hxy hiny.
+      rewrite Mvar.setP_neq; last by apply/eqP.
+      case: Mvar.get (hget' y).
+      + by move=> [sy yi] /(_ _ erefl) /= [_ hinyi] heqy; apply hxi; rewrite heqy.
+      move=> _ heqy;apply hxi; rewrite heqy.
+      move/Sv_memP: hiny; SvD.fsetdec.
+    have := hwf z.
+    case heqz: Mvar.get => [[sgz zi] | ] => //.
+    move=> [?? h]; split => // y hzy hiny.
+    rewrite Mvar.setP; case: eqP => hxy; last by apply h.
+    by have [/= _ hinzi]:= hget' _ _ heqz; SvD.fsetdec.
+  move=> h {}/h -/(_ [::]) [] //.
+  + by move=> ? /Sv_elemsP.
+  by move=> ? /Sv_elemsP ->.
+Qed.
+
+Lemma wi2w_callP p' :
+  wi2i_prog info p = ok p' ->
+  forall fn fd, get_fundef (p_funcs p) fn = Some fd ->
+  forall scs m vargs scs' m' vres,
+    let fsig := (build_sig info (fn, fd)).2 in
+    all2 (λ ety v, esubtype ety (to_etype (sign_of_etype ety) (type_of_val v))) fsig.1 vargs ->
+    let vargsi := map2 (λ ety v, val_to_int (sign_of_etype ety) v) fsig.1 vargs in
+    let vresi  := map2 (λ ety v, val_to_int (sign_of_etype ety) v) fsig.2 vres in
+    sem_call p ev scs m fn vargs scs' m' vres ->
+    sem_call p' ev scs m fn vargsi scs' m' vresi.
+Proof.
+  rewrite /wi2i_prog; t_xrbindP.
+  move=> M /build_infoP [hwf_m hMeq].
+  move=> p_funcsi heqp'.
+  have hp' := get_map_cfprog_name_gen heqp'.
+  move=> <- fn fd hfn scs m vargs scs' m' vres hargs hsem.
+  have hsigs : ∀ fn fd,
+    get_fundef (p_funcs p) fn = Some fd →
+    get_fundef [seq build_sig info i | i <- p_funcs p] fn =
+       Some
+          (map2 (λ (x : var_i) (ty : stype), to_etype (sign_of_var M x) ty) (f_params fd) (f_tyin fd),
+           map2 (λ (x : var_i) (ty : stype), to_etype (sign_of_var M x) ty) (f_res fd) (f_tyout fd)).
+  + move=> fn' fd' hfn'.
+    rewrite /get_fundef assoc_mapE; last by move=> ? [].
+    rewrite -/(get_fundef (p_funcs p) fn') hfn' /= /build_sig.
+    case: fd' hfn' => /= finfo ftyin fparams fbody ftyout fres fextra hfn'.
+    have heq : forall xs ty,
+      (forall x, x \in map v_var xs -> Sv.In x (vars_p (p_funcs p))) ->
+      map2 (λ (x : var_i) (ty : stype), to_etype (sign_of_var info x) ty) xs ty =
+      map2 (λ (x : var_i) (ty : stype), to_etype (sign_of_var M x) ty) xs ty.
+    + elim => [|x xs hrec] [|t ts] => //= hin.
+      rewrite hrec.
+      + by rewrite /sign_of_var hMeq //; apply hin; rewrite in_cons eqxx.
+      by move=> z h; apply hin; rewrite in_cons h orbT.
+    have /(_ _ _ _ hfn') := [elaborate vars_pP].
+    rewrite /vars_fd /=.
+    have vars_lP: forall l, Sv.Equal (vars_l l) (sv_of_list v_var l).
+    + by elim => //= ?? ->; rewrite sv_of_list_cons.
+    rewrite !vars_lP => hsub.
+    by rewrite !heq // => z /sv_of_listP; SvD.fsetdec.
+  have hsig : get_fundef [seq build_sig info i | i <- p_funcs p] fn = Some (build_sig info (fn, fd)).2.
+  + rewrite /get_fundef assoc_mapE; last by move=> ? [].
+    by rewrite -/(get_fundef (p_funcs p) fn) hfn.
+  by have /= [] := wi2w_callP_aux hwf_m hsigs hp' hsem hsig hargs.
+Qed.
+
+End FINAL.
+End PROOF.

--- a/proofs/compiler/wint_word.v
+++ b/proofs/compiler/wint_word.v
@@ -1,0 +1,124 @@
+(* ** Imports and settings *)
+From HB Require Import structures.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssralg.
+From mathcomp Require Import word_ssrZ.
+From Coq Require Import ZArith.
+Require Import expr sem_op_typed compiler_util allocation.
+Import Utf8.
+Import oseq.
+Require Import flag_combination.
+
+Local Open Scope seq_scope.
+Local Open Scope Z_scope.
+
+
+Definition wi2w_wiop1 s (o : wiop1) (e : pexpr) : pexpr :=
+  match o with
+  | WIwint_of_int sz => Papp1 (Oword_of_int sz) e
+  | WIint_of_wint sz => Papp1 (Oint_of_word s sz) e
+  | WIword_of_wint _ => e
+  | WIwint_of_word _ => e
+  | WIwint_ext sz1 sz2 =>
+    let o := if s is Unsigned then Ozeroext sz1 sz2 else Osignext sz1 sz2 in
+    Papp1 o e
+  | WIneg sz => Papp1 (Oneg (Op_w sz)) e
+  end.
+
+Definition wi2w_op1 (o : sop1) (e : pexpr) : pexpr :=
+  if o is Owi1 s o then wi2w_wiop1 s o e else Papp1 o e.
+
+Definition wi2w_wiop2 s sz (o : wiop2) : sop2 :=
+  match o with
+  | WIadd => Oadd (Op_w sz)
+  | WImul => Omul (Op_w sz)
+  | WIsub => Osub (Op_w sz)
+  | WIeq  => Oeq  (Op_w sz)
+  | WIneq => Oneq (Op_w sz)
+  | WIlt  => Olt  (Cmp_w s sz)
+  | WIle  => Ole  (Cmp_w s sz)
+  | WIgt  => Ogt  (Cmp_w s sz)
+  | WIge  => Oge  (Cmp_w s sz)
+  | WIdiv => Odiv s (Op_w sz)
+  | WImod => Omod s (Op_w sz)
+  | WIshl => Olsl (Op_w sz)
+  | WIshr => if s is Signed then Oasr (Op_w sz) else Olsr sz
+  end.
+
+Definition wi2w_op2 (o : sop2) : sop2 :=
+  if o is Owi2 s sz o then wi2w_wiop2 s sz o else o.
+
+Fixpoint wi2w_e (e: pexpr) : pexpr :=
+  match e with
+  | Pconst _
+  | Pbool _
+  | Parr_init _
+  | Pvar _
+      => e
+  | Pget al aa ws x e => Pget al aa ws x (wi2w_e e)
+  | Psub al ws len x e => Psub al ws len x (wi2w_e e)
+  | Pload al ws x e => Pload al ws x (wi2w_e e)
+  | Papp1 o e => wi2w_op1 o (wi2w_e e)
+  | Papp2 o e1 e2 => Papp2 (wi2w_op2 o) (wi2w_e e1) (wi2w_e e2)
+  | PappN o es => PappN o (map wi2w_e es)
+  | Pif ty e1 e2 e3 => Pif ty (wi2w_e e1) (wi2w_e e2) (wi2w_e e3)
+  end.
+
+Definition wi2w_lv (x : lval) : lval :=
+  match x with
+  | Lnone vi t => Lnone vi t
+  | Lvar x => Lvar x
+  | Lmem al ws x e => Lmem al ws x (wi2w_e e)
+  | Laset al aa ws x e => Laset al aa ws x (wi2w_e e)
+  | Lasub aa ws len x e => Lasub aa ws len x (wi2w_e e)
+  end.
+
+Section WITH_PARAMS.
+
+Context `{asmop:asmOp}.
+
+Fixpoint wi2w_ir (ir:instr_r) : instr_r :=
+  match ir with
+  | Cassgn x tag ty e =>
+    Cassgn (wi2w_lv x) tag ty (wi2w_e e)
+
+  | Copn xs t o es =>
+    Copn (map wi2w_lv xs) t o (map wi2w_e es)
+
+  | Csyscall xs o es =>
+    Csyscall (map wi2w_lv xs) o (map wi2w_e es)
+
+  | Cif b c1 c2 =>
+    Cif (wi2w_e b) (map wi2w_i c1) (map wi2w_i c2)
+
+  | Cfor x (dir, e1, e2) c =>
+    Cfor x (dir, wi2w_e e1, wi2w_e e2) (map wi2w_i c)
+
+  | Cwhile a c e info c' =>
+    Cwhile a (map wi2w_i c) (wi2w_e e) info (map wi2w_i c')
+
+  | Ccall xs f es =>
+    Ccall (map wi2w_lv xs) f (map wi2w_e es)
+
+  end
+
+with wi2w_i (i:instr) : instr :=
+  let (ii,ir) := i in
+  MkI ii (wi2w_ir ir).
+
+Definition wi2w_fun {eft} (f: _fundef eft) :=
+  let 'MkFun ii si p c so r ev := f in
+  MkFun ii si p (map wi2w_i c) so r ev.
+
+(* This function is internal, variable annotation still contain "sint" "uint" after this pass *)
+Definition wi2w_prog_internal {pT:progT} (p: prog) : prog := map_prog wi2w_fun p.
+
+Definition wi2w_prog {wsw: WithSubWord}
+   (remove_wint_annot: funname -> fundef -> fundef)
+   (dead_vars_fd : fun_decl → instr_info → Sv.t)
+   (p : prog) :=
+  let p := wi2w_prog_internal p in
+  let pv := map_prog_name remove_wint_annot p in
+  Let _ := allocation.check_uprog dead_vars_fd p.(p_extra) p.(p_funcs) pv.(p_extra) pv.(p_funcs) in
+  ok pv.
+
+End WITH_PARAMS.

--- a/proofs/compiler/wint_word_proof.v
+++ b/proofs/compiler/wint_word_proof.v
@@ -1,0 +1,403 @@
+Require Import compiler_util psem psem_facts.
+Require Import wint_word allocation_proof.
+Import Utf8.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssralg.
+
+Section PROOF.
+
+#[local] Existing Instance progUnit.
+#[local] Existing Instance indirect_c.
+#[local] Existing Instance withsubword.
+
+Context
+  {asm_op syscall_state : Type}
+  {ep : EstateParams syscall_state}
+  {spp : SemPexprParams}
+  {sip : SemInstrParams asm_op syscall_state}.
+
+Context
+  (remove_wint_annot: funname -> fundef -> fundef)
+  (dead_vars_fd : fun_decl → instr_info → Sv.t).
+
+Variable (p:prog) (ev:extra_val_t).
+
+Notation gd := (p_globs p).
+
+#[local]Open Scope vm_scope.
+
+Section E.
+
+  Context (s:estate) (vm:Vm.t) (hincl : evm s <=1 vm) (wdb : bool).
+
+  Let s' := with_vm s vm.
+
+  Let P e : Prop :=
+    ∀ v,
+      sem_pexpr wdb gd s e = ok v →
+      exists2 v', sem_pexpr wdb gd s' (wi2w_e e) = ok v' & value_uincl v v'.
+
+  Let Q es : Prop :=
+    ∀ vs,
+      sem_pexprs wdb gd s es = ok vs →
+      exists2 vs', sem_pexprs wdb gd s' (map wi2w_e es) = ok vs' & List.Forall2 value_uincl vs vs'.
+
+  Lemma wi2w_e_esP : (∀ e, P e) ∧ (∀ es, Q es).
+  Proof.
+    apply: pexprs_ind_pair; subst P Q; split => //=; t_xrbindP.
+    + by move=> _ <-; exists [::].
+    + move=> e he es hes ? v /he [v' -> /= hu] vs /hes [vs' -> /= hus] <-.
+      by eexists; [reflexivity | eauto].
+    1-3: move=> > ->; by eexists; [reflexivity | eauto].
+    + by move=> x v; apply: get_gvar_uincl.
+    + move=> al aa sz x e he v.
+      apply: on_arr_gvarP => n t1 wt /(get_gvar_uincl hincl) [_] -> /value_uinclE [t2] -> htu.
+      t_xrbindP => i ve /he [v' -> +] /to_intI ?; subst ve.
+      move=> /value_uinclE ?; subst v' => ? /= /(WArray.uincl_get htu) -> <- /=.
+      by (eexists; first reflexivity) => /=.
+    + move=> aa sz len x e he v.
+      apply: on_arr_gvarP => n t1 wt /(get_gvar_uincl hincl) [_] -> /value_uinclE [t2] -> htu.
+      t_xrbindP => i ve /he [v' -> +] /to_intI ?; subst ve.
+      move=> /value_uinclE -> /= ? /(WArray.uincl_get_sub htu) [t'] -> ht'u <- /=.
+      by (eexists; first reflexivity) => /=.
+    + move=> al sz x e he v a ve /(get_var_uincl hincl) [?] -> + /to_wordI [? [? [? htr1]]]; subst ve.
+      move=> /value_uinclE [? [? [-> hu1]]] ?? /he [v' -> +] /to_wordI [sz' [w' [? htr]]]; subst.
+      move=> /value_uinclE [?] [w''] [->] hu ? /=.
+      rewrite (word_uincl_truncate hu1 htr1) (word_uincl_truncate hu htr) /= => -> <- /=.
+      by (eexists; first reflexivity) => /=.
+    + move=> o e he v v1 /he{he} [v' he hu].
+      rewrite /sem_sop1 /=; t_xrbindP => + /(of_value_uincl_te hu).
+      case: o => [sz | si sz | si sz | si sz | | sz | [ | sz] | sg o] /=;
+        rewrite /= ?he /sem_sop1 /=; t_xrbindP;
+        try by move=> > -> /= > [->] <-; (eexists; first reflexivity) => /=.
+      case: o => /=; rewrite he /sem_sop1 /=.
+      + move=> > /to_intI -> > /wint_of_intP [-> h] <- /=.
+        by (eexists; first reflexivity) => /=.
+      + move=> > /to_wordI [? [? [-> htr]]] > [<-] <- /=.
+        by rewrite htr /=; eexists; first reflexivity.
+      + move=> > /to_wordI [sz' [w' [?]]] htr ? [<-] <-; subst v'.
+        eexists; first reflexivity.
+        by apply: truncate_word_uincl htr.
+      + move=> > /to_wordI [sz' [w' [?]]] htr ? [<-] <-; subst v'.
+        eexists; first reflexivity.
+        by apply: truncate_word_uincl htr.
+      + move=> > /to_wordI [sz' [w' [?]]] htr ? [] + <-; subst v'.
+        by case: sg => /=; rewrite htr /= => ->; (eexists; first reflexivity) => /=.
+      move=> > /to_wordI [sz' [w' [?]]] htr ? + <-; subst v'.
+      move=> /wint_of_intP [-> ?] /=; rewrite htr /=.
+      (eexists; first reflexivity) => /=.
+      by rewrite wrepr_opp wrepr_int_of_word.
+
+    + move=> o e he1 e2 he2 v v1 /he1{he1} [v1' -> hu1] v2 /he2{he2} [v2' -> hu2] /=.
+      rewrite /sem_sop2 /=; t_xrbindP.
+      move=> w1 /(of_value_uincl_te hu1) h1 w2 /(of_value_uincl_te hu2) h2 {hu1 hu2}.
+      case: o w1 h1 w2 h2 =>
+       [ | | | k | k | k | si k | si k | ws | ws | ws | ws | k | k | ws | ws | k | k | k | k | k | k
+                              | ve ws | ve ws | ve ws | ve ws | ve ws | ve ws | si ws o];
+        try by move => /= > -> > -> > /= [<-] <-; eexists; first reflexivity.
+      1-3: by rewrite /=; case: k => /= > -> > -> > [<-] <- /=; (eexists; first reflexivity) => /=.
+      1-2: by rewrite /=; (case: k => /= > -> > -> >; first case) => /= -> <-;
+             (eexists; first reflexivity).
+      1-8: by case: k => /= > -> /= > -> /= > [->] <-; (eexists; first reflexivity).
+      case: o; rewrite /= /mk_sem_wiop2 /=.
+      1-3: by move=> > -> > -> /= > /wint_of_intP [-> _] <-; (eexists; first reflexivity);
+           rewrite (wrepr_add, wrepr_mul, wrepr_sub) !wrepr_int_of_word.
+      1-2: by move=> > -> > -> /= > -> <- /=; (eexists; first reflexivity) => /=.
+      + move=> > -> w2 -> /= > /wint_of_intP /= [-> _] <-; (eexists; first reflexivity).
+        rewrite /zlsl /sem_shl /sem_shift; case: ifPn => /ZleP ?.
+        + by rewrite wrepr_mul wrepr_int_of_word GRing.mulrC wshl_sem.
+        by have := wunsigned_range w2; Lia.lia.
+      + rewrite /mk_sem_wishift; case: si => /= w1 -> w2 -> > /=;
+        move=> /wint_of_intP [-> ?] <-;  (eexists; first reflexivity) => /=;
+        rewrite /sem_sar /sem_shr /sem_shift /wsar /wshr /zasr /zlsl;
+        have [h _ ] := wunsigned_range w2;
+        (case: ZleP;
+        [ case/Zle_lt_or_eq: h; first Lia.lia;
+          by move=> <- _ /=; rewrite Z.mul_1_r Z.shiftr_0_r
+        | by move=> _; rewrite Z.opp_involutive Z.shiftr_div_pow2]).
+
+      1-2: by move=> > -> > -> > /= [<-] <-; (eexists; first reflexivity) => /=;
+          rewrite int_of_word_eqb.
+
+      1-4: move=> > -> > -> > /= [<-] <-; (eexists; first reflexivity) => /=;
+           case: si => //=; rewrite ?(Z.gtb_ltb, Z.geb_leb) //.
+    + move=> op es hes v vs /hes [vs']; rewrite /sem_pexprs => -> /= hus hs.
+      by rewrite (vuincl_sem_opN hus hs); eexists; first reflexivity.
+
+    move=> t e he e1 he1 e2 he2 v b v0 /he [v0' -> hu0].
+    move=> /to_boolI => ?; subst v0.
+    have ? := value_uinclE hu0; subst v0'.
+    move=> v1_ v1 /he1 [v1' -> hu1] htr1 v2_ v2 /he2 [v2'-> hu2] htr2 /= <-.
+    have [? -> ?]:= value_uincl_truncate hu1 htr1.
+    have [? -> ?] /= := value_uincl_truncate hu2 htr2.
+    by eexists; first reflexivity; case b.
+  Qed.
+
+  Lemma wi2w_eP : ∀ e, P e.
+  Proof. by case wi2w_e_esP. Qed.
+
+  Lemma wi2w_esP : ∀ e, Q e.
+  Proof. by case wi2w_e_esP. Qed.
+
+End E.
+
+Lemma wi2w_lvalP wdb lv s s' vm v1 v2 :
+  evm s <=1 vm ->
+  value_uincl v1 v2 ->
+  write_lval wdb gd lv v1 s = ok s' ->
+  exists2 vm', write_lval wdb gd (wi2w_lv lv) v2 (with_vm s vm) = ok (with_vm s' vm') &
+               evm s' <=1 vm'.
+Proof.
+  case: lv => [ vi ty | x | al w x e | al aa sz x e | aa sz len x e] /=.
+  + move=> hu hvu hw; rewrite (uincl_write_none _ hvu hw).
+    by have [-> _ _] := write_noneP hw; eauto.
+  + by apply write_var_uincl.
+  + move=> hu hvu; t_xrbindP => ?? /(get_var_uincl hu) [? -> hu1] /to_wordI [?[?[? htr1]]] /=; subst.
+    have [? [? [? hw1 {hu1}]]]:= value_uinclE hu1; subst => /=.
+    have -> := word_uincl_truncate hw1 htr1.
+    move=> ?? /(wi2w_eP hu) [? -> hu2] /to_wordI [?[?[? htr2]]] /=; subst.
+    have [? [? [? hw2 {hu2}]]]:= value_uinclE hu2; subst => /=.
+    have -> := word_uincl_truncate hw2 htr2.
+    move=> ? /to_wordI [?[?[? htr3]]] /=; subst.
+    have [? [? [? hw3 {hvu}]]]:= value_uinclE hvu; subst => /=.
+    have -> /= := word_uincl_truncate hw3 htr3.
+    by move=> m' -> <- /=; exists vm.
+  + move=> hu hvu; apply on_arr_varP; t_xrbindP; rewrite /on_arr_var.
+    move=> ?? hty /(get_var_uincl hu) [? -> hu1] ?? /(wi2w_eP hu) [? -> hu2] /to_intI ?; subst.
+    have [? ? htu]:= value_uinclE hu1; subst => /=.
+    have ? := value_uinclE hu2; subst => /=.
+    move=> ? /to_wordI [?[?[? htr3]]] /=; subst.
+    have [? [? [? hw3 {hvu}]]]:= value_uinclE hvu; subst => /=.
+    have -> /= := word_uincl_truncate hw3 htr3.
+    move=> ? /(WArray.uincl_set htu) [? [-> htu']] /=.
+    by apply write_var_uincl.
+  move=> hu hvu; apply on_arr_varP; t_xrbindP; rewrite /on_arr_var.
+  move=> ?? hty /(get_var_uincl hu) [? -> hu1] ?? /(wi2w_eP hu) [? -> hu2] /to_intI ?; subst.
+  have [? ? htu {hu1} ]:= value_uinclE hu1; subst => /=.
+  have ? := value_uinclE hu2; subst => /=.
+  move=> ? /to_arrI ?; subst.
+  have [? ? htu']:= value_uinclE hvu; subst => /=.
+  rewrite WArray.castK /=.
+  move=> ? /(WArray.uincl_set_sub htu htu') [? -> ?] /=.
+  by apply write_var_uincl.
+Qed.
+
+Lemma wi2w_lvalsP wdb lvs s s' vm vs1 vs2 :
+  evm s <=1 vm ->
+  List.Forall2 value_uincl vs1 vs2 ->
+  write_lvals wdb gd s lvs vs1 = ok s' ->
+  exists2 vm', write_lvals wdb gd (with_vm s vm) (map wi2w_lv lvs) vs2 = ok (with_vm s' vm') &
+               evm s' <=1 vm'.
+Proof.
+  elim: lvs s vm vs1 vs2 => /= [ | x xs Hrec] s1 vm1 vs1 vs2 Hvm [] //=.
+  + by move=> [] <-;eauto.
+  move=> {vs1 vs2} v1 v2 vs1 vs2 Hv Hvs;apply: rbindP => s1'.
+  by move=> /(wi2w_lvalP Hvm Hv) []vm2 -> Hvm2 /(Hrec _ _ _ _ Hvm2 Hvs).
+Qed.
+
+Section Internal.
+
+Let p' := wi2w_prog_internal p.
+
+Lemma eq_globs : gd = p_globs p'.
+Proof. done. Qed.
+
+Lemma eq_p_extra : p_extra p = p_extra p'.
+Proof. done. Qed.
+
+Let Pi_r s (i:instr_r) s' :=
+  forall vm, evm s <=1 vm ->
+    exists2 vm', sem_i p' ev (with_vm s vm) (wi2w_ir i) (with_vm s' vm') &
+                 evm s' <=1 vm'.
+
+Let Pi s (i:instr) s' :=
+  forall vm, evm s <=1 vm ->
+    exists2 vm', sem_I p' ev (with_vm s vm) (wi2w_i i) (with_vm s' vm') &
+                 evm s' <=1 vm'.
+
+Let Pc s (c:cmd) s' :=
+  forall vm, evm s <=1 vm ->
+    exists2 vm', sem p' ev (with_vm s vm) (map wi2w_i c) (with_vm s' vm') &
+                 evm s' <=1 vm'.
+
+Let Pfor (i:var_i) vs s c s' :=
+ forall vm, evm s <=1 vm ->
+    exists2 vm', sem_for p' ev i vs (with_vm s vm) (map wi2w_i c) (with_vm s' vm') &
+                 evm s' <=1 vm'.
+
+Let Pfun scs1 m1 fn vargs scs2 m2 vres :=
+  forall vargs', List.Forall2 value_uincl vargs vargs' ->
+  exists2 vres',
+     List.Forall2 value_uincl vres vres' &
+     sem_call p' ev scs1 m1 fn vargs' scs2 m2 vres'.
+
+Local Lemma Hskip : sem_Ind_nil Pc.
+Proof. move=> s vm; exists vm => //; constructor. Qed.
+
+Local Lemma Hcons : sem_Ind_cons p ev Pc Pi.
+Proof.
+  move=> s1 s2 s3 i c _ hi _ hc vm hu1.
+  have [? h1 hu2] := hi _ hu1.
+  have [vm' h2 hu3] := hc _ hu2.
+  exists vm' => //; apply: Eseq h1 h2.
+Qed.
+
+Local Lemma HmkI : sem_Ind_mkI p ev Pi_r Pi.
+Proof. move=> ii i s1 s2 _ hi vm hu; have [vm' ??] := hi _ hu; exists vm' => //; constructor. Qed.
+
+Local Lemma Hassgn : sem_Ind_assgn p Pi_r.
+Proof.
+  move=> s1 s2 x t ty e v v' he htr hw vm hu.
+  have [v1 he1 hu1] := wi2w_eP hu he.
+  have [v1' htr1 hu2] := value_uincl_truncate hu1 htr.
+  have [vm' hw' hu'] := wi2w_lvalP hu hu2 hw.
+  exists vm' => //; econstructor; eauto.
+Qed.
+
+Local Lemma Hopn : sem_Ind_opn p Pi_r.
+Proof.
+  move => s1 s2 t o xs es; rewrite /sem_sopn; t_xrbindP => vr ve hes hex hws vm hu.
+  have [vs' hes' hu1] := wi2w_esP hu hes.
+  have [vr' hex' hu2] := vuincl_exec_opn hu1 hex.
+  have [vm' hw' hu'] := wi2w_lvalsP hu hu2 hws.
+  exists vm' => //; econstructor; eauto.
+  by rewrite /sem_sopn hes' /= hex' /=.
+Qed.
+
+Local Lemma Hsyscall : sem_Ind_syscall p Pi_r.
+Proof.
+  move=> s1 scs m s2 o xs es ves vs hes ho hws vm hu.
+  have [vs' hes' hu1] := wi2w_esP hu hes.
+  have [vr' hex' hu2] := exec_syscallP ho hu1.
+  have /(_ _ hu) [vm' hw' hu'] := wi2w_lvalsP _ hu2 hws.
+  exists vm' => //; econstructor; eauto.
+Qed.
+
+Local Lemma Hif_true : sem_Ind_if_true p ev Pc Pi_r.
+Proof.
+  move=> s1 s2 e c1 c2 he _ hc vm hu.
+  have [v1 he1 /value_uinclE ?] := wi2w_eP hu he; subst v1.
+  have [vm' h1 h2] := hc _ hu.
+  by exists vm' => //; apply: Eif_true h1.
+Qed.
+
+Local Lemma Hif_false : sem_Ind_if_false p ev Pc Pi_r.
+Proof.
+  move=> s1 s2 e c1 c2 he _ hc vm hu.
+  have [v1 he1 /value_uinclE ?] := wi2w_eP hu he; subst v1.
+  have [vm' h1 h2] := hc _ hu.
+  by exists vm' => //; apply: Eif_false h1.
+Qed.
+
+Local Lemma Hwhile_true : sem_Ind_while_true p ev Pc Pi_r.
+Proof.
+  move=> s1 s2 s3 s4 a c e ei c' _ hc he _ hc' _ hwh vm hu.
+  have [vm1 hc1 hu1]:= hc _ hu.
+  have [v1 he1 /value_uinclE ?] := wi2w_eP hu1 he; subst v1.
+  have [vm2 hc2 hu2] := hc' _ hu1.
+  have [vm' hwh' hu'] := hwh _ hu2.
+  by exists vm' => //; apply: Ewhile_true hc2 hwh'.
+Qed.
+
+Local Lemma Hwhile_false : sem_Ind_while_false p ev Pc Pi_r.
+Proof.
+  move=> s1 s2 a c e ei c' _ hc he vm hu.
+  have [vm' hc1 hu1]:= hc _ hu.
+  have [v1 he1 /value_uinclE ?] := wi2w_eP hu1 he; subst v1.
+  by exists vm' => //; apply: Ewhile_false.
+Qed.
+
+Local Lemma Hfor : sem_Ind_for p ev Pi_r Pfor.
+Proof.
+  move=> s1 s2 i d lo hi c vlo vhi hlo hhi _ hfor vm hu.
+  have [? hlo' /value_uinclE ?] := wi2w_eP hu hlo.
+  have [? hhi' /value_uinclE ?] := wi2w_eP hu hhi; subst.
+  have [vm' h hu'] := hfor _ hu.
+  exists vm' => //; econstructor; eauto.
+Qed.
+
+Local Lemma Hfor_nil : sem_Ind_for_nil Pfor.
+Proof. move=> s i c vm hu; exists vm => //; apply EForDone. Qed.
+
+Local Lemma Hfor_cons : sem_Ind_for_cons p ev Pc Pfor.
+Proof.
+  move=> s1 s1' s2 s3 i w ws c hw _ hc _ hfor vm hu.
+  have [vm1 hw' hu1] := [elaborate write_var_uincl hu (value_uincl_refl w) hw].
+  have [vm2 hs1 hu2] := hc _ hu1.
+  have [vm' hs2 hu'] := hfor _ hu2.
+  exists vm' => //; econstructor; eauto.
+Qed.
+
+Local Lemma Hcall : sem_Ind_call p ev Pi_r Pfun.
+Proof.
+  move=> s1 scs2 m2 s2 xs fn args vargs vs hes _ hf hws vm hu.
+  have [vs' hes' hu1] := wi2w_esP hu hes.
+  have [vr hu2 h] := hf _ hu1.
+  rewrite /= in hws.
+  have /(_ _ hu) [vm' hw' hu'] := wi2w_lvalsP _ hu2 hws.
+  exists vm' => //; econstructor; eauto.
+Qed.
+
+Local Lemma Hproc : sem_Ind_proc p ev Pc Pfun.
+Proof.
+  move=> scs1 m1 scs2 m2 fn f vargs vargs' s0 s1 s2 vres vres' Hfun htra Hi Hw _ Hc Hres Hfull Hscs Hfi vargs1 hu.
+  have hfun' : get_fundef (p_funcs p') fn = Some (wi2w_fun f).
+  + by rewrite get_map_prog Hfun.
+  move=> {Hfun}.
+  case: f htra Hi Hw Hc Hres Hfull Hfi hfun' => /=.
+  move=> info tyin params body tyout res extra htra hi hw hc hres hfull hfi hfun'.
+  have [vargs2 {}htra hu1] := mapM2_dc_truncate_val htra hu.
+  have [vm1 {}hw hu2] := [elaborate write_vars_uincl (vm_uincl_refl _) hu1 hw].
+  have [vm' {}hc hu3] := hc _ hu2.
+  have [vres1 {}hres hu4]:= get_var_is_uincl hu3 hres.
+  have [vres2 {}hfull hu5] := mapM2_dc_truncate_val hfull hu4.
+  rewrite with_vm_same in hw.
+  exists vres2 => //; econstructor; first (by apply hfun'); eauto.
+Qed.
+
+Lemma wi2w_call_internalP fn scs mem scs' mem' va va' vr:
+  List.Forall2 value_uincl va va' ->
+  sem_call p ev scs mem fn va scs' mem' vr ->
+  exists2 vr',
+    List.Forall2 value_uincl vr vr' &
+    sem_call p' ev scs mem fn va' scs' mem' vr'.
+Proof.
+  move=> Hall Hsem.
+  exact:
+    (sem_call_Ind
+       Hskip
+       Hcons
+       HmkI
+       Hassgn
+       Hopn
+       Hsyscall
+       Hif_true
+       Hif_false
+       Hwhile_true
+       Hwhile_false
+       Hfor
+       Hfor_nil
+       Hfor_cons
+       Hcall
+       Hproc
+       Hsem
+       _
+       Hall).
+Qed.
+
+End Internal.
+
+Lemma wi2w_progP (p' : uprog) scs m fn va scs' m' vr :
+  wi2w_prog remove_wint_annot dead_vars_fd p = ok p' →
+  sem_call p ev scs m fn va scs' m' vr →
+  exists2 vr' : seq value,
+    List.Forall2 value_uincl vr vr' &
+    sem_call p' ev scs m fn va scs' m' vr'.
+Proof.
+  rewrite /wi2w_prog; t_xrbindP => ok_pv <- h.
+  have [vr1 hu1 {}h]:= wi2w_call_internalP (List_Forall2_refl _ value_uincl_refl) h.
+  have [vr2 [{}h hu2]] := alloc_call_uprogP ok_pv h.
+  exists vr2 => //.
+  apply (Forall2_trans value_uincl_trans hu1 hu2).
+Qed.
+
+End PROOF.

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -304,7 +304,7 @@ Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
         let (op, args) := mulr sz a b in
         LowerFopn sz (Ox86 op) args (Some U32)
       end
-    | Odiv (Cmp_w u sz) =>
+    | Odiv u (Op_w sz) =>
       let opn :=
         match u with
         | Unsigned => Ox86 (DIV sz)
@@ -312,7 +312,7 @@ Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
         end in
       k16 sz (LowerDivMod DM_Fst u sz opn a b)
 
-    | Omod (Cmp_w u sz) =>
+    | Omod u (Op_w sz) =>
        let opn :=
         match u with
         | Unsigned => Ox86 (DIV sz)
@@ -373,7 +373,7 @@ Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
     else
       LowerAssgn
 
-  | PappN (Opack U256 PE128) [:: Papp1 (Oint_of_word U128) h ; Papp1 (Oint_of_word U128) (Pvar _ as l) ] =>
+  | PappN (Opack U256 PE128) [:: Papp1 (Oint_of_word Unsigned U128) h ; Papp1 (Oint_of_word Unsigned U128) (Pvar _ as l) ] =>
     if ty == sword U256 then LowerConcat h l else LowerAssgn
 
   | _ => LowerAssgn

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -404,12 +404,12 @@ Section PROOF.
     wunsigned w2 != 0%Z ->
     ~~(wunsigned w1 / wunsigned w2 >? wmax_unsigned sz)%Z.
   Proof.
-  have ? := wunsigned_range w2.
-  move/eqP => hnz.
-  rewrite Z.gtb_ltb -Z.leb_antisym; apply/leZP.
-  rewrite /wmax_unsigned.
-  have := wunsigned_range w1.
-  elim_div; nia.
+    have ? := wunsigned_range w2.
+    move/eqP => hnz.
+    rewrite Z.gtb_ltb -Z.leb_antisym; apply/leZP.
+    rewrite /wmax_unsigned.
+    have := wunsigned_range w1.
+    elim_div; nia.
   Qed.
 
   Lemma size_16_64_ve (ve:velem) : (U16 ≤ ve)%CMP -> size_16_64 ve.
@@ -633,20 +633,21 @@ Section PROOF.
         do 3 f_equal.
         exact: zero_extend_cut.
       (* Olnot *)
-      + rewrite /= /sem_sop1 => sz; t_xrbindP => w Hz z' /to_wordI' [sz' [z [Hsz ? ->]]] ?; subst.
+      + rewrite /= /sem_sop1 /= => sz; t_xrbindP => w Hz z' /to_wordI' [sz' [z [Hsz ? ->]]] ?; subst.
         case: andP => // - [hsz] /eqP ?; subst ty.
         rewrite /truncate_val /= truncate_word_u in Hv'.
         case: Hv' => ?; subst v'.
         by rewrite /sem_pexprs /= Hz /exec_sopn /= truncate_word_le // /= /sopn_sem /sopn_sem_ /=
           /x86_NOT /size_8_64 hsz.
       (* Oneg *)
-      + rewrite /= /sem_sop1 => - [] // sz; t_xrbindP => w Hv z' /to_wordI' [sz' [z [Hsz ? ->]]] ?; subst.
+      + rewrite /= /sem_sop1 /= => - [] // sz; t_xrbindP => w Hv z' /to_wordI' [sz' [z [Hsz ? ->]]] ?; subst.
         case: andP => // - [hsz] /eqP ?; subst ty.
+        move=> [?] ?; subst.
         split. reflexivity.
-        rewrite /truncate_val /= truncate_word_u in Hv'.
+        rewrite /= /truncate_val /= truncate_word_u in Hv'.
         case: Hv' => ?; subst v'.
         by rewrite /sem_pexprs /= Hv /exec_sopn /= truncate_word_le // /sopn_sem /sopn_sem_ /= /x86_NEG /size_8_64 hsz /= Hw.
-    + case: o => // [[] sz |[] sz|[] sz|[]// u sz| []// u sz|sz|sz|sz|sz|sz|sz|sz|sz| ve sz | ve sz | ve sz | ve sz | ve sz | ve sz] //.
+    + case: o => // [[] sz |[] sz|[] sz|u []// sz| u []// sz|sz|sz|sz|sz|sz|sz|sz|sz| ve sz | ve sz | ve sz | ve sz | ve sz | ve sz] //.
       case: andP => // - [hsz64] /eqP ?; subst ty.
       (* Oadd Op_w *)
        + rewrite /= /sem_sop2 /=; t_xrbindP => v1 ok_v1 v2 ok_v2.
@@ -737,7 +738,7 @@ Section PROOF.
         (* SubNone *)
         + split. by rewrite read_es_swap.
           by rewrite /= ok_v1 ok_v2 /= /exec_sopn /sopn_sem /sopn_sem_ /= !truncate_word_le // /x86_SUB /size_8_64 hsz64 /= Hw.
-      (* Odiv (Cmp_w u sz) *)
+      (* Odiv u (Op_w sz) *)
       + case: ifP => // /andP [] /andP [] hsz1 hsz2 /eqP ?;subst ty.
         rewrite /sem_pexprs /=; t_xrbindP => v1 hv1 v2 hv2.
         rewrite /sem_sop2 /= /mk_sem_divmod;t_xrbindP => /= w1 hw1 w2 hw2 w3 hw3 ?; subst v.
@@ -1041,8 +1042,8 @@ Section PROOF.
         by rewrite !truncate_word_le.
     (* PappN *)
     + case: op => // - [] // - [] //.
-      case: es => // - [] // [] // [] // hi.
-      case => // [] // [] // [] // [] // [] // lo [] //.
+      case: es => // - [] // [] // [] // [] // hi.
+      case => // [] // [] // [] // [] // [] // [] // lo [] //.
       case: ty Hv' => // - [] //= ok_v'.
       rewrite /= /sem_opN /exec_sopn /sem_sop1 /=.
       t_xrbindP => ??? -> _ /to_wordI'[] szhi [] whi [] szhi_ge -> -> <- ??? ->.

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -52,7 +52,7 @@ Variant sop2 :=
 | Oland of wsize
 | Olor  of wsize
 | Olxor of wsize
-| Olsr  of wsize 
+| Olsr  of wsize
 | Olsl  of op_kind
 | Oasr  of op_kind
 | Oror  of wsize
@@ -76,7 +76,7 @@ Variant sop2 :=
 
 (* N-ary operators *)
 Variant combine_flags :=
-| CF_LT    of signedness   (* Alias : signed => L  ; unsigned => B   *) 
+| CF_LT    of signedness   (* Alias : signed => L  ; unsigned => B   *)
 | CF_LE    of signedness   (* Alias : signed => LE ; unsigned => BE  *)
 | CF_EQ                    (* Alias : E                              *)
 | CF_NEQ                   (* Alias : !E                             *)
@@ -174,7 +174,7 @@ Definition type_of_opN (op: opN) : seq stype * stype :=
   | Opack ws p =>
     let n := nat_of_wsize ws %/ nat_of_pelem p in
     (nseq n sint, sword ws)
-  | Ocombine_flags c => (tin_combine_flags, sbool) 
+  | Ocombine_flags c => (tin_combine_flags, sbool)
   end.
 
 (* ** Expressions
@@ -208,8 +208,8 @@ Definition mk_var_i (x : var) :=
 Notation vid ident :=
   (mk_var_i {| vtype := sword Uptr; vname := ident%string; |}).
 
-Variant v_scope := 
-  | Slocal 
+Variant v_scope :=
+  | Slocal
   | Sglob.
 
 Scheme Equality for v_scope.
@@ -376,7 +376,7 @@ Context `{asmop:asmOp}.
 Inductive instr_r :=
 | Cassgn   : lval -> assgn_tag -> stype -> pexpr -> instr_r
 | Copn     : lvals -> assgn_tag -> sopn -> pexprs -> instr_r
-| Csyscall : lvals -> syscall_t -> pexprs -> instr_r 
+| Csyscall : lvals -> syscall_t -> pexprs -> instr_r
 | Cif      : pexpr -> seq instr -> seq instr  -> instr_r
 | Cfor     : var_i -> range -> seq instr -> instr_r
 | Cwhile   : align -> seq instr -> pexpr -> instr_info -> seq instr -> instr_r
@@ -510,7 +510,7 @@ Section ASM_OP.
 Context {pd: PointerData}.
 Context `{asmop:asmOp}.
 
-(* ** Programs before stack/memory allocation 
+(* ** Programs before stack/memory allocation
  * -------------------------------------------------------------------- *)
 
 Definition progUnit : progT :=
@@ -531,7 +531,7 @@ Definition _ufun_decls :=  seq (_fun_decl unit).
 Definition _uprog      := _prog unit unit.
 Definition to_uprog (p:_uprog) : uprog := p.
 
-(* ** Programs after stack/memory allocation 
+(* ** Programs after stack/memory allocation
  * -------------------------------------------------------------------- *)
 
 Variant saved_stack :=
@@ -774,7 +774,7 @@ Fixpoint write_i_rec s (i:instr_r) :=
   match i with
   | Cassgn x _ _ _  => vrv_rec s x
   | Copn xs _ _ _   => vrvs_rec s xs
-  | Csyscall xs _ _ => vrvs_rec s xs 
+  | Csyscall xs _ _ => vrvs_rec s xs
   | Cif   _ c1 c2   => foldl write_I_rec (foldl write_I_rec s c2) c1
   | Cfor  x _ c     => foldl write_I_rec (Sv.add x s) c
   | Cwhile _ c _ _ c' => foldl write_I_rec (foldl write_I_rec s c') c
@@ -809,7 +809,7 @@ Fixpoint use_mem (e : pexpr) :=
 (* ** Compute read variables
  * -------------------------------------------------------------------- *)
 
-Definition read_gvar (x:gvar) := 
+Definition read_gvar (x:gvar) :=
   if is_lvar x then Sv.singleton x.(gv)
   else Sv.empty.
 
@@ -904,7 +904,7 @@ End ASM_OP.
 (* --------------------------------------------------------------------- *)
 (* Test the equality of two expressions modulo variable info             *)
 
-Definition eq_gvar x x' := 
+Definition eq_gvar x x' :=
   (x.(gs) == x'.(gs)) && (v_var x.(gv) == v_var x'.(gv)).
 
 Fixpoint eq_expr e e' :=
@@ -925,7 +925,7 @@ Fixpoint eq_expr e e' :=
   end.
 
 (* ------------------------------------------------------------------- *)
-Definition to_lvals (l:seq var) : seq lval := 
+Definition to_lvals (l:seq var) : seq lval :=
   map (fun x => Lvar (mk_var_i x)) l.
 
 (* ------------------------------------------------------------------- *)

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -28,14 +28,44 @@ Variant op_kind :=
   | Op_int
   | Op_w of wsize.
 
+Variant wiop1 :=
+| WIwint_of_int  of wsize (* int → word *)
+| WIint_of_wint  of wsize (* word/uint/sint → int, signed or unsigned interpretation *)
+| WIword_of_wint of wsize (* uint/sint -> word *)
+| WIwint_of_word of wsize (* word -> uint/sint *)
+| WIwint_ext     of wsize & wsize (* Size-extension: output-size, input-size *)
+| WIneg          of wsize (* negation *)
+.
+
 Variant sop1 :=
 | Oword_of_int of wsize     (* int → word *)
-| Oint_of_word of wsize     (* word → unsigned int *)
+| Oint_of_word of signedness & wsize (* word → signed/unsigned int *)
 | Osignext of wsize & wsize (* Sign-extension: output-size, input-size *)
 | Ozeroext of wsize & wsize (* Zero-extension: output-size, input-size *)
 | Onot                      (* Boolean negation *)
 | Olnot of wsize            (* Bitwize not: 1s’ complement *)
 | Oneg  of op_kind          (* Arithmetic negation *)
+(* wint operations *)
+| Owi1 of signedness & wiop1
+.
+
+Definition uint_of_word ws := Oint_of_word Unsigned ws.
+Definition sint_of_word ws := Oint_of_word Signed ws.
+
+Variant wiop2 :=
+| WIadd
+| WImul
+| WIsub
+| WIdiv
+| WImod
+| WIshl
+| WIshr
+| WIeq
+| WIneq
+| WIlt
+| WIle
+| WIgt
+| WIge
 .
 
 Variant sop2 :=
@@ -46,8 +76,8 @@ Variant sop2 :=
 | Oadd  of op_kind
 | Omul  of op_kind
 | Osub  of op_kind
-| Odiv  of cmp_kind
-| Omod  of cmp_kind
+| Odiv  of signedness & op_kind
+| Omod  of signedness & op_kind
 
 | Oland of wsize
 | Olor  of wsize
@@ -72,6 +102,9 @@ Variant sop2 :=
 | Ovlsr of velem & wsize
 | Ovlsl of velem & wsize
 | Ovasr of velem & wsize
+
+(* wint operations *)
+| Owi2 of signedness & wsize & wiop2
 .
 
 (* N-ary operators *)
@@ -89,6 +122,16 @@ Variant opN :=
 | Ocombine_flags of combine_flags
 .
 
+Scheme Equality for wiop1.
+(* Definition wiop1_beq : wiop1 -> wiop1 -> bool *)
+
+Lemma wiop1_eq_axiom : Equality.axiom wiop1_beq.
+Proof.
+  exact: (eq_axiom_of_scheme internal_wiop1_dec_bl internal_wiop1_dec_lb).
+Qed.
+
+HB.instance Definition _ := hasDecEq.Build wiop1 wiop1_eq_axiom.
+
 Scheme Equality for sop1.
 (* Definition sop1_beq : sop1 -> sop1 -> bool *)
 
@@ -98,6 +141,16 @@ Proof.
 Qed.
 
 HB.instance Definition _ := hasDecEq.Build sop1 sop1_eq_axiom.
+
+Scheme Equality for wiop2.
+(* Definition wiop2_beq : wiop2 -> wiop2 -> bool *)
+
+Lemma wiop2_eq_axiom : Equality.axiom wiop2_beq.
+Proof.
+  exact: (eq_axiom_of_scheme internal_wiop2_dec_bl internal_wiop2_dec_lb).
+Qed.
+
+HB.instance Definition _ := hasDecEq.Build wiop2 wiop2_eq_axiom.
 
 Scheme Equality for sop2.
 (* Definition sop2_beq : sop2 -> sop2 -> bool *)
@@ -121,49 +174,186 @@ HB.instance Definition _ := hasDecEq.Build opN opN_eq_axiom.
 (* ----------------------------------------------------------------------------- *)
 
 (* Type of unany operators: input, output *)
+Definition etype_of_wiop1 {len:Type} (s: signedness) (o:wiop1) : extended_type len * extended_type len :=
+  match o with
+  | WIwint_of_int  sz => (tint, twint s sz)
+  | WIint_of_wint  sz => (twint s sz, tint)
+  | WIword_of_wint sz => (twint s sz, tword sz)
+  | WIwint_of_word sz => (tword sz, twint s sz)
+  | WIwint_ext szo szi => (twint s szi, twint s szo)
+  | WIneg          sz => (twint s sz, twint s sz)
+  end.
+
+Definition type_of_wiop1 (o:wiop1) : stype * stype :=
+  match o with
+  | WIwint_of_int  sz => (sint, sword sz)
+  | WIint_of_wint  sz => (sword sz, sint)
+  | WIword_of_wint sz => (sword sz, sword sz)
+  | WIwint_of_word sz => (sword sz, sword sz)
+  | WIwint_ext szo szi => (sword szi, sword szo)
+  | WIneg          sz => (sword sz, sword sz)
+  end.
+
+Lemma e_type_of_wiop1 s o :
+  let t := etype_of_wiop1 s o in
+  type_of_wiop1 o = (to_stype t.1, to_stype t.2).
+Proof. by case: o. Qed.
+
+Definition type_of_opk (k:op_kind) :=
+  match k with
+  | Op_int => sint
+  | Op_w sz => sword sz
+  end.
+
+Definition etype_of_opk {len} (k:op_kind) : extended_type len :=
+  match k with
+  | Op_int => tint
+  | Op_w sz => tword sz
+  end.
+
+Lemma e_type_of_opk k : type_of_opk k = to_stype (etype_of_opk k).
+Proof. by case: k. Qed.
+
+(* Type of unany operators: input, output *)
+Definition etype_of_op1 {len} (o: sop1) : extended_type len * extended_type len :=
+  match o with
+  | Oword_of_int sz => (tint, tword sz)
+  | Oint_of_word _ sz => (tword sz, tint)
+  | Osignext szo szi
+  | Ozeroext szo szi
+    => (tword szi, tword szo)
+  | Onot => (tbool, tbool)
+  | Olnot sz => (tword sz, tword sz)
+  | Oneg k => let t := etype_of_opk k in (t, t)
+  | Owi1 s o => etype_of_wiop1 s o
+  end.
+
 Definition type_of_op1 (o: sop1) : stype * stype :=
   match o with
   | Oword_of_int sz => (sint, sword sz)
-  | Oint_of_word sz => (sword sz, sint)
+  | Oint_of_word _ sz => (sword sz, sint)
   | Osignext szo szi
   | Ozeroext szo szi
     => (sword szi, sword szo)
   | Onot => (sbool, sbool)
-  | Olnot sz
-  | Oneg (Op_w sz)
-    => let t := sword sz in (t, t)
-  | Oneg Op_int => (sint, sint)
+  | Olnot sz => (sword sz, sword sz)
+  | Oneg k => let t := type_of_opk k in (t, t)
+  | Owi1 s o => type_of_wiop1 o
+  end.
+
+Lemma e_type_of_op1 o :
+  let t := etype_of_op1 o in
+  type_of_op1 o = (to_stype t.1, to_stype t.2).
+Proof.
+  case: o => //= >.
+  + by rewrite !e_type_of_opk.
+  apply e_type_of_wiop1.
+Qed.
+
+(* Type of binany operators: inputs, output *)
+Definition etype_of_wiop2 {len} s sz (o : wiop2) :
+  extended_type len * extended_type len * extended_type len :=
+  match o with
+  | WIadd | WImul | WIsub | WIdiv | WImod =>
+    let t := twint s sz in (t, t, t)
+
+  | WIshl | WIshr =>
+    let t := twint s sz in
+    let tu8 := tuint U8 in
+    (t, tu8, t)
+
+  | WIeq | WIneq | WIlt | WIle | WIgt | WIge =>
+    let t := twint s sz in (t, t, tbool)
+  end.
+
+Definition type_of_wiop2 sz (o : wiop2) :
+  stype * stype * stype :=
+  match o with
+  | WIadd | WImul | WIsub | WIdiv | WImod =>
+    let t := sword sz in (t, t, t)
+
+  | WIshl | WIshr =>
+    let t := sword sz in
+    let tu8 := sword U8 in
+    (t, tu8, t)
+
+  | WIeq | WIneq | WIlt | WIle | WIgt | WIge =>
+    let t := sword sz in (t, t, sbool)
+  end.
+
+Lemma e_type_of_wiop2 s sz o :
+  let t := etype_of_wiop2 s sz o in
+  type_of_wiop2 sz o = (to_stype t.1.1, to_stype t.1.2, to_stype t.2).
+Proof. by case: o. Qed.
+
+Definition opk8 k :=
+  match k with
+  | Op_int => Op_int
+  | Op_w _ => Op_w U8
+  end.
+
+Definition opk_of_cmpk k :=
+  match k with
+  | Cmp_int => Op_int
+  | Cmp_w _ sz => Op_w sz
   end.
 
 (* Type of binany operators: inputs, output *)
-Definition type_of_op2 (o: sop2) : stype * stype * stype :=
-  match o with
+Definition etype_of_op2 {len} (o : sop2) : extended_type len * extended_type len * extended_type len :=
+ match o with
+  | Obeq | Oand | Oor => (tbool, tbool, tbool)
+  | Oadd k | Omul k | Osub k | Odiv _ k | Omod _ k =>
+    let t := etype_of_opk k in (t, t, t)
+  | Olsl k | Oasr k =>
+    let t1 := etype_of_opk k in
+    let t2 := etype_of_opk (opk8 k) in
+    (t1, t2, t1)
+  | Oland s | Olor s | Olxor s | Ovadd _ s | Ovsub _ s | Ovmul _ s
+    => let t := tword s in (t, t, t)
+  | Olsr s | Oror s | Orol s
+    => let t := tword s in (t, tword U8, t)
+  | Ovlsr _ s | Ovlsl _ s | Ovasr _ s
+    => let t := tword s in (t, tword U128, t)
+  | Oeq k | Oneq k =>
+    let t := etype_of_opk k in
+    (t, t, tbool)
+  | Olt k | Ole k | Ogt k | Oge k =>
+    let t := etype_of_opk (opk_of_cmpk k) in
+    (t, t, tbool)
+  | Owi2 s sz o => etype_of_wiop2 s sz o
+  end.
+
+Definition type_of_op2 (o : sop2) : stype * stype * stype :=
+ match o with
   | Obeq | Oand | Oor => (sbool, sbool, sbool)
-  | Oadd Op_int
-  | Omul Op_int
-  | Osub Op_int
-  | Odiv Cmp_int | Omod Cmp_int
-  | Olsl Op_int | Oasr Op_int
-    => (sint, sint, sint)
-  | Oadd (Op_w s)
-  | Omul (Op_w s)
-  | Osub (Op_w s)
-  | Odiv (Cmp_w _ s) | Omod (Cmp_w _ s)
+  | Oadd k | Omul k | Osub k | Odiv _ k | Omod _ k =>
+    let t := type_of_opk k in (t, t, t)
+  | Olsl k | Oasr k =>
+    let t1 := type_of_opk k in
+    let t2 := type_of_opk (opk8 k) in
+    (t1, t2, t1)
   | Oland s | Olor s | Olxor s | Ovadd _ s | Ovsub _ s | Ovmul _ s
     => let t := sword s in (t, t, t)
-  | Olsr s | Olsl (Op_w s) | Oasr (Op_w s) | Oror s | Orol s
+  | Olsr s | Oror s | Orol s
     => let t := sword s in (t, sword8, t)
   | Ovlsr _ s | Ovlsl _ s | Ovasr _ s
     => let t := sword s in (t, sword128, t)
-  | Oeq Op_int | Oneq Op_int
-  | Olt Cmp_int | Ole Cmp_int
-  | Ogt Cmp_int | Oge Cmp_int
-    => (sint, sint, sbool)
-  | Oeq (Op_w s) | Oneq (Op_w s)
-  | Olt (Cmp_w _ s) | Ole (Cmp_w _ s)
-  | Ogt (Cmp_w _ s) | Oge (Cmp_w _ s)
-    => let t := sword s in (t, t, sbool)
+  | Oeq k | Oneq k =>
+    let t := type_of_opk k in
+    (t, t, sbool)
+  | Olt k | Ole k | Ogt k | Oge k =>
+    let t := type_of_opk (opk_of_cmpk k) in
+    (t, t, sbool)
+  | Owi2 s sz o => type_of_wiop2 sz o
   end.
+
+Lemma e_type_of_op2 o :
+  let t := etype_of_op2 o in
+  type_of_op2 o = (to_stype t.1.1, to_stype t.1.2, to_stype t.2).
+Proof.
+  case: o => //= *; try rewrite !(e_type_of_opk) //.
+  by apply e_type_of_wiop2.
+Qed.
 
 (* Type of n-ary operators: inputs, output *)
 
@@ -244,13 +434,13 @@ Inductive pexpr : Type :=
 
 Notation pexprs := (seq pexpr).
 
-Definition Plvar x := Pvar (mk_lvar x).
+Definition Plvar x : pexpr := Pvar (mk_lvar x).
 
-Definition enot e := Papp1 Onot e.
-Definition eor e1 e2 := Papp2 Oor e1 e2.
-Definition eand e1 e2 := Papp2 Oand e1 e2.
-Definition eeq e1 e2 := Papp2 Obeq e1 e2.
-Definition eneq e1 e2 := enot (eeq e1 e2).
+Definition enot e : pexpr := Papp1 Onot e.
+Definition eor e1 e2 : pexpr := Papp2 Oor e1 e2.
+Definition eand e1 e2 : pexpr := Papp2 Oand e1 e2.
+Definition eeq e1 e2 : pexpr := Papp2 Obeq e1 e2.
+Definition eneq e1 e2 : pexpr := enot (eeq e1 e2).
 
 Definition cf_of_condition (op : sop2) : option (combine_flags * wsize) :=
   match op with
@@ -267,7 +457,6 @@ Definition pexpr_of_cf (cf : combine_flags) (vi : var_info) (flags : seq var) : 
   let eflags := [seq Plvar {| v_var := x; v_info := vi |} | x <- flags ] in
   PappN (Ocombine_flags cf) eflags.
 
-
 (* ** Left values
  * -------------------------------------------------------------------- *)
 
@@ -276,7 +465,7 @@ Variant lval : Type :=
 | Lvar  `(var_i)
 | Lmem  of aligned & wsize & var_i & pexpr
 | Laset of aligned & arr_access & wsize & var_i & pexpr
-| Lasub `(arr_access) `(wsize) `(positive) `(var_i) `(pexpr).
+| Lasub of arr_access & wsize & positive & var_i & pexpr.
 
 Coercion Lvar : var_i >-> lval.
 
@@ -646,7 +835,7 @@ Definition _sprog      := _prog stk_fun_extra sprog_extra.
 Definition to_sprog (p:_sprog) : sprog := p.
 
 (* Update functions *)
-Definition with_body eft (fd:_fundef eft) body := {|
+Definition with_body eft (fd:_fundef eft) (body : cmd) := {|
   f_info   := fd.(f_info);
   f_tyin   := fd.(f_tyin);
   f_params := fd.(f_params);
@@ -691,7 +880,24 @@ Definition is_bool (e:pexpr) :=
 Definition is_Papp2 (e : pexpr) : option (sop2 * pexpr * pexpr) :=
   if e is Papp2 op e0 e1 then Some (op, e0, e1) else None.
 
-Definition is_array_init e :=
+Definition is_Pload e :=
+  if e is Pload _ _ _ _ then true else false.
+
+Definition is_load (e: pexpr) : bool :=
+  match e with
+  | Pconst _ | Pbool _ | Parr_init _
+  | Psub _ _ _ _ _
+  | Papp1 _ _ | Papp2 _ _ _ | PappN _ _ | Pif _ _ _ _
+    => false
+  | Pvar {| gs := Sglob |}
+  | Pget _ _ _ _ _
+  | Pload _ _ _ _
+    => true
+  | Pvar {| gs := Slocal ; gv := x |}
+    => is_var_in_memory x
+  end.
+
+Definition is_array_init (e : pexpr) :=
   match e with
   | Parr_init _ => true
   | _           => false
@@ -714,9 +920,14 @@ Fixpoint cast_w ws (e: pexpr) : pexpr :=
   | Papp1 (Oneg Op_int) e' =>
       let: e' := cast_w ws e' in
       Papp1 (Oneg (Op_w ws)) e'
-  | Papp1 (Oint_of_word ws') e' =>
-      if (ws ≤ ws')%CMP then e'
-      else Papp1 (Oword_of_int ws) e
+  | Papp1 (Oint_of_word sign ws') e' =>
+      if sign is Unsigned then
+        if (ws ≤ ws')%CMP then e'
+        else Papp1 (Oword_of_int ws) e
+      else
+        (* FIXME : can we have (ws ≤ ws')%CMP *)
+        if (ws == ws')%CMP then e'
+        else Papp1 (Oword_of_int ws) e
   | _ => Papp1 (Oword_of_int ws) e
   end.
 
@@ -907,7 +1118,7 @@ End ASM_OP.
 Definition eq_gvar x x' :=
   (x.(gs) == x'.(gs)) && (v_var x.(gv) == v_var x'.(gv)).
 
-Fixpoint eq_expr e e' :=
+Fixpoint eq_expr (e e' : pexpr) :=
   match e, e' with
   | Pconst z      , Pconst z'         => z == z'
   | Pbool  b      , Pbool  b'         => b == b'

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -81,4 +81,5 @@ Separate Extraction
   riscv_instr_decl
   riscv_extra
   riscv_params
-  compiler.
+  compiler
+  wint_int.

--- a/proofs/lang/psem_defs.v
+++ b/proofs/lang/psem_defs.v
@@ -19,7 +19,8 @@ Open Scope vm_scope.
 Definition sem_sop1 (o: sop1) (v: value) : exec value :=
   let t := type_of_op1 o in
   Let x := of_val _ v in
-  ok (to_val (sem_sop1_typed o x)).
+  Let r := sem_sop1_typed o x in
+  ok (to_val r).
 
 Definition sem_sop2 (o: sop2) (v1 v2: value) : exec value :=
   let t := type_of_op2 o in

--- a/proofs/lang/psem_facts.v
+++ b/proofs/lang/psem_facts.v
@@ -708,14 +708,20 @@ Proof.
   3: by move => > _ > _ > _ > -> /= -> > -> /= -> > -> /= -> /= -> ->; eauto.
   - case.
     7: case.
-    1, 3-6, 8: by move => > _ > /= -> /= -> /= ->; eauto.
-    + move => > _ >.
-      case: ifP; last by move => _ /= -> /= -> /= ->; eauto.
-      rewrite /sem_sop1; t_xrbindP => A -> /= ? /to_wordI[] ? [] ? [] -> /truncate_wordP[] B -> <- /=.
-      t_xrbindP => ? <- <-; eexists; first reflexivity.
-      rewrite -/(zero_extend sz _) zero_extend_idem //=.
-      apply: word_uincl_zero_ext.
-      exact: cmp_le_trans A B.
+    1, 3-6, 8-9: by move => > _ > /= -> /= -> /= ->; eauto.
+    + move => [] > _ >; last first.
+      + case: ifP; last by move => _ /= -> /= -> /= ->; eauto.
+        rewrite /sem_sop1 /=; t_xrbindP => A -> /= ? /to_wordI[] ? [] ? [] -> /truncate_wordP[] B -> <- /=.
+        t_xrbindP => ? <- <-; eexists; first reflexivity.
+        rewrite -/(zero_extend sz _) zero_extend_idem //=.
+        apply: word_uincl_zero_ext.
+        exact: cmp_le_trans A B.
+      + case: ifP; last by move => _ /= -> /= -> /= ->; eauto.
+        rewrite /sem_sop1 /=; t_xrbindP => /eqP A -> /= ? /to_wordI[] ? [] ? [] -> /truncate_wordP[] B -> <- /=.
+        t_xrbindP => ? <- <-; eexists; first reflexivity.
+        subst sz.
+        rewrite wrepr_signed /=.
+        by apply: word_uincl_zero_ext.
     rewrite /= /sem_sop1 /=.
     t_xrbindP => e ih > A > B ? > /to_intI h ?; subst; case: h => ?; subst.
     move: ih.

--- a/proofs/lang/sem_op_typed.v
+++ b/proofs/lang/sem_op_typed.v
@@ -5,18 +5,39 @@ Require Export type expr sem_type.
 Require Export flag_combination.
 Import Utf8.
 
-Definition sem_sop1_typed (o: sop1) :
+Definition mk_sem_sop1 (t1 t2 : Type) (o:t1 -> t2) v1 : exec t2 :=
+  ok (o v1).
+
+Definition sem_wiop1_typed (sign : signedness) (o: wiop1) :
+  let t := type_of_wiop1 o in
+  sem_t t.1 → exec (sem_t t.2) :=
+  match o return let t := type_of_wiop1 o in sem_t t.1 → exec (sem_t t.2) with
+  | WIwint_of_int sz => wint_of_int sign sz
+  | WIint_of_wint sz => mk_sem_sop1 (@int_of_word sign sz)
+
+  | WIword_of_wint sz => mk_sem_sop1 (fun (w:word sz) => w)
+  | WIwint_of_word sz => mk_sem_sop1 (fun (w:word sz) => w)
+
+  | WIwint_ext szo szi => mk_sem_sop1 (@sem_word_extend sign szo szi)
+
+  | WIneg sz => fun (w: word sz) => wint_of_int sign sz (- int_of_word sign w)
+  end.
+
+Arguments sem_wiop1_typed : clear implicits.
+
+Definition sem_sop1_typed (o : sop1) :
   let t := type_of_op1 o in
-  sem_t t.1 → sem_t t.2 :=
-  match o with
-  | Oword_of_int sz => wrepr sz
-  | Oint_of_word sz => wunsigned
-  | Osignext szo szi => @sign_extend szo szi
-  | Ozeroext szo szi => @zero_extend szo szi
-  | Onot => negb
-  | Olnot sz => wnot
-  | Oneg Op_int => Z.opp
-  | Oneg (Op_w sz) => (-%R)%R
+  sem_t t.1 → exec (sem_t t.2) :=
+  match o return let t := type_of_op1 o in sem_t t.1 → exec (sem_t t.2) with
+  | Oword_of_int sz => mk_sem_sop1 (wrepr sz)
+  | Oint_of_word sign sz => mk_sem_sop1 (@int_of_word sign sz)
+  | Osignext szo szi => mk_sem_sop1 (@sign_extend szo szi)
+  | Ozeroext szo szi => mk_sem_sop1 (@zero_extend szo szi)
+  | Onot => mk_sem_sop1 negb
+  | Olnot sz => mk_sem_sop1 (@wnot sz)
+  | Oneg Op_int => mk_sem_sop1 Z.opp
+  | Oneg (Op_w sz) => mk_sem_sop1 (-%R)%R
+  | Owi1 sign o => sem_wiop1_typed sign o
   end.
 
 Arguments sem_sop1_typed : clear implicits.
@@ -25,7 +46,7 @@ Definition zlsl (x i : Z) : Z :=
   if (0 <=? i)%Z then (x * 2^i)%Z
   else (x / 2^(-i))%Z.
 
-Definition zasr (x i : Z) : Z := 
+Definition zasr (x i : Z) : Z :=
   zlsl x (-i).
 
 Definition sem_shift (shift:forall {s}, word s -> Z -> word s) s (v:word s) (i:u8) :=
@@ -51,18 +72,47 @@ Definition sem_vsar (ve:velem) {ws:wsize} (v : word ws) (i: u128) :=
 Definition sem_vshl (ve:velem) {ws:wsize} (v : word ws) (i: u128) :=
   lift1_vec ve (fun x => wshl x (wunsigned i)) ws v.
 
-Definition signed {A:Type} (fu fs:A) s :=
-  match s with
-  | Unsigned => fu
-  | Signed => fs
-  end.
-
 Definition mk_sem_divmod (si: signedness) sz o (w1 w2: word sz) : exec (word sz) :=
   if ((w2 == 0) || [&& si == Signed, wsigned w1 == wmin_signed sz & w2 == -1])%R then Error ErrArith
   else ok (o w1 w2).
 
 Definition mk_sem_sop2 (t1 t2 t3: Type) (o:t1 -> t2 -> t3) v1 v2 : exec t3 :=
   ok (o v1 v2).
+
+Definition mk_sem_wiop2 sign sz (o:Z -> Z -> Z) (w1 w2 : word sz) : exec (word sz) :=
+  wint_of_int sign sz (o (int_of_word sign w1) (int_of_word sign w2)).
+
+Definition mk_sem_wishift sign sz (o:Z -> Z -> Z) (w1 : word sz) (w2 : word U8) : exec (word sz) :=
+  wint_of_int sign sz (o (int_of_word sign w1) (int_of_word Unsigned w2)).
+
+Definition mk_sem_wicmp sign sz (o:Z -> Z -> bool) (w1 w2 : word sz) : exec bool :=
+  ok (o (int_of_word sign w1) (int_of_word sign w2)).
+
+Definition sem_wiop2_typed (sign : signedness) (sz : wsize) ( o : wiop2) :
+  let t := type_of_wiop2 sz o in
+  sem_t t.1.1 → sem_t t.1.2 → exec (sem_t t.2) :=
+  match o return
+   let t := type_of_wiop2 sz o in
+   sem_t t.1.1 → sem_t t.1.2 → exec (sem_t t.2) with
+
+  | WIadd => @mk_sem_wiop2 sign sz Z.add
+  | WImul => @mk_sem_wiop2 sign sz Z.mul
+  | WIsub => @mk_sem_wiop2 sign sz Z.sub
+  | WIdiv => @mk_sem_divmod sign sz (signed wdiv wdivi sign)
+  | WImod => @mk_sem_divmod sign sz (signed wmod wmodi sign)
+
+  | WIshl => @mk_sem_wishift sign sz zlsl
+  | WIshr => @mk_sem_wishift sign sz zasr
+
+  | WIeq  => @mk_sem_wicmp sign sz Z.eqb
+  | WIneq => @mk_sem_wicmp sign sz (fun z1 z2 => ~~ Z.eqb z1 z2)
+  | WIlt  => @mk_sem_wicmp sign sz Z.ltb
+  | WIle  => @mk_sem_wicmp sign sz Z.leb
+  | WIgt  => @mk_sem_wicmp sign sz Z.gtb
+  | WIge  => @mk_sem_wicmp sign sz Z.geb
+  end.
+
+Arguments sem_wiop2_typed : clear implicits.
 
 Definition sem_sop2_typed (o: sop2) :
   let t := type_of_op2 o in
@@ -72,28 +122,28 @@ Definition sem_sop2_typed (o: sop2) :
   | Oand => mk_sem_sop2 andb
   | Oor  => mk_sem_sop2 orb
 
-  | Oadd Op_int      => mk_sem_sop2 Z.add
-  | Oadd (Op_w s)    => mk_sem_sop2 +%R
-  | Omul Op_int      => mk_sem_sop2 Z.mul
-  | Omul (Op_w s)    => mk_sem_sop2 *%R
-  | Osub Op_int      => mk_sem_sop2 Z.sub
-  | Osub (Op_w s)    => mk_sem_sop2 (fun x y =>  x - y)%R
-  | Odiv Cmp_int     => mk_sem_sop2 Z.div
-  | Odiv (Cmp_w u s) => @mk_sem_divmod u s (signed wdiv wdivi u)
-  | Omod Cmp_int     => mk_sem_sop2 Z.modulo
-  | Omod (Cmp_w u s) => @mk_sem_divmod u s (signed wmod wmodi u)
+  | Oadd Op_int     => mk_sem_sop2 Z.add
+  | Oadd (Op_w s)   => mk_sem_sop2 +%R
+  | Omul Op_int     => mk_sem_sop2 Z.mul
+  | Omul (Op_w s)   => mk_sem_sop2 *%R
+  | Osub Op_int     => mk_sem_sop2 Z.sub
+  | Osub (Op_w s)   => mk_sem_sop2 (fun x y =>  x - y)%R
+  | Odiv u Op_int   => mk_sem_sop2 (signed Z.div Z.quot u)
+  | Odiv u (Op_w s) => @mk_sem_divmod u s (signed wdiv wdivi u)
+  | Omod u Op_int   => mk_sem_sop2 (signed Z.modulo Z.rem u)
+  | Omod u (Op_w s) => @mk_sem_divmod u s (signed wmod wmodi u)
 
   | Oland s       => mk_sem_sop2 wand
   | Olor  s       => mk_sem_sop2 wor
   | Olxor s       => mk_sem_sop2 wxor
   | Olsr s        => mk_sem_sop2 sem_shr
-  | Olsl Op_int   => mk_sem_sop2 zlsl 
+  | Olsl Op_int   => mk_sem_sop2 zlsl
   | Olsl (Op_w s) => mk_sem_sop2 sem_shl
-  | Oasr Op_int   => mk_sem_sop2 zasr 
+  | Oasr Op_int   => mk_sem_sop2 zasr
   | Oasr (Op_w s) => mk_sem_sop2 sem_sar
   | Oror s        => mk_sem_sop2 sem_ror
   | Orol s        => mk_sem_sop2 sem_rol
- 
+
   | Oeq Op_int    => mk_sem_sop2 Z.eqb
   | Oeq (Op_w s)  => mk_sem_sop2 eq_op
   | Oneq Op_int   => mk_sem_sop2 (fun x y => negb (Z.eqb x y))
@@ -115,6 +165,8 @@ Definition sem_sop2_typed (o: sop2) :
   | Ovlsr ve ws     => mk_sem_sop2 (sem_vshr ve)
   | Ovlsl ve ws     => mk_sem_sop2 (sem_vshl ve)
   | Ovasr ve ws     => mk_sem_sop2 (sem_vsar ve)
+
+  | Owi2 s sz o => sem_wiop2_typed s sz o
   end.
 
 Arguments sem_sop2_typed : clear implicits.

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -285,7 +285,7 @@ Proof. by apply /eqP; case sz. Qed.
 
 Lemma wrepr_opp sz (x: Z) :
   wrepr sz (- x) = (- wrepr sz x)%R.
-Proof. 
+Proof.
   have -> : (- x) = (- x)%R by done.
   by rewrite -(mulN1r x) wrepr_mul wrepr_m1 mulN1r.
 Qed.
@@ -303,13 +303,13 @@ Proof.
 Qed.
 
 Lemma wunsigned_add_if ws (a b : word ws) :
-  wunsigned (a + b) = 
+  wunsigned (a + b) =
    if wunsigned a + wunsigned b <? wbase ws then wunsigned a + wunsigned b
    else wunsigned a + wunsigned b - wbase ws.
 Proof.
   move: (wunsigned_range a) (wunsigned_range b).
   rewrite /wunsigned mathcomp.word.word.addwE /GRing.add /= -/(wbase ws) => ha hb.
-  case: ZltP => hlt. 
+  case: ZltP => hlt.
   + by rewrite Zmod_small //; lia.
   by rewrite -(Z_mod_plus_full _ (-1)) Zmod_small; lia.
 Qed.
@@ -322,20 +322,20 @@ Proof.
   by rewrite -wrepr_sub wunsigned_repr Z.mod_small.
 Qed.
 
-Lemma wunsigned_sub_if ws (a b : word ws) : 
-  wunsigned (a - b) = 
-    if wunsigned b <=? wunsigned a then wunsigned a - wunsigned b 
+Lemma wunsigned_sub_if ws (a b : word ws) :
+  wunsigned (a - b) =
+    if wunsigned b <=? wunsigned a then wunsigned a - wunsigned b
     else  wbase ws + wunsigned a - wunsigned b.
 Proof.
   move: (wunsigned_range a) (wunsigned_range b).
   rewrite /wunsigned mathcomp.word.word.subwE -/(wbase ws) => ha hb.
   have -> : (word.urepr a - word.urepr b)%R = word.urepr a - word.urepr b by done.
-  case: ZleP => hle. 
+  case: ZleP => hle.
   + by rewrite Zmod_small //; lia.
   by rewrite -(Z_mod_plus_full _ 1) Zmod_small; lia.
 Qed.
 
-Lemma wunsigned_opp_if ws (a : word ws) : 
+Lemma wunsigned_opp_if ws (a : word ws) :
   wunsigned (-a) = if wunsigned a == 0 then 0 else wbase ws - wunsigned a.
 Proof.
   have ha := wunsigned_range a.
@@ -870,7 +870,7 @@ Qed.
 
 Lemma zero_extend1 sz sz' :
   @zero_extend sz sz' 1%R = 1%R.
-Proof. 
+Proof.
   apply/eqP/eq_from_wbit => -[i hi].
   have := @wbit_zero_extend sz sz' 1%R i.
   by rewrite /wbit_n => ->; rewrite -ltnS hi.
@@ -1063,18 +1063,18 @@ Lemma zero_extend_m1 sz sz' :
   @zero_extend sz sz' (-1) = (-1)%R.
 Proof. exact: zero_extend_wrepr. Qed.
 
-Lemma wopp_zero_extend sz sz' (x: word sz') : 
+Lemma wopp_zero_extend sz sz' (x: word sz') :
   (sz ≤ sz')%CMP →
   zero_extend sz (-x) = (- zero_extend sz x)%R.
 Proof.
  by move=> hsz; rewrite -(mulN1r x) wmul_zero_extend // zero_extend_m1 // mulN1r.
 Qed.
 
-Lemma wsub_zero_extend sz sz' (x y : word sz'): 
+Lemma wsub_zero_extend sz sz' (x y : word sz'):
   (sz ≤ sz')%CMP →
   zero_extend sz (x - y) = (zero_extend sz x - zero_extend sz y)%R.
 Proof.
-  by move=> hsz; rewrite wadd_zero_extend // wopp_zero_extend. 
+  by move=> hsz; rewrite wadd_zero_extend // wopp_zero_extend.
 Qed.
 
 Lemma zero_extend_wshl sz sz' (x: word sz') c :
@@ -1362,7 +1362,7 @@ Definition pextr sz (w1 w2: word sz) :=
 Fixpoint bitpdep sz (w:word sz) (i:nat) (mask:bitseq) :=
   match mask with
   | [::] => [::]
-  | b :: mask => 
+  | b :: mask =>
       if b then wbit_n w i :: bitpdep w (i.+1) mask
       else false :: bitpdep w i mask
   end.


### PR DESCRIPTION
This PR introduce new types in jasmin source: siXX and uiXX.
For the compiler they are equal to wXX.
It also introduce the operator word_to_sint and word_to_uint 
    (int) w  : is word_to_uint      (for compatibility)
    (uint) w : is word_to_uint   
    (sint) w : is word_to_sint   ( NEW)
    (XXsi) w : cast from wXX to siXX 
    (XXsi) si : cast from siYY to siXX
    (XXsi) i : cast from int to sint  
    Same with XXui
    (int) si | (sint) si : cast from siXX to int
    (int) ui | (uint) si : cast from uiXX to int

New notation for uXX : wXX is not accepted and used for printing
Compilation starts by replacing all operations on siXX uiXX by corresponding wXX operations.
Extraction starts by replacing all operations on siXX uiXX by corresponding int operations.









