### PR TITLE
Updating pre-typing to detect deprecated intrinsic operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 
 ## Other changes
 
+- Add warning to signal deprecated intrinsic operators 
+  ([PR #1092](https://github.com/jasmin-lang/jasmin/pull/1092)).
+
 - Some warnings are now disabled by default: when introducing assignements
   (`-wea`), destinations (`-w_`), array copies (`-winsertarraycopy`), or `LEA`
   instructions (`-wlea`); they can be enabled using a new command-line argument

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1429,9 +1429,28 @@ let default_suffix =
   | x :: _ -> x
   | [] -> Sopn.PVp U8
 
-let tt_prim asmOp id =
+(**
+Deprecated intrinsic operators map (old name -> new name)
+*)
+let deprecated_intrinsic = 
+  let m = Ms.empty in 
+  let m = Ms.add "VPBLENDVB" "BLENDV" m in
+  Ms.add "VPMOVMSKB" "MOVEMASK" m
+
+(**
+  Check if intrinsic opperator is deprecated and emit a warning if so.
+*)
+let check_deprecated_intrinsic (old_name: string) (loc:L.t) =
+  match Ms.find_opt old_name deprecated_intrinsic with
+  | None -> ()
+  | Some new_name ->
+    warning Deprecated (L.i_loc0 loc) "Intrinsic operator '%s' is deprecated. Please use '%s' instead." old_name new_name
+
+
+let tt_prim asmOp id = 
   let { L.pl_loc = loc ; L.pl_desc = s } = id in
   let name, sz = extract_size s in
+  check_deprecated_intrinsic name loc;
   let c =
     match List.assoc name asmOp.Sopn.prim_string with
     | PrimX86 (valid_suffixes, preop) ->


### PR DESCRIPTION
Introduction of operators `BLENDV` and `MOVEMASK` made `VPBLENDVB` and `VPMOVMSKB` deprecated. This PR add a warning to signal it. 

For genericity reasons, this is done during pre-typing step of compilation.