### PR TITLE
Adapt to MC#1256

### DIFF
--- a/proofs/compiler/arm_stack_zeroization_proof.v
+++ b/proofs/compiler/arm_stack_zeroization_proof.v
@@ -291,10 +291,10 @@ Proof.
     move=> k hk.
     apply hsr.(sr_mem_valid).
     rewrite /between /zbetween wsize8 !zify addE /top.
-    rewrite -wrepr_sub -GRing.addrA -wrepr_add.
+    rewrite -wrepr_sub -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
     have hbound := hsr.(sr_bound).
     have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
-    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+    by rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split=> /=.
   apply: lsem_step2.
@@ -514,10 +514,10 @@ Local Opaque wsize_size Z.of_nat.
     move=> k hk.
     apply hsr.(sr_mem_valid).
     rewrite /between /zbetween wsize8 !zify addE /top.
-    rewrite -GRing.addrA -wrepr_add.
+    rewrite -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
     have hbound := hsr.(sr_bound).
     have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
-    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+    by rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split.
   + apply: lsem_step1.

--- a/proofs/compiler/riscv_stack_zeroization_proof.v
+++ b/proofs/compiler/riscv_stack_zeroization_proof.v
@@ -284,10 +284,10 @@ Proof.
     move=> k hk.
     apply hsr.(sr_mem_valid).
     rewrite /between /zbetween wsize8 !zify addE /top.
-    rewrite -wrepr_sub -GRing.addrA -wrepr_add.
+    rewrite -wrepr_sub -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
     have hbound := hsr.(sr_bound).
     have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
-    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+    rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split=> /=.
   apply: lsem_step3.
@@ -516,10 +516,10 @@ Local Opaque wsize_size Z.of_nat.
     move=> k hk.
     apply hsr.(sr_mem_valid).
     rewrite /between /zbetween wsize8 !zify addE /top.
-    rewrite -GRing.addrA -wrepr_add.
+    rewrite -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
     have hbound := hsr.(sr_bound).
     have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
-    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+    by rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split.
   + apply: lsem_step1.

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -737,7 +737,7 @@ Proof.
   move=> hwf hread hmem hofs hbound hget.
   apply read8_read.
   move=> al' k hk.
-  rewrite addE -GRing.addrA -wrepr_add (read8_alignment Aligned).
+  rewrite addE -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add (read8_alignment Aligned).
   apply hread; last by apply hget.
   rewrite memi_mem_U8; apply: mem_incl_r hmem; rewrite subset_interval_of_zone.
   rewrite -(sub_zone_at_ofs_compose _ _ _ (wsize_size ws)).
@@ -1021,7 +1021,7 @@ Section EXPR.
     have /vs_slot_valid hptr := hwf.(wfr_slot).
     apply /validwP; split=> //.
     move=> k hk; rewrite (validw8_alignment Aligned); apply hptr; move: hk.
-    apply between_byte.
+    apply: between_byte.
     + by apply (no_overflow_sub_region_addr hwf).
     by apply (zbetween_sub_region_addr hwf).
   Qed.
@@ -2607,7 +2607,7 @@ Proof.
       (Varr a').
   + rewrite /= get_var_bytes_set_move_bytes /= !eqxx /=.
     move=> off hmem w' /[dup] /get_val_byte_bound /= hoff /hay.
-    rewrite -sub_region_addr_offset -GRing.addrA -wrepr_add.
+    rewrite -sub_region_addr_offset -GRing.addrA -[(_ + wrepr _ off)%R]wrepr_add.
     assert (hval := wfr_val hgvalidy hgety).
     case: hval => hread _.
     apply hread.
@@ -2780,7 +2780,7 @@ Proof.
       (Varr a').
   + rewrite /= get_var_bytes_set_move_bytes /= !eqxx /=.
     move=> off hmem w' /[dup] /get_val_byte_bound /= hoff /hay.
-    rewrite -sub_region_addr_offset -GRing.addrA -wrepr_add.
+    rewrite -sub_region_addr_offset -GRing.addrA -[(_ + wrepr _ off)%R]wrepr_add.
     assert (hval := wfr_val hgvalidy hgety).
     case: hval => hread _.
     apply hread.

--- a/proofs/compiler/x86_stack_zeroization_proof.v
+++ b/proofs/compiler/x86_stack_zeroization_proof.v
@@ -163,10 +163,10 @@ Proof.
     move=> k hk.
     apply hsr.(sr_mem_valid).
     rewrite /between /zbetween wsize8 !zify addE /top.
-    rewrite -wrepr_sub -GRing.addrA -wrepr_add.
+    rewrite -wrepr_sub -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
     have hbound := hsr.(sr_bound).
     have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
-    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+    by rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split=> /=.
   + apply: lsem_step.
@@ -471,10 +471,10 @@ Proof.
     move=> k hk.
     apply hsr.(sr_mem_valid).
     rewrite /between /zbetween wsize8 !zify addE /top.
-    rewrite -wrepr_sub -GRing.addrA -wrepr_add.
+    rewrite -wrepr_sub -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
     have hbound := hsr.(sr_bound).
     have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
-    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+    by rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split=> /=.
   + apply: lsem_step.
@@ -837,10 +837,10 @@ Local Opaque wsize_size Z.of_nat.
     move=> k hk.
     apply hsr.(sr_mem_valid).
     rewrite /between /zbetween wsize8 !zify addE /top.
-    rewrite -GRing.addrA -wrepr_add.
+    rewrite -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
     have hbound := hsr.(sr_bound).
     have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
-    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+    by rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split.
   + apply: lsem_step1.
@@ -1093,10 +1093,10 @@ Local Opaque wsize_size Z.of_nat.
     move=> k hk.
     apply hsr.(sr_mem_valid).
     rewrite /between /zbetween wsize8 !zify addE /top.
-    rewrite -GRing.addrA -wrepr_add.
+    rewrite -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
     have hbound := hsr.(sr_bound).
     have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
-    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+    by rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
   move=> /(writeV 0) [m' hm'].
   eexists (Estate _ _ _); split.
   + apply: lsem_step1.

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -909,11 +909,8 @@ Proof.
   have [hle hlt] := wunsigned_range (p - wrepr Uptr sz).
   have := Z.mod_le _ _ hle (wsize_size_pos ws).
   have := Z_mod_lt (wunsigned (p - wrepr Uptr sz)) (wsize_size ws) ltac:(done).
-  move=> [] mod_ge0 _ hle_mod.
-  split; first exact: Zle_minus_le_0.
-  apply/Z.lt_sub_lt_add_l/(Z.lt_le_trans _ _ _ hlt).
-  rewrite -{1}[wbase _]Z.add_0_l.
-  exact: Zplus_le_compat_r.
+  move: (wunsigned (p - wrepr Uptr sz)) hlt.
+  lia.
 Qed.
 
 Lemma top_stack_after_alloc_bounded p ws sz :

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -909,8 +909,11 @@ Proof.
   have [hle hlt] := wunsigned_range (p - wrepr Uptr sz).
   have := Z.mod_le _ _ hle (wsize_size_pos ws).
   have := Z_mod_lt (wunsigned (p - wrepr Uptr sz)) (wsize_size ws) ltac:(done).
-  rewrite -[(_ : zmodType -> nmodType) (word Uptr)]/(word Uptr : nmodType).
-  lia.
+  move=> [] mod_ge0 _ hle_mod.
+  split; first exact: Zle_minus_le_0.
+  apply/Z.lt_sub_lt_add_l/(Z.lt_le_trans _ _ _ hlt).
+  rewrite -{1}[wbase _]Z.add_0_l.
+  exact: Zplus_le_compat_r.
 Qed.
 
 Lemma top_stack_after_alloc_bounded p ws sz :


### PR DESCRIPTION
https://github.com/math-comp/math-comp/pull/1256 changes the behavior of rewrite (seemingly because it generalizes some operations). This PR makes the necessary changes to keep compiling. `lia` also does not like at all the change in the hierarchy.