### PR TITLE
Tests: disable a few redundant checks

### DIFF
--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -73,27 +73,21 @@ exclude = tests/success/noextract
 bin     = ./scripts/check
 args    = -arch x86-64 -stack-zero=loop
 okdirs  = examples/**/x86-64 tests/success/**/x86-64
-kodirs  = tests/fail/**/x86-64
-exclude = tests/fail/warning
 
 [test-x86-64-stack-zero-unrolled]
 bin     = ./scripts/check
 args    = -arch x86-64 -stack-zero=unrolled
 okdirs  = examples/**/x86-64 tests/success/**/x86-64
-kodirs  = tests/fail/**/x86-64
-exclude = tests/fail/warning
 
 [test-arm-m4-stack-zero-loop]
 bin     = ./scripts/check
 args    = -arch arm-m4 -stack-zero=loop
 okdirs  = examples/**/arm-m4 tests/success/**/arm-m4
-kodirs  = tests/fail/**/arm-m4
 
 [test-arm-m4-stack-zero-unrolled]
 bin     = ./scripts/check
 args    = -arch arm-m4 -stack-zero=unrolled
 okdirs  = examples/**/arm-m4 tests/success/**/arm-m4
-kodirs  = tests/fail/**/arm-m4
 exclude = tests/success/arm-m4/large_stack
 
 [test-risc-v]

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -37,7 +37,7 @@ bin = ./scripts/check
 args = -arch x86-64 -intel
 okdirs = examples/**/x86-64 tests/success/**/x86-64 tests/success/**/common
 kodirs = tests/fail/**/x86-64 tests/fail/**/common
-exclude = tests/fail/warning
+exclude = tests/fail/warning tests/fail/nolea
 
 [test-x86-64-print]
 bin = ./scripts/parse-print-parse

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -31,8 +31,6 @@ okdirs = CCT/success/speculative
 bin     = ./scripts/check
 args    = -arch x86-64 -ATT
 okdirs  = examples/**/x86-64 tests/success/**/x86-64 tests/success/**/common
-kodirs  = tests/fail/**/x86-64 tests/fail/**/common
-exclude = tests/fail/warning
 
 [test-x86-64-Intel]
 bin = ./scripts/check


### PR DESCRIPTION
It is wrong to verify that negative tests fail under any possible configuration (when said configuration is unrelated to the test).