### PR TITLE
Checksafety: normalize often the list of if-conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ## Bug fixes
 
+- Improve memory usage in safety pre-analysis
+  ([PR #1103](https://github.com/jasmin-lang/jasmin/pull/1103)).
+
 - Fix liveness annotation of while loops
   ([PR #1098](https://github.com/jasmin-lang/jasmin/pull/1098);
   fixes [#1097](https://github.com/jasmin-lang/jasmin/issues/1097)).

--- a/compiler/safetylib/safetyPreanalysis.ml
+++ b/compiler/safetylib/safetyPreanalysis.ml
@@ -272,7 +272,8 @@ end = struct
       cfg = mcfg st1.cfg st2.cfg;
       while_vars = Sv.union st1.while_vars st2.while_vars;
       f_done = Ss.union st1.f_done st2.f_done;
-      if_conds = List.rev_append st1.if_conds st2.if_conds;
+      if_conds = List.rev_append st1.if_conds st2.if_conds
+                 |> List.sort_uniq Stdlib.compare;
       ct = ct }
 
   let set_ct ct st = { st with ct = ct }


### PR DESCRIPTION
In the safety pre-analysis, a set of expressions is represented by a list (without duplicates). Duplicates are tolerated during the construction of the list which is normalized at the end of the pre-analysis.

This runs normalization more often so as to prevent the size of this list to blow-up.