### PR TITLE
Update warnings (v2)

### DIFF
--- a/proofs/3rdparty/ssrring.v
+++ b/proofs/3rdparty/ssrring.v
@@ -307,14 +307,14 @@ Qed.
 
 Lemma RZ (R : ringType):
   ring_morph (R := R) 0 1 +%R *%R ~%R -%R eq
-    0%Z 1%Z Zplus Zmult Zminus Z.opp Zeq_bool (@R_of_Z _).
+    0%Z 1%Z Zplus Zmult Zminus Z.opp Z.eqb (@R_of_Z _).
 Proof.
   split=> //=.
   + by move=> x y; rewrite rmorphD.
   + by move=> x y; rewrite rmorphB.
   + by move=> x y; rewrite rmorphM.
   + by move=> x; rewrite raddfN.
-  + by move=> x y /Zeq_bool_eq ->.
+  + by move=> x y /Z.eqb_eq ->.
 Qed.
 
 Lemma PN (R : ringType):

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -6,7 +6,6 @@
 -arg "-w -extraction-reserved-identifier"
 -arg "-w -extraction-opaque-accessed"
 -arg "-w -ambiguous-paths"
--arg "-w -argument-scope-delimiter"
 -arg "-w -redundant-canonical-projection"
 -arg "-w -projection-no-head-constant"
 -arg "-w -postfix-notation-not-level-1"

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -9,8 +9,6 @@
 -arg "-w -argument-scope-delimiter"
 -arg "-w -redundant-canonical-projection"
 -arg "-w -projection-no-head-constant"
--arg "-w -extraction-default-directory"
--arg "-w -change-dir-deprecated"
 -arg "-w -postfix-notation-not-level-1"
 -arg "-w -deprecated-since-mathcomp-2.3.0"
 -arg "-w -deprecated-from-Coq"

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -61,9 +61,9 @@ Proof.
 Qed.
 
 End ToIdent.
-Arguments ToIdent [t] T%type_scope {tS}.
-Arguments of_var {t} {T}%type_scope {tS toI} v.
-Arguments to_var {t} {T}%type_scope {tS toI} r.
+Arguments ToIdent [t] T%_type_scope {tS}.
+Arguments of_var {t} {T}%_type_scope {tS toI} v.
+Arguments to_var {t} {T}%_type_scope {tS toI} r.
 
 Module Type MkToIdent_T.
 

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -255,7 +255,7 @@ Qed.
 Definition disjoint_labels (lo hi: label) (c: lcmd) : Prop :=
   ∀ lbl, (lo <= lbl < hi)%positive → ~~ has (is_label lbl) c.
 
-Arguments disjoint_labels _%positive _%positive _.
+Arguments disjoint_labels _%_positive _%_positive _.
 
 Lemma disjoint_labels_cat lo hi P Q :
   disjoint_labels lo hi P →

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -51,7 +51,7 @@ Extract Constant ident.Cident.id_kind => "CoreIdent.Cident.id_kind".
 
 Extract Constant ident.Cident.spill_to_mmx => "CoreIdent.Cident.spill_to_mmx".
 
-Cd  "lang/ocaml".
+Set Extraction Output Directory "lang/ocaml".
 
 Extraction Blacklist String List Nat Uint63 Utils Var Array.
 
@@ -80,5 +80,3 @@ Separate Extraction
   riscv_extra
   riscv_params
   compiler.
-
-Cd  "../..".

--- a/proofs/lang/psem_defs.v
+++ b/proofs/lang/psem_defs.v
@@ -66,7 +66,7 @@ Record estate
     evm  : Vm.t
   }.
 
-Arguments Estate {syscall_state}%type_scope {ep} _ _ _%vm_scope.
+Arguments Estate {syscall_state}%_type_scope {ep} _ _ _%_vm_scope.
 
 (* ** Variable map
  * -------------------------------------------------------------------- *)

--- a/proofs/lang/sem_one_varmap.v
+++ b/proofs/lang/sem_one_varmap.v
@@ -104,7 +104,7 @@ Definition top_stack_aligned fd m : bool :=
 
 Definition set_RSP m vm : Vm.t :=
   vm.[vrsp <- Vword (top_stack m)].
-#[global] Arguments set_RSP _ _%vm_scope.
+#[global] Arguments set_RSP _ _%_vm_scope.
 
 Definition valid_RSP m (vm: Vm.t) : Prop :=
   vm.[vrsp] = Vword (top_stack m).

--- a/proofs/lang/sem_type.v
+++ b/proofs/lang/sem_type.v
@@ -73,14 +73,14 @@ Fixpoint sem_prod_ok {T: Type} (tin : seq stype) : sem_prod tin T -> sem_prod ti
   | [::] => fun o => ok o
   | t :: ts => fun o v => @sem_prod_ok T ts (o v)
   end.
-Arguments sem_prod_ok {T}%type_scope tin%seq_scope _.
+Arguments sem_prod_ok {T}%_type_scope tin%_seq_scope _.
 
 Fixpoint sem_forall {T: Type} (P: T -> Prop) (tin : seq stype) : sem_prod tin T -> Prop :=
   match tin return sem_prod tin T -> Prop with
   | [::] => P
   | t :: ts => fun o => forall v, @sem_forall T P ts (o v)
   end.
-Arguments sem_forall {T}%type_scope P%function_scope tin%seq_scope _.
+Arguments sem_forall {T}%_type_scope P%_function_scope tin%_seq_scope _.
 
 Lemma sem_prod_ok_ok {T: Type} (tin : seq stype) (o : sem_prod tin T) :
   sem_forall (fun et => exists t, et = ok t) tin (sem_prod_ok tin o).

--- a/proofs/lang/strings.v
+++ b/proofs/lang/strings.v
@@ -90,6 +90,6 @@ Declare Scope mstring_scope.
 Delimit Scope mstring_scope with ms.
 Notation "m .[ x ]" := (@Ms.get _ m x) : mstring_scope.
 Notation "m .[ x  <- v ]" := (@Ms.set _ m x v) : mstring_scope.
-Arguments Ms.get T%type_scope m%mstring_scope k.
-Arguments Ms.set T%type_scope m%mstring_scope k v.
+Arguments Ms.get T%_type_scope m%_mstring_scope k.
+Arguments Ms.set T%_type_scope m%_mstring_scope k v.
 

--- a/proofs/lang/type.v
+++ b/proofs/lang/type.v
@@ -181,8 +181,8 @@ Declare Scope mtype_scope.
 Delimit Scope mtype_scope with mt.
 Notation "m .[ x ]" := (@Mt.get _ m x) : mtype_scope.
 Notation "m .[ x  <- v ]" := (@Mt.set _ m x v) : mtype_scope.
-Arguments Mt.get P m%mtype_scope k.
-Arguments Mt.set P m%mtype_scope k v.
+Arguments Mt.get P m%_mtype_scope k.
+Arguments Mt.set P m%_mtype_scope k v.
 
 
 Definition is_sbool t := t == sbool.

--- a/proofs/lang/varmap.v
+++ b/proofs/lang/varmap.v
@@ -1171,6 +1171,6 @@ End REL_EQUIV.
 #[export] Existing Instance po_uincl_ex.
 #[export] Existing Instance uincl_ex_trans.
 
-#[ global ]Arguments get_var {wsw} wdb vm%vm_scope x.
-#[ global ]Arguments set_var {wsw} wdb vm%vm_scope x v.
+#[ global ]Arguments get_var {wsw} wdb vm%_vm_scope x.
+#[ global ]Arguments set_var {wsw} wdb vm%_vm_scope x v.
 


### PR DESCRIPTION
Now that we dropped support for < 8.20, we can make a bit of cleaning.

Also removes some warning in 9.0.