### PR TITLE
Use relative paths in -print-dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 
 ## Other changes
 
+- Option `-print-dependencies` now uses relative paths
+  ([PR #1107](https://github.com/jasmin-lang/jasmin/pull/1107)).
+
 - Add warning to signal deprecated intrinsic operators 
   ([PR #1092](https://github.com/jasmin-lang/jasmin/pull/1092)).
 

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -428,7 +428,8 @@ end  = struct
   let decls env = env.e_decls 
 
   let dependencies env =
-    Map.fold ( @ ) env.e_loader.loaded []
+    let mk_rel = Path.relative_to_any env.e_loader.idir in
+    Map.fold (fun ps acc -> List.rev_map mk_rel ps @ acc) env.e_loader.loaded []
 
   let find (proj: 'asm global_bindings -> (A.symbol, 'a) Map.t) (x: A.symbol) (env: 'asm env) : 'a option =
     let stack, bot = env.e_bindings in


### PR DESCRIPTION
This makes the output of `-print-dependencies` reusable in different contexts.