### PR TITLE
Removing printing of trailing whitespaces in riscv

### DIFF
--- a/compiler/src/pp_riscv.ml
+++ b/compiler/src/pp_riscv.ml
@@ -52,7 +52,7 @@ let print_asm_line fmt ln =
   | LLabel lbl ->
       Format.fprintf fmt "%s:" lbl
   | LInstr (s, []) ->
-      Format.fprintf fmt "\t%-*s" iwidth s
+      Format.fprintf fmt "\t%s" s
   | LInstr (s, args) ->
       Format.fprintf fmt "\t%-*s\t%s" iwidth s (String.concat ", " args)
   | LByte n -> Format.fprintf fmt "\t.byte\t%s" n


### PR DESCRIPTION
In riscv pretty printer, we write trailing whitespaces even for instructions without arguments. This whitespace is not useful in this case and should be removed