### PR TITLE
changed pseudo-monadic notation (>>= -> >>r= | >>o=, similarly for >>…

### DIFF
--- a/proofs/arch/arch_sem.v
+++ b/proofs/arch/arch_sem.v
@@ -435,7 +435,7 @@ Definition eval_instr (i : asm_i_r) (s: asm_state) : exec asm_state :=
     else type_error
   | JMP lbl   => eval_JMP p lbl s
   | JMPI d =>
-    Let v := eval_asm_arg (AK_mem Aligned) s d (sword Uptr) >>= to_pointer in
+    Let v := eval_asm_arg (AK_mem Aligned) s d (sword Uptr) >>r= to_pointer in
     if decode_label labels v is Some lbl then
       eval_JMP p lbl s
     else type_error
@@ -447,7 +447,7 @@ Definition eval_instr (i : asm_i_r) (s: asm_state) : exec asm_state :=
       else type_error
   | CALL lbl =>
       if return_address_from s is Some ra then
-        eval_PUSH ra s >>= eval_JMP p lbl
+        eval_PUSH ra s >>r= eval_JMP p lbl
       else type_error
   | POPPC =>
     Let: (s', dst) := eval_POP s in

--- a/proofs/compiler/allocation.v
+++ b/proofs/compiler/allocation.v
@@ -442,23 +442,23 @@ Fixpoint check_e (e1 e2:pexpr) (m:M.t) : cexec M.t :=
   | Pvar   x1, Pvar   x2 => check_gv x1 x2 m
   | Pget al1 aa1 w1 x1 e1, Pget al2 aa2 w2 x2 e2 =>
     Let _ := assert ((al1 == al2) && (aa1 == aa2) && (w1 == w2)) error_e in
-    check_gv x1 x2 m >>= check_e e1 e2
+    check_gv x1 x2 m >>r= check_e e1 e2
   | Psub aa1 w1 len1 x1 e1, Psub aa2 w2 len2 x2 e2 =>
     Let _ := assert ([&& aa1 == aa2, w1 == w2 & len1 == len2]) error_e in
-    check_gv x1 x2 m >>= check_e e1 e2
+    check_gv x1 x2 m >>r= check_e e1 e2
   | Pload al1 w1 x1 e1, Pload al2 w2 x2 e2 =>
     Let _ := assert ((al1 == al2) && (w1 == w2)) error_e in
-    check_v x1 x2 m >>= check_e e1 e2
+    check_v x1 x2 m >>r= check_e e1 e2
   | Papp1 o1 e1, Papp1 o2 e2 =>
     Let _ := assert (o1 == o2) error_e in check_e e1 e2 m
    | Papp2 o1 e11 e12, Papp2 o2 e21 e22 =>
-    Let _ := assert (o1 == o2) error_e in check_e e11 e21 m >>= check_e e12 e22
+    Let _ := assert (o1 == o2) error_e in check_e e11 e21 m >>r= check_e e12 e22
   | PappN o1 es1, PappN o2 es2 =>
     Let _ := assert (o1 == o2) error_e in
     fold2 (alloc_error "check_e (appN)") check_e es1 es2 m
   | Pif t e e1 e2, Pif t' e' e1' e2' =>
     Let _ := assert (t == t') error_e in
-    check_e e e' m >>= check_e e1 e1' >>= check_e e2 e2'
+    check_e e e' m >>r= check_e e1 e1' >>r= check_e e2 e2'
   | _, _ => Error error_e
   end.
 
@@ -498,13 +498,13 @@ Definition check_lval (e2:option (stype * pexpr)) (x1 x2:lval) m : cexec M.t :=
     end
   | Lmem al1 w1 x1 e1, Lmem al2 w2 x2 e2  =>
     Let _ := assert ((al1 == al2) && (w1 == w2)) error_lv in
-    check_v x1 x2 m >>= check_e e1 e2
+    check_v x1 x2 m >>r= check_e e1 e2
   | Laset al1 aa1 w1 x1 e1, Laset al2 aa2 w2 x2 e2 =>
     Let _ := assert ((al1 == al2) && (aa1 == aa2) && (w1 == w2)) error_lv in
-    check_v x1 x2 m >>= check_e e1 e2 >>= check_varc x1 x2
+    check_v x1 x2 m >>r= check_e e1 e2 >>r= check_varc x1 x2
   | Lasub aa1 w1 len1 x1 e1, Lasub aa2 w2 len2 x2 e2 =>
     Let _ := assert [&& aa1 == aa2, w1 == w2 & len1 == len2] error_lv in
-    check_v x1 x2 m >>= check_e e1 e2 >>= check_varc x1 x2
+    check_v x1 x2 m >>r= check_e e1 e2 >>r= check_varc x1 x2
   | _          , _           => Error error_lv
   end.
 
@@ -568,19 +568,19 @@ Fixpoint check_i (i1 i2:instr_r) r :=
     match i1, i2 with
     | Cassgn x1 _ ty1 e1, Cassgn x2 _ ty2 e2 =>
       Let _ := assert (ty1 == ty2) (alloc_error "bad type in assignment") in
-      check_e e1 e2 r >>= check_lval (Some (ty2,e2)) x1 x2
+      check_e e1 e2 r >>r= check_lval (Some (ty2,e2)) x1 x2
 
     | Copn xs1 _ o1 es1, Copn xs2 _ o2 es2 =>
       Let _ := assert (o1 == o2) (alloc_error "operators not equals") in
-      check_es es1 es2 r >>= check_lvals xs1 xs2
+      check_es es1 es2 r >>r= check_lvals xs1 xs2
 
     | Csyscall xs1 o1 es1, Csyscall xs2 o2 es2 =>
       Let _ := assert (o1 == o2) (alloc_error "syscall not equals") in
-      check_es es1 es2 r >>= check_lvals xs1 xs2
+      check_es es1 es2 r >>r= check_lvals xs1 xs2
 
     | Ccall x1 f1 arg1, Ccall x2 f2 arg2 =>
       Let _ := assert (f1 == f2) (alloc_error "functions not equals") in
-      check_es arg1 arg2 r >>= check_lvals x1 x2
+      check_es arg1 arg2 r >>r= check_lvals x1 x2
 
     | Cif e1 c11 c12, Cif e2 c21 c22 =>
       Let re := check_e e1 e2 r in
@@ -590,9 +590,9 @@ Fixpoint check_i (i1 i2:instr_r) r :=
 
     | Cfor x1 (d1,lo1,hi1) c1, Cfor x2 (d2,lo2,hi2) c2 =>
       Let _ := assert (d1 == d2) (alloc_error "loop directions not equals") in
-      Let rhi := check_e lo1 lo2 r >>=check_e hi1 hi2 in
+      Let rhi := check_e lo1 lo2 r >>r=check_e hi1 hi2 in
       let check_c r :=
-        check_var x1 x2 r >>=
+        check_var x1 x2 r >>r=
         fold2 E.fold2 check_I c1 c2 in
       loop check_c Loop.nb rhi
 

--- a/proofs/compiler/allocation_proof.v
+++ b/proofs/compiler/allocation_proof.v
@@ -254,7 +254,7 @@ Lemma check_lvalP wdb gd r1 r1' x1 x2 e2 s1 s1' vm1 v1 v2 :
   eq_alloc r1 s1.(evm) vm1 ->
   value_uincl v1 v2 ->
   oapp (fun te2 =>
-      sem_pexpr wdb gd (with_vm s1 vm1) te2.2 >>= truncate_val te2.1 = ok v2) true e2 ->
+      sem_pexpr wdb gd (with_vm s1 vm1) te2.2 >>r= truncate_val te2.1 = ok v2) true e2 ->
   write_lval wdb gd x1 v1 s1 = ok s1' ->
   exists2 vm1',
     write_lval wdb gd x2 v2 (with_vm s1 vm1) = ok (with_vm s1' vm1') &

--- a/proofs/compiler/arm_params_common_proof.v
+++ b/proofs/compiler/arm_params_common_proof.v
@@ -75,7 +75,7 @@ Notation next_mem_ls ls m := (lnext_pc (lset_mem ls m)) (only parsing).
 
 Lemma addi_sem_fopn_args {s xname vi y imm wy} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy
   -> let: wx' := Vword (wy + wrepr reg_size imm)in
      let: vm' := (evm s).[x <- wx'] in
      sem_fopn_args (ARMFopn.addi xi y imm) s = ok (with_vm s vm').
@@ -83,14 +83,14 @@ Proof. by move=> h; rewrite -sem_fopn_equiv; apply ARMFopn_coreP.addi_sem_fopn_a
 
 Lemma mov_sem_fopn_args {s xname vi y} {wy : word Uptr} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: vm' := (evm s).[x <- Vword wy] in
   sem_fopn_args (ARMFopn.mov xi y) s = ok (with_vm s vm').
 Proof. by move=> h; rewrite -sem_fopn_equiv; apply ARMFopn_coreP.mov_sem_fopn_args. Qed.
 
 Lemma align_sem_fopn_args xname vi y al s (wy : word Uptr) :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: wx' := Vword (align_word al wy) in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (ARMFopn.align xi y al) s = ok (with_vm s vm').
@@ -221,7 +221,7 @@ Lemma smart_addi_sem_fopn_args xname vi y imm s (w : wreg) :
   let: (xi, x) := mkv xname vi in
   let: lc := ARMFopn.smart_addi xi y imm in
   is_arith_small imm \/ x <> v_var y ->
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok w -> 
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok w -> 
   exists vm',
     [/\ sem_fopns_args s lc = ok (with_vm s vm')
       , vm' =[\ Sv.singleton x ] evm s
@@ -241,7 +241,7 @@ Lemma smart_subi_sem_fopn_args xname vi y imm s (w : wreg) :
   let: (xi, x) := mkv xname vi in
   let: lc := ARMFopn.smart_subi xi y imm in
   is_arith_small imm \/ x <> v_var y ->
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok w ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok w ->
   exists vm',
     [/\ sem_fopns_args s lc = ok (with_vm s vm')
       , vm' =[\ Sv.singleton x ] evm s
@@ -262,7 +262,7 @@ Lemma smart_addi_tmp_sem_fopn_args s (tmp : var_i) xname vi imm w :
   let: lcmd := ARMFopn.smart_addi_tmp xi tmp imm in
   x <> v_var tmp -> 
   vtype tmp = sword U32 ->
-  get_var true (evm s) x >>= to_word Uptr = ok w ->
+  get_var true (evm s) x >>r= to_word Uptr = ok w ->
   exists vm',
     [/\ sem_fopns_args s lcmd = ok (with_vm s vm')
       , evm s =[\ Sv.add x (Sv.singleton tmp) ] vm'
@@ -284,7 +284,7 @@ Lemma smart_subi_tmp_sem_fopn_args s (tmp : var_i) xname vi imm w :
   let: lcmd := ARMFopn.smart_subi_tmp xi tmp imm in
   x <> v_var tmp ->
   vtype tmp = sword Uptr ->
-  get_var true (evm s) x >>= to_word Uptr = ok w ->
+  get_var true (evm s) x >>r= to_word Uptr = ok w ->
   exists vm',
     [/\ sem_fopns_args s lcmd = ok (with_vm s vm')
       , evm s =[\ Sv.add x (Sv.singleton tmp) ] vm'

--- a/proofs/compiler/arm_params_core_proof.v
+++ b/proofs/compiler/arm_params_core_proof.v
@@ -57,8 +57,8 @@ Let mkv xname vi :=
 
 Lemma add_sem_fopn_args {s xname vi y} {wy : word Uptr} {z} {wz : word Uptr} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
-  get_var true (evm s) (v_var z) >>= to_word Uptr = ok wz ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var z) >>r= to_word Uptr = ok wz ->
   let: wx' := Vword (wy + wz)in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (ARMFopn_core.add xi y z) s = ok (with_vm s vm').
@@ -66,7 +66,7 @@ Proof. by rewrite /=; t_xrbindP => *; t_arm_op. Qed.
 
 Lemma addi_sem_fopn_args {s xname vi y imm wy} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: wx' := Vword (wy + wrepr reg_size imm)in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (ARMFopn_core.addi xi y imm) s = ok (with_vm s vm').
@@ -74,8 +74,8 @@ Proof. by rewrite /=; t_xrbindP => *; t_arm_op. Qed.
 
 Lemma sub_sem_fopn_args {s xname vi y} {wy : word Uptr} {z} {wz : word Uptr} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
-  get_var true (evm s) (v_var z) >>= to_word Uptr = ok wz ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var z) >>r= to_word Uptr = ok wz ->
   let: wx' := Vword (wy - wz)in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (ARMFopn_core.sub xi y z) s = ok (with_vm s vm').
@@ -83,7 +83,7 @@ Proof. by red; t_xrbindP => *; t_arm_op; rewrite /= wsub_wnot1. Qed.
 
 Lemma subi_sem_fopn_args {s xname vi y imm wy} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: wx' := Vword (wy - wrepr reg_size imm)in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (ARMFopn_core.subi xi y imm) s = ok (with_vm s vm').
@@ -91,7 +91,7 @@ Proof. by red; t_xrbindP => *; t_arm_op; rewrite /= wsub_wnot1. Qed.
 
 Lemma mov_sem_fopn_args {s xname vi y} {wy : word Uptr} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: vm' := (evm s).[x <- Vword wy] in
   sem_fopn_args (ARMFopn_core.mov xi y) s = ok (with_vm s vm').
 Proof. by rewrite /=; t_xrbindP => *; t_arm_op. Qed.
@@ -302,11 +302,11 @@ Opaque ARMFopn_core.li.
 Lemma smart_mov_sem_fopns_args s (w : wreg) xname vi y :
   let: (xi, x) := mkv xname vi in
   let: lc := ARMFopn_core.smart_mov xi y in
-  get_var true (evm s) y >>= to_word Uptr = ok w ->
+  get_var true (evm s) y >>r= to_word Uptr = ok w ->
   exists vm,
     [/\ sem_fopns_args s lc = ok (with_vm s vm)
       , vm =[\ Sv.singleton x ] evm s
-      & get_var true vm x >>= to_word Uptr = ok w ].
+      & get_var true vm x >>r= to_word Uptr = ok w ].
 Proof.
   move=> hgety.
   rewrite /ARMFopn_core.smart_mov /=.
@@ -328,15 +328,15 @@ Lemma gen_smart_opi_sem_fopn_args
   (op_sem_fopn_args :
     forall {s xname vi y} {wy : word Uptr} {z} {wz : word Uptr},
       let: (xi, x) := mkv xname vi in
-      get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy
-      -> get_var true (evm s) (v_var z) >>= to_word Uptr = ok wz
+      get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy
+      -> get_var true (evm s) (v_var z) >>r= to_word Uptr = ok wz
       -> let: wx' := Vword (op wy wz)in
       let: vm' := (evm s).[x <- wx'] in
       sem_fopn_args (on_reg xi y z) s = ok (with_vm s vm'))
   (opi_sem_fopn_args :
     forall {s xname vi y imm wy},
     let: (xi, x) := mkv xname vi in
-      get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy
+      get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy
       -> let: wx' := Vword (op wy (wrepr reg_size imm)) in
      let: vm' := (evm s).[x <- wx'] in
      sem_fopn_args (on_imm xi y imm) s = ok (with_vm s vm'))
@@ -346,7 +346,7 @@ Lemma gen_smart_opi_sem_fopn_args
   let: (xi, x) := mkv xname vi in
   let: lc := ARMFopn_core.gen_smart_opi on_reg on_imm is_arith_small neutral tmp xi y imm in
   is_arith_small imm \/ v_var tmp <> v_var y -> 
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok w -> 
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok w -> 
   exists vm',
     [/\ sem_fopns_args s lc = ok (with_vm s vm')
       , vm' =[\ Sv.add x (Sv.singleton tmp) ] evm s

--- a/proofs/compiler/arm_stack_zeroization_proof.v
+++ b/proofs/compiler/arm_stack_zeroization_proof.v
@@ -65,7 +65,7 @@ Lemma store_zero_eval_instr lp ii ws e (ls:lstate) (w1 w2 : word Uptr) m' :
   (ws <= U32)%CMP ->
   get_var true (lvm ls) vzero = ok (@Vword Uptr 0) ->
   get_var true (lvm ls) rspi = ok (Vword w1) ->
-  sem_fexpr (lvm ls) e >>= to_word Uptr = ok w2 ->
+  sem_fexpr (lvm ls) e >>r= to_word Uptr = ok w2 ->
   write (lmem ls) Aligned (w1 + w2)%R (sz:=ws) 0 = ok m' ->
   let i := MkLI ii (store_zero rspi ws e) in
   eval_instr lp i ls = ok (lnext_pc (lset_mem ls m')).

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -465,6 +465,6 @@ Definition compiler_back_end_to_asm (entries: seq funname) (p: sprog) :=
   assemble_prog agparams lp.
 
 Definition compile_prog_to_asm entries (p: prog): cexec asm_prog :=
-  compiler_front_end entries p >>= compiler_back_end_to_asm entries.
+  compiler_front_end entries p >>r= compiler_back_end_to_asm entries.
 
 End COMPILER.

--- a/proofs/compiler/constant_prop.v
+++ b/proofs/compiler/constant_prop.v
@@ -229,7 +229,7 @@ Definition is_cmp_const (ty: cmp_kind) (e: pexpr) : option Z :=
   match ty with
   | Cmp_int => is_const e
   | Cmp_w sg sz =>
-    is_wconst sz e >>= λ w,
+    is_wconst sz e >>o= λ w,
     Some match sg with
     | Signed => wsigned w
     | Unsigned => wunsigned w

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -469,7 +469,7 @@ Qed.
 
 Lemma app_sopnP T0 ts o es x s :
   @app_sopn T0 ts o es = ok x ->
-  sem_pexprs wdb gd s es >>= values.app_sopn ts o = ok x.
+  sem_pexprs wdb gd s es >>r= values.app_sopn ts o = ok x.
 Proof.
   elim: ts es o => /= [ | t ts ih ].
   + by case=> // _ -> [<-].

--- a/proofs/compiler/lea_proof.v
+++ b/proofs/compiler/lea_proof.v
@@ -23,15 +23,15 @@ Section PROOF.
 
   Definition sem_lea sz vm l : exec (word sz) :=
     Let base :=
-      oapp (fun (x:var_i) => get_var true vm x >>= to_word sz) (ok 0%R) l.(lea_base) in
+      oapp (fun (x:var_i) => get_var true vm x >>r= to_word sz) (ok 0%R) l.(lea_base) in
     Let offset :=
-      oapp (fun (x:var_i) => get_var true vm x >>= to_word sz) (ok 0%R) l.(lea_offset) in
+      oapp (fun (x:var_i) => get_var true vm x >>r= to_word sz) (ok 0%R) l.(lea_offset) in
     ok (wrepr sz l.(lea_disp) + (base + (wrepr sz l.(lea_scale) * offset)))%R.
 
   Lemma lea_constP sz w vm : sem_lea sz vm (lea_const w) = ok (wrepr sz w).
   Proof. by rewrite /sem_lea /lea_const /=; f_equal; ssring. Qed.
 
-  Lemma lea_varP x sz vm : sem_lea sz vm (lea_var x) = get_var true vm x >>= to_word sz.
+  Lemma lea_varP x sz vm : sem_lea sz vm (lea_var x) = get_var true vm x >>r= to_word sz.
   Proof.
     rewrite /sem_lea /lea_var /=.
     case: (Let _ := get_var _ _ _ in _) => //= w.

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -428,7 +428,7 @@ Definition pop_to_save
     Fixpoint check_c (c:cmd) : cexec unit :=
       match c with
       | [::] => ok tt
-      | i::c => check_c c >> check_i i
+      | i::c => check_c c >>r check_i i
       end.
 
   End CHECK_c.
@@ -442,18 +442,18 @@ Definition pop_to_save
     match ir with
     | Cassgn lv _ _ e => Error (E.assign_remains ii lv e)
     | Copn xs tag o es =>
-      allM (check_rexpr ii) es >> allM (check_lexpr ii) xs
+      allM (check_rexpr ii) es >>r allM (check_lexpr ii) xs
     | Csyscall xs o es =>
       ok tt
     | Cif b c1 c2 =>
-      check_fexpr ii b >> check_c check_i c1 >> check_c check_i c2
+      check_fexpr ii b >>r check_c check_i c1 >>r check_c check_i c2
     | Cfor _ _ _ =>
       Error (E.ii_error ii "for found in linear")
     | Cwhile _ c e _ c' =>
       match is_bool e with
       | Some false => check_c check_i c
-      | Some true => check_c check_i c >> check_c check_i c'
-      | None => check_fexpr ii e >> check_c check_i c >> check_c check_i c'
+      | Some true => check_c check_i c >>r check_c check_i c'
+      | None => check_fexpr ii e >>r check_c check_i c >>r check_c check_i c'
       end
     | Ccall xs fn es =>
       Let _ := assert (fn != this) (E.ii_error ii "call to self") in

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -404,8 +404,8 @@ Definition lstore_correct_aux lip_check_ws lip_lstore :=
   forall (xd xs : var_i) ofs ws (w: word ws) wp s m,
     vtype xs = sword ws ->
     lip_check_ws ws ->
-    (get_var true (evm s) xd >>= to_word Uptr) = ok wp ->
-    (get_var true (evm s) xs >>= to_word ws) = ok w ->
+    (get_var true (evm s) xd >>r= to_word Uptr) = ok wp ->
+    (get_var true (evm s) xs >>r= to_word ws) = ok w ->
     write (emem s) Aligned (wp + wrepr Uptr ofs)%R w = ok m ->
     sem_fopn_args (lip_lstore xd ofs xs) s = ok (with_mem s m).
 
@@ -415,7 +415,7 @@ Definition lload_correct_aux lip_check_ws lip_lload :=
   forall (xd xs : var_i) ofs ws wp s w vm,
     vtype xd = sword ws ->
     lip_check_ws ws ->
-    (get_var true (evm s) xs >>= to_word Uptr) = ok wp ->
+    (get_var true (evm s) xs >>r= to_word Uptr) = ok wp ->
     read (emem s) Aligned (wp + wrepr Uptr ofs)%R ws = ok w ->
     set_var true (evm s) xd (Vword w) = ok vm ->
     sem_fopn_args (lip_lload xd xs ofs) s = ok (with_vm s vm).
@@ -451,11 +451,11 @@ Definition lstores_correct_aux lip_check_ws lip_tmp2 lip_lstores :=
   let lcmd := lip_lstores rspi to_save in
   ~~ Sv.mem tmp2 (sv_of_list fst to_save) ->
   v_var tmp2 <> v_var rspi ->
-  get_var true vm1 rspi >>= to_word Uptr = ok top ->
+  get_var true vm1 rspi >>r= to_word Uptr = ok top ->
   foldM (λ '(x, ofs) m,
      Let: ws := if vtype x is sword ws then ok ws else Error ErrType in
      Let _ := assert (lip_check_ws ws) ErrType in
-     Let: v := get_var true vm1 x >>= to_word ws in
+     Let: v := get_var true vm1 x >>r= to_word ws in
      write m Aligned (top + wrepr Uptr ofs)%R v) m1 to_save = ok m2 ->
   exists2 vm2,
       sem_fopns_args s lcmd = ok (with_mem (with_vm s vm2) m2)
@@ -473,7 +473,7 @@ Definition lloads_correct_aux lip_check_ws lip_tmp2 lip_lloads :=
   ~~ Sv.mem rspi (sv_of_list fst to_save) ->
   ~~ Sv.mem tmp2 (sv_of_list fst to_save) ->
   v_var tmp2 <> v_var rspi ->
-  get_var true vm1 rspi >>= to_word Uptr = ok top ->
+  get_var true vm1 rspi >>r= to_word Uptr = ok top ->
   foldM (λ '(x, ofs) vm1,
      Let: ws := if vtype x is sword ws then ok ws else Error ErrType in
      Let _ := assert (lip_check_ws ws) ErrType in
@@ -527,7 +527,7 @@ Context (lload_correct : lload_correct_aux lip_check_ws lip_lload).
 Definition ladd_imm_correct_aux :=
   forall (x1 x2:var_i) s (w: word Uptr) ofs,
     vtype x1 = sword Uptr -> v_var x1 <> v_var x2 ->
-    get_var true (evm s) x2 >>= to_word Uptr = ok w ->
+    get_var true (evm s) x2 >>r= to_word Uptr = ok w ->
     exists vm,
        [/\ sem_fopns_args s (lip_add_imm x1 x2 ofs) = ok (with_vm s vm)
          , vm =[\ Sv.singleton x1 ] evm s
@@ -575,7 +575,7 @@ Proof.
   rewrite sem_fopns_args_cat.
   have [vm2 [-> heq hget' /=]]:= ladd_imm_correct (x1:=tmp2) ofs0 erefl hne hget.
   exists vm2; last by apply eq_exS.
-  have hget1 : get_var true (evm (with_vm s vm2)) tmp2 >>= to_word Uptr = ok (top + wrepr Uptr ofs0)%R.
+  have hget1 : get_var true (evm (with_vm s vm2)) tmp2 >>r= to_word Uptr = ok (top + wrepr Uptr ofs0)%R.
   + by rewrite hget' /= truncate_word_u.
   apply: (lstores_dfl_correct1 hget1) => {hget1}.
   elim: to_save s hnin heq hget hget' hf => //= -[x ofs] to_save ih s hnin heq hget hget'.
@@ -594,13 +594,13 @@ Lemma lloads_aux_correct rspi to_restore s top vm2 :
     let vm1 := evm s in
     let lcmd := lloads_aux lip_lload rspi to_restore in
     ~~ Sv.mem rspi (sv_of_list fst to_restore) ->
-    get_var true vm1 rspi >>= to_word Uptr = ok top ->
+    get_var true vm1 rspi >>r= to_word Uptr = ok top ->
     foldM (λ '(x, ofs) vm1,
        Let: ws := if vtype x is sword ws then ok ws else Error ErrType in
        Let _ := assert (lip_check_ws ws) ErrType in
        Let w := read m1 Aligned (top + wrepr Uptr ofs)%R ws in
        set_var true vm1 x (Vword w)) vm1 to_restore = ok vm2 ->
-     sem_fopns_args s lcmd = ok (with_vm s vm2) /\ get_var true vm2 rspi >>= to_word Uptr = ok top.
+     sem_fopns_args s lcmd = ok (with_vm s vm2) /\ get_var true vm2 rspi >>r= to_word Uptr = ok top.
 Proof.
   rewrite /= => /Sv_memP/sv_of_listP.
   elim: to_restore s => /=.
@@ -653,7 +653,7 @@ Proof.
                       | sword ws => ok ws
                       | _ => Error ErrType
                       end
-            in (assert (lip_check_ws ws) ErrType >>
+            in (assert (lip_check_ws ws) ErrType >>r
                 Let w := read (emem s) Aligned ((top + wrepr Uptr ofs0) + wrepr Uptr ofs)%R ws in set_var true vm1 x (Vword w)))
          vm1 to_restore = ok vm2' & vm2 =[\Sv.singleton tmp2] vm2'.
   + move: hnin2'; rewrite /to_restore => {to_restore hget hnin hne hget' hnin2}.
@@ -3503,7 +3503,7 @@ Section PROOF.
     foldM (λ '(x, ofs) m,
            Let: ws := if vtype x is sword ws then ok ws else Error ErrType in
            Let _ := assert (lip_check_ws liparams ws) ErrType in
-           Let: v := get_var true vm x >>= to_word ws in
+           Let: v := get_var true vm x >>r= to_word ws in
            write m Aligned (top + wrepr Uptr ofs)%R v)
           m1 to_spill = ok m2 →
     [/\
@@ -3514,7 +3514,7 @@ Section PROOF.
      &
      ∀ x ofs, (x, ofs) \in to_spill →
        exists2 ws, is_word_type x.(vtype) = Some ws /\ lip_check_ws liparams ws &
-       exists2 v, get_var true vm x >>= to_word ws = ok v & read m2 Aligned (top + wrepr Uptr ofs)%R ws = ok v
+       exists2 v, get_var true vm x >>r= to_word ws = ok v & read m2 Aligned (top + wrepr Uptr ofs)%R ws = ok v
     ].
   Proof.
     move => no_overflow.
@@ -3654,7 +3654,7 @@ Section PROOF.
             [/\ foldM (λ '(x, ofs) m,
                 Let: ws := if vtype x is sword ws then ok ws else Error ErrType in
                 Let _ := assert (lip_check_ws liparams ws) ErrType in
-                Let: v := get_var true vm1 x >>= to_word ws in
+                Let: v := get_var true vm1 x >>r= to_word ws in
                 write m Aligned (top + wrepr Uptr ofs)%R v) m2 to_save = ok m3
               , preserved_metadata s1 m2 m3
               , match_mem_gen (top_stack m0) s1 m3
@@ -4066,8 +4066,8 @@ Section PROOF.
         have is_ok_vm1_vm2 :
           forall x,
             Sv.mem x (sv_of_list fst (sf_to_save (f_extra fd)))
-            -> is_ok (get_var true vm1 x >>= of_val (vtype x))
-            -> is_ok (get_var true vm2 x >>= of_val (vtype x)).
+            -> is_ok (get_var true vm1 x >>r= of_val (vtype x))
+            -> is_ok (get_var true vm2 x >>r= of_val (vtype x)).
         + move=> x hx ok_x.
           case: (SvP.MP.In_dec x (Sv.add var_tmp (Sv.add var_tmp2 (Sv.add vrsp vflags)))) => hin;
             last by rewrite /get_var (hvm2 _ hin).
@@ -4153,7 +4153,7 @@ Section PROOF.
           by rewrite vm2'_get_rsp /top /top_stack_after_alloc wrepr_opp.
         have [m4 vm4 {}E K4 X4 H4 M4 U4] :=
           E (setpc _ _) m3 vm2' P Q M3 X'  D ok_body erefl hfn _ hrsp S' MAX'.
-        have vm4_get_rsp : get_var true vm4 vrsp >>= to_pointer = ok top.
+        have vm4_get_rsp : get_var true vm4 vrsp >>r= to_pointer = ok top.
         + rewrite -(get_var_eq_ex _ _ K4).
           + by rewrite vm2'_get_rsp /= truncate_word_u.
           have /disjointP K := sem_RSP_GD_not_written var_tmps_not_magic exec_body.

--- a/proofs/compiler/post_unrolling_check.v
+++ b/proofs/compiler/post_unrolling_check.v
@@ -43,7 +43,7 @@ Fixpoint check_no_for_loop_instr_r i : cexec unit :=
   | (Cassgn _ _ _ _ | Copn _ _ _ _ | Csyscall _ _ _ | Ccall _ _ _)
     => ok tt
   | (Cif _ c c' | Cwhile _ c _ _ c') =>
-      check_no_for_loop_cmd check_no_for_loop_instr c >> check_no_for_loop_cmd check_no_for_loop_instr c'
+      check_no_for_loop_cmd check_no_for_loop_instr c >>r check_no_for_loop_cmd check_no_for_loop_instr c'
   | Cfor _ _ _ => Error E.for_loop_remains
   end
 with check_no_for_loop_instr i : cexec unit :=
@@ -64,12 +64,12 @@ Fixpoint check_no_inline_instr_instr_r i : cexec unit :=
   | (Cassgn _ _ _ _ | Copn _ _ _ _ | Csyscall _ _ _ | Cfor _ _ _ | Ccall _ _ _)
       => ok tt
   | (Cif _ c c' | Cwhile _ c _ _ c') =>
-      check_no_inline_instr_cmd check_no_inline_instr_instr c >> check_no_inline_instr_cmd check_no_inline_instr_instr c'
+      check_no_inline_instr_cmd check_no_inline_instr_instr c >>r check_no_inline_instr_cmd check_no_inline_instr_instr c'
   end
 with check_no_inline_instr_instr i : cexec unit :=
   let: MkI ii i := i in
   add_iinfo ii (
-      assert (negb (ii_is_inline ii)) E.inline_instr_remains >>
+      assert (negb (ii_is_inline ii)) E.inline_instr_remains >>r
       check_no_inline_instr_instr_r i).
 
 Definition check_no_inline_instr_fd (f : funname * ufundef) :=

--- a/proofs/compiler/riscv_lower_addressing_proof.v
+++ b/proofs/compiler/riscv_lower_addressing_proof.v
@@ -152,15 +152,15 @@ Proof.
 Qed.
 
 Lemma compute_addrP ii (tmp x:var_i) e prelude disp s1 wx we :
-  get_var true (evm s1) x >>= to_pointer = ok wx ->
-  sem_pexpr true p'.(p_globs) s1 e >>= to_pointer = ok we ->
+  get_var true (evm s1) x >>r= to_pointer = ok wx ->
+  sem_pexpr true p'.(p_globs) s1 e >>r= to_pointer = ok we ->
   vtype tmp = sword Uptr ->
   compute_addr tmp x e = Some (prelude, disp) ->
   exists vm1 wtmp wdisp, [/\
     sem p' ev s1 (map (MkI ii) prelude) (with_vm s1 vm1),
     evm s1 =[\Sv.singleton tmp] vm1,
-    get_var true vm1 tmp >>= to_pointer = ok wtmp,
-    sem_pexpr true p'.(p_globs) (with_vm s1 vm1) disp >>= to_pointer = ok wdisp &
+    get_var true vm1 tmp >>r= to_pointer = ok wtmp,
+    sem_pexpr true p'.(p_globs) (with_vm s1 vm1) disp >>r= to_pointer = ok wdisp &
     (wx + we = wtmp + wdisp)%R].
 Proof.
   move=> ok_wx ok_we tmp_ty.

--- a/proofs/compiler/riscv_lowering_proof.v
+++ b/proofs/compiler/riscv_lowering_proof.v
@@ -113,7 +113,7 @@ Lemma check_shift_amountP e sa s z w :
   sem_pexpr true (p_globs p) s e = ok z ->
   to_word U8 z = ok w ->
   Sv.Subset (read_e sa) (read_e e) /\
-  exists2 n, sem_pexpr true (p_globs p) s sa >>= to_word U8 = ok n & forall f (a: word U32), sem_shift f a w = sem_shift f a (wand n (wrepr U8 31)).
+  exists2 n, sem_pexpr true (p_globs p) s sa >>r= to_word U8 = ok n & forall f (a: word U32), sem_shift f a w = sem_shift f a (wand n (wrepr U8 31)).
 Proof.
   rewrite /check_shift_amount.
   case en: is_wconst => [ n | ].
@@ -159,8 +159,8 @@ Lemma Hassgn_op2_generic s e1 e2 v1 v2 op2 v ws v' lv s1 (op2' : sopn) :
       forall e1' e2' w1' w2'
         (hcmp1 : (ws1' <= ws1)%CMP)
         (hcmp2 : (ws2' <= ws2)%CMP),
-        sem_pexpr true (p_globs p) s e1' >>= to_word ws1 = ok w1' ->
-        sem_pexpr true (p_globs p) s e2' >>= to_word ws2 = ok w2' ->
+        sem_pexpr true (p_globs p) s e1' >>r= to_word ws1 = ok w1' ->
+        sem_pexpr true (p_globs p) s e2' >>r= to_word ws2 = ok w2' ->
         Let w := ecast t (let t := t in _) eq1 (sem_sop2_typed op2) w1 w2 in
         ok (zero_extend ws w)
         = ecast l (sem_prod l _) eq2
@@ -239,7 +239,7 @@ Lemma Hassgn_op2_shift s e1 e2 v1 v2 op2 v v' lv s1 (op2' : sopn) :
       to_word ws v1 = ok w1,
       to_word U8 v2 = ok w2 &
       forall e2' w2',
-        sem_pexpr true (p_globs p) s e2' >>= to_word U8 = ok w2' ->
+        sem_pexpr true (p_globs p) s e2' >>r= to_word U8 = ok w2' ->
         Let w := ecast t (let t := t in _) eq1 (sem_sop2_typed op2) w1 w2 in
         ok (zero_extend U32 w)
         = ecast l (sem_prod l _) eq2

--- a/proofs/compiler/riscv_params_common_proof.v
+++ b/proofs/compiler/riscv_params_common_proof.v
@@ -77,7 +77,7 @@ Notation next_mem_ls ls m := (lnext_pc (lset_mem ls m)) (only parsing).
 
 Lemma addi_sem_fopn_args {s xname vi y imm wy} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy
   -> let: wx' := Vword (wy + wrepr reg_size imm)in
      let: vm' := (evm s).[x <- wx'] in
      sem_fopn_args (RISCVFopn.addi xi y imm) s = ok (with_vm s vm').
@@ -85,14 +85,14 @@ Proof. by move=> h; rewrite -sem_fopn_equiv; apply RISCVFopn_coreP.addi_sem_fopn
 
 Lemma mov_sem_fopn_args {s xname vi y} {wy : word Uptr} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: vm' := (evm s).[x <- Vword wy] in
   sem_fopn_args (RISCVFopn.mov xi y) s = ok (with_vm s vm').
 Proof. by move=> h; rewrite -sem_fopn_equiv; apply RISCVFopn_coreP.mov_sem_fopn_args. Qed.
 
 Lemma align_sem_fopn_args xname vi y al s (wy : word Uptr) :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: wx' := Vword (align_word al wy) in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (RISCVFopn.align xi y al) s = ok (with_vm s vm').
@@ -184,7 +184,7 @@ Lemma smart_addi_sem_fopn_args xname vi y imm s (w : wreg) :
   let: (xi, x) := mkv xname vi in
   let: lc := RISCVFopn.smart_addi xi y imm in
   is_arith_small imm \/ x <> v_var y ->
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok w -> 
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok w -> 
   exists vm',
     [/\ sem_fopns_args s lc = ok (with_vm s vm')
       , vm' =[\ Sv.singleton x ] evm s
@@ -204,7 +204,7 @@ Lemma smart_subi_sem_fopn_args xname vi y imm s (w : wreg) :
   let: (xi, x) := mkv xname vi in
   let: lc := RISCVFopn.smart_subi xi y imm in
   is_arith_small_neg imm \/ x <> v_var y ->
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok w ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok w ->
   exists vm',
     [/\ sem_fopns_args s lc = ok (with_vm s vm')
       , vm' =[\ Sv.singleton x ] evm s
@@ -225,7 +225,7 @@ Lemma smart_addi_tmp_sem_fopn_args s (tmp : var_i) xname vi imm w :
   let: lcmd := RISCVFopn.smart_addi_tmp xi tmp imm in
   x <> v_var tmp -> 
   vtype tmp = sword U32 ->
-  get_var true (evm s) x >>= to_word Uptr = ok w ->
+  get_var true (evm s) x >>r= to_word Uptr = ok w ->
   exists vm',
     [/\ sem_fopns_args s lcmd = ok (with_vm s vm')
       , evm s =[\ Sv.add x (Sv.singleton tmp) ] vm'
@@ -247,7 +247,7 @@ Lemma smart_subi_tmp_sem_fopn_args s (tmp : var_i) xname vi imm w :
   let: lcmd := RISCVFopn.smart_subi_tmp xi tmp imm in
   x <> v_var tmp ->
   vtype tmp = sword Uptr ->
-  get_var true (evm s) x >>= to_word Uptr = ok w ->
+  get_var true (evm s) x >>r= to_word Uptr = ok w ->
   exists vm',
     [/\ sem_fopns_args s lcmd = ok (with_vm s vm')
       , evm s =[\ Sv.add x (Sv.singleton tmp) ] vm'

--- a/proofs/compiler/riscv_params_core_proof.v
+++ b/proofs/compiler/riscv_params_core_proof.v
@@ -60,8 +60,8 @@ Let mkv xname vi :=
 
 Lemma add_sem_fopn_args {s xname vi y} {wy : word Uptr} {z} {wz : word Uptr} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
-  get_var true (evm s) (v_var z) >>= to_word Uptr = ok wz ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var z) >>r= to_word Uptr = ok wz ->
   let: wx' := Vword (wy + wz)in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (RISCVFopn_core.add xi y z) s = ok (with_vm s vm').
@@ -69,7 +69,7 @@ Proof. by rewrite /=; t_xrbindP => *; t_riscv_op. Qed.
 
 Lemma addi_sem_fopn_args {s xname vi y imm wy} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: wx' := Vword (wy + wrepr reg_size imm)in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (RISCVFopn_core.addi xi y imm) s = ok (with_vm s vm').
@@ -77,8 +77,8 @@ Proof. by rewrite /=; t_xrbindP => *; t_riscv_op. Qed.
 
 Lemma sub_sem_fopn_args {s xname vi y} {wy : word Uptr} {z} {wz : word Uptr} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
-  get_var true (evm s) (v_var z) >>= to_word Uptr = ok wz ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var z) >>r= to_word Uptr = ok wz ->
   let: wx' := Vword (wy - wz)in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (RISCVFopn_core.sub xi y z) s = ok (with_vm s vm').
@@ -88,7 +88,7 @@ Qed.
 
 Lemma subi_sem_fopn_args {s xname vi y imm wy} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: wx' := Vword (wy - wrepr reg_size imm)in
   let: vm' := (evm s).[x <- wx'] in
   sem_fopn_args (RISCVFopn_core.subi xi y imm) s = ok (with_vm s vm').
@@ -106,7 +106,7 @@ Proof.
   
 Lemma mov_sem_fopn_args {s xname vi y} {wy : word Uptr} :
   let: (xi, x) := mkv xname vi in
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy ->
   let: vm' := (evm s).[x <- Vword wy] in
   sem_fopn_args (RISCVFopn_core.mov xi y) s = ok (with_vm s vm').
 Proof. by rewrite /=; t_xrbindP => *; t_riscv_op. Qed.
@@ -265,11 +265,11 @@ Qed.
 Lemma smart_mov_sem_fopns_args s (w : wreg) xname vi y :
   let: (xi, x) := mkv xname vi in
   let: lc := RISCVFopn_core.smart_mov xi y in
-  get_var true (evm s) y >>= to_word Uptr = ok w ->
+  get_var true (evm s) y >>r= to_word Uptr = ok w ->
   exists vm,
     [/\ sem_fopns_args s lc = ok (with_vm s vm)
       , vm =[\ Sv.singleton x ] evm s
-      & get_var true vm x >>= to_word Uptr = ok w ].
+      & get_var true vm x >>r= to_word Uptr = ok w ].
 Proof.
   move=> hgety.
   rewrite /RISCVFopn_core.smart_mov /=.
@@ -291,15 +291,15 @@ Lemma gen_smart_opi_sem_fopn_args
   (op_sem_fopn_args :
     forall {s xname vi y} {wy : word Uptr} {z} {wz : word Uptr},
       let: (xi, x) := mkv xname vi in
-      get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy
-      -> get_var true (evm s) (v_var z) >>= to_word Uptr = ok wz
+      get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy
+      -> get_var true (evm s) (v_var z) >>r= to_word Uptr = ok wz
       -> let: wx' := Vword (op wy wz)in
       let: vm' := (evm s).[x <- wx'] in
       sem_fopn_args (on_reg xi y z) s = ok (with_vm s vm'))
   (opi_sem_fopn_args :
     forall {s xname vi y imm wy},
     let: (xi, x) := mkv xname vi in
-      get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy
+      get_var true (evm s) (v_var y) >>r= to_word Uptr = ok wy
       -> let: wx' := Vword (op wy (wrepr reg_size imm)) in
      let: vm' := (evm s).[x <- wx'] in
      sem_fopn_args (on_imm xi y imm) s = ok (with_vm s vm'))
@@ -309,7 +309,7 @@ Lemma gen_smart_opi_sem_fopn_args
   let: (xi, x) := mkv xname vi in
   let: lc := RISCVFopn_core.gen_smart_opi on_reg on_imm is_small neutral tmp xi y imm in
   is_small imm \/ v_var tmp <> v_var y -> 
-  get_var true (evm s) (v_var y) >>= to_word Uptr = ok w -> 
+  get_var true (evm s) (v_var y) >>r= to_word Uptr = ok w -> 
   exists vm',
     [/\ sem_fopns_args s lc = ok (with_vm s vm')
       , vm' =[\ Sv.add x (Sv.singleton tmp) ] evm s

--- a/proofs/compiler/stack_alloc_proof.v
+++ b/proofs/compiler/stack_alloc_proof.v
@@ -780,7 +780,7 @@ Proof.
 Qed.
 
 Lemma cast_ptrP wdb gd s e i :
-  sem_pexpr wdb gd s e >>= to_int = ok i ->
+  sem_pexpr wdb gd s e >>r= to_int = ok i ->
   exists2 v, sem_pexpr wdb gd s (cast_ptr e) = ok v & value_uincl (Vword (wrepr Uptr i)) v.
 Proof.
   t_xrbindP => v he hi.
@@ -789,7 +789,7 @@ Proof.
 Qed.
 
 Lemma mk_ofsP wdb aa sz gd s2 ofs e i :
-  sem_pexpr wdb gd s2 e >>= to_int = ok i ->
+  sem_pexpr wdb gd s2 e >>r= to_int = ok i ->
   sem_pexpr wdb gd s2 (mk_ofs aa sz e ofs) = ok (Vword (wrepr Uptr (i * mk_scale aa sz + ofs)%Z)).
 Proof.
   rewrite /mk_ofs; case is_constP => /= [? [->] //| {}e he] /=.
@@ -943,7 +943,7 @@ Section EXPR.
     valid_pk rmap s' sr pk ->
     addr_from_pk pmap x pk = ok (xi, ofs) ->
     exists w,
-      get_var wdb (evm s') xi >>= to_pointer = ok w /\
+      get_var wdb (evm s') xi >>r= to_pointer = ok w /\
       sub_region_addr sr = (w + wrepr _ ofs)%R.
   Proof.
     case: pk => //.
@@ -959,7 +959,7 @@ Section EXPR.
 
   (* If [x] is a local variable *)
   Lemma check_mk_addr_ptr (x:var_i) aa ws xi ei e1 i1 pk sr :
-    sem_pexpr true [::] s' e1 >>= to_int = ok i1 ->
+    sem_pexpr true [::] s' e1 >>r= to_int = ok i1 ->
     wf_local x pk ->
     valid_pk rmap s' sr pk ->
     mk_addr_ptr pmap x aa ws pk e1 = ok (xi, ei) ->
@@ -982,7 +982,7 @@ Section EXPR.
     valid_vpk rmap s' x sr vpk ->
     addr_from_vpk pmap x vpk = ok (xi, ofs) ->
     exists w,
-      get_var wdb (evm s') xi >>= to_pointer = ok w /\
+      get_var wdb (evm s') xi >>r= to_pointer = ok w /\
       sub_region_addr sr = (w + wrepr _ ofs)%R.
   Proof.
     case: vpk => [[ofs' ws]|pk].
@@ -994,7 +994,7 @@ Section EXPR.
   Qed.
 
   Lemma check_mk_addr (x:var_i) aa ws xi ei e1 i1 vpk sr :
-    sem_pexpr true [::] s' e1 >>= to_int = ok i1 ->
+    sem_pexpr true [::] s' e1 >>r= to_int = ok i1 ->
     wf_vpk x vpk ->
     valid_vpk rmap s' x sr vpk ->
     mk_addr pmap x aa ws vpk e1 = ok (xi, ei) ->
@@ -1194,7 +1194,7 @@ Section EXPR.
       move: he'; t_xrbindP => e1' /he1{he1}.
       rewrite /truncate_val /= hvi /= => /(_ _ erefl) [] v' [] he1'.
       t_xrbindP=> i' hv' ?; subst i'.
-      have h0 : sem_pexpr true [::] s' e1' >>= to_int = ok i.
+      have h0 : sem_pexpr true [::] s' e1' >>r= to_int = ok i.
       + by rewrite he1' /= hv'.
       move=> [vpk | ]; last first.
       + t_xrbindP => h /check_diffP h1 <- /=.
@@ -1820,7 +1820,7 @@ Proof.
     case heq: is_word_type => [ws | //]; move /is_word_typeP : heq => hty.
     case htyv: subtype => //.
     t_xrbindP => -[xi ei] ha sr hsr rmap2 hsetw <- /= s1' /write_varP [-> hdb htr] /=.
-    have he1 : sem_pexpr true [::] s2 0 >>= to_int = ok 0 by done.
+    have he1 : sem_pexpr true [::] s2 0 >>r= to_int = ok 0 by done.
     have hpk := sub_region_pk_valid rmap s2 hsr.
     have [wx [wi [-> -> /= <-]]]:= check_mk_addr_ptr hvs he1 (wf_locals hlx) hpk ha.
     have := htr; rewrite {1}hty => /(vm_truncate_val_subtype_word hdb htyv) [w htrw -> /=].
@@ -1853,7 +1853,7 @@ Proof.
   + move=> al ws x e1 /=; t_xrbindP => /check_varP hx /check_diffP hnnew e1' /(alloc_eP hvs) he1 <-.
     move=> s1' xp ? hgx hxp w1 v1 /he1 he1' hv1 w hvw mem1 hmem1 <- /=.
     have := get_var_kindP hvs hx hnnew; rewrite /get_gvar /= => /(_ _ _ hgx) -> /=.
-    have {}he1': sem_pexpr true [::] s2 e1' >>= to_pointer = ok w1.
+    have {}he1': sem_pexpr true [::] s2 e1' >>r= to_pointer = ok w1.
     + have [ws1 [wv1 [? hwv1]]] := to_wordI hv1; subst.
       move: he1'; rewrite /truncate_val /= hwv1 /= => /(_ _ erefl) [] ve1' [] -> /=.
       by t_xrbindP=> w1' -> ? /=; subst w1'.
@@ -1898,7 +1898,7 @@ Proof.
   move=> al aa ws x e1 /=; t_xrbindP => e1' /(alloc_eP hvs) he1.
   move=> hr2 s1'; apply on_arr_varP => n t hty hxt.
   t_xrbindP => i1 v1 /he1 he1' hi1 w hvw t' htt' /write_varP [? hdb htr]; subst s1'.
-  have {}he1 : sem_pexpr true [::] s2 e1' >>= to_int = ok i1.
+  have {}he1 : sem_pexpr true [::] s2 e1' >>r= to_int = ok i1.
   + have ? := to_intI hi1; subst.
     move: he1'; rewrite /truncate_val /= => /(_ _ erefl) [] ve1' [] -> /=.
     by t_xrbindP=> i1' -> ? /=; subst i1'.
@@ -1978,7 +1978,7 @@ Hypothesis P'_globs : P'.(p_globs) = [::].
 Local Opaque arr_size.
 
 Lemma get_ofs_subP wdb gd s i aa ws x e ofs :
-  sem_pexpr wdb gd s e >>= to_int = ok i ->
+  sem_pexpr wdb gd s e >>r= to_int = ok i ->
   get_ofs_sub aa ws x e = ok ofs ->
   ofs = i * mk_scale aa ws.
 Proof.
@@ -2086,7 +2086,7 @@ Proof.
   t_xrbindP=> n _ hty _ i v' he' hv' _ /WArray.get_sub_bound hbound _ ofs' hofs' <- <- [<- <-].
   split=> //.
   rewrite hty.
-  have {hv'}he' : sem_pexpr wdb gd s1 e' >>= to_int = ok i by rewrite he'.
+  have {hv'}he' : sem_pexpr wdb gd s1 e' >>r= to_int = ok i by rewrite he'.
   by move: hofs' => /(get_ofs_subP he') ->.
 Qed.
 
@@ -2141,7 +2141,7 @@ Lemma mk_addr_pexprP wdb rmap m0 s1 s2 (x : var_i) vpk sr e1 ofs :
   valid_vpk rmap s2 x sr vpk ->
   mk_addr_pexpr pmap rmap x vpk = ok (e1, ofs) ->
   exists w,
-    sem_pexpr wdb [::] s2 e1 >>= to_pointer = ok w /\
+    sem_pexpr wdb [::] s2 e1 >>r= to_pointer = ok w /\
     sub_region_addr sr = (w + wrepr _ ofs)%R.
 Proof.
   move=> hvs hwfpk hpk.
@@ -2481,7 +2481,7 @@ Proof.
   t_xrbindP=> aa ws {}len x' e ofs' hofs ? <- [? <-]; subst x' ofs'.
   apply: on_arr_varP; t_xrbindP => nx ax htyx hxa i v he hv a2 ha2 a3 ha3 /write_varP [ -> hdb h].
   have /vm_truncate_valE [hty heq]:= h.
-  have {hv}he : sem_pexpr true gd s1 e >>= to_int = ok i.
+  have {hv}he : sem_pexpr true gd s1 e >>r= to_int = ok i.
   + by rewrite he.
   have {hofs} -> := get_ofs_subP he hofs.
   move=> hlx hget hsub hread.

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -464,7 +464,7 @@ Section PROOF.
     sem_pexpr true gd s e = ok z →
     to_word U8 z = ok w →
     Sv.Subset (read_e sa) (read_e e) ∧
-    exists2 n, sem_pexpr true gd s sa >>= to_word U8 = ok n & ∀ f (a: word sz), sem_shift f a w = sem_shift f a (wand n (x86_shift_mask sz)).
+    exists2 n, sem_pexpr true gd s sa >>r= to_word U8 = ok n & ∀ f (a: word sz), sem_shift f a w = sem_shift f a (wand n (x86_shift_mask sz)).
   Proof.
     rewrite /check_shift_amount.
     case en: is_wconst => [ n | ].
@@ -499,21 +499,21 @@ Section PROOF.
       exists2 sz, ty = sword sz & (sz ≤ U64)%CMP ∧
       ∃ sz' (w : word sz'), (sz ≤ sz')%CMP ∧ v = Vword w
     | LowerCopn o a =>
-      sem_pexprs true gd s a >>= exec_sopn o = ok [:: v' ]
+      sem_pexprs true gd s a >>r= exec_sopn o = ok [:: v' ]
     | LowerInc o a =>
-      ∃ b1 b2 b3 b4, sem_pexprs true gd s [:: a] >>= exec_sopn o = ok [:: Vbool b1; Vbool b2; Vbool b3; Vbool b4; v']
+      ∃ b1 b2 b3 b4, sem_pexprs true gd s [:: a] >>r= exec_sopn o = ok [:: Vbool b1; Vbool b2; Vbool b3; Vbool b4; v']
     | LowerFopn _ o e' _ =>
       let vi := var_info_of_lval l in
       let f  := Lnone vi sbool in
       Sv.Subset (read_es e') (read_e e) ∧
-      sem_pexprs true gd s e' >>= exec_sopn o >>=
+      sem_pexprs true gd s e' >>r= exec_sopn o >>r=
       write_lvals true gd s [:: f; f; f; f; f; l] = ok s'
     | LowerDiscardFlags n op e' =>
       let f := Lnone (var_info_of_lval l) sbool in
       Sv.Subset (read_es e') (read_e e)
       /\ sem_pexprs true gd s e'
-         >>= exec_sopn op
-         >>= write_lvals true gd s (nseq n f ++ [:: l ]) = ok s'
+         >>r= exec_sopn op
+         >>r= write_lvals true gd s (nseq n f ++ [:: l ]) = ok s'
     | LowerDivMod p u sz o a b =>
       let vi := var_info_of_lval l in
       let f  := Lnone vi sbool in
@@ -535,7 +535,7 @@ Section PROOF.
                let v0 : word sz :=
                  if u is Unsigned then 0%R
                  else if msb wa then (-1)%R else 0%R in
-               exec_sopn o [::Vword v0; va; vb] >>=
+               exec_sopn o [::Vword v0; va; vb] >>r=
                  write_lvals true gd s1 lv) = ok s1' /\
                eq_exc_fresh s1' s'])]),
           ty = sword sz , (U16 ≤ sz)%CMP & (sz ≤ U64)%CMP]
@@ -548,7 +548,7 @@ Section PROOF.
        exists w: word sz,
         v' = Vword w /\ sem_lea sz (evm s) l = ok w)
     | LowerConcat hi lo =>
-      sem_pexprs true gd s [:: hi ; lo ] >>= exec_sopn (Oasm (ExtOp Oconcat128)) = ok [:: v' ]
+      sem_pexprs true gd s [:: hi ; lo ] >>r= exec_sopn (Oasm (ExtOp Oconcat128)) = ok [:: v' ]
     | LowerAssgn => True
     end.
   Proof.
@@ -1231,8 +1231,8 @@ Section PROOF.
       set ob := oapp Plvar _ b; set oo := oapp Plvar _ o.
       have [wb [wo [Hwb Hwo Ew ]]]:
         exists (wb wo: word sz),
-          [/\ sem_pexpr true gd s1' ob >>= to_word sz = ok wb,
-              sem_pexpr true gd s1' oo >>= to_word sz = ok wo &
+          [/\ sem_pexpr true gd s1' ob >>r= to_word sz = ok wb,
+              sem_pexpr true gd s1' oo >>r= to_word sz = ok wo &
               w = (wrepr sz d + (wb + (wrepr sz sc * wo)))%R].
       + move: Hslea; rewrite /sem_lea /=; t_xrbindP => wb Hwb wo Hwo H.
         exists wb, wo; split.

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -205,7 +205,7 @@ Qed.
 
 Lemma x86_lassign_correct s x ws e (w : word ws) s':
   let lcmd := x86_lassign x ws e in
-  sem_rexpr (emem s) (evm s) e >>= to_word ws = ok w ->
+  sem_rexpr (emem s) (evm s) e >>r= to_word ws = ok w ->
   write_lexpr x (Vword w) s = ok s' ->
   sem_fopn_args lcmd s = ok s'.
 Proof.

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -729,7 +729,7 @@ Definition is_wconst (sz: wsize) (e: pexpr) : option (word sz) :=
   match e with
   | Papp1 (Oword_of_int sz') e =>
     if (sz ≤ sz')%CMP then
-      is_const e >>= λ n, Some (wrepr sz n)
+      is_const e >>o= λ n, Some (wrepr sz n)
     else None
   | _       => None
   end%O.

--- a/proofs/lang/fexpr_sem.v
+++ b/proofs/lang/fexpr_sem.v
@@ -14,12 +14,12 @@ Section SEM_EXPR.
     | Fvar x => get_var true vm x
     | Fapp1 op a => Let v := sem_fexpr a in sem_sop1 op v
     | Fapp2 op a b=> Let v := sem_fexpr a in Let w := sem_fexpr b in sem_sop2 op v w
-    | Fif a b c => Let u := sem_fexpr a >>= to_bool in Let v := sem_fexpr b >>= to_bool in Let w := sem_fexpr c >>= to_bool in ok (Vbool (if u then v else w))
+    | Fif a b c => Let u := sem_fexpr a >>r= to_bool in Let v := sem_fexpr b >>r= to_bool in Let w := sem_fexpr c >>r= to_bool in ok (Vbool (if u then v else w))
     end.
 
   Definition sem_rexpr (e: rexpr) : exec value :=
     match e with
-    | Load al ws x a => Let p := get_var true vm x >>= to_pointer in Let off := sem_fexpr a >>= to_pointer in Let v := read m al (p + off)%R ws in ok (@to_val (sword ws) v)
+    | Load al ws x a => Let p := get_var true vm x >>r= to_pointer in Let off := sem_fexpr a >>r= to_pointer in Let v := read m al (p + off)%R ws in ok (@to_val (sword ws) v)
     | Rexpr a => sem_fexpr a
     end.
 
@@ -34,8 +34,8 @@ Context
 Definition write_lexpr e v (s: estate) : exec estate :=
   match e with
   | Store al ws x a =>
-      Let p := get_var true (evm s) x >>= to_pointer in
-      Let off := sem_fexpr (evm s) a >>= to_pointer in
+      Let p := get_var true (evm s) x >>r= to_pointer in
+      Let off := sem_fexpr (evm s) a >>r= to_pointer in
       Let w := to_word ws v in
       Let m := write (emem s) al (p + off)%R w in
       ok (with_mem s m)

--- a/proofs/lang/linear_sem.v
+++ b/proofs/lang/linear_sem.v
@@ -134,7 +134,7 @@ Definition eval_instr (i : linstr) (s1: lstate) : exec lstate :=
     ok (lnext_pc (lset_estate' s1 s'))
   | Lcall None d =>
     let vrsp := v_var (vid (lp_rsp P)) in
-    Let sp := get_var true s1.(lvm) vrsp >>= to_pointer in
+    Let sp := get_var true s1.(lvm) vrsp >>r= to_pointer in
     let nsp := (sp - wrepr Uptr (wsize_size Uptr))%R in
     Let vm := set_var true s1.(lvm) vrsp (Vword nsp) in
     Let lbl := get_label_after_pc s1 in
@@ -148,7 +148,7 @@ Definition eval_instr (i : linstr) (s1: lstate) : exec lstate :=
     eval_jump d (lset_vm s1 vm)
   | Lret =>
     let vrsp := v_var (vid (lp_rsp P)) in
-    Let sp := get_var true s1.(lvm) vrsp >>= to_pointer in
+    Let sp := get_var true s1.(lvm) vrsp >>r= to_pointer in
     let nsp := (sp + wrepr Uptr (wsize_size Uptr))%R in
     Let p  := read s1.(lmem) Aligned sp Uptr in
     Let vm := set_var true s1.(lvm) vrsp (Vword nsp) in
@@ -158,7 +158,7 @@ Definition eval_instr (i : linstr) (s1: lstate) : exec lstate :=
   | Llabel _ _ => ok (lnext_pc s1)
   | Lgoto d => eval_jump d s1
   | Ligoto e =>
-    Let p := sem_rexpr s1.(lmem) s1.(lvm) e >>= to_pointer in
+    Let p := sem_rexpr s1.(lmem) s1.(lvm) e >>r= to_pointer in
     Let d := rdecode_label labels p in
     eval_jump d s1
   | LstoreLabel x lbl =>
@@ -166,7 +166,7 @@ Definition eval_instr (i : linstr) (s1: lstate) : exec lstate :=
     Let vm := set_var true s1.(lvm) x (Vword p) in
     ok (lnext_pc (lset_vm s1 vm))
   | Lcond e lbl =>
-    Let b := sem_fexpr s1.(lvm) e >>= to_bool in
+    Let b := sem_fexpr s1.(lvm) e >>r= to_bool in
     if b then
       eval_jump (s1.(lfn),lbl) s1
     else ok (lnext_pc s1)

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -445,7 +445,7 @@ Qed.
 
 Lemma get_var_to_word wdb vm x ws w :
   vtype x = sword ws ->
-  get_var wdb vm x >>= to_word ws = ok w ->
+  get_var wdb vm x >>r= to_word ws = ok w ->
   get_var wdb vm x = ok (Vword w).
 Proof.
   t_xrbindP => htx v /[dup] /get_varP [] -> hdef + ->.
@@ -457,7 +457,7 @@ Qed.
 
 Lemma to_word_get_var wdb vm x ws (w:word ws) :
   get_var wdb vm x = ok (Vword w) ->
-  get_var wdb vm x >>= to_word ws = ok w.
+  get_var wdb vm x >>r= to_word ws = ok w.
 Proof. by move=> -> /=; rewrite truncate_word_u. Qed.
 
 (* Remark compat_type b = if b then subtype else eq *)
@@ -867,7 +867,7 @@ Qed.
 
 Lemma is_wconstP wdb gd s sz e w:
   is_wconst sz e = Some w →
-  sem_pexpr wdb gd s e >>= to_word sz = ok w.
+  sem_pexpr wdb gd s e >>r= to_word sz = ok w.
 Proof.
   case: e => // - [] // sz' e /=; case: ifP => // hle /oseq.obindI [z] [h] [<-].
   have := is_constP e; rewrite h => {h} /is_reflect_some_inv -> {e}.

--- a/proofs/lang/psem_defs.v
+++ b/proofs/lang/psem_defs.v
@@ -124,17 +124,17 @@ Fixpoint sem_pexpr (s:estate) (e : pexpr) : exec value :=
   | Pvar v => get_gvar wdb gd s.(evm) v
   | Pget al aa ws x e =>
       Let (n, t) := wdb, gd, s.[x] in
-      Let i := sem_pexpr s e >>= to_int in
+      Let i := sem_pexpr s e >>r= to_int in
       Let w := WArray.get al aa ws t i in
       ok (Vword w)
   | Psub aa ws len x e =>
     Let (n, t) := wdb, gd, s.[x] in
-    Let i := sem_pexpr s e >>= to_int in
+    Let i := sem_pexpr s e >>r= to_int in
     Let t' := WArray.get_sub aa ws len t i in
     ok (Varr t')
   | Pload al sz x e =>
-    Let w1 := get_var wdb s.(evm) x >>= to_pointer in
-    Let w2 := sem_pexpr s e >>= to_pointer in
+    Let w1 := get_var wdb s.(evm) x >>r= to_pointer in
+    Let w2 := sem_pexpr s e >>r= to_pointer in
     Let w  := read s.(emem) al (w1 + w2)%R sz in
     ok (@to_val (sword sz) w)
   | Papp1 o e1 =>
@@ -148,9 +148,9 @@ Fixpoint sem_pexpr (s:estate) (e : pexpr) : exec value :=
     Let vs := mapM (sem_pexpr s) es in
     sem_opN op vs
   | Pif t e e1 e2 =>
-    Let b := sem_pexpr s e >>= to_bool in
-    Let v1 := sem_pexpr s e1 >>= truncate_val t in
-    Let v2 := sem_pexpr s e2 >>= truncate_val t in
+    Let b := sem_pexpr s e >>r= to_bool in
+    Let v1 := sem_pexpr s e1 >>r= truncate_val t in
+    Let v2 := sem_pexpr s e2 >>r= truncate_val t in
     ok (if b then v1 else v2)
   end.
 
@@ -173,21 +173,21 @@ Definition write_lval (l : lval) (v : value) (s : estate) : exec estate :=
   | Lnone _ ty => write_none s ty v
   | Lvar x => write_var x v s
   | Lmem al sz x e =>
-    Let vx := get_var wdb (evm s) x >>= to_pointer in
-    Let ve := sem_pexpr s e >>= to_pointer in
+    Let vx := get_var wdb (evm s) x >>r= to_pointer in
+    Let ve := sem_pexpr s e >>r= to_pointer in
     let p := (vx + ve)%R in (* should we add the size of value, i.e vx + sz * se *)
     Let w := to_word sz v in
     Let m := write s.(emem) al p w in
     ok (with_mem s m)
   | Laset al aa ws x i =>
     Let (n,t) := wdb, s.[x] in
-    Let i := sem_pexpr s i >>= to_int in
+    Let i := sem_pexpr s i >>r= to_int in
     Let v := to_word ws v in
     Let t := WArray.set t al aa i v in
     write_var x (@to_val (sarr n) t) s
   | Lasub aa ws len x i =>
     Let (n,t) := wdb, s.[x] in
-    Let i := sem_pexpr s i >>= to_int in
+    Let i := sem_pexpr s i >>r= to_int in
     Let t' := to_arr (Z.to_pos (arr_size ws len)) v in
     Let t := @WArray.set_sub n aa ws len t i t' in
     write_var x (@to_val (sarr n) t) s
@@ -212,7 +212,7 @@ Definition exec_sopn (o:sopn) (vs:values) : exec values :=
   ok (list_ltuple t).
 
 Definition sem_sopn gd o m lvs args :=
-  sem_pexprs true gd m args >>= exec_sopn o >>= write_lvals true gd m lvs.
+  sem_pexprs true gd m args >>r= exec_sopn o >>r= write_lvals true gd m lvs.
 
 End EXEC_ASM.
 

--- a/proofs/lang/sem_one_varmap.v
+++ b/proofs/lang/sem_one_varmap.v
@@ -258,7 +258,7 @@ Lemma sem_iE ii k s i s' :
   match i with
   | Cassgn x tag ty e =>
     k = vrv x ∧
-    exists2 v', sem_pexpr true gd s e >>= truncate_val ty = ok v' & write_lval true gd x v' s = ok s'
+    exists2 v', sem_pexpr true gd s e >>r= truncate_val ty = ok v' & write_lval true gd x v' s = ok s'
   | Copn xs t o es => k = vrvs xs ∧ sem_sopn gd o s xs es = ok s'
   | Csyscall xs o es => 
     k = Sv.union syscall_kill (vrvs (to_lvals (syscall_sig o).(scs_vout))) /\  

--- a/proofs/lang/values.v
+++ b/proofs/lang/values.v
@@ -511,7 +511,7 @@ Qed.
   * -------------------------------------------------------------------- *)
 
 Definition truncate_val (ty: stype) (v: value) : exec value :=
-  of_val ty v >>= λ x, ok (to_val x).
+  of_val ty v >>r= λ x, ok (to_val x).
 
 Lemma truncate_val_typeE ty v vt :
   truncate_val ty v = ok vt ->

--- a/proofs/lang/varmap.v
+++ b/proofs/lang/varmap.v
@@ -540,7 +540,7 @@ Definition get_var wdb vm x :=
 Definition get_vars wdb vm := mapM (get_var wdb vm).
 
 Definition vm_initialized_on vm : seq var → Prop :=
-  all (λ x, is_ok (get_var true vm x >>= of_val (vtype x))).
+  all (λ x, is_ok (get_var true vm x >>r= of_val (vtype x))).
 
 Lemma set_varP wdb vm x v vm' :
   set_var wdb vm x v = ok vm' <-> [/\ DB wdb v, truncatable wdb (vtype x) v & vm' = vm.[x <- v]].

--- a/proofs/ssrmisc/oseq.v
+++ b/proofs/ssrmisc/oseq.v
@@ -177,17 +177,17 @@ Qed.
 Declare Scope option_scope.
 Delimit Scope option_scope with O.
 
-Notation "m >>= f" := (ssrfun.Option.bind f m)
+Notation "m >>o= f" := (ssrfun.Option.bind f m)
   (at level 25, left associativity) : option_scope.
 
 Local Open Scope option_scope.
 
 Lemma foldl_bind_None {A B: Type} (f: A -> B -> option B) m :
-  foldl (fun a b => a >>= f b) None m = None.
+  foldl (fun a b => a >>o= f b) None m = None.
 Proof. by elim: m. Qed.
 
 (* -------------------------------------------------------------------- *)
 
 Lemma obindI {T1 T2:Type} {f:T1 -> option T2} {o t2} :
-  (o >>= f) = Some t2 -> exists t1, o = Some t1 /\ f t1 = Some t2.
+  (o >>o= f) = Some t2 -> exists t1, o = Some t1 /\ f t1 = Some t2.
 Proof. by case: o => [t1|]//=;exists t1. Qed.


### PR DESCRIPTION
Minor modification of the pseudo-monadic notation (>>= and >>) for 'result' and 'option', proposed in order to avoid conflicts with the actual monadic notation, which is widely used in the Interaction Trees development, and prevent confusion.  