### PR TITLE
CI/libjade: expose jasmin2ec

### DIFF
--- a/scripts/test-libjade.sh
+++ b/scripts/test-libjade.sh
@@ -11,7 +11,7 @@ ROOT=$(echo -n $NAME-$BRANCH | tr / -)
 
 DIR="libjade/$1"
 
-MAKELINE="-C $DIR CI=1 JASMIN=$PWD/compiler/jasminc"
+MAKELINE="-C $DIR CI=1 JASMIN=$PWD/compiler/jasminc JASMIN2EC=$PWD/compiler/jasmin2ec"
 
 # Exclude primitives that are known not to build
 export EXCLUDE=""


### PR DESCRIPTION
This enables the use of `jasmin2ec` in libjade without breaking jasmin CI.