### PR TITLE
Generalize forced explicit registers in instr. descriptors

### DIFF
--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -634,9 +634,12 @@ module Regalloc (Arch : Arch_full.Arch)
         match ad with
         | ADImplicit v ->
            mallocate_one e (translate_var v) a
-        | ADExplicit (_, Some v) ->
+        | ADExplicit (_, ACR_exact v) ->
            mallocate_one e (translate_var v) a
-        | ADExplicit (_, None) -> ()) id.i_in es
+        | ADExplicit (_, ACR_vector v) ->
+           mallocate_one e (translate_var v) a
+        | ADExplicit (_, ACR_subset _) (* TODO *)
+        | ADExplicit (_, ACR_any) -> ()) id.i_in es
 
 let allocate_forced_registers return_addresses translate_var nv (vars: int Hv.t) (cnf: conflicts)
     (f: ('info, 'asm) func) (a: A.allocation) : unit =

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -237,10 +237,18 @@ Definition var_of_implicit_arg (i : implicit_arg) : var :=
   | IAreg r => to_var r
   end.
 
+Definition sopn_constrained_register acr :=
+  match acr with
+  | ACR_any      => sopn.ACR_any
+  | ACR_exact x  => sopn.ACR_exact (to_var x)
+  | ACR_vector x => sopn.ACR_vector (to_var x)
+  | ACR_subset s => sopn.ACR_subset (map to_var s)
+  end.
+
 Definition sopn_arg_desc (ad:arg_desc) :=
   match ad with
   | ADImplicit ia => sopn.ADImplicit (var_of_implicit_arg ia)
-  | ADExplicit _ n ox => sopn.ADExplicit n (omap to_var ox)
+  | ADExplicit _ n ox => sopn.ADExplicit n (sopn_constrained_register ox)
   end.
 
 End ARCH.

--- a/proofs/compiler/arm_extra.v
+++ b/proofs/compiler/arm_extra.v
@@ -42,7 +42,7 @@ Instance eqTC_arm_extra_op : eqTypeC arm_extra_op :=
 
 (* Extra instructions descriptions. *)
 
-Local Notation E n := (sopn.ADExplicit n None).
+Local Notation E n := (sopn.ADExplicit n sopn.ACR_any).
 
 (* [conflicts] ensures that the returned register is distinct from the first
    argument. *)

--- a/proofs/compiler/riscv_extra.v
+++ b/proofs/compiler/riscv_extra.v
@@ -16,7 +16,7 @@ Require Import
   riscv_instr_decl
   riscv.
 
-Local Notation E n := (sopn.ADExplicit n None).
+Local Notation E n := (sopn.ADExplicit n sopn.ACR_any).
 
 
 Variant riscv_extra_op : Type :=  

--- a/proofs/compiler/x86_extra.v
+++ b/proofs/compiler/x86_extra.v
@@ -71,7 +71,7 @@ Qed.
 
 HB.instance Definition _ := hasDecEq.Build x86_extra_op x86_extra_op_eq_axiom.
 
-Local Notation E n := (ADExplicit n None).
+Local Notation E n := (ADExplicit n ACR_any).
 
 Section Section.
 Context {atoI : arch_toIdent}.

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -461,7 +461,7 @@ Qed.
 Lemma check_sopn_dests_xmm rip ii oargs xs ads cond n al k ws:
   check_sopn_dests x86_agparams rip ii oargs xs ads ->
   check_i_args_kinds [::cond] oargs ->
-  nth (Ea 0, sword8) ads n = (ADExplicit (AK_mem al) k None, sword ws) ->
+  nth (Ea 0, sword8) ads n = (ADExplicit (AK_mem al) k ACR_any, sword ws) ->
   nth xmm cond k = xmm ->
   n < size xs ->
   exists (r: xreg_t),

--- a/proofs/lang/sopn.v
+++ b/proofs/lang/sopn.v
@@ -15,10 +15,16 @@ Require Import
 Local Unset Elimination Schemes.
 
 (* ----------------------------------------------------------------------------- *)
+Variant arg_constrained_register :=
+| ACR_any
+| ACR_exact of var
+| ACR_vector of var
+| ACR_subset of seq var
+.
 
 Variant arg_desc :=
 | ADImplicit  of var
-| ADExplicit  of nat & option var.
+| ADExplicit  of nat & arg_constrained_register.
 
 Variant arg_position :=
 | APout of nat
@@ -148,7 +154,7 @@ Definition sopn_subcarry (ws : wsize) : sopn := Opseudo_op (Osubcarry ws).
    of in- and out- arguments, but apart from that, we give some trivial values.
 *)
 
-Local Notation E n := (ADExplicit n None).
+Local Notation E n := (ADExplicit n ACR_any).
 
 Lemma array_copy_errty ws p:
   let sz := Z.to_pos (arr_size ws p) in


### PR DESCRIPTION
Some x86 instructions have a mandatory explicit operand XMM0 (e.g. SHA256RNDS2)

Some ARM instructions only accept registers in the [r0; r7] range (e.g., MULS)