### PR TITLE
Changing assembly debug info pretty printing for coherence between all printers

### DIFF
--- a/compiler/src/debugInfo.ml
+++ b/compiler/src/debugInfo.ml
@@ -22,5 +22,5 @@ let source_positions ii =
   else
     let n, isFresh = internFile ii.loc_fname in
     let line, col = ii.loc_start in
-    let loc = [ asprintf ".loc %d %d %d\n" n line col ] in
-    if isFresh then asprintf ".file %d %S\n" n ii.loc_fname :: loc else loc
+    let loc = [ asprintf ".loc %d %d %d" n line col ] in
+    if isFresh then asprintf ".file %d %S" n ii.loc_fname :: loc else loc

--- a/compiler/src/ppasm.ml
+++ b/compiler/src/ppasm.ml
@@ -450,7 +450,7 @@ module Printer (BP:BPrinter) = struct
   (* -------------------------------------------------------------------- *)
   let pp_instr name (fmt : Format.formatter) (i : (_, _, _, _, _, _) Arch_decl.asm_i) =
     let Arch_decl.({ asmi_i = i ; asmi_ii = ii }) = i in
-    List.iter (pp_gen fmt) (pp_ii ii);
+    (pp_gens fmt) (pp_ii ii);
     pp_gen fmt (pp_instr name i)
 
   (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
A little change to the way pretty printing of debug is handled. Without this change, arm and riscv assembly pretty printing return add an empty line after printing of debug info. This PR remove it while maintaining x86 pretty printing behaviour. 