### PR TITLE
changing .globl to .global in pp_x86 for simplification

### DIFF
--- a/compiler/src/pp_x86.ml
+++ b/compiler/src/pp_x86.ml
@@ -430,8 +430,8 @@ module X86AsmTranslate (AsmSyntax: X86AsmSyntax) = struct
     if d.asm_fd_export then
       let fn = escape n.fn_name in
     [
-      Instr (".globl", [mangle fn]);
-      Instr (".globl", [fn])
+      Instr (".global", [mangle fn]);
+      Instr (".global", [fn])
     ]
     else []
 


### PR DESCRIPTION
As stated by [GAS doc](https://sourceware.org/binutils/docs/as/Global.html), `.globl` and `.global` are equivalent. Yet we use `.globl` for x86 and `.global` for arm and riscv. This PR make all headers use `.global`. This will help to factor assembly printing