### PR TITLE
Be less verbose if not debug

### DIFF
--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -137,8 +137,8 @@ let main () =
     (* Check if generated assembly labels will generate conflicts*)
     let label_errors = Label_check.get_labels_errors pprog in 
     List.iter Label_check.warn_duplicate_label label_errors;
-    
-    eprint Compiler.Typing (Printer.pp_pprog Arch.reg_size Arch.asmOp) pprog;
+
+    eprint Compiler.Typing (Printer.pp_pprog ~debug:true Arch.reg_size Arch.asmOp) pprog;
 
     let prog =
       try Compile.preprocess Arch.reg_size Arch.asmOp pprog

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -82,6 +82,8 @@ let pp_suffix fmt =
   | PVvv (ve, sz, ve', sz') -> F.fprintf fmt "_%s_%s" (string_of_velem Unsigned sz ve) (string_of_velem Unsigned sz' ve')
 
 let pp_tyerror fmt (code : tyerror) =
+  (* We do not need the extra verbosity of [debug] in this context *)
+  let pp_eptype = Printer.pp_eptype ~debug:false in
   match code with
   | UnknownVar x ->
       F.fprintf fmt "unknown variable: `%s'" x
@@ -91,20 +93,20 @@ let pp_tyerror fmt (code : tyerror) =
 
   | InvalidArrayType ty ->
     F.fprintf fmt "the expression has type %a instead of array"
-       Printer.pp_eptype ty
+       pp_eptype ty
 
   | TypeMismatch (t1,t2) ->
     F.fprintf fmt
       "the expression has type %a instead of %a"
-      Printer.pp_eptype t1 Printer.pp_eptype t2
+      pp_eptype t1 pp_eptype t2
 
   | InvalidCast (t1,t2) ->
     F.fprintf fmt "can not implicitly cast %a into %a"
-      Printer.pp_eptype t1 Printer.pp_eptype t2
+      pp_eptype t1 pp_eptype t2
 
   | InvalidTypeForGlobal ty ->
       F.fprintf fmt "globals should have type word; found: ‘%a’"
-        Printer.pp_eptype ty
+        pp_eptype ty
 
   | GlobArrayNotWord ->
     F.fprintf fmt "the definition is an array and not a word"
@@ -122,13 +124,13 @@ let pp_tyerror fmt (code : tyerror) =
       F.fprintf fmt
         "no operator %s for these types %a"
         (S.string_of_peop2 o)
-        (pp_list " * " Printer.pp_eptype) ts
+        (pp_list " * " pp_eptype) ts
 
   | NoOperator (`Op1 o, ts) ->
       F.fprintf fmt
         "no operator %s for these type %a"
         (S.string_of_peop1 o)
-        (pp_list " * " Printer.pp_eptype) ts
+        (pp_list " * " pp_eptype) ts
 
   | NoReturnStatement (name, expected) ->
      F.fprintf fmt "function “%s” has no return statement (but its signature claims that %d values should be returned)" name.P.fn_name expected
@@ -160,9 +162,9 @@ let pp_tyerror fmt (code : tyerror) =
       F.fprintf fmt
         "Type '%s' (ie: '%a') is already declared at %s (with type : '%a')"
         id
-        Printer.pp_eptype (L.unloc newtype)
+        pp_eptype (L.unloc newtype)
         (L.tostring (L.loc oldtype))
-        Printer.pp_eptype (L.unloc oldtype)
+        pp_eptype (L.unloc oldtype)
 
   | TypeNotFound (id) ->
       F.fprintf fmt
@@ -172,9 +174,9 @@ let pp_tyerror fmt (code : tyerror) =
   | InvalidTypeAlias (id,typ) ->
       let pp_id fmt (id, typ) =
         match id with
-        | None -> F.fprintf fmt "'%a'" Printer.pp_eptype typ
+        | None -> F.fprintf fmt "'%a'" pp_eptype typ
         | Some id ->
-            F.fprintf fmt "'%s' (ie: '%a'), defined at %s," (L.unloc id) Printer.pp_eptype typ
+            F.fprintf fmt "'%s' (ie: '%a'), defined at %s," (L.unloc id) pp_eptype typ
                (L.tostring (L.loc id)) in
       F.fprintf fmt
       "Type %a is not allowed as array element. Only machine words (w8, w16 ...) allowed"

--- a/compiler/src/printCommon.ml
+++ b/compiler/src/printCommon.ml
@@ -62,23 +62,28 @@ let string_of_int_cast sg =
 let string_of_wi_cast sg sz =
   asprintf "%d%s" (int_of_ws sz) (string_of_wi sg)
 
-let string_of_wiop1 sg = function
+let string_of_wiop1 ~debug sg = function
   | E.WIwint_of_int sz ->
-      asprintf "(%s /* of int */)" (string_of_wi_cast sg sz)
+      asprintf "(%s%s)" (string_of_wi_cast sg sz)
+        (if debug then " /* of int */" else "")
   | WIint_of_wint sz ->
-      asprintf "(%s /* of %s */)" (string_of_int_cast sg) (string_of_wi_ty sg sz)
+      asprintf "(%s%s)" (string_of_int_cast sg)
+        (if debug then " /* of " ^ (string_of_wi_ty sg sz) ^ " */" else "")
   | WIword_of_wint sz ->
-      asprintf "(%s /* of %s */)" (string_of_w_cast sz) (string_of_wi_ty sg sz)
+      asprintf "(%s%s)" (string_of_w_cast sz)
+        (if debug then " /* of " ^ (string_of_wi_ty sg sz) ^ " */" else "")
   | WIwint_of_word sz ->
-      asprintf "(%s /* of %s */)" (string_of_wi_cast sg sz) (string_of_w_ty sz)
+      asprintf "(%s%s)" (string_of_wi_cast sg sz)
+        (if debug then " /* of " ^ (string_of_w_ty sz) ^ " */" else "")
   | WIwint_ext(szo, _) ->
       asprintf "(%s)" (string_of_wi_cast sg szo)
   | WIneg sz ->
       asprintf "-%s" (string_of_wi_cast sg sz)
 
-let string_of_op1 = function
+let string_of_op1 ~debug = function
   | E.Oint_of_word (s, sz) ->
-      asprintf "(%s /* of %s */)" (string_of_int_cast s) (string_of_w_ty sz)
+      asprintf "(%s%s)" (string_of_int_cast s)
+        (if debug then " /* of " ^ (string_of_w_ty sz) ^ " */" else "")
   | E.Oword_of_int szo  -> asprintf "(%du)" (int_of_ws szo)
   | E.Osignext (szo, _) -> asprintf "(%ds)" (int_of_ws szo)
   | E.Ozeroext (szo, _) -> asprintf "(%du)" (int_of_ws szo)
@@ -86,7 +91,7 @@ let string_of_op1 = function
       asprintf "!%s" (string_of_w_cast sz)
   | E.Onot -> "!"
   | E.Oneg k -> "-" ^ string_of_op_kind k
-  | E.Owi1(sg, o) -> string_of_wiop1 sg o
+  | E.Owi1(sg, o) -> string_of_wiop1 ~debug sg o
 
 let string_of_wiop2 sg sz = function
   | E.WIadd -> "+" ^ string_of_wi_cast sg sz

--- a/compiler/src/printCommon.mli
+++ b/compiler/src/printCommon.mli
@@ -5,7 +5,7 @@ val pp_wsize : Format.formatter -> Wsize.wsize -> unit
 val pp_aligned : Format.formatter -> Memory_model.aligned -> unit
 val string_of_signess : Wsize.signedness -> string
 val string_of_velem : Wsize.signedness -> Wsize.wsize -> Wsize.velem -> string
-val string_of_op1 : Expr.sop1 -> string
+val string_of_op1 : debug:bool -> Expr.sop1 -> string
 val string_of_op2 : Expr.sop2 -> string
 
 val pp_opn :

--- a/compiler/src/printFexpr.ml
+++ b/compiler/src/printFexpr.ml
@@ -1,12 +1,12 @@
 open Fexpr
 open PrintCommon
 
-let rec pp_fexpr fmt =
-  let pp_fexpr = pp_fexpr in
-  function
+let rec pp_fexpr fmt = function
   | Fconst z -> Z.pp_print fmt (Conv.z_of_cz z)
   | Fvar x -> pp_var_i fmt x
-  | Fapp1 (op, e) -> Format.fprintf fmt "(%s %a)" (string_of_op1 op) pp_fexpr e
+  | Fapp1 (op, e) ->
+      (* no casts left at this stage, so the value of [debug] has no impact *)
+      Format.fprintf fmt "(%s %a)" (string_of_op1 ~debug:false op) pp_fexpr e
   | Fapp2 (op, e1, e2) -> Format.fprintf fmt "(%a %s %a)" pp_fexpr e1 (string_of_op2 op) pp_fexpr e2
   | Fif (c, e1, e2) -> Format.fprintf fmt "(%a ? %a : %a)" pp_fexpr c pp_fexpr e1 pp_fexpr e2
 

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -444,20 +444,19 @@ let pp_warning_msg fmt = function
   | Compiler_util.Use_lea -> Format.fprintf fmt "LEA instruction is used"
 
 let pp_err ~debug fmt (pp_e : Compiler_util.pp_error) =
-  let pp_var fmt v =
-    let v = Conv.var_of_cvar v in
-    Format.fprintf fmt "%a" (pp_dvar ~debug) v
+  let pp_var =
+    if debug then pp_dvar ~debug else pp_var ~debug
   in
   let rec pp_err fmt pp_e =
     match pp_e with
     | Compiler_util.PPEstring s -> Format.fprintf fmt "%s" s
     | Compiler_util.PPEz z -> Format.fprintf fmt "%a" Z.pp_print (Conv.z_of_cz z)
-    | Compiler_util.PPEvar v -> Format.fprintf fmt "%a" pp_var v
+    | Compiler_util.PPEvar v -> Format.fprintf fmt "%a" pp_var (Conv.var_of_cvar v)
     | Compiler_util.PPEvarinfo loc ->
       Format.fprintf fmt "%a" L.pp_loc loc
     | Compiler_util.PPElval x ->
        x |> Conv.lval_of_clval |>
-       pp_glv ~debug pp_len (pp_dvar ~debug) fmt
+       pp_glv ~debug pp_len pp_var fmt
     | Compiler_util.PPEfunname fn -> Format.fprintf fmt "%s" fn.fn_name
     | Compiler_util.PPEiinfo ii ->
       let i_loc, _ = ii in

--- a/compiler/src/printer.mli
+++ b/compiler/src/printer.mli
@@ -6,11 +6,11 @@ val pp_err : debug:bool -> Format.formatter -> Compiler_util.pp_error -> unit
 val pp_print_X : Format.formatter -> Z.t -> unit
 
 val pp_pvar  : Format.formatter -> pvar -> unit
-val pp_ptype : Format.formatter -> pty -> unit
-val pp_eptype : Format.formatter -> epty -> unit
-val pp_plval : Format.formatter -> plval -> unit
-val pp_pexpr : Format.formatter -> pexpr -> unit
-val pp_pprog : Wsize.wsize -> ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op Sopn.asmOp ->
+val pp_ptype : debug:bool -> Format.formatter -> pty -> unit
+val pp_eptype : debug:bool -> Format.formatter -> epty -> unit
+val pp_plval : debug:bool -> Format.formatter -> plval -> unit
+val pp_pexpr : debug:bool -> Format.formatter -> pexpr -> unit
+val pp_pprog : debug:bool -> Wsize.wsize -> ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op Sopn.asmOp ->
                Format.formatter -> ('info, ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op) pprog -> unit
 
 val pp_var   : debug:bool -> Format.formatter -> var -> unit
@@ -32,6 +32,7 @@ val pp_stmt  : debug:bool ->
                Format.formatter -> ('info, ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op) stmt  -> unit
 
 val pp_fun :
+             debug:bool ->
              ?pp_locals:(Sv.t Utils.pp) ->
              ?pp_info:((Location.i_loc * 'info) Utils.pp) ->
              (('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op Sopn.sopn) Utils.pp ->

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -1121,7 +1121,7 @@ let pp_liveness vars liveness_per_callsite liveness_table a =
   printf "/* Ready to allocate variables to registers: */@.";
   liveness_table |> Hf.iter (fun fn fd ->
     reset_max();
-    printf "%a@." (pp_fun ~pp_locals ~pp_info (pp_opn Arch.reg_size Arch.asmOp) pp_var) fd;
+    printf "%a@." (pp_fun ~debug:!Glob_options.debug ~pp_locals ~pp_info (pp_opn Arch.reg_size Arch.asmOp) pp_var) fd;
     let intern = !m_word, !m_extra, !m_vector, !m_flag in
     reset_max();
     printf "%a@." pp_callsites fn;

--- a/compiler/src/subst.ml
+++ b/compiler/src/subst.ml
@@ -182,7 +182,7 @@ let rec int_of_expr ?loc e =
       op (int_of_expr ?loc e1) (int_of_expr ?loc e2)
   | Pbool _ | Parr_init _ | Pvar _
   | Pget _ | Psub _ | Pload _ | Papp1 _ | PappN _ | Pif _ ->
-      hierror ?loc "expression %a not allowed in array size (only constant arithmetic expressions are allowed)" Printer.pp_pexpr e
+      hierror ?loc "expression %a not allowed in array size (only constant arithmetic expressions are allowed)" (Printer.pp_pexpr ~debug:false) e
 
 
 let isubst_len ?loc (PE e) =


### PR DESCRIPTION
- do not print ` /* of uXX */` for casts if not debug
- do not print ` (defined at loc)` for vars if not debug

The goal is to hopefully get more readable error messages by default, and a more verbose one if `-debug` is given to the command line.