### PR TITLE
Putting .global (export) directive at top of generated assembly (for coherence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
   ([PR #1114](https://github.com/jasmin-lang/jasmin/pull/1114)).
 
 - Rewriting of assembly printers
-  ([PR #1118](https://github.com/jasmin-lang/jasmin/pull/1118)).
+  ([PR #1118](https://github.com/jasmin-lang/jasmin/pull/1118),
+  [PR #1125](https://github.com/jasmin-lang/jasmin/pull/1125)).
 
 # Jasmin 2025.02.1 — Nancy, 2025-04-10
 

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -262,12 +262,6 @@ let pp_body fn =
     (List.map (fun x -> Dwarf x) (DebugInfo.source_positions ii.base_loc))
     i
 
-let pp_fn_head fn fd =
-  let fn = escape fn in
-  if fd.asm_fd_export then
-    [ Instr (".global", [ mangle fn ]); Instr (".global", [ fn ]) ]
-  else []
-
 let pp_fn_prefix fn fd =
   let fn = escape fn in
   if fd.asm_fd_export then
@@ -286,11 +280,10 @@ let pp_fn_pos fn fd =
 
 let pp_fun (fn, fd) =
   let fn = fn.fn_name in
-  let head = pp_fn_head fn fd in
   let pre = pp_fn_prefix fn fd in
   let body = pp_body fn fd.asm_fd_body in
   let pos = pp_fn_pos fn fd in
-  head @ pre @ body @ pos
+  pre @ body @ pos
 
 let pp_funcs funs = List.concat_map pp_fun funs
 
@@ -301,9 +294,19 @@ let pp_data globs names =
     format_glob_data globs names
   else []
 
+let pp_fn_decl (fn,fd) =
+  let fn = escape fn.fn_name in
+  if fd.asm_fd_export then
+    [ Instr (".global", [ mangle fn ]); Instr (".global", [ fn ]) ]
+  else []
+  
+let pp_decls funcs = 
+  List.concat_map pp_fn_decl funcs
+
 let pp_prog p =
+  let decls = pp_decls p.asm_funcs in 
   let code = pp_funcs p.asm_funcs in
   let data = pp_data p.asm_globs p.asm_glob_names in
-  headers @ code @ data
+  headers @ decls @ code @ data
 
 let print_prog fmt p = PrintASM.pp_asm fmt (pp_prog p)


### PR DESCRIPTION
Currently, we have two different behaviour regarding the position of `.global` directive in generated assembly sources. In x86, we put them at the top of the file. In arm and riscv, we put them just before the function label.

This PR modify the behaviour of arm and riscv assembly printer to put `.global` directives after file header like it is done in x86. This will increase readability of generated assembly and improve coherence between generated assembly for all architectures.

The doc only specify that export directive should be placed before function label, so this change shouldn't break anything (documentation of this feature is however lacking).