### PR TITLE
safety: use dune to run tests

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -17,8 +17,7 @@ CHECKCATS ?= \
 	arm-m4-stack-zero-loop \
 	arm-m4-stack-zero-unrolled \
 	risc-v \
-	CCT CCT-DOIT SCT \
-	safety
+	CCT CCT-DOIT SCT
 
 # --------------------------------------------------------------------
 DESTDIR  ?=

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -5,11 +5,6 @@ bin    = ./scripts/check
 args   = -arch x86-64 -nolea
 kodirs = tests/fail/nolea/x86-64
 
-[test-safety]
-bin    = ./scripts/check-safety
-okdirs = safety/success
-kodirs = safety/fail
-
 [test-CCT]
 bin    = ./scripts/check-cct
 okdirs = CCT/success

--- a/compiler/safety/dune
+++ b/compiler/safety/dune
@@ -1,0 +1,9 @@
+(tests
+  (libraries jasmin.jasmin jasmin_checksafety)
+  (deps
+    (glob_files success/*)
+    (glob_files fail/*))
+  (modules run)
+  (names
+    run))
+

--- a/compiler/safety/fail/carry_flags_err.jazz
+++ b/compiler/safety/fail/carry_flags_err.jazz
@@ -1,7 +1,7 @@
 export
 fn test() -> reg u64 {
-  reg bool cf, zf;
-  reg u64 i, acc;
+  reg bool cf;
+  reg u64 i;
 
   i = 2;
   cf, i -= 1;

--- a/compiler/safety/fail/carry_flags_err2.jazz
+++ b/compiler/safety/fail/carry_flags_err2.jazz
@@ -1,7 +1,7 @@
 export
 fn test() -> reg u64 {
-  reg bool cf, zf;
-  reg u64 i, acc;
+  reg bool cf;
+  reg u64 i;
 
   i = 0;
   cf, i -= 1;

--- a/compiler/safety/fail/load.jazz
+++ b/compiler/safety/fail/load.jazz
@@ -1,5 +1,5 @@
 export
-fn load_last(reg u64 ptr, reg u64 len) -> reg u64[2]
+fn load_last(reg u64 input, reg u64 len) -> reg u64[2]
 {
   reg   u64    j;
   reg   u64[2] x;
@@ -11,7 +11,7 @@ fn load_last(reg u64 ptr, reg u64 len) -> reg u64[2]
 
   j = 0;
   while(j < len)
-  { c = [:u8 ptr + j];
+  { c = [:u8 input + j];
     s[:u8 j] = c;
     j += 1;
   }

--- a/compiler/safety/fail/loop2.jazz
+++ b/compiler/safety/fail/loop2.jazz
@@ -2,9 +2,7 @@ export
 fn poly1305(reg u64 in, reg u64 inlen) -> reg u64 {
   inline int i;
   reg u8 tmp;
-  reg u64 ret, one;
-  reg bool of, cf, sf, zf;
-  stack u32[17] r, h, c;
+  reg u64 one;
 
   one = 1;
   while (inlen > 0) {

--- a/compiler/safety/run.expected
+++ b/compiler/safety/run.expected
@@ -1,0 +1,307 @@
+File fail/arr_init_fail.jazz:
+Analyzing function main
+
+
+*** Possible Safety Violation(s):
+  "fail/arr_init_fail.jazz", line 16 (4-15): in_bound: tmp[U8 j ] (length 16 U8)
+  "fail/arr_init_fail.jazz", line 14 (2) to line 18 (3): termination
+  
+Memory ranges:
+  mem_len: [0; 0]
+  mem_x0: [0; 0]
+  mem_x1: [0; 0]
+  mem_x2: [0; 0]
+  mem_x3: [0; 0]
+  
+* Rel:
+{inv_len ≤ 18446744073709551615, inv_x3 ≥ 0, inv_x2 ≥ 0, inv_len ≥ 0, inv_x1 ≥ 0, inv_x0 ≥ 0, inv_x3 ≤ 4294967295, inv_x2 ≤ 4294967295, inv_x1 ≤ 4294967295, inv_x0 ≤ 4294967295, mem_x3 = 0, mem_x2 = 0, mem_x1 = 0, mem_x0 = 0, mem_len = 0}
+mem_len ∊ [0; 0]
+mem_x0 ∊ [0; 0]
+mem_x1 ∊ [0; 0]
+mem_x2 ∊ [0; 0]
+mem_x3 ∊ [0; 0]
+
+
+
+Program is not safe!
+
+File fail/array-export.jazz:
+Analyzing function main
+
+
+*** Possible Safety Violation(s):
+  "fail/array-export.jazz", line 4 (2-11): in_bound: a[U8 ((uint) i) ] (length 4 U8)
+  
+Memory ranges:
+  mem_a: [0; 0]
+  mem_i: [0; 0]
+  
+* Rel:
+{inv_i ≤ 18446744073709551615, inv_i ≥ 0, mem_a = 0, mem_i = 0}
+mem_a ∊ [0; 0]
+mem_i ∊ [0; 0]
+
+
+
+Program is not safe!
+
+File fail/array-len3.jazz:
+Analyzing function array
+
+
+*** Possible Safety Violation(s):
+  "fail/array-len3.jazz", line 33 (4-18): is_init blk[U64 i ]
+  
+* Rel:
+⊤
+
+
+
+Program is not safe!
+
+File fail/array_init.jazz:
+Analyzing function bad_read
+
+
+*** Possible Safety Violation(s):
+  "fail/array_init.jazz", line 8 (2-11): is_init t[U64 0 ]
+  
+* Rel:
+⊤
+
+
+
+Program is not safe!
+
+File fail/bad_align.jazz:
+Analyzing function main
+
+
+*** Possible Safety Violation(s):
+  "fail/bad_align.jazz", line 6 (2-30): aligned pointer pt + ((64u) 1) u64
+  
+Memory ranges:
+  mem_pt: [0; 9]
+  
+* Rel:
+{mem_pt ≥ 0, inv_pt ≥ 0, mem_pt ≤ 9, inv_pt ≤ 18446744073709551615}
+mem_pt ∊ [0; 9]
+
+* Alignment: pt 64; 
+
+Program is not safe!
+
+File fail/bad_align2.jazz:
+Analyzing function main
+
+
+*** Possible Safety Violation(s):
+  main return: is_init tmp
+  
+Memory ranges:
+  mem_pt: [0; 120]
+  
+* Rel:
+{mem_pt ≤ 120, inv_pt ≤ 18446744073709551615, inv_pt ≥ 0, mem_pt ≥ 0}
+mem_pt ∊ [0; 120]
+
+
+
+Program is not safe!
+
+File fail/bounded_while.jazz:
+Analyzing function uninit
+
+
+*** Possible Safety Violation(s):
+  "fail/bounded_while.jazz", line 15 (2-17): is_init t[U64 (4 - 1) ]
+  
+Memory ranges:
+  mem_bound: [0; 0]
+  
+* Rel:
+{inv_bound ≤ 18446744073709551615, inv_bound ≥ 0, mem_bound = 0}
+mem_bound ∊ [0; 0]
+
+
+
+Program is not safe!
+
+File fail/carry_flags_err.jazz:
+Analyzing function test
+
+
+*** Possible Safety Violation(s):
+  "fail/carry_flags_err.jazz", line 9 (4-27): termination
+  
+Bottom ⊥
+
+
+Program is not safe!
+
+File fail/carry_flags_err2.jazz:
+Analyzing function test
+
+
+*** Possible Safety Violation(s):
+  "fail/carry_flags_err2.jazz", line 9 (4-27): termination
+  
+Bottom ⊥
+
+
+Program is not safe!
+
+File fail/decompile_fail.jazz:
+Analyzing function test
+
+
+*** Possible Safety Violation(s):
+  "fail/decompile_fail.jazz", line 11 (4-11): is_init i
+  "fail/decompile_fail.jazz", line 9 (2) to line 12 (3): termination
+  
+Bottom ⊥
+
+
+Program is not safe!
+
+File fail/fail_land.jazz:
+Analyzing function BS2POLVECq
+
+
+*** Possible Safety Violation(s):
+  "fail/fail_land.jazz", line 7 (2-25): termination
+  
+Memory ranges:
+  mem_b: [0; 0]
+  
+* Rel:
+{inv_b ≤ 18446744073709551615, inv_b ≥ 0, mem_b = 0}
+mem_b ∊ [0; 0]
+
+
+
+Program is not safe!
+
+File fail/fail_land2.jazz:
+Analyzing function BS2POLVECq
+
+
+*** Possible Safety Violation(s):
+  "fail/fail_land2.jazz", line 6 (2-25): termination
+  
+Memory ranges:
+  mem_b: [0; 0]
+  
+* Rel:
+{inv_b ≥ 0, inv_b ≤ 18446744073709551615, mem_b = 0}
+mem_b ∊ [0; 0]
+
+
+
+Program is not safe!
+
+File fail/init-join.jazz:
+Analyzing function main
+
+
+*** Possible Safety Violation(s):
+  main return: is_init r
+  
+Memory ranges:
+  mem_x: [0; 0]
+  
+* Rel:
+{inv_x ≥ 0, inv_x ≤ 18446744073709551615, mem_x = 0}
+mem_x ∊ [0; 0]
+
+
+
+Program is not safe!
+
+File fail/load.jazz:
+Analyzing function load_last
+
+
+*** Possible Safety Violation(s):
+  "fail/load.jazz", line 15 (4-17): in_bound: s[U8 ((uint) j) ] (length 16 U8)
+  "fail/load.jazz", line 19 (2-17): in_bound: s[U8 ((uint) j) ] (length 16 U8)
+  
+Memory ranges:
+  mem_input: [0; 18446744073709551615]
+  mem_len: [0; 0]
+  
+* Rel:
+{inv_len ≤ 18446744073709551615, inv_input ≤ 18446744073709551615, inv_input ≥ 0, inv_len ≥ mem_input, mem_input ≥ 0, mem_len = 0}
+mem_input ∊ [0; 18446744073709551615]
+mem_len ∊ [0; 0]
+
+
+
+Program is not safe!
+
+File fail/loop2.jazz:
+Analyzing function poly1305
+
+
+*** Possible Safety Violation(s):
+  "fail/loop2.jazz", line 8 (2) to line 20 (3): termination
+  
+Memory ranges:
+  mem_in: [0; 18446744073709551615]
+  mem_inlen: [0; 0]
+  
+* Rel:
+{inv_inlen ≤ 18446744073709551615, inv_in ≥ 0, inv_in ≤ 18446744073709551615, mem_in ≥ 0, inv_inlen ≥ mem_in, mem_inlen = 0}
+mem_in ∊ [0; 18446744073709551615]
+mem_inlen ∊ [0; 0]
+
+
+
+Program is not safe!
+
+File fail/mul0.jazz:
+Analyzing function addNumber
+
+
+*** Possible Safety Violation(s):
+  "fail/mul0.jazz", line 12 (5-28): termination
+  
+Bottom ⊥
+
+
+Program is not safe!
+
+File fail/shld.jazz:
+Analyzing function undefined
+
+
+*** Possible Safety Violation(s):
+  "fail/shld.jazz", line 2 (2-30): (((uint) ((8u) 17)) % 32) ∈ [0; 16]
+  
+Memory ranges:
+  mem_x: [0; 0]
+  mem_y: [0; 0]
+  
+* Rel:
+{inv_y ≥ 0, inv_x ≥ 0, inv_x ≤ 65535, inv_y ≤ 65535, mem_x = 0, mem_y = 0}
+mem_x ∊ [0; 0]
+mem_y ∊ [0; 0]
+
+
+
+Program is not safe!
+
+File fail/wint_overflow.jazz:
+Analyzing function wint_overflow
+
+
+*** Possible Safety Violation(s):
+  "fail/wint_overflow.jazz", line 3 (28-48): 137 ∈ [-128; 127]
+  
+* Rel:
+⊤
+
+
+
+Program is not safe!
+

--- a/compiler/safety/run.ml
+++ b/compiler/safety/run.ml
@@ -1,0 +1,65 @@
+open Jasmin
+open Jasmin_checksafety
+
+let params =
+  [
+    ("success/loop2.jazz", "poly1305>in;");
+    ("success/loop3.jazz", "poly1305>in;");
+  ]
+
+module Arch =
+  (val let use_set0 = !Glob_options.set0 and use_lea = !Glob_options.lea in
+       let call_conv = !Glob_options.call_conv in
+       let module C =
+         (val CoreArchFactory.core_arch_x86 ~use_lea ~use_set0 call_conv)
+       in
+       (module Arch_full.Arch_from_Core_arch (C) : Arch_full.Arch
+         with type reg = X86_decl.register
+          and type regx = X86_decl.register_ext
+          and type xreg = X86_decl.xmm_register
+          and type rflag = X86_decl.rflag
+          and type cond = X86_decl.condt
+          and type asm_op = X86_instr_decl.x86_op
+          and type extra_op = X86_extra.x86_extra_op))
+
+let load_file name =
+  let open Pretyping in
+  name
+  |> tt_file Arch.arch_info Env.empty None None
+  |> fst |> Env.decls
+  |> Compile.preprocess Arch.reg_size Arch.asmOp
+
+let analyze ~fmt pd asmOp source_f_decl f_decl p =
+  let module AbsInt = SafetyInterpreter.AbsAnalyzer (struct
+    let main_source = source_f_decl
+    let main = f_decl
+    let prog = p
+  end) in
+  AbsInt.analyze ~fmt pd asmOp ()
+
+let load_and_analyze ~fmt expect path name =
+  let name = Filename.concat path name in
+  Format.fprintf fmt "File %s:@." name;
+  Glob_options.safety_param := List.assoc_opt name params;
+  let ((_, fds) as p) = load_file name in
+  List.iter
+    (fun fd ->
+      if FInfo.is_export fd.Prog.f_cc then
+        let () =
+          Format.fprintf fmt "@[<v>Analyzing function %s@]" fd.f_name.fn_name
+        in
+        let safe = analyze ~fmt Arch.pointer_data Arch.asmOp fd fd p in
+        assert (safe = expect))
+    fds
+
+let doit ~fmt expect path =
+  let cases = Sys.readdir path in
+  Array.sort String.compare cases;
+  Array.iter (load_and_analyze ~fmt expect path) cases
+
+let () =
+  let fmt = Format.std_formatter in
+  doit ~fmt false "fail";
+  (* Discard messages from successful tests *)
+  let fmt = Format.make_formatter (fun _ _ _ -> ()) (fun () -> ()) in
+  doit ~fmt true "success"

--- a/compiler/safety/success/bounded_while.jazz
+++ b/compiler/safety/success/bounded_while.jazz
@@ -1,4 +1,4 @@
-param int N = 256;
+param int N = 4;
 
 export
 fn test() -> reg u64 {

--- a/compiler/safety/success/carry_flags.jazz
+++ b/compiler/safety/success/carry_flags.jazz
@@ -1,7 +1,7 @@
 export
 fn test() -> reg u64 {
-  reg bool cf, zf;
-  reg u64 i, acc;
+  reg bool cf;
+  reg u64 i;
 
   i = 1;
   cf, i -= 1;

--- a/compiler/safety/success/loop1.jazz
+++ b/compiler/safety/success/loop1.jazz
@@ -1,6 +1,5 @@
 export
 fn poly1305(reg u64 in, reg u64 inlen) -> reg u64 {
-  inline int i;
   reg u8 tmp;
   reg u64 r;
 

--- a/compiler/safety/success/loop3.jazz
+++ b/compiler/safety/success/loop3.jazz
@@ -1,5 +1,5 @@
 export
-fn poly1305(reg u64 out, reg u64 in, reg u64 inlen, reg u64 k) -> reg u32 {
+fn poly1305(reg u64 in inlen k) -> reg u32 {
   inline int i;
   reg u8 tmp;
   reg u32 tmp32, one;

--- a/compiler/safetylib/safetyInterpreter.ml
+++ b/compiler/safetylib/safetyInterpreter.ml
@@ -2333,7 +2333,7 @@ module AbsAnalyzer (EW : ExportWrap) = struct
           | [ps] -> (None, parse_pt_rels ps)
           | _ -> raise (Failure "-safetyparam ill-formed (too many '>' ?)"))
 
-  let analyze pd asmOp () =
+  let analyze ?(fmt=Format.err_formatter) pd asmOp () =
     try
     let ps_assoc = Option.map_default parse_params
         [ None, [ { relationals = None; pointers = None } ]]
@@ -2369,7 +2369,7 @@ module AbsAnalyzer (EW : ExportWrap) = struct
       let pp_mem_range fmt = match npt with
         | [] -> Format.fprintf fmt ""
         | _ ->
-          Format.eprintf "@[<v 2>Memory ranges:@;%a@]@;"
+          Format.fprintf fmt "@[<v 2>Memory ranges:@;%a@]@;"
             (pp_list res.print_var_interval) npt in
 
       let violations, assumptions = List.partition (fun (_, v) -> severe_violation v) res.violations in
@@ -2383,7 +2383,7 @@ module AbsAnalyzer (EW : ExportWrap) = struct
           Format.fprintf fmt "@[<v 2>Warnings:@;%a@]@;"
             (pp_list (fun fmt x -> x fmt)) warns in
 
-      Format.eprintf "@?@[<v>%a@;\
+      Format.fprintf fmt "@?@[<v>%a@;\
                       %a@;\
                       %a@;\
                       %a@;\
@@ -2396,9 +2396,9 @@ module AbsAnalyzer (EW : ExportWrap) = struct
         pp_mem_range
         (pp_list (fun fmt res -> res.mem_ranges_printer fmt ())) l_res;
 
-      if violations <> [] then begin
-        Format.eprintf "@[<v>Program is not safe!@;@]@.";
-        exit(2)
+      violations = [] || begin
+        Format.fprintf fmt "@[<v>Program is not safe!@;@]@.";
+        false
       end;
     with | Manager.Error _ as e -> hndl_apr_exc e
 end

--- a/compiler/safetylib/safetyInterpreter.mli
+++ b/compiler/safetylib/safetyInterpreter.mli
@@ -1,8 +1,8 @@
 open Jasmin
+
 module type ExportWrap = sig
   (* main function, before any compilation pass *)
   val main_source : (unit, X86_extra.x86_extended_op) Prog.func
-      
   val main : (unit, X86_extra.x86_extended_op) Prog.func
   val prog : (unit, X86_extra.x86_extended_op) Prog.prog
 end
@@ -10,7 +10,11 @@ end
 (* Abstract Interpreter. *)
 module AbsAnalyzer (PW : ExportWrap) : sig
   val analyze :
+    ?fmt:Format.formatter ->
     Wsize.wsize ->
     X86_extra.x86_extended_op Sopn.asmOp ->
-    unit -> unit
+    unit ->
+    bool
+  (** Analyze the main function, prints the results to the given formatter
+      (defaults to standard error), and returns whether the program is safe. *)
 end

--- a/compiler/scripts/check-safety
+++ b/compiler/scripts/check-safety
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -ex
-
-exec $(dirname $0)/../jasminc -checksafety "$@"

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -46,8 +46,8 @@ let check_safety_p pd asmOp analyze s (p : (_, 'asm) Prog.prog) source_p =
 
   let () = SafetyConfig.pp_current_config_diff () in
 
-  let () =
-    List.iter (fun f_decl ->
+  let is_safe =
+    List.fold_left (fun res f_decl ->
         if FInfo.is_export f_decl.f_cc then
           let () = Format.eprintf "@[<v>Analyzing function %s@]@."
               f_decl.f_name.fn_name in
@@ -55,9 +55,11 @@ let check_safety_p pd asmOp analyze s (p : (_, 'asm) Prog.prog) source_p =
           let source_f_decl = List.find (fun source_f_decl ->
               f_decl.f_name.fn_name = source_f_decl.f_name.fn_name
             ) (snd source_p) in
-          analyze source_f_decl f_decl p)
+          analyze source_f_decl f_decl p && res
+        else res)
+      true
       (List.rev (snd p)) in
-  ()
+  if not is_safe then exit(2)
 
 (* -------------------------------------------------------------------- *)
 module type ArchCoreWithAnalyze = sig
@@ -67,7 +69,8 @@ module type ArchCoreWithAnalyze = sig
     (C.reg, C.regx, C.xreg, C.rflag, C.cond, C.asm_op, C.extra_op) Arch_extra.extended_op Sopn.asmOp ->
     (unit, (C.reg, C.regx, C.xreg, C.rflag, C.cond, C.asm_op, C.extra_op) Arch_extra.extended_op) func ->
     (unit, (C.reg, C.regx, C.xreg, C.rflag, C.cond, C.asm_op, C.extra_op) Arch_extra.extended_op) func ->
-    (unit, (C.reg, C.regx, C.xreg, C.rflag, C.cond, C.asm_op, C.extra_op) Arch_extra.extended_op) prog -> unit
+    (unit, (C.reg, C.regx, C.xreg, C.rflag, C.cond, C.asm_op, C.extra_op) Arch_extra.extended_op) prog ->
+    bool
 end
 
 

--- a/compiler/src/x86_safety.mli
+++ b/compiler/src/x86_safety.mli
@@ -7,4 +7,4 @@ val analyze :
   (unit, x86_extended_op) Prog.func ->
   (unit, x86_extended_op) Prog.func ->
   (unit, x86_extended_op) Prog.prog ->
-  unit
+  bool


### PR DESCRIPTION
The outputs of the checker on the test suite are now saved. This makes it easier to spot regression, in particular to be sure that failing tests actually fail for the expected reason (and no due to e.g., a syntactic error).