### PR TITLE
Dist. tarball now includes eclib/

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,7 +158,7 @@ build-from-tarball:
   - tarball
   script:
   - tar xvf compiler/$TARBALL.tgz
-  - nix-build -o out $TARBALL
+  - nix-build -o out $TARBALL/compiler
   - ./out/bin/jasminc -version
 
 check:
@@ -276,11 +276,9 @@ push-compiler-code:
   - git clone git@gitlab.com:jasmin-lang/jasmin-compiler.git _deploy
   - cd _deploy
   - git checkout $CI_COMMIT_REF_NAME || git checkout --orphan $CI_COMMIT_REF_NAME
-  - rm -rf compiler eclib
+  - rm -rf compiler eclib Makefile
   - tar xzvf ../compiler/$TARBALL.tgz
-  - mv $TARBALL/ compiler
-  - mv ../eclib .
-  - mv ../Makefile.compiler Makefile
+  - mv $TARBALL/* .
   - git add compiler eclib Makefile
   - git commit -m "Jasmin compiler on branch “$CI_COMMIT_REF_NAME” at $CI_COMMIT_SHORT_SHA"  || true
   - git push --set-upstream origin $CI_COMMIT_REF_NAME

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -86,7 +86,9 @@ dist: $(DISTDIR).tgz
 
 $(DISTDIR).tgz: MANIFEST
 	$(RM) -r $(DISTDIR)
-	../scripts/distribution $(DISTDIR) $<
+	../scripts/distribution $(DISTDIR)/compiler $<
+	cp -riv ../eclib $(DISTDIR)/
+	cp ../Makefile.compiler $(DISTDIR)/Makefile
 	tar -czvf $(DISTDIR).tgz --owner=0 --group=0 $(DISTDIR)
 	$(RM) -r $(DISTDIR)
 


### PR DESCRIPTION
This moves some logic from the CI script to the makefile to:

1. make it easier to reproduce locally
2. produce a more useful CI artifact (in the `tarball` job).