### PR TITLE
Factoring behaviour of assembly printer in a functor module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@
 - Rewriting of assembly printers
   ([PR #1118](https://github.com/jasmin-lang/jasmin/pull/1118),
   [PR #1125](https://github.com/jasmin-lang/jasmin/pull/1125),
-  [PR #1128](https://github.com/jasmin-lang/jasmin/pull/1128)).
+  [PR #1128](https://github.com/jasmin-lang/jasmin/pull/1128),
+  [PR #1130](https://github.com/jasmin-lang/jasmin/pull/1130)).
 
 # Jasmin 2025.02.1 — Nancy, 2025-04-10
 

--- a/compiler/src/AsmTargetBuilder.ml
+++ b/compiler/src/AsmTargetBuilder.ml
@@ -1,0 +1,113 @@
+open PrintASM
+open Arch_decl
+open Utils
+open Asm_utils
+open PrintCommon
+open CoreIdent
+
+module type AsmTarget = sig
+
+    type reg
+    type regx
+    type xreg
+    type rflag
+    type cond
+    type asm_op
+
+    val headers             : asm_element list
+    val data_segment_header : asm_element list
+    val function_header     : asm_element list
+    val function_tail       : asm_element list
+    val pp_instr_r          : Name.t -> (reg, regx, xreg, rflag, cond, asm_op) Arch_decl.asm_i_r -> asm_element list
+
+end
+
+module type S = sig
+    type reg
+    type regx
+    type xreg
+    type rflag
+    type cond
+    type asm_op
+
+    val asm_of_prog : (reg,regx,xreg,rflag,cond,asm_op) asm_prog -> asm_element list
+end
+
+module Make(Target : AsmTarget) : S
+    with type reg    = Target.reg
+    and  type regx   = Target.regx
+    and  type xreg   = Target.xreg
+    and  type rflag  = Target.rflag
+    and  type cond   = Target.cond
+    and  type asm_op = Target.asm_op
+= struct
+
+    type reg    = Target.reg
+    type regx   = Target.regx
+    type xreg   = Target.xreg
+    type rflag  = Target.rflag
+    type cond   = Target.cond
+    type asm_op = Target.asm_op
+
+    let asm_debug_info ({Location.base_loc = ii; _}, _) =
+        List.map (fun x -> Dwarf x) (DebugInfo.source_positions ii)
+
+    let pp_instr name instr =
+        let Arch_decl.({ asmi_i = i; asmi_ii = ii}) = instr in
+        asm_debug_info ii @ Target.pp_instr_r name i
+
+    let pp_instrs name instrs = List.concat_map (pp_instr name) instrs
+
+    let pp_body name decl =pp_instrs name decl.asm_fd_body
+
+    let pp_function_header (name:string) decl =
+        if decl.asm_fd_export then
+            [
+                Label (mangle name);
+                Label name;
+            ] @ Target.function_header
+        else []
+
+    let pp_function_tail decl =
+        if decl.asm_fd_export then
+            Target.function_tail
+        else []
+
+    let pp_function (fname,decl) =
+        let name = escape fname.fn_name in
+        let headers = pp_function_header name decl in
+        let body = pp_body name decl in
+        let tail = pp_function_tail decl in
+        headers @ body @ tail
+
+    let pp_functions funcs = List.concat_map pp_function funcs
+
+    let pp_function_decl (name, decl : CoreIdent.funname * (_,_,_,_,_,_) asm_fundef) =
+        if decl.asm_fd_export then
+            let fn = escape name.fn_name in
+            [
+                Instr (".global", [mangle fn]);
+                Instr (".global", [fn])
+            ]
+        else []
+
+    let pp_functions_decl (funcs) = List.concat_map pp_function_decl funcs
+
+    let pp_data_segment_body globs names = Asm_utils.format_glob_data globs names
+
+    let pp_data_segment globs names =
+    if not (List.is_empty globs) then
+        let headers = Target.data_segment_header in
+        let data = pp_data_segment_body globs names in
+        headers @ data
+    else
+        []
+
+    let asm_of_prog (asm: (reg,regx,xreg,rflag,cond,asm_op) asm_prog) : asm_element list =
+        let headers = Target.headers in
+        let functions_head = pp_functions_decl asm.asm_funcs in
+        let functions_body = pp_functions asm.asm_funcs in
+        let data_segment = pp_data_segment asm.asm_globs asm.asm_glob_names in
+        headers @ functions_head @ functions_body @ data_segment
+
+end

--- a/compiler/src/AsmTargetBuilder.mli
+++ b/compiler/src/AsmTargetBuilder.mli
@@ -1,0 +1,68 @@
+(**
+Module AsmTarget :
+    This module defines the interface for generating assembly code for a target architecture.
+    You need to provide archtecture types as defined in Arch_decl module.
+    You also need to provide the header, function header, function tail and instruction generation function.
+*)
+module type AsmTarget = sig
+
+    (* type definitions for target architecture*)
+    type reg
+    type regx
+    type xreg
+    type rflag
+    type cond
+    type asm_op
+
+    (* Header of the file*)
+    val headers             : PrintASM.asm_element list
+
+    (* Data segment header*)
+    val data_segment_header : PrintASM.asm_element list
+
+    (* Start of the function*)
+    val function_header     : PrintASM.asm_element list
+
+    (* Function return instructions
+    It is called only on exported functions.
+    *)
+    val function_tail       : PrintASM.asm_element list
+
+    (* Pretty print of instruction*)
+    val pp_instr_r : CoreIdent.Name.t -> (reg, regx, xreg, rflag, cond, asm_op) Arch_decl.asm_i_r -> PrintASM.asm_element list
+
+end
+
+
+module type S = sig
+    (* type definitions for target architecture*)
+    type reg
+    type regx
+    type xreg
+    type rflag
+    type cond
+    type asm_op
+
+    (*
+        Entrypoint of assembly printer : generate a list of instructions defined in PrintASM module.
+        args :
+            - asm_prog : assembly program
+        returns :
+            - asm_line list : assembly program
+
+    *)
+    val asm_of_prog : (reg, regx, xreg, rflag, cond, asm_op) Arch_decl.asm_prog -> PrintASM.asm_element list
+end
+
+(**
+    Module AsmTargetBuilder.Make:
+        Functor abstration that take an architecture module and generate corresponding assembly printer.
+*)
+module Make :
+  functor (Target : AsmTarget) -> S with
+      type reg = Target.reg
+      and type regx = Target.regx
+      and type xreg = Target.xreg
+      and type rflag = Target.rflag
+      and type cond = Target.cond
+      and type asm_op = Target.asm_op


### PR DESCRIPTION
This PR introduce a new module `AsmTarget` which abstract traversal of assembly program during the printing pass. It has been tested for all supported architectures on libjade and common test file without provoking any change to generated assembly.