### PR TITLE
Small improvement to warnings

### DIFF
--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1906,7 +1906,7 @@ let mk_call loc inline lvs f es =
   | Internal -> ()
   | Export _ ->
     if not inline then
-      warning Always (L.i_loc0 loc) "export function will be inlined"
+      warning InlinedCallToExport (L.i_loc0 loc) "export function will be inlined"
   | Subroutine _ when not inline ->
     let check_lval = function
       | Lnone _ | Lvar _ | Lasub _ -> ()

--- a/compiler/src/utils.ml
+++ b/compiler/src/utils.ml
@@ -336,6 +336,7 @@ type warning =
   | UseLea (* -wlea *)
   | IntroduceNone (* -w_ *)
   | IntroduceArrayCopy (* -winsertarraycopy *)
+  | InlinedCallToExport
   | SimplifyVectorSuffix
   | DuplicateVar (* -wduplicatevar *)
   | UnusedVar (* -wunusedvar *)
@@ -347,6 +348,7 @@ type warning =
 
 let default_warnings =
     [
+      InlinedCallToExport;
       SimplifyVectorSuffix;
       DuplicateVar;
       UnusedVar;
@@ -368,6 +370,11 @@ let add_warning (w: warning) () =
   let ws = !warns in
   if not (List.mem w ws) then
     warns := w :: ws
+
+let remove_warning (w: warning) =
+  let ws = !warns in
+  if List.mem w ws then
+    warns := List.remove ws w
 
 let set_all_warnings () = warns := all_warnings
 

--- a/compiler/src/utils.mli
+++ b/compiler/src/utils.mli
@@ -142,9 +142,10 @@ type warning =
   | UseLea
   | IntroduceNone
   | IntroduceArrayCopy
+  | InlinedCallToExport
   | SimplifyVectorSuffix
-  | DuplicateVar 
-  | UnusedVar 
+  | DuplicateVar
+  | UnusedVar
   | SCTchecker
   | Deprecated
   | Experimental
@@ -155,6 +156,7 @@ val set_warn_recoverable : bool -> unit
 val set_all_warnings : unit -> unit
 val nowarning : unit -> unit
 val add_warning : warning -> unit -> unit
+val remove_warning : warning -> unit
 val warning :
       warning -> Location.i_loc
    -> ('a, Format.formatter, unit) format -> 'a


### PR DESCRIPTION
- Add `Utils.remove_warning` to silence a specific warning category

- Introduce `InlinedCallToExport` category to make it possible to silence the warning that an export function is inlined at every call site.