### PR TITLE
Makefile: small cleaning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,8 +193,7 @@ check-proofs:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './compiler/jasminc -version'
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt why3config -why3 $WHY3_CONF'
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt     config -why3 $WHY3_CONF'
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -C compiler/examples/gimli/proofs'
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -C compiler/examples/extraction-unit-tests'
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -C compiler check-ec'
 
 libjade-compile-to-asm:
   stage: test

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -52,6 +52,9 @@ check: all
 check-ci:
 	$(CHECK) --report=- $(CHECKCATS)
 
+check-all: check
+	dune runtest -f
+
 clean:
 	dune clean
 	$(RM) jasminc jasmin2tex jasmin-ct jasmin2ec

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -52,6 +52,10 @@ check: all
 check-ci:
 	$(CHECK) --report=- $(CHECKCATS)
 
+check-ec:
+	$(MAKE) -C examples/gimli/proofs
+	$(MAKE) -C examples/extraction-unit-tests
+
 check-all: check
 	dune runtest -f
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -32,25 +32,13 @@ DISTDIR ?= jasmin-compiler
 OBELISK ?= obelisk
 
 # --------------------------------------------------------------------
-.PHONY: all build byte native CIL check check-ci
+.PHONY: all CIL check check-ci
 .PHONY: clean install uninstall dist
 
-all: build
-	@true
-
-build: native
-
-define do-build
+all:
 	$(RM) jasminc jasmin2tex jasmin-ct jasmin2ec
 	dune build @check @install
 	for p in _build/install/default/bin/*; do ln -sf $$p $$(basename $$p); done
-endef
-
-byte:
-	$(call do-build,bc)
-
-native:
-	$(call do-build,exe)
 
 CIL:
 	$(RM) -f src/CIL/*.ml src/CIL/*.mli ../proofs/extraction.vo
@@ -58,7 +46,7 @@ CIL:
 	cp ../proofs/lang/ocaml/*.ml  src/CIL/
 	cp ../proofs/lang/ocaml/*.mli src/CIL/
 
-check: build
+check: all
 	$(CHECK) --report=report.log $(CHECKCATS)
 
 check-ci:

--- a/compiler/examples/extraction-unit-tests/Makefile
+++ b/compiler/examples/extraction-unit-tests/Makefile
@@ -10,7 +10,7 @@ all: gcd.ec loops.ec proofs.ec sdiv.ec
 clean:
 	$(RM) loops.ec sdiv.ec
 
-%.ec: %.jazz
-	$(JASMIN2EC) -o $@ $^
+%.ec: %.jazz $(JASMIN2EC)
+	$(JASMIN2EC) -o $@ $<
 
 .PHONY: all


### PR DESCRIPTION
Removes the legacy [byte], [native], and [build] targets, and the [do-build] function.

The `byte` and `native` targets have been made identical in #838.

~Question: does it make sense to have both `build` and `all` targets or should they be merged?~