### PR TITLE
Changing dune version to 3.7

### DIFF
--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.0)
+(lang dune 3.7)
 (name jasmin)
 (license MIT)
 (authors "The Jasmin development team")

--- a/compiler/safetylib/dune
+++ b/compiler/safetylib/dune
@@ -2,5 +2,5 @@
 
 (library
   (name jasmin_checksafety)
-  (flags (:standard -w -9-27-32-39))
+  (flags (:standard -w -9-27-32-39-67))
   (libraries jasmin yojson apron.octMPQ apron.ppl apron.boxMPQ))

--- a/compiler/src/dune
+++ b/compiler/src/dune
@@ -10,7 +10,7 @@
 (library
  (name jasmin)
  (public_name jasmin.jasmin)
- (flags (:standard -w -9-27-32-33-34-37-39-50))
+ (flags (:standard -w -9-27-32-33-34-37-39-50-67))
  (modules :standard \ main_compiler x86_safety)
  (libraries angstrom batteries.unthreaded zarith menhirLib uint63))
 


### PR DESCRIPTION
This PR replace version of dune used by the compiler from 3.0 to 3.7. This will allow the usage of new features such as qualify subdirs. I also add to make dune ignore warning 67 because it was detected with this new version.