### PR TITLE
Support mathcomp 2.4

### DIFF
--- a/compiler/src/printCommon.mli
+++ b/compiler/src/printCommon.mli
@@ -55,6 +55,6 @@ val pp_arr_slice :
 
 val pp_len : Format.formatter -> int -> unit
 val pp_ty : Format.formatter -> Prog.ty -> unit
-val pp_datas : Format.formatter -> Ssralg.GRing.ComRing.sort list -> unit
+val pp_datas : Format.formatter -> Obj.t list -> unit
 val pp_var : Format.formatter -> Var0.Var.var -> unit
 val pp_var_i : Format.formatter -> Expr.var_i -> unit

--- a/opam
+++ b/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind" { build }
   "coq" {>= "8.20.0" & < "9.1~"}
   "coq-elpi" {>= "2.3.0"}
-  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.4~"}
+  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.5~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-algebra-tactics"
   "coq-mathcomp-word" {>= "3.2"}

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -10,6 +10,7 @@
 -arg "-w -projection-no-head-constant"
 -arg "-w -postfix-notation-not-level-1"
 -arg "-w -deprecated-since-mathcomp-2.3.0"
+-arg "-w -deprecated-since-mathcomp-2.4.0"
 -arg "-w -deprecated-from-Coq"
 -arg "-w -deprecated-dirpath-Coq"
 


### PR DESCRIPTION
With mathcomp 2.4, we get a lot of warnings of the form
```
Notation ringType is deprecated since mathcomp 2.4.0.
Try pzRingType (the potentially-zero counterpart) first, or use nzRingType instead.
```
This is not possible to solve without requiring 2.4.0, so for the moment, warnings are silenced.