### PR TITLE
SCT checker: ignore annotations on local variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@
   ([PR #1150](https://github.com/jasmin-lang/jasmin/pull/1150);
   fixes [#483](https://github.com/jasmin-lang/jasmin/issues/483)).
 
+- The S-CT checker now ignores annotations on local variables
+  ([PR #1182](https://github.com/jasmin-lang/jasmin/pull/1182);
+  fixes [#1179](https://github.com/jasmin-lang/jasmin/issues/1179)).
+
 ## Other changes
 
 - The deprecated legacy interface to extract to EasyCrypt has been removed

--- a/compiler/src/sct_checker_forward.ml
+++ b/compiler/src/sct_checker_forward.ml
@@ -22,7 +22,6 @@ let pp_vset fmt xs =
 
 (* ----------------------------------------------------------- *)
 let ssecret = "secret"
-let spoly   = "poly"
 let spublic = "public"
 let stransient = "transient"
 let smsf = "msf"
@@ -1378,8 +1377,7 @@ let init_constraint fenv f =
 
   (* init type for local *)
   let do_local x venv =
-    let ls = parse_var_annot ~msf:false x.v_annot in
-    let _, vty = mk_vty x.v_dloc ~is_local:true ~msf:false x ls None in
+    let _, vty = mk_vty x.v_dloc ~is_local:true ~msf:false x [] None in
     Env.add_var env venv x vty in
 
   let venv = Sv.fold do_local (locals f) venv in

--- a/compiler/tests/sct-checker/fail/bug_1179.jazz
+++ b/compiler/tests/sct-checker/fail/bug_1179.jazz
@@ -1,0 +1,10 @@
+export
+fn main() {
+  #public
+  stack u64 s;
+  reg u64 x = 0;
+  if false {
+    x = s;
+  }
+  [ x ] = 0;
+}

--- a/compiler/tests/sct-checker/reject.expected
+++ b/compiler/tests/sct-checker/reject.expected
@@ -27,6 +27,9 @@ Failed as expected after_branch: "fail/basic.jazz", line 10 (18-19):
                                    } are
 Failed as expected leak_transient: "fail/basic.jazz", line 1 (42-50):
                                    speculative constant type checker: x has type #transient but should be at most #public
+File bug_1179.jazz:
+Failed as expected main: "fail/bug_1179.jazz", line 9 (4-5):
+                         speculative constant type checker: x has type #secret but should be at most #public
 File bug_887.jazz:
 Failed as expected test_venv: "fail/bug_887.jazz", line 13 (3-4):
                               speculative constant type checker: r has type #secret but should be at most #public


### PR DESCRIPTION
Fixes #1179.