### PR TITLE
Stricter syntactic rules for initializing variables at declaration time

### DIFF
--- a/changes/03-other/1185-decl-init.md
+++ b/changes/03-other/1185-decl-init.md
@@ -1,0 +1,5 @@
+- Syntax for initializing variables at declaration time is less flexible: in
+  any given declaration sequence, either no variable is initialized, and
+  declarations may be separated by space or comma, or *all* variables are
+  initialized and are separated by a mandatory comma.
+  ([PR #1185](https://github.com/jasmin-lang/jasmin/pull/1185)).

--- a/compiler/examples/extraction-unit-tests/loops.jazz
+++ b/compiler/examples/extraction-unit-tests/loops.jazz
@@ -1,7 +1,8 @@
 /* Tests bounds of decreasing for loops */
 export
 fn forty() -> reg u32 {
-  inline int i j = 0;
+  inline int i j;
+  j = 0;
   for i = 10 downto 5 {
     j += i;
   }
@@ -13,7 +14,8 @@ fn forty() -> reg u32 {
 param int a = 10;
 export
 fn for_nest() -> reg u32 {
-  inline int i j k = 0;
+  inline int i j k;
+  k = 0;
   for i = 0 to a + a {
      for j = 0 to a * a {
        k += 1;

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -276,17 +276,9 @@ let pp_args fmt (sty, xs) =
     pp_sto_ty sty
     (pp_list " " pp_var) xs
 
-let pp_decl fmt (x: vardecl L.located) =
-  let x, e = L.unloc x in
-  let pp fmt = F.fprintf fmt " = %a" pp_expr in
-  F.fprintf fmt "%s%a" (L.unloc x) (pp_opt pp) e
-
-let pp_decls fmt (sty, vd) =
-  F.fprintf
-    fmt
-    "%a %a"
-    pp_sto_ty sty
-    (pp_list " " pp_decl) vd
+let pp_varinit fmt v =
+  let (x, e) = L.unloc v in
+  F.fprintf fmt "%a = %a" pp_var x pp_expr e
 
 let pp_annot_args fmt  (annot, args) =
   F.fprintf fmt "%a%a" pp_inline_annotations annot pp_args args
@@ -319,14 +311,13 @@ let pp_eqop fmt op =
 let pp_sidecond fmt =
   F.fprintf fmt " %a %a" kw "if" pp_expr
 
-let pp_vardecls fmt (d:vardecls) =
-  F.fprintf fmt "%a;" pp_decls d
-
 let rec pp_instr depth fmt (annot, p) =
   if annot <> [] then F.fprintf fmt "%a%a" indent depth pp_top_annotations annot;
   indent fmt depth;
   match L.unloc p with
-  | PIdecl d -> pp_vardecls fmt d
+  | PIdecl (sty, vds) -> F.fprintf fmt "%a %a;" pp_sto_ty sty (pp_list " " pp_var) vds
+  | PIdeclinit (sty, vds) ->
+     F.fprintf fmt "%a %a;" pp_sto_ty sty (pp_list ", " pp_varinit) vds
   | PIArrayInit x -> F.fprintf fmt "%a (%a);" kw "arrayinit" pp_var x
   | PIAssign ((pimp,lvs), op, e, cnd) ->
     begin match pimp, lvs with

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -392,8 +392,11 @@ pinstr_r:
 | WHILE is1=pblock? LPAREN b=pexpr RPAREN is2=pblock?
     { PIWhile (is1, b, is2) }
 
-| vd=postfix(pvardecl(COMMA?), SEMICOLON)
-    { PIdecl vd }
+| ty=stor_type vs=separated_nonempty_list(COMMA, loc(decl)) SEMICOLON
+    { PIdeclinit (ty, vs) }
+
+| ty=stor_type vs=separated_nonempty_list(COMMA?, var) SEMICOLON
+    { PIdecl (ty, vs) }
 
 pif:
 | IF c=pexpr i1s=pblock
@@ -447,13 +450,8 @@ storage:
 | INLINE         { `Inline }
 | GLOBAL         { `Global }
 
-
 %inline decl:
-| v=var { v, None }
-| v=var EQ e=pexpr { v, Some e }
-
-%inline pvardecl(S):
-| ty=stor_type vs=separated_nonempty_list(S, loc(decl)) { (ty, vs) }
+| v=var EQ e=pexpr { v, e }
 
 pparamdecl(S):
     ty=stor_type vs=separated_nonempty_list(S, var) { (ty, vs) }
@@ -552,9 +550,6 @@ module_:
 
 %inline prefix(S, X):
 | S x=X { x }
-
-%inline postfix(X, S):
-| x=X S { x }
 
 %inline parens(X):
 | x=delimited(LPAREN, X, RPAREN) { x }

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1920,12 +1920,10 @@ let mk_call loc inline lvs f es =
 
   P.Ccall (lvs, f.P.f_name, es)
 
-let assign_from_decl (decl: S.vardecl L.located) =
+let assign_from_decl decl =
   let v, e = L.unloc decl in
-  Option.map (fun e ->
-      let d = L.mk_loc (L.loc decl) (S.PLVar v) in
-      (None, [d]), `Raw, e, None
-    ) e
+  let d = L.mk_loc (L.loc decl) (S.PLVar v) in
+  (None, [d]), `Raw, e, None
 
 let tt_annot_paramdecls dfl_writable pd env (annot, (ty,vs)) =
   let aty = annot, ty in
@@ -2088,19 +2086,25 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
       let c = tt_expr_bool arch_info.pd env_rhs cp in
       mk_i (P.Cassgn (x, default_tag, ty, Pif (ty, c, e, e'))) :: is
   in
-  let tt_annot_decl env (vd: S.vardecl L.located) (aty: A.annotations * S.pstotype) =
+  let tt_annot_decl env vd (aty: A.annotations * S.pstotype) =
     (* remember the environment prior to the declaration:
       it will be used to type-check the right-hand side initializing expression, if any *)
     let env_rhs = env in
-    let var = tt_vardecl (fun _ -> true) arch_info.pd env (aty, S.var_decl_id (L.unloc vd)) in
+    let var = tt_vardecl (fun _ -> true) arch_info.pd env (aty, fst (L.unloc vd)) in
     let env = Env.Vars.push_local env_rhs (L.unloc var) in
-    match assign_from_decl vd with
-    | None -> env, []
-    | Some (ls, eq, op, ocp) -> env, tt_assign env env_rhs ls eq op ocp
+    let (ls, eq, op, ocp) = assign_from_decl vd in
+    env, tt_assign env env_rhs ls eq op ocp
   in
 
   match L.unloc pi with
-  | S.PIdecl (ty,vds) ->
+  | S.PIdecl (ty, vds) ->
+     List.fold (fun env v ->
+         let var = tt_vardecl (fun _ -> true) arch_info.pd env ((annot, ty), v) in
+         Env.Vars.push_local env (L.unloc var))
+       env
+       vds, []
+
+  | S.PIdeclinit (ty,vds) ->
     List.fold (fun (env, acc) v ->
         let env, cmd = tt_annot_decl env v (annot, ty) in
         env, acc @ cmd)
@@ -2277,7 +2281,9 @@ let process_f_annot loc funname f_cc annot =
 let rec add_reserved_i env (_,i) =
   match L.unloc i with
   | S.PIdecl (_, ids) ->
-      List.fold_left (fun env id -> Env.add_reserved env (L.unloc (S.var_decl_id (L.unloc id)))) env ids
+     List.fold_left (fun env id -> Env.add_reserved env (L.unloc id)) env ids
+  | S.PIdeclinit (_, ids) ->
+      List.fold_left (fun env id -> Env.add_reserved env (L.unloc (fst (L.unloc id)))) env ids
   | PIArrayInit _ | PIAssign _ -> env
   | PIIf(_, c, oc) -> add_reserved_oc (add_reserved_c' env c) oc
   | PIFor(_, _, c) -> add_reserved_c' env c

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -230,10 +230,7 @@ type align = [`Align | `NoAlign]
 type plvals = annotations L.located option * plvalue list
 
 
-type vardecl = pident * pexpr option
-type vardecls = pstotype * vardecl L.located list
-
-let var_decl_id (v, _ : vardecl) : pident = v
+type vardecls = pstotype * pident list
 
 type pinstr_r =
   | PIArrayInit of pident
@@ -248,6 +245,8 @@ type pinstr_r =
       (** while { … } (x > 0) { … } *)
   | PIdecl      of vardecls
       (** reg u32 x y z; *)
+  | PIdeclinit  of pstotype * (pident * pexpr) L.located list
+      (** reg u32 x = 42; *)
 
 and pblock_r = pinstr list
 and fordir   = [ `Down | `Up ]

--- a/compiler/tests/sct-checker/success/paper.jazz
+++ b/compiler/tests/sct-checker/success/paper.jazz
@@ -12,9 +12,10 @@ fn fig3a(
   reg mut ptr u64[N] w,
   reg u64 i)
   ->  reg mut ptr u64[N] {
-  reg u64 ms x = 0;
+  reg u64 ms x;
   reg bool b;
   ms = #init_msf();
+  x = 0;
   b = i < N;
   if b {
     ms = #update_msf(b, ms);

--- a/compiler/tests/success/common/variable_initialization.jazz
+++ b/compiler/tests/success/common/variable_initialization.jazz
@@ -34,14 +34,15 @@ fn test_calls () {
     reg u32  x= test_basic();
 }
 
-export fn whitespace() -> reg u32 {
-  reg u32 x = 1 y = x + 1;
+export fn sequence() -> reg u32 {
+  reg u32 x = 1, y = x + 1;
   return y;
 }
 
 #[stacksize = 4]
 export fn rand() -> reg u32 {
-  stack u8[4] _x x = #randombytes(_x);
+  stack u8[4] _x x;
+  x = #randombytes(_x);
   reg u32 r;
   r = x[:u32 0];
   return r;

--- a/compiler/tests/success/x86-64/vpblendvb.jazz
+++ b/compiler/tests/success/x86-64/vpblendvb.jazz
@@ -19,14 +19,14 @@ fn test_vpblendvb(reg u64 rp) {
 export
 fn test_blendv(reg u64 p) {
   reg u256
-    x = [:u256 p]
-    m = [:u256 p + 32]
+    x = [:u256 p],
+    m = [:u256 p + 32],
     y = #BLENDV_32u8(x, [:u256 p + 16], m);
   x = #BLENDV_8u32(y, m, x);
   y = #BLENDV_4u64(m, x, x);
 
   reg u128
-    z = #BLENDV_16u8(x, y, m)
+    z = #BLENDV_16u8(x, y, m),
     w = #BLENDV_4u32(y, m, z);
   z = #BLENDV_2u64(m, z, w);
 

--- a/docs/source/language/syntax/code.md
+++ b/docs/source/language/syntax/code.md
@@ -37,10 +37,33 @@ Syntax for variable declaration is as follows:
 ```
 For instance,
 ```
-u64 var;
+reg u64 var;
 stack u64[N] arr;
-inline int i;
+inline int i, j;
 ```
+
+Note that the separating comma may be omitted.
+
+### Declaration with initialization
+
+Variables may be declared and initialized at once, in which case if several
+variables are declared, they must all be given an initial value, and separating
+commas are mandatory. Variables are declared and initialized in the given order,
+therefore an initialization expression can refer to a variable declared earlier
+in the same declaration list.
+
+Some examples are given below.
+
+~~~
+reg u32 x = 1; // Declares and initializes a variable x
+reg u64 a = 2, b = 0x10, c = 0o07; // Declares and initializes three variables: a, b, and c
+reg u32 base = 10, exp = x << base; // Declares and initilizes two variables: base, and exp.
+~~~
+
+The expression representing the initial value of a declared variable is any
+Jasmin expression evaluating to a single value, for instance an immediate value,
+an arithmetic expression, a memory read, a function call, etc.
+
 
 ## Assignments
 

--- a/docs/source/language/syntax/index.md
+++ b/docs/source/language/syntax/index.md
@@ -10,6 +10,7 @@ You can read these for the [[x86-64|x86-64]] and the [[ARMv7-M|ARMv7-M]] target
 architectures.
 
 :::{toctree}
+:maxdepth: 2
 
 structure.md
 code.md


### PR DESCRIPTION
In any given declaration sequence, either no variable is initialized,
and declarations may be separated by space or comma,
or *all* variables are initialized and are separated by a mandatory
comma.