### PR TITLE
fixing edge case of copy in dead variables checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Bug fixes
 
+- Linter : More precise diagnostics
+  ([PR #1199](https://github.com/jasmin-lang/jasmin/pull/1199)).
+
 - Consider LHS array variables as assigned
   ([PR #1214](https://github.com/jasmin-lang/jasmin/pull/1214)).
 

--- a/compiler/linter/Analysis/Liveness/LivenessAnalyser.ml
+++ b/compiler/linter/Analysis/Liveness/LivenessAnalyser.ml
@@ -67,10 +67,16 @@ module LivenessDomain : BackwardAnalyser.Logic with type domain = Sv.t = struct
     (_ : Location.i_loc)
     (lvs : lvals)
     (_ : E.assgn_tag)
-    (_ : 'asm Sopn.sopn)
+    (op : 'asm Sopn.sopn)
     (exprs : exprs)
     (domain : domain) =
-    Annotation (live_assigns domain lvs exprs)
+    match op with
+    | Opseudo_op (Ocopy _) ->
+      (*We do not kill copied variables in that case since copy is substituted with a loop, and thus not a real assignment*)
+      Annotation (Sv.union  (List.fold_left vars_lv domain lvs) (Prog.vars_es exprs))
+    | Oslh _ | Oasm _ | Opseudo_op _ ->
+      Annotation (live_assigns domain lvs exprs)
+
 end
 
 include BackwardAnalyser.Make (LivenessDomain)

--- a/compiler/tests/fail/linter/dead_variables.jazz
+++ b/compiler/tests/fail/linter/dead_variables.jazz
@@ -87,3 +87,21 @@ export fn bug_1214(reg ptr u8[4] p) -> reg ptr u8[4] {
   q[0] = v;
   return p;
 }
+
+
+export fn explicit_copy() -> reg u64 {
+  reg u64[1] r;
+  stack u64[1] s;
+  reg ptr u64[1] p = s;
+  r[0] = 0;
+  p = #copy(r);
+  s = p;
+  reg u64 a = s[0];
+  return a;
+}
+
+export fn load(reg ptr u32[1] a) {
+  stack u32[1] q;
+  reg ptr u32[1] p = q;
+  p = #copy_32(a);
+}

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -39,6 +39,8 @@
   warning: Variable 'y' is affected but never used
   "fail/linter/dead_variables.jazz", line 87 (2-11)
   warning: Variable 'q' is affected but never used
+  "fail/linter/dead_variables.jazz", line 106 (2-18)
+  warning: Variable 'p' is affected but never used
 
   $ ../jasminc -wall fail/linter/variables_initialisation.jazz
   "fail/linter/variables_initialisation.jazz", line 3 (5-6)


### PR DESCRIPTION
Fixing a bug in linting pass to account the case of `#copy` opperator