### PR TITLE
Test compiler warnings

### DIFF
--- a/compiler/tests/dune
+++ b/compiler/tests/dune
@@ -3,3 +3,9 @@
   (deps (glob_files_rec success/*))
   (modules printing)
   (names printing))
+
+(cram
+  (deps
+    ../jasminc
+    (glob_files_rec fail/warning/*)
+    (glob_files_rec fail/linter/*)))

--- a/compiler/tests/fail/warning/x86-64/compatible_types.jazz
+++ b/compiler/tests/fail/warning/x86-64/compatible_types.jazz
@@ -1,5 +1,0 @@
-fn f () -> reg u64 {
-  stack u64[4] a;
-  stack u64[5] b;
-  b = a;
-}

--- a/compiler/tests/fail/warning/x86-64/extra_assignment.jazz
+++ b/compiler/tests/fail/warning/x86-64/extra_assignment.jazz
@@ -1,4 +1,4 @@
-inline fn f () -> reg u64 {
+inline fn f () -> inline u64 {
   inline u64 res;
   res = 0;
   return res;

--- a/compiler/tests/fail/warning/x86-64/lea.jazz
+++ b/compiler/tests/fail/warning/x86-64/lea.jazz
@@ -1,5 +1,7 @@
+export
 fn f () -> reg u64 {
   reg u64 res res1;
+  res = 0;
   res1 = 4;
   res += 3 + res1;
   return res;

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -1,0 +1,55 @@
+  $ ../jasminc -wea -arch riscv fail/warning/risc-v/load_constant_warning.jazz
+  warning: support of the RISC-V architecture is experimental
+  "fail/warning/risc-v/load_constant_warning.jazz", line 3 (9-15)
+  warning: extra assignment introduced:
+             ra = #LI(((32u) 10)); /* :r */
+
+  $ ../jasminc -wea fail/warning/x86-64/extra_assignment.jazz
+  "fail/warning/x86-64/extra_assignment.jazz", line 9 (2-12)
+  from line 15 (2-12)
+  warning: extra assignment introduced:
+             RAX = #MOV_64(((64u) 0)); /* :r */
+
+  $ ../jasminc -w_ fail/warning/x86-64/introduce_lvalues.jazz
+  "fail/warning/x86-64/introduce_lvalues.jazz", line 9 (2-13)
+  warning: introduce 2 _ lvalues
+
+  $ ../jasminc -wlea fail/warning/x86-64/lea.jazz
+  "fail/warning/x86-64/lea.jazz", line 6 (2-18)
+  warning: LEA instruction is used
+
+  $ ../jasminc fail/warning/x86-64/reg_const_ptr.jazz
+  "fail/warning/x86-64/reg_const_ptr.jazz", line 2 (9-10)
+  warning: no need to return a [reg const ptr] r
+
+  $ ../jasminc -wall -until_cstexp fail/linter/dead_variables.jazz
+  "fail/linter/dead_variables.jazz", line 6 (8-18)
+  warning: Variable 'y' is affected but never used
+  "fail/linter/dead_variables.jazz", line 11 (2-8)
+  warning: Variable 'x' is affected but never used
+  "fail/linter/dead_variables.jazz", line 23 (4-28)
+  warning: Variable 'y' is affected but never used
+  "fail/linter/dead_variables.jazz", line 32 (4-10)
+  warning: Variable 'y' is affected but never used
+  "fail/linter/dead_variables.jazz", line 37 (8-12)
+  warning: Variable 'y' is affected but never used
+  "fail/linter/dead_variables.jazz", line 65 (4-10)
+  warning: Variable 'x' is affected but never used
+  "fail/linter/dead_variables.jazz", line 76 (12-22)
+  warning: Variable 'y' is affected but never used
+
+  $ ../jasminc -wall fail/linter/variables_initialisation.jazz
+  "fail/linter/variables_initialisation.jazz", line 3 (5-6)
+  warning: Variable p (declared at : "fail/linter/variables_initialisation.jazz", line 2 (12-13)) not initialized
+  "fail/linter/variables_initialisation.jazz", line 8 (4-9)
+  warning: Variable state (declared at : "fail/linter/variables_initialisation.jazz", line 7 (20-25)) not initialized
+  "fail/linter/variables_initialisation.jazz", line 13 (11-12)
+  warning: Variable r (declared at : "fail/linter/variables_initialisation.jazz", line 12 (12-13)) not initialized
+  "fail/linter/variables_initialisation.jazz", line 18 (14-15)
+  warning: Variable x (declared at : "fail/linter/variables_initialisation.jazz", line 17 (12-13)) not initialized
+  "fail/linter/variables_initialisation.jazz", line 18 (16-17)
+  warning: Variable x (declared at : "fail/linter/variables_initialisation.jazz", line 17 (12-13)) not initialized
+  "fail/linter/variables_initialisation.jazz", line 25 (11-12)
+  warning: Variable x (declared at : "fail/linter/variables_initialisation.jazz", line 22 (12-13)) not initialized
+  "fail/linter/variables_initialisation.jazz", line 18 (4-18)
+  warning: Variable 'y' is affected but never used


### PR DESCRIPTION
This captures the output of the compiler when run on example programs so as to ensure that (only) expected warnings are printed.