### PR TITLE
Run the linter only when Linter warnings are enabled

### DIFF
--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -155,7 +155,7 @@ let main () =
       else prog
     in
 
-    let () =
+    if to_warn Linter then begin
       let open Linter in
       let (_globs, funcs) = prog in
       let funcs = List.map Analysis.ReachingDefinitions.RDAnalyser.analyse_function funcs in
@@ -167,7 +167,7 @@ let main () =
           warning Linter (Location.i_loc0 error.location) "%t" error.to_text
         )
         (vi_errors @ dv_errors)
-    in
+    end;
 
     (* The source program, before any compilation pass. *)
     let source_prog = prog in

--- a/compiler/src/utils.mli
+++ b/compiler/src/utils.mli
@@ -163,6 +163,7 @@ val set_all_warnings : unit -> unit
 val nowarning : unit -> unit
 val add_warning : warning -> unit -> unit
 val remove_warning : warning -> unit
+val to_warn : warning -> bool
 val warning :
       warning -> Location.i_loc
    -> ('a, Format.formatter, unit) format -> 'a


### PR DESCRIPTION
There is no need to run any analysis nor check when the results are going to be discarded.