### PR TITLE
Improvements to the opam files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,8 +129,8 @@ opam-compiler:
   - >-
     nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run
     'eval $(opam env) &&
-     make -C compiler -j$NIX_BUILD_CORES &&
-     (cd compiler && mkdir -p bin && cp -L _build/install/default/bin/* bin/ && mkdir -p lib/jasmin/easycrypt && cp ../eclib/*.ec lib/jasmin/easycrypt/)'
+     opam install --yes --no-depexts --working-dir --inplace-build --destdir=./compiler ./jasmin-compiler.opam &&
+     opam remove .'
   artifacts:
     paths:
     - compiler/bin/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -281,9 +281,9 @@ push-compiler-code:
   - git clone git@gitlab.com:jasmin-lang/jasmin-compiler.git _deploy
   - cd _deploy
   - git checkout $CI_COMMIT_REF_NAME || git checkout --orphan $CI_COMMIT_REF_NAME
-  - rm -rf compiler eclib Makefile
+  - rm -rf compiler eclib Makefile jasmin-compiler.opam
   - tar xzvf ../compiler/$TARBALL.tgz
   - mv $TARBALL/* .
-  - git add compiler eclib Makefile
+  - git add compiler eclib Makefile jasmin-compiler.opam
   - git commit -m "Jasmin compiler on branch “$CI_COMMIT_REF_NAME” at $CI_COMMIT_SHORT_SHA"  || true
   - git push --set-upstream origin $CI_COMMIT_REF_NAME

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,8 @@
 Makefile
 MANIFEST
 default.nix
+jasmin.opam
+jasmin-compiler.opam
 
 # Proofs
 proofs/Makefile
@@ -23,7 +25,6 @@ compiler/scripts/runtest
 compiler/Makefile
 compiler/dune
 compiler/dune-project
-compiler/jasmin.opam
 compiler/safetylib/dune
 compiler/src/CIL/.keep
 compiler/src/dune

--- a/compiler/MANIFEST
+++ b/compiler/MANIFEST
@@ -6,7 +6,6 @@ default.nix
 Makefile
 dune-project
 dune
-jasmin.opam
 
 find:entry:*.ml
 find:linter:*.ml

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -76,6 +76,7 @@ $(DISTDIR).tgz: MANIFEST
 	../scripts/distribution $(DISTDIR)/compiler $<
 	cp -riv ../eclib $(DISTDIR)/
 	cp ../Makefile.compiler $(DISTDIR)/Makefile
+	cp ../jasmin-compiler.opam $(DISTDIR)/
 	tar -czvf $(DISTDIR).tgz --owner=0 --group=0 $(DISTDIR)
 	$(RM) -r $(DISTDIR)
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -71,6 +71,7 @@ install:
 uninstall:
 	$(RM) $(DESTDIR)$(BINDIR)/jasminc
 	$(RM) $(DESTDIR)$(BINDIR)/jasmin2tex
+	$(RM) $(DESTDIR)$(BINDIR)/jasmin-ct
 	$(RM) $(DESTDIR)$(BINDIR)/jasmin2ec
 
 # --------------------------------------------------------------------

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -22,6 +22,7 @@ DESTDIR  ?=
 PREFIX   ?= /usr/local
 BINDIR   := $(PREFIX)/bin
 INSTALL  ?= install
+DUNE_OPTS ?= --prefix $(PREFIX)
 
 # --------------------------------------------------------------------
 DISTDIR ?= jasmin-compiler
@@ -62,17 +63,10 @@ clean:
 	$(RM) jasminc jasmin2tex jasmin-ct jasmin2ec
 
 install:
-	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 0755 -T jasminc $(DESTDIR)$(BINDIR)/jasminc
-	$(INSTALL) -m 0755 -T jasmin2tex $(DESTDIR)$(BINDIR)/jasmin2tex
-	$(INSTALL) -m 0755 -T jasmin-ct $(DESTDIR)$(BINDIR)/jasmin-ct
-	$(INSTALL) -m 0755 -T jasmin2ec $(DESTDIR)$(BINDIR)/jasmin2ec
+	dune install $(DUNE_OPTS)
 
 uninstall:
-	$(RM) $(DESTDIR)$(BINDIR)/jasminc
-	$(RM) $(DESTDIR)$(BINDIR)/jasmin2tex
-	$(RM) $(DESTDIR)$(BINDIR)/jasmin-ct
-	$(RM) $(DESTDIR)$(BINDIR)/jasmin2ec
+	dune uninstall $(DUNE_OPTS)
 
 # --------------------------------------------------------------------
 dist: $(DISTDIR).tgz

--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -1,5 +1,6 @@
 (lang dune 3.7)
 (name jasmin)
+(package (name jasmin))
 (license MIT)
 (authors "The Jasmin development team")
 (using menhir 2.1)

--- a/jasmin-compiler.opam
+++ b/jasmin-compiler.opam
@@ -1,24 +1,23 @@
 opam-version: "2.0"
-name: "jasmin"
 version: "dev"
+synopsis: "Compiler for High-Assurance and High-Speed Cryptography"
+description: """
+Jasmin is a workbench for high-assurance and high-speed cryptography. Jasmin
+implementations aim at being efficient, safe, correct, and secure.
+"""
 maintainer: "Jean-Christophe Léchenet <jean-christophe.lechenet@inria.fr>"
-authors: "Jasmin authors and contributors"
+authors: ["Jasmin authors and contributors"]
+license: "MIT"
 homepage: "https://github.com/jasmin-lang/jasmin"
 bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
-synopsis: "High-Assurance and High-Speed Cryptography"
-license: "MIT"
+dev-repo: "git+https://gitlab.com/jasmin-lang/jasmin-compiler.git"
 
 build: [
-  make "build"
+  [make "-C" "compiler"]
 ]
 install: [
-  mkdir -p "%{prefix}%/bin"
-  cp -L "_build/install/default/bin/jasminc" "%{prefix}%/bin/jasminc"
-  cp -L "_build/install/default/bin/jasmin2tex" "%{prefix}%/bin/jasmin2tex"
-  cp -L "_build/install/default/bin/jasmin-ct" "%{prefix}%/bin/jasmin-ct"
-  cp -L "_build/install/default/bin/jasmin2ec" "%{prefix}%/bin/jasmin2ec"
-  mkdir -p "%{prefix}%/lib/jasmin/easycrypt"
-  sh -c "cp ../eclib/*.ec \"%{prefix}%/lib/jasmin/easycrypt/\""
+  [make "-C" "compiler" "install"]
+  [make "-C" "eclib" "install"]
 ]
 depends: [
   "ocaml" { >= "4.11" & build }

--- a/jasmin.opam
+++ b/jasmin.opam
@@ -1,12 +1,16 @@
 opam-version: "2.0"
-name: "jasmin"
 version: "dev"
+synopsis: "High-Assurance and High-Speed Cryptography"
+description: """
+Jasmin is a workbench for high-assurance and high-speed cryptography. Jasmin
+implementations aim at being efficient, safe, correct, and secure.
+"""
 maintainer: "Jean-Christophe Léchenet <jean-christophe.lechenet@inria.fr>"
-authors: "Jasmin authors and contributors"
+authors: ["Jasmin authors and contributors"]
+license: "MIT"
 homepage: "https://github.com/jasmin-lang/jasmin"
 bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
-synopsis: "High-Assurance and High-Speed Cryptography"
-license: "MIT"
+dev-repo: "git+https://github.com/jasmin-lang/jasmin.git"
 
 build: [
   make "build"

--- a/scripts/opam-setup.sh
+++ b/scripts/opam-setup.sh
@@ -6,9 +6,7 @@ opam init --disable-sandboxing --no-setup --compiler=4.14.2
 if [ 1 -le $# ]
 then
   opam repo add coq-released https://coq.inria.fr/opam/released
-  opam pin --yes --no-depexts --no-action add .
+  opam install --yes --no-depexts --deps-only ./jasmin.opam
 else
-  opam pin --yes --no-depexts --no-action add compiler
+  opam install --yes --no-depexts --deps-only ./jasmin-compiler.opam
 fi
-opam install --yes --no-depexts --deps-only jasmin
-


### PR DESCRIPTION
My initial goal was to call `dune install` in `compiler/jasmin.opam` to install both the executables and the library.

I realized that this file was broken syntactically (and also the `cp ../eclib/*.ec` cannot work because the build is done in a sandbox where only `compiler` and its descendants can be seen). So I had two questions: why does it work when we publish it on opam-repository? And why was it not detected by the CI?

For the first question, this `compiler/jasmin.opam` file and the one we distribute for each Jasmin release in opam-repository were quite different. And also the one we distribute in opam-repository is considered at the same level as `compiler` and `eclib`, not inside `compiler`, so here the `cp eclib/*` is valid. Since it is not possible to make `compiler/jasmin.opam` work, I decided to make it nearly identical to the one distributed in opam-repository.

For the second question, in the CI, we just checked that the dependencies were ok, and then we called the `build` section by hand. I changed the job to really try an opam installation. This is hacky in two ways:
- to reproduce the opam installation, I need the file to be at the root instead of inside `compiler`, so I copy it (actually, I tried to have it at the root of the repo, but then dune explains that it does not find the package definition...)
- it messes with the opam switch that is cached, so I call `opam remove` just after the installation, but in some unlikely situation, this may break

I made several small commits, so that we can drop some of them if they are debatable.