### PR TITLE
Linter: include subdirs unqualified

### DIFF
--- a/compiler/linter/Analyser/BackwardAnalyser.ml
+++ b/compiler/linter/Analyser/BackwardAnalyser.ml
@@ -1,6 +1,5 @@
 open Jasmin
 open Prog
-open Types
 open Annotation
 
 module type Logic = sig

--- a/compiler/linter/Analyser/ForwardAnalyser.ml
+++ b/compiler/linter/Analyser/ForwardAnalyser.ml
@@ -1,6 +1,5 @@
 open Jasmin
 open Prog
-open Types
 open Annotation
 
 module type Logic = sig

--- a/compiler/linter/Analysis/Liveness/LivenessAnalyser.ml
+++ b/compiler/linter/Analysis/Liveness/LivenessAnalyser.ml
@@ -1,7 +1,6 @@
 open Jasmin
 open Prog
-open Analyser.Annotation
-open Analyser
+open Annotation
 
 (**
     Computes used variables in an lvalue

--- a/compiler/linter/Analysis/Liveness/LivenessAnalyser.mli
+++ b/compiler/linter/Analysis/Liveness/LivenessAnalyser.mli
@@ -10,4 +10,4 @@ type domain = Sv.t
 *)
 val analyse_function :
   ('info, 'asm) Jasmin.Prog.func ->
-  (domain Analyser.Annotation.annotation, 'asm) Jasmin.Prog.func
+  (domain Annotation.annotation, 'asm) Jasmin.Prog.func

--- a/compiler/linter/Analysis/ReachingDefinitions/RDAnalyser.ml
+++ b/compiler/linter/Analysis/ReachingDefinitions/RDAnalyser.ml
@@ -1,7 +1,5 @@
 open Jasmin.Prog
-open Analyser
-open Analyser.Annotation
-open Types
+open Annotation
 
 (* TODO : remove when added to Prog.mli*)
 let written_lvs = List.fold_left written_lv Sv.empty

--- a/compiler/linter/Analysis/ReachingDefinitions/RDAnalyser.mli
+++ b/compiler/linter/Analysis/ReachingDefinitions/RDAnalyser.mli
@@ -1,5 +1,5 @@
 open Jasmin.Prog
-open Analyser.Annotation
+open Annotation
 
 type domain = RDDomain.t
 

--- a/compiler/linter/Analysis/ReachingDefinitions/RDDomain.ml
+++ b/compiler/linter/Analysis/ReachingDefinitions/RDDomain.ml
@@ -1,5 +1,4 @@
 open Jasmin
-open Types
 open Prog
 open Format
 

--- a/compiler/linter/Analysis/ReachingDefinitions/RDDomain.mli
+++ b/compiler/linter/Analysis/ReachingDefinitions/RDDomain.mli
@@ -9,7 +9,6 @@ We also define a default value for each variable (notated as (v,?) in Nielson, N
 *)
 
 open Jasmin.Prog
-open Types
 
 (**
 domain type

--- a/compiler/linter/Checker/DeadVariables.ml
+++ b/compiler/linter/Checker/DeadVariables.ml
@@ -1,13 +1,12 @@
 open Jasmin
 open Utils
 open Prog
-open Analyser
 
 let create_dv_error err_payload loc =
-  let open Error.CompileError in
+  let open CompileError in
   {
     location = loc;
-    error_strategy = Error.CompileError.Fail;
+    error_strategy = CompileError.Fail;
     code = "DV-E001";
     to_text =
       (

--- a/compiler/linter/Checker/DeadVariables.mli
+++ b/compiler/linter/Checker/DeadVariables.mli
@@ -1,10 +1,10 @@
 
 
-open Analysis.Liveness.LivenessAnalyser
-open Analyser.Annotation
+open LivenessAnalyser
+open Annotation
 
 (**
     Dead Variable Checker :
     This module check if an affected variable is used in the program.
 *)
-val check_prog : (domain annotation, 'asm) Jasmin.Prog.prog -> Error.CompileError.t list
+val check_prog : (domain annotation, 'asm) Jasmin.Prog.prog -> CompileError.t list

--- a/compiler/linter/Checker/VariableInitialisation.ml
+++ b/compiler/linter/Checker/VariableInitialisation.ml
@@ -1,14 +1,13 @@
 open Jasmin
 open Utils
 open Prog
-open Types
-open Analyser.Annotation
+open Annotation
 
 let create_vi_error err_payload loc =
-  let open Error.CompileError in
+  let open CompileError in
   {
     location = loc;
-    error_strategy = Error.CompileError.Fail;
+    error_strategy = CompileError.Fail;
     code = "VI-E001";
     to_text =
       (fun fmt ->

--- a/compiler/linter/Checker/VariableInitialisation.mli
+++ b/compiler/linter/Checker/VariableInitialisation.mli
@@ -5,7 +5,7 @@
     every (syntactically) used variable is initialised in the domain. *)
 
 open Jasmin
-open Analyser.Annotation
+open Annotation
 
 (** Check mode for initialised variable analysis
     - [Strict] : Check if a path exists where variable may not be initialised
@@ -16,5 +16,5 @@ type check_mode = Strict | NotStrict
 
 val check_prog :
   ?mode:check_mode ->
-  (Analysis.ReachingDefinitions.RDDomain.t annotation, 'asm) Prog.prog ->
-  Error.CompileError.t list
+  (RDDomain.t annotation, 'asm) Prog.prog ->
+  CompileError.t list

--- a/compiler/linter/dune
+++ b/compiler/linter/dune
@@ -3,5 +3,5 @@
  (libraries jasmin cmdliner)
 )
 
-(include_subdirs qualified)
+(include_subdirs unqualified)
 

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -158,12 +158,12 @@ let main () =
     if to_warn Linter then begin
       let open Linter in
       let (_globs, funcs) = prog in
-      let funcs = List.map Analysis.ReachingDefinitions.RDAnalyser.analyse_function funcs in
-      let vi_errors = Checker.VariableInitialisation.check_prog ([], funcs) in
-      let funcs = List.map Analysis.Liveness.LivenessAnalyser.analyse_function funcs in
-      let dv_errors = Checker.DeadVariables.check_prog ([], funcs) in
+      let funcs = List.map RDAnalyser.analyse_function funcs in
+      let vi_errors = VariableInitialisation.check_prog ([], funcs) in
+      let funcs = List.map LivenessAnalyser.analyse_function funcs in
+      let dv_errors = DeadVariables.check_prog ([], funcs) in
       List.iter (
-          fun (error: Error.CompileError.t) ->
+          fun (error: CompileError.t) ->
           warning Linter (Location.i_loc0 error.location) "%t" error.to_text
         )
         (vi_errors @ dv_errors)


### PR DESCRIPTION
This patch has been applied for the Debian packages of release 2025.06.0 so as to be able to build the Jasmin compiler using dune 2 (latest version available on Debian stable), so why not upstreaming it?