### PR TITLE
Prog.assigns: array variables are assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+## Bug fixes
+
+- Consider LHS array variables as assigned
+  ([PR #1214](https://github.com/jasmin-lang/jasmin/pull/1214)).
+
 # Jasmin 2025.06.0 — Nancy, 2025-06-18
 
 ## New features

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -314,7 +314,10 @@ let locals fc =
 
 let written_lv s =
   function
-  | Lvar x -> Sv.add (L.unloc x) s
+  | Lvar x
+  | Laset (_, _, _, x, _)
+  | Lasub (_, _, _, x, _)
+    -> Sv.add (L.unloc x) s
   | _ -> s
 
 let rec written_vars_i ((v, f) as acc) i =

--- a/compiler/tests/fail/common/bug_1214.jazz
+++ b/compiler/tests/fail/common/bug_1214.jazz
@@ -1,0 +1,16 @@
+inline fn consume(reg ptr u32[1] x) -> reg ptr u32[1] {
+  if x[0] > 0 {
+    x[0] = 0;
+  }
+  return x;
+}
+
+export fn main(reg u32 a) -> reg u32 {
+  stack u32[1] s;
+  s[0] = a;
+  reg ptr u32[1] x = s;
+  reg ptr u32[1] y = consume(x);
+  a = x[0];
+  a += y[0];
+  return a;
+}

--- a/compiler/tests/fail/linter/dead_variables.jazz
+++ b/compiler/tests/fail/linter/dead_variables.jazz
@@ -81,3 +81,9 @@ export fn test_while2() -> reg u64 {
     return x;
 }
 
+export fn bug_1214(reg ptr u8[4] p) -> reg ptr u8[4] {
+  reg ptr u32[1] q = p;
+  reg u32 v = 42;
+  q[0] = v;
+  return p;
+}

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -37,6 +37,8 @@
   warning: Variable 'x' is affected but never used
   "fail/linter/dead_variables.jazz", line 76 (12-22)
   warning: Variable 'y' is affected but never used
+  "fail/linter/dead_variables.jazz", line 87 (2-11)
+  warning: Variable 'q' is affected but never used
 
   $ ../jasminc -wall fail/linter/variables_initialisation.jazz
   "fail/linter/variables_initialisation.jazz", line 3 (5-6)
@@ -51,5 +53,7 @@
   warning: Variable x (declared at : "fail/linter/variables_initialisation.jazz", line 17 (12-13)) not initialized
   "fail/linter/variables_initialisation.jazz", line 25 (11-12)
   warning: Variable x (declared at : "fail/linter/variables_initialisation.jazz", line 22 (12-13)) not initialized
+  "fail/linter/variables_initialisation.jazz", line 8 (4-17)
+  warning: Variable 'state' is affected but never used
   "fail/linter/variables_initialisation.jazz", line 18 (4-18)
   warning: Variable 'y' is affected but never used


### PR DESCRIPTION
The linter currently fails to report some dead assignments.

Bug #483 still shows up when using arrays.

This change addresses both issues: the linter now reports when writing to a dead array and compilation of `bug_1214.jazz` now produces a normal error (instead of an internal one) and a warning.