### PR TITLE
Improvements to the opam files, second try

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -281,9 +281,9 @@ push-compiler-code:
   - git clone git@gitlab.com:jasmin-lang/jasmin-compiler.git _deploy
   - cd _deploy
   - git checkout $CI_COMMIT_REF_NAME || git checkout --orphan $CI_COMMIT_REF_NAME
-  - rm -rf compiler eclib Makefile
+  - rm -rf compiler eclib Makefile jasmin.opam
   - tar xzvf ../compiler/$TARBALL.tgz
   - mv $TARBALL/* .
-  - git add compiler eclib Makefile
+  - git add compiler eclib Makefile jasmin.opam
   - git commit -m "Jasmin compiler on branch “$CI_COMMIT_REF_NAME” at $CI_COMMIT_SHORT_SHA"  || true
   - git push --set-upstream origin $CI_COMMIT_REF_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,34 +108,6 @@ eclib:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt     config -why3 eclib/why3.conf'
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make ECARGS="-why3 why3.conf" -C eclib'
 
-opam-compiler:
-  stage: build
-  variables:
-    OPAMROOTISOK: 'true'
-    OPAMROOT: mapo
-    EXTRA_NIX_ARGUMENTS: --arg opamDeps true
-  extends: .common
-  needs:
-  - coq-program
-  cache:
-    key:
-      files:
-        - scripts/nixpkgs.nix
-      prefix: opam
-    paths:
-      - $OPAMROOT
-  script:
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'scripts/opam-setup.sh'
-  - >-
-    nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run
-    'eval $(opam env) &&
-     make -C compiler -j$NIX_BUILD_CORES &&
-     (cd compiler && mkdir -p bin && cp -L _build/install/default/bin/* bin/ && mkdir -p lib/jasmin/easycrypt && cp ../eclib/*.ec lib/jasmin/easycrypt/)'
-  artifacts:
-    paths:
-    - compiler/bin/
-    - compiler/lib/
-
 tarball:
   stage: build
   variables:
@@ -160,6 +132,32 @@ build-from-tarball:
   - tar xvf compiler/$TARBALL.tgz
   - nix-build -o out $TARBALL/compiler
   - ./out/bin/jasminc -version
+
+opam-from-tarball:
+  stage: test
+  variables:
+    OPAMROOTISOK: 'true'
+    OPAMROOT: mapo
+    EXTRA_NIX_ARGUMENTS: --arg opamDeps true
+    TARBALL: jasmin-compiler-$CI_COMMIT_SHORT_SHA
+  extends: .common
+  needs:
+  - tarball
+  cache:
+    key:
+      files:
+        - scripts/nixpkgs.nix
+      prefix: opam
+    paths:
+      - $OPAMROOT
+  script:
+  - tar xvf compiler/$TARBALL.tgz
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'scripts/opam-setup.sh'
+  - >-
+    nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run
+    'eval $(opam env) &&
+     opam install ./$TARBALL &&
+     opam uninstall ./$TARBALL'
 
 check:
   stage: test

--- a/compiler/MANIFEST
+++ b/compiler/MANIFEST
@@ -6,7 +6,6 @@ default.nix
 Makefile
 dune-project
 dune
-jasmin.opam
 
 find:entry:*.ml
 find:linter:*.ml

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -76,6 +76,7 @@ $(DISTDIR).tgz: MANIFEST
 	../scripts/distribution $(DISTDIR)/compiler $<
 	cp -riv ../eclib $(DISTDIR)/
 	cp ../Makefile.compiler $(DISTDIR)/Makefile
+	cp jasmin.opam $(DISTDIR)/
 	tar -czvf $(DISTDIR).tgz --owner=0 --group=0 $(DISTDIR)
 	$(RM) -r $(DISTDIR)
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -22,6 +22,7 @@ DESTDIR  ?=
 PREFIX   ?= /usr/local
 BINDIR   := $(PREFIX)/bin
 INSTALL  ?= install
+DUNE_OPTS ?= --prefix $(PREFIX)
 
 # --------------------------------------------------------------------
 DISTDIR ?= jasmin-compiler
@@ -62,16 +63,10 @@ clean:
 	$(RM) jasminc jasmin2tex jasmin-ct jasmin2ec
 
 install:
-	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 0755 -T jasminc $(DESTDIR)$(BINDIR)/jasminc
-	$(INSTALL) -m 0755 -T jasmin2tex $(DESTDIR)$(BINDIR)/jasmin2tex
-	$(INSTALL) -m 0755 -T jasmin-ct $(DESTDIR)$(BINDIR)/jasmin-ct
-	$(INSTALL) -m 0755 -T jasmin2ec $(DESTDIR)$(BINDIR)/jasmin2ec
+	dune install $(DUNE_OPTS)
 
 uninstall:
-	$(RM) $(DESTDIR)$(BINDIR)/jasminc
-	$(RM) $(DESTDIR)$(BINDIR)/jasmin2tex
-	$(RM) $(DESTDIR)$(BINDIR)/jasmin2ec
+	dune uninstall $(DUNE_OPTS)
 
 # --------------------------------------------------------------------
 dist: $(DISTDIR).tgz

--- a/compiler/dune-project
+++ b/compiler/dune-project
@@ -1,5 +1,6 @@
 (lang dune 3.7)
 (name jasmin)
+(package (name jasmin))
 (license MIT)
 (authors "The Jasmin development team")
 (using menhir 2.1)

--- a/compiler/jasmin.opam
+++ b/compiler/jasmin.opam
@@ -1,24 +1,22 @@
 opam-version: "2.0"
-name: "jasmin"
 version: "dev"
+synopsis: "Compiler for High-Assurance and High-Speed Cryptography"
+description: """
+Jasmin is a workbench for high-assurance and high-speed cryptography. Jasmin
+implementations aim at being efficient, safe, correct, and secure.
+"""
 maintainer: "Jean-Christophe Léchenet <jean-christophe.lechenet@inria.fr>"
-authors: "Jasmin authors and contributors"
+authors: ["Jasmin authors and contributors"]
+license: "MIT"
 homepage: "https://github.com/jasmin-lang/jasmin"
 bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
-synopsis: "High-Assurance and High-Speed Cryptography"
-license: "MIT"
+dev-repo: "git+https://gitlab.com/jasmin-lang/jasmin-compiler.git"
 
 build: [
-  make "build"
+  [make "all"]
 ]
 install: [
-  mkdir -p "%{prefix}%/bin"
-  cp -L "_build/install/default/bin/jasminc" "%{prefix}%/bin/jasminc"
-  cp -L "_build/install/default/bin/jasmin2tex" "%{prefix}%/bin/jasmin2tex"
-  cp -L "_build/install/default/bin/jasmin-ct" "%{prefix}%/bin/jasmin-ct"
-  cp -L "_build/install/default/bin/jasmin2ec" "%{prefix}%/bin/jasmin2ec"
-  mkdir -p "%{prefix}%/lib/jasmin/easycrypt"
-  sh -c "cp ../eclib/*.ec \"%{prefix}%/lib/jasmin/easycrypt/\""
+  [make "install" "DUNE_OPTS="]
 ]
 depends: [
   "ocaml" { >= "4.11" & build }

--- a/opam
+++ b/opam
@@ -1,12 +1,17 @@
 opam-version: "2.0"
 name: "jasmin"
 version: "dev"
+synopsis: "High-Assurance and High-Speed Cryptography"
+description: """
+Jasmin is a workbench for high-assurance and high-speed cryptography. Jasmin
+implementations aim at being efficient, safe, correct, and secure.
+"""
 maintainer: "Jean-Christophe Léchenet <jean-christophe.lechenet@inria.fr>"
-authors: "Jasmin authors and contributors"
+authors: ["Jasmin authors and contributors"]
+license: "MIT"
 homepage: "https://github.com/jasmin-lang/jasmin"
 bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
-synopsis: "High-Assurance and High-Speed Cryptography"
-license: "MIT"
+dev-repo: "git+https://github.com/jasmin-lang/jasmin.git"
 
 build: [
   make "build"


### PR DESCRIPTION
Alternative to https://github.com/jasmin-lang/jasmin/pull/1210

In this PR, `compiler/jasmin.opam` is distributed with the extracted OCaml and only makes sense there, in the same spirit as `compiler/Makefile.compiler`.