### PR TITLE
adding developper nix file that contains developpers packages

### DIFF
--- a/compiler/shell-dev.nix
+++ b/compiler/shell-dev.nix
@@ -1,0 +1,9 @@
+with import <nixpkgs> {};
+
+let
+  jasminCompiler = import ./default.nix;
+in
+pkgs.mkShell {
+  inputsFrom = [ jasminCompiler ];
+  nativeBuildInputs = ([llvmPackages.bintools-unwrapped]) ++ (with ocamlPackages; [ ocaml-lsp ocamlformat]) ;
+}


### PR DESCRIPTION
Little PR to add an utilitary nix file to create a shell that contains developers tools (ocaml-lsp and ocamlformat for development, llvm packages to run make check)