### PR TITLE
Pretyping: introduce implicit flags only when needed

### DIFF
--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1802,6 +1802,7 @@ let tt_lvalues arch_info env loc (pimp, pls) implicit tys =
       List.iter check pimp;
       let pimp_c, pimp_f = List.partition (fun (id,_) -> List.mem_assoc (L.unloc id) combines) pimp in
 
+      let has_no_pimp = List.is_empty pimp_c in
       let implicits = ref [] in
       let get_implicit i =
         let error loc =
@@ -1815,10 +1816,12 @@ let tt_lvalues arch_info env loc (pimp, pls) implicit tys =
                                                    ~on_id:(fun loc _nid s -> mk loc s)
                                                    error) pimp_f in
         match a with
+        | Some a -> a
         | None ->
-          (try mk loc (List.assoc i (Env.get_known_implicits env))
-           with Not_found -> L.mk_loc loc (S.PLIgnore))
-        | Some a -> a in
+           let default = L.mk_loc loc S.PLIgnore in
+           if has_no_pimp then default else
+             try mk loc (List.assoc i (Env.get_known_implicits env))
+             with Not_found -> default in
 
       let rec aux arguments pls =
         match arguments, pls with

--- a/compiler/tests/fail/linter/dead_variables.jazz
+++ b/compiler/tests/fail/linter/dead_variables.jazz
@@ -105,3 +105,10 @@ export fn load(reg ptr u32[1] a) {
   reg ptr u32[1] p = q;
   p = #copy_32(a);
 }
+
+fn implicit_flag_name() -> reg bool {
+  reg bool b _cf_;
+  _cf_ = true; // must warn
+  ?{zf = b}, _ = #set0(); // must not warn
+  return b;
+}

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -41,6 +41,8 @@
   warning: Variable 'q' is affected but never used
   "fail/linter/dead_variables.jazz", line 106 (2-18)
   warning: Variable 'p' is affected but never used
+  "fail/linter/dead_variables.jazz", line 111 (2-14)
+  warning: Variable '_cf_' is affected but never used
 
   $ ../jasminc -wall fail/linter/variables_initialisation.jazz
   "fail/linter/variables_initialisation.jazz", line 3 (5-6)


### PR DESCRIPTION
When elaborating `?{…}`, give names to implicit flags only when they are used in combinations.