### PR TITLE
opam: fix bounds and install command

### DIFF
--- a/compiler/jasmin.opam
+++ b/compiler/jasmin.opam
@@ -16,13 +16,13 @@ build: [
   [make "all"]
 ]
 install: [
-  [make "install" "DUNE_OPTS="]
+  [make "install" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" { >= "4.11" & build }
+  "ocaml" { >= "4.12" & build }
   "batteries" {>= "3.5"}
   "cmdliner" {>= "1.1" & build }
-  "dune" {>= "3.2"}
+  "dune" {>= "3.7"}
   "menhir" {>= "20160825" & build }
   "menhirLib"
   "camlidl"

--- a/opam
+++ b/opam
@@ -20,9 +20,10 @@ install: [
   make "PREFIX=%{prefix}%" "install"
 ]
 depends: [
-  "ocaml" { >= "4.10" & build }
+  "ocaml" { >= "4.12" & build }
   "batteries" {>= "3.5"}
-  "cmdliner" { build }
+  "cmdliner" {>= "1.1" & build }
+  "dune" {>= "3.7"}
   "menhir" {>= "20160825" & build }
   "menhirLib"
   "camlidl"


### PR DESCRIPTION
Publishing the latest version of jasmin to opam (https://github.com/ocaml/opam-repository/pull/28116) and playing with it revealed a few bugs.