### PR TITLE
Docs: set default highlight-language to “none”

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,8 @@ myst_enable_extensions = ["colon_fence"]
 
 graphviz_output_format = "svg"
 
+highlight_language = 'none'
+
 # templates_path = ['_templates']
 # exclude_patterns = []
 


### PR DESCRIPTION
Current value is “default” which puts random inconsistent decorations.