### PR TITLE
POC: updating the changelog with a script

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+# Description
+
+Please include a summary of the changes and the related issue (if applicable). Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue) <!-- if applicable -->
+
+# Checklist
+
+- [ ] Add a changelog entry in `changes` if the PR is a user-visible change
+- [ ] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
+- [ ] Update the documentation if needed
+<!-- if this is your first contribution - [ ] Add your name to `AUTHORS` -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-# [unreleased]
-
 # Jasmin 2025.06.1 — Nancy, 2025-08-29
 
 ## New features

--- a/changes/01-feature/00000-title.md
+++ b/changes/01-feature/00000-title.md
@@ -1,0 +1,1 @@
+## New features

--- a/changes/02-bugfix/00000-title.md
+++ b/changes/02-bugfix/00000-title.md
@@ -1,0 +1,1 @@
+## Bug fixes

--- a/changes/03-other/00000-title.md
+++ b/changes/03-other/00000-title.md
@@ -1,0 +1,1 @@
+## Other changes

--- a/changes/04-documentation/00000-title.md
+++ b/changes/04-documentation/00000-title.md
@@ -1,0 +1,1 @@
+## Documentation

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,29 @@
+# Unreleased changelog
+
+## Description
+
+This directory contains the pieces of changelog describing the unreleased changes to Jasmin.
+Each change is described in its own file.
+The files will be merged into [`CHANGELOG.md`](../CHANGELOG.md) when the changes make it to a release.
+This avoids having conflicts between PRs just because of additions to the changelog.
+
+## Describing your change
+
+- Pick one of the existing directories depending on the kind of change you implemented.
+- Create a file `<PR number>-some-title.md` in the corresponding directory.
+- Describe your change in a concise manner, and mention the fixed issue if applicable.
+  For instance:
+  ```
+  - This is a precise but short description of the change that I wrote
+    ([PR #<PR number>](https://github.com/jasmin-lang/jasmin/pull/<PR number>);
+    fixes [#<issue number>](https://github.com/jasmin-lang/jasmin/issues/<issue number>)).
+  ```
+
+## Generating the unreleased changelog
+
+If you prepare the next release, or just want to get a synthetic view of the unreleased changes,
+just run from the root of the repository:
+
+```
+./scripts/generate-release-changelog.sh
+```

--- a/scripts/generate-release-changelog.sh
+++ b/scripts/generate-release-changelog.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+OUT=CHANGELOG_UNRELEASED.md
+
+echo "Add the lines below to CHANGELOG.md" > ${OUT}
+echo "" >> ${OUT}
+
+changelog_entries_with_title=(changes/*/*.md)
+for f in "${changelog_entries_with_title[@]}"; do
+    cat ${f} >> ${OUT}
+    echo "" >> ${OUT}
+done
+
+echo "Output written in ${OUT}"


### PR DESCRIPTION
Alternative to https://github.com/jasmin-lang/jasmin/pull/1236

This is a POC of a design to avoid stupid merge conflicts involving the changelog. It relies on a simple script taken from https://github.com/math-comp/math-comp.

Instead of editing CHANGELOG.md, PRs have to create a file `<PR number>-some-text.md` in a sub-directory of `changes`, depending on the kind of changes done by the PR, where <PR number> is the PR number. I create the same categories as in https://github.com/jasmin-lang/jasmin/pull/1236.

Before doing a release, one should type `./changes/generate-release-changelog.sh`. It will generate a file called CHANGELOG_UNREALEASED.md that the release manager should insert inside CHANGELOG.md.
