### PR TITLE
CI: tag the coq-proof job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,6 +59,8 @@ coq-program:
 
 coq-proof:
   stage: prove
+  tags:
+  - snob
   variables:
     EXTRA_NIX_ARGUMENTS: --arg coqDeps true
   extends: .common


### PR DESCRIPTION
Let’s make the `coq-proof` job be picky when choosing the CI VM.