### PR TITLE
Linearization generates correct code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
 - Escape '#' sign in variable and function names
   ([PR #1241](https://github.com/jasmin-lang/jasmin/pull/1241)).
 
+- Make sure linearization generate correct instructions
+  when the stack frame is large and the return address passed
+  on the stack
+  ([PR #1247](https://github.com/jasmin-lang/jasmin/pull/1247)).
+
 ## Other changes
 
 - The deprecated x86 intrinsic `#VPBLENDVB` has been removed

--- a/compiler/tests/success/arm-m4/large_stack/large_stack_return_address.jazz
+++ b/compiler/tests/success/arm-m4/large_stack/large_stack_return_address.jazz
@@ -1,0 +1,27 @@
+// This checks that we properly deal with large stack frames
+// when the return address is passed on the stack
+
+fn g () -> reg u32 {
+  reg u32 res = 0;
+  return res;
+}
+
+fn f () -> reg u32 {
+  // we can add the immediate 7584 in arm-m4, but not 7580
+  stack u8[7580] s;
+  reg u32 res;
+
+  // we make a call to be sure the return address in on the stack
+  res = g();
+
+  s[u32 0] = res;
+  res = s[u32 0];
+
+  return res;
+}
+
+export fn main () -> reg u32 {
+  reg u32 res;
+  res = f ();
+  return res;
+}

--- a/compiler/tests/success/arm-m4/large_stack/large_stack_return_address.jazz
+++ b/compiler/tests/success/arm-m4/large_stack/large_stack_return_address.jazz
@@ -14,8 +14,8 @@ fn f () -> reg u32 {
   // we make a call to be sure the return address in on the stack
   res = g();
 
-  s[u32 0] = res;
-  res = s[u32 0];
+  s[:u32 0] = res;
+  res = s[:u32 0];
 
   return res;
 }


### PR DESCRIPTION
with a large stack frame and the return address passed on the stack

First reported by @xvzcf