### PR TITLE
Regalloc: small refactoring

### DIFF
--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -179,16 +179,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
 
     let return_addresses = Regalloc.create_return_addresses get_internal_size fds in
 
-    let fds =
-      Regalloc.alloc_prog
-        (fun _fd extra ->
-          match extra.Expr.sf_save_stack with
-          | Expr.SavedStackReg _ | Expr.SavedStackStk _ -> true
-          | Expr.SavedStackNone -> false)
-        return_addresses
-        fds
-    in
-    let fds = List.map (fun (y, _, x) -> (y, x)) fds in
+    let _subst, _killed, fds = Regalloc.alloc_prog return_addresses fds in
     let fds = List.map Conv.csfdef_of_fdef fds in
     fds
   in

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -171,11 +171,13 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     CheckAnnot.check_stack_size fds;
 
 
-    let get_internal_size _fd sfe =
+    let get_internal_size (sfe, _fd) =
       let stk_size =
         BinInt.Z.add sfe.Expr.sf_stk_sz sfe.Expr.sf_stk_extra_sz in
       Conv.z_of_cz (Memory_model.round_ws sfe.sf_align stk_size)
     in
+
+    let return_addresses = Regalloc.create_return_addresses get_internal_size fds in
 
     let fds =
       Regalloc.alloc_prog
@@ -183,7 +185,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
           match extra.Expr.sf_save_stack with
           | Expr.SavedStackReg _ | Expr.SavedStackStk _ -> true
           | Expr.SavedStackNone -> false)
-        get_internal_size
+        return_addresses
         fds
     in
     let fds = List.map (fun (y, _, x) -> (y, x)) fds in

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -627,11 +627,15 @@ module type Regalloc = sig
 
   val subroutine_ra_by_stack : (unit, extended_op) func -> bool
 
+  val get_reg_oracle :
+    (('info, 'asm) func -> bool) ->
+    (var -> var) ->
+    (funname -> Sv.t) -> retaddr -> ('info, 'asm) func -> reg_oracle_t
+
   val alloc_prog :
-    ((unit, extended_op) func -> 'a -> bool) ->
     retaddr Hf.t ->
     ('a * (unit, extended_op) func) list ->
-    ('a * reg_oracle_t * (unit, extended_op) func) list
+    (var -> var) * (funname -> Sv.t) * ('a * (unit, extended_op) func) list
 end
 
 module Regalloc (Arch : Arch_full.Arch)
@@ -1046,7 +1050,6 @@ let post_process
   ~not_saved_stack
   ~stack_needed
   (subst: var -> var)
-  (live: Sv.t)
   ~(killed: funname -> Sv.t)
   (f: _ func) :
   Sv.t * var option =
@@ -1060,7 +1063,6 @@ let post_process
      end
   | Export _ ->
      begin
-       assert (Sv.is_empty live);
        let used_in_f = List.fold_left (fun s x -> Sv.add (subst x) s) killed_in_f f.f_args in
        let free_regs = Sv.diff allocatable_vars used_in_f in
        let to_save = Sv.inter callee_save_vars killed_in_f in
@@ -1388,47 +1390,55 @@ let global_allocation return_addresses (funcs: ('info, 'asm) func list) :
   subst
   , killed
 
-let alloc_prog (has_stack: ('info, 'asm) func -> 'a -> bool) return_addresses (dfuncs: ('a * ('info, 'asm) func) list)
-    : ('a * reg_oracle_t * (unit, 'asm) func) list =
+let allocatable_vars = Sv.of_list Arch.allocatable_vars
+let callee_save_vars = Sv.of_list Arch.callee_save_vars
+let not_saved_stack = Sv.of_list (Arch.not_saved_stack @ Arch.callee_save_vars)
+
+let get_reg_oracle
+      (has_stack: ('info, 'asm) func -> bool)
+      subst
+      killed
+      return_address
+      f : reg_oracle_t =
+  let stack_needed = has_stack f in
+  let to_save, ro_rsp =
+    post_process
+      ~allocatable_vars
+      ~callee_save_vars
+      ~not_saved_stack
+      ~stack_needed
+      ~killed
+      subst
+      f in
+  let ro_return_address =
+    match return_address with
+    | StackDirect -> StackDirect
+    | StackByReg(ra_call, ra_return, tmp) ->
+       StackByReg (subst ra_call, Option.map subst ra_return, Option.map subst tmp)
+    | ByReg(r, tmp) -> ByReg (subst r, Option.map subst tmp) in
+  let ro_to_save = if FInfo.is_export f.f_cc then Sv.elements to_save else [] in
+  { ro_to_save ; ro_rsp ; ro_return_address }
+
+let alloc_prog return_addresses (dfuncs: ('a * ('info, 'asm) func) list)
+    : (var -> var) * _ * ('a * (unit, 'asm) func) list =
   (* Ensure that instruction locations are really unique,
      so that there is no confusion on the position of the “extra free register”. *)
   let dfuncs =
     List.map (fun (a,f) -> a, Prog.refresh_i_loc_f f) dfuncs in
 
   let extra : 'a Hf.t = Hf.create 17 in
-  let allocatable_vars = Sv.of_list Arch.allocatable_vars in
-  let callee_save_vars = Sv.of_list Arch.callee_save_vars in
-  let not_saved_stack =
-    Sv.of_list (Arch.not_saved_stack @ Arch.callee_save_vars)
-  in
 
   let funcs, get_liveness, subst, killed =
     dfuncs
     |> List.map (fun (a, f) -> Hf.add extra f.f_name a; f)
     |> global_allocation return_addresses
   in
+  subst,
+  killed,
   funcs |>
   List.map (fun f ->
       let e = Hf.find extra f.f_name in
-      let stack_needed = has_stack f e in
-      let to_save, ro_rsp =
-         post_process
-          ~allocatable_vars
-          ~callee_save_vars
-          ~not_saved_stack
-          ~stack_needed
-          ~killed
-          subst
-          (get_liveness f.f_name)
-          f in
-      let ro_return_address =
-        match Hf.find return_addresses f.f_name with
-        | StackDirect -> StackDirect
-        | StackByReg(ra_call, ra_return, tmp) ->
-          StackByReg (subst ra_call, Option.map subst ra_return, Option.map subst tmp)
-        | ByReg(r, tmp) -> ByReg (subst r, Option.map subst tmp) in
-      let ro_to_save = if FInfo.is_export f.f_cc then Sv.elements to_save else [] in
-      e, { ro_to_save ; ro_rsp ; ro_return_address }, f
+      e, f
     )
 
 end

--- a/compiler/src/regalloc.mli
+++ b/compiler/src/regalloc.mli
@@ -16,10 +16,13 @@ type reg_oracle_t = {
 module type Regalloc = sig
   type extended_op
 
+  val create_return_addresses :
+    (('info, 'asm) sfundef -> Z.t) -> ('info, 'asm) sfundef list -> retaddr Hf.t
+  (** Compute where the return address will be stored *)
+
   val renaming : (unit, extended_op) func -> (unit, extended_op) func
 
   val subroutine_ra_by_stack : (unit, extended_op) func -> bool
-
 
   (** Returns:
     - the input function with variables turned into registers
@@ -33,7 +36,7 @@ module type Regalloc = sig
    *)
   val alloc_prog :
     ((unit, extended_op) func -> 'a -> bool) ->
-    ((unit, extended_op) func -> 'a -> Z.t) ->
+    retaddr Hf.t ->
     ('a * (unit, extended_op) func) list ->
     ('a * reg_oracle_t * (unit, extended_op) func) list
 end

--- a/compiler/src/regalloc.mli
+++ b/compiler/src/regalloc.mli
@@ -24,21 +24,27 @@ module type Regalloc = sig
 
   val subroutine_ra_by_stack : (unit, extended_op) func -> bool
 
-  (** Returns:
-    - the input function with variables turned into registers
-    - the set of killed registers (see note below)
-    - a free register in which the stack pointer can be saved; only when asked
-    - a free register for the return address; only for subroutines
+  val get_reg_oracle :
+    (('info, 'asm) func -> bool) ->
+    (var -> var) ->
+    (funname -> Sv.t) ->
+    retaddr ->
+    ('info, 'asm) func ->
+    reg_oracle_t
+  (** Extract from the outcome of register allocation the information that is
+      needed by stack-allocation. *)
 
-  Note: Export functions can freely use caller-saved registers: they are not
-  reported as killed. Subroutines report ALL killed registers.
-
-   *)
   val alloc_prog :
-    ((unit, extended_op) func -> 'a -> bool) ->
     retaddr Hf.t ->
     ('a * (unit, extended_op) func) list ->
-    ('a * reg_oracle_t * (unit, extended_op) func) list
+    (var -> var) * (funname -> Sv.t) * ('a * (unit, extended_op) func) list
+  (** Returns:
+      - the global renaming function
+      - the set of killed registers (see note below)
+      - the input function with variables turned into registers
+
+      Note: Export functions can freely use caller-saved registers: they are not
+      reported as killed. Subroutines report ALL killed registers. *)
 end
 
 module Regalloc (Arch : Arch_full.Arch) :

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -248,7 +248,7 @@ let memory_analysis pp_sr pp_err ~debug up =
 
   let internal_size_tbl = Hf.create 117 in
   let add_internal_size fd sz = Hf.add internal_size_tbl fd sz in
-  let get_internal_size fd _ = Hf.find internal_size_tbl fd.f_name in
+  let get_internal_size (_, fd) = Hf.find internal_size_tbl fd.f_name in
 
   let fix_subroutine_csao (_, fd) =
     match fd.f_cc with
@@ -327,7 +327,8 @@ let memory_analysis pp_sr pp_err ~debug up =
 
   List.iter fix_subroutine_csao (List.rev fds);
 
-  let fds = Regalloc.alloc_prog (fun fd _ -> has_stack fd) get_internal_size fds in
+  let return_addresses = Regalloc.create_return_addresses get_internal_size fds in
+  let fds = Regalloc.alloc_prog (fun fd _ -> has_stack fd) return_addresses fds in
 
   let fix_csao (_, ro, fd) =
     match fd.f_cc with

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -328,9 +328,10 @@ let memory_analysis pp_sr pp_err ~debug up =
   List.iter fix_subroutine_csao (List.rev fds);
 
   let return_addresses = Regalloc.create_return_addresses get_internal_size fds in
-  let fds = Regalloc.alloc_prog (fun fd _ -> has_stack fd) return_addresses fds in
+  let subst, killed, fds = Regalloc.alloc_prog return_addresses fds in
 
-  let fix_csao (_, ro, fd) =
+  let fix_csao (_, fd) =
+    let ro = Regalloc.get_reg_oracle has_stack subst killed (Hf.find return_addresses fd.f_name) fd in
     match fd.f_cc with
     | Subroutine _ ->
       (* It as been already fixed by the previous pass fix_subroutine_csao,


### PR DESCRIPTION
Extracts two subroutines from the register allocation pass:
- a pre-processing step that creates fresh variables to compute and store the return addresses;
- a post-processing step that builds the “oracle” for stack allocation.

This makes it easier to reuse these steps and slightly decreases complexity (smaller functions, less arguments).