### PR TITLE
Make pp_arm_m4 check exhaustive

### DIFF
--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -176,7 +176,11 @@ end = struct
     | MOV -> chk_imm_w16_encoding args 1 opts
     | AND | BIC | EOR | ORR -> chk_imm_reject_shift args 2
     | MVN | TST -> chk_imm_reject_shift args 1
-    | _ -> ""
+    | MUL | MLA | MLS | SDIV | UDIV | UMULL | UMAAL | UMLAL | SMULL | SMLAL
+    | SMMUL | SMMULR | SMUL_hw _ | SMLA_hw _ | SMULW_hw _ | BFC | BFI | ASR
+    | LSL | LSR | ROR | REV | REV16 | REVSH | ADR | MOVT | UBFX | UXTB | UXTH
+    | SBFX | CLZ | LDR | LDRB | LDRH | LDRSB | LDRSH | STR | STRB | STRH
+      -> ""
 end
 
 (* Split an [ADR] instruction to a global symbol into a [MOVW]/[MOVT] pair. *)


### PR DESCRIPTION
I would like to get a warning when we add a new instruction and we forget to check that its arguments are valid.