### PR TITLE
eclib: lightweight proof for to_uintBb

### DIFF
--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -811,7 +811,11 @@ have /= x_range := to_uint_cmp x.
 have /= y_range := to_uint_cmp y.
 rewrite /b2i to_uintD.
 case: c => _; last first.
-+ case: (to_uint y = 0) => /= hy; rewrite to_uintN ?hy /#.
++ rewrite to_uintN !addr0 modzDmr.
+  case: (to_uint x < to_uint y) => Hxy /=.
+  + rewrite (addzC (to_uint x - to_uint y) modulus).
+    by rewrite &(modz_sub_carry) // subz_lt0 //.
+  + by rewrite pmod_small /#.
 rewrite to_uintN.
 case: (to_uint y = max_uint) => /= hy.
 + rewrite to_uintD hy /#.


### PR DESCRIPTION
Hi, the CI check of the latest EC commit [failed](https://github.com/EasyCrypt/easycrypt/actions/runs/17068200471/job/48403958178) for the new lemma `to_uintBb`. Also, I ran JWord.ec on my laptop, and I failed at `to_uintBb` too. The reason is probably the instability of SMT solving. So, I rewrote the proof to unburden the SMT solver.

I found that the CI check failed after I contributed to EasyCrypt for the first time. I felt a bit embarrassed. I hope this PR can make the CI of EasyCrypt work again. Thanks :)