### PR TITLE
Add x86 instruction BSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Extraction as EasyCrypt code targets version 2025.08
   ([PR #1255](https://github.com/jasmin-lang/jasmin/pull/1255)).
 
+- Add support for x86 `BSR` instruction
+  ([PR #1266](https://github.com/jasmin-lang/jasmin/pull/1266);
+  fixes [#1257](https://github.com/jasmin-lang/jasmin/issues/1257)).
+
 ## Bug fixes
 
 - Linter : More precise diagnostics

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -65,6 +65,7 @@ module X86_core = struct
     | ANDN _ -> true
     | BLENDV (VE8, _) -> true
     | BLENDV _ -> false (* Not DOIT *)
+    | BSR _ -> false (* Not DOIT *)
     | BSWAP _ -> false (* Not DOIT *)
     | BT _ -> true
     | BTR _ -> true

--- a/compiler/tests/printing.ml
+++ b/compiler/tests/printing.ml
@@ -176,8 +176,11 @@ let eq_pmod_items x y = List.for_all2 eq_pmod_item x y
 (* ---------------------------------------------------------------- *)
 let parse arch_info fname =
   try
-    let _env, pprog, _ast = Compile.parse_file arch_info fname in
-    pprog
+    try
+      let _env, pprog, _ast = Compile.parse_file arch_info fname in
+      pprog
+    with Pretyping.TyError (loc, msg) ->
+      hierror ~loc:(Lone loc) ~kind:"typing error" "%a" Pretyping.pp_tyerror msg
   with HiError err ->
     Format.eprintf "%a@." pp_hierror err;
     exit 1

--- a/compiler/tests/success/x86-64/lzcnt.jazz
+++ b/compiler/tests/success/x86-64/lzcnt.jazz
@@ -26,3 +26,34 @@ export fn tzcnt(reg u64 x p) -> reg u16 {
   ?{}, z = #TZCNT_16(z);
   return z;
 }
+
+export fn bsr(reg u64 x) -> reg u16 {
+  // Enforce safety
+  x |= 1;
+
+  stack u64[1] s;
+  s[0] = x;
+
+  reg u64 a;
+  reg u32 b;
+  reg u16 c;
+
+  reg u16 r = 0;
+
+  ?{}, a = #BSR_64(x);
+  r ^= a;
+  ?{}, a = #BSR_64(s[0]);
+  r ^= a;
+
+  ?{}, b = #BSR_32(x);
+  r ^= b;
+  ?{}, b = #BSR_32(s[:u32 0]);
+  r ^= b;
+
+  ?{}, c = #BSR_16(x);
+  r ^= c;
+  ?{}, c = #BSR_16(s[:u16 0]);
+  r ^= c;
+
+  return r;
+}

--- a/eclib/JModel_x86.ec
+++ b/eclib/JModel_x86.ec
@@ -154,11 +154,12 @@ abbrev [-printing] XCHG_64 (x y:W64.t) = swap_ x y.
 
 | LZCNT  of wsize             (* number of leading zero *)
 | TZCNT  of wsize             (* number of trailing zero *)
+| BSR    of wsize             (* bit scan reverse *)
 *)
 
 (* Remark: W8.ALU W16.ALU W32.ALU W64.ALU are exported *)
 (* ALU defines the operators: 
-   ADD SUB IMUL IMUL_r IMUL_ri DIV IDIV CQO ADC SBB NEG INC DEC LZCNT TZCNT
+   ADD SUB IMUL IMUL_r IMUL_ri DIV IDIV CQO ADC SBB NEG INC DEC LZCNT TZCNT BSR
 *)
 
 (* Flag *)

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -1691,6 +1691,10 @@ op TZCNT_XX (w:t) =
   let v = of_int (lzcnt (w2bits w)) in
   (undefined_flag, ZF_of w, undefined_flag, undefined_flag, ZF_of v, v).
 
+op BSR_XX (w: t) =
+  (undefined_flag, undefined_flag, undefined_flag, undefined_flag, false,
+   of_int (size - 1 - lzcnt (w2bits w))).
+
 lemma DEC_XX_counter n (c:t) :
   c <> zero =>
   (n - to_uint c + 1 = n - to_uint (DEC_XX c).`5 /\


### PR DESCRIPTION
The first commit is unrelated but proved itself useful in debugging the instruction descriptor.

This instruction has a safety precondition: its argument should not be zero, since the result is undefined in this case.