### PR TITLE
eclib: install a configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ Makefile.coq
 Makefile.coq.bak
 Makefile.coq.conf
 
+/eclib/*.conf
+
 /jasmin/
 /jasmin.tar.gz
 /compiler/config/checker_config_default.json

--- a/Makefile.compiler
+++ b/Makefile.compiler
@@ -3,6 +3,7 @@ all:
 
 clean:
 	$(MAKE) -C compiler clean
+	$(MAKE) -C eclib clean
 
 install:
 	$(MAKE) -C compiler install

--- a/eclib/Makefile
+++ b/eclib/Makefile
@@ -8,25 +8,35 @@ CHECKS   ?= jasmin
 # --------------------------------------------------------------------
 DESTDIR  ?=
 PREFIX   ?= /usr/local
-BINDIR   := $(PREFIX)/bin
 LIBDIR   := $(PREFIX)/lib
-SHRDIR   := $(PREFIX)/share
 INSTALL  ?= install
 
 # --------------------------------------------------------------------
-.PHONY: default usage check install uninstall
+.PHONY: default usage check install uninstall clean
 
 default: check
 
 usage:
-	@echo "Usage: make <target> where <target> in [check|install|uninstall]" >&2
+	@echo "Usage: make <target> where <target> in [check|clean|install|uninstall]" >&2
 
 check:
 	easycrypt runtest $(ECARGS) $(ECCONF) $(CHECKS)
 
-install:
-	$(INSTALL) -m 0755 -d $(DESTDIR)$(LIBDIR)/jasmin/easycrypt
-	$(INSTALL) -m 0644 -t $(DESTDIR)$(LIBDIR)/jasmin/easycrypt *.ec
+jasmin.conf:
+	@echo "# DO NOT MODIFY" | tee $@
+	@echo "# This file is generated and may be silently overwritten" | tee -a $@
+	@echo "[general]" | tee -a $@
+	@echo "idirs=Jasmin:$(LIBDIR)/easycrypt/jasmin" | tee -a $@
+
+install: jasmin.conf
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(LIBDIR)/easycrypt/jasmin
+	$(INSTALL) -m 0644 -t $(DESTDIR)$(LIBDIR)/easycrypt/jasmin *.ec
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(LIBDIR)/easycrypt/config
+	$(INSTALL) -m 0644 -t $(DESTDIR)$(LIBDIR)/easycrypt/config *.conf
 
 uninstall:
-	$(RM) -r $(DESTDIR)$(LIBDIR)/jasmin
+	$(RM) -r $(DESTDIR)$(LIBDIR)/easycrypt/jasmin
+	$(RM) $(DESTDIR)$(LIBDIR)/easycrypt/config/jasmin.conf
+
+clean:
+	$(RM) *.conf


### PR DESCRIPTION
This make it possible for EasyCrypt (next version) to automatically detect the installed Jasmin library (without extra configuration step by the user).