### PR TITLE
Linter: less false alarms about dead assignments

### DIFF
--- a/changes/02-bugfix/1273-less-dead-warnings.md
+++ b/changes/02-bugfix/1273-less-dead-warnings.md
@@ -1,0 +1,2 @@
+- The linter (dead assignments) raises less false alarms
+  ([PR 1273](https://github.com/jasmin-lang/jasmin/pull/1273)).

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -512,6 +512,16 @@ let assigns = function
       List.fold_left written_lv Sv.empty xs
   | Cif _ | Cwhile _ |Cfor _ -> Sv.empty
 
+let is_lmem = function
+  | Lmem _ -> true
+  | _ -> false
+
+let has_effect = function
+  | Csyscall _ | Ccall _ -> true
+  | Cassgn (x, _, _, _) -> is_lmem x
+  | Copn (xs, _, _, _) -> List.exists is_lmem xs
+  | Cif _ | Cwhile _ | Cfor _ -> false
+
 (* -------------------------------------------------------------------- *)
 let rec iter_instr f stmt = List.iter (iter_instr_i f) stmt
 

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -295,6 +295,14 @@ val assigns : ('info, 'asm) instr_r -> Sv.t
 (** Computes the set of variables that the given instruction writes to, if any.
     NB: control flow instructions (if, while, and for) do not write to any variable. *)
 
+val has_effect : ('info, 'asm) instr_r -> bool
+(** Whether the instruction has an “effect”. What is treated as an effect is:
+    - a function call / system call;
+    - a memory store.
+
+    Note that other control-flow constructions do not count as an effect (i.e.,
+    this function does not recurse within nested code blocks). *)
+
 (* -------------------------------------------------------------------- *)
 val iter_instr :
   (('len, 'info, 'asm) ginstr -> unit) -> ('len, 'info, 'asm) gstmt -> unit

--- a/compiler/tests/fail/linter/bug_1223.jazz
+++ b/compiler/tests/fail/linter/bug_1223.jazz
@@ -3,3 +3,24 @@ export fn only_one_live_result(reg u64 x) -> reg u64 {
   x, z = #swap(z, x);
   return x;
 }
+
+export fn not(reg u32 x) -> reg u32 {
+  if x == 0 {
+    x = 1;
+  } else {
+    x = 0;
+  }
+  return x;
+}
+
+export fn store(reg u64 p, reg u8 b) {
+  [:u8 p] = b;
+}
+
+export fn store_with_dead(reg u64 s, reg u32 a) -> reg u32 {
+  reg bool c;
+  [:u32 s] = 0;
+  c, [:u32 s] +32u= a;
+  a = [:u32 s];
+  return a;
+}

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -19,33 +19,17 @@
   warning: no need to return a [reg const ptr] r
 
   $ ../jasminc -wall -until_cstexp fail/linter/dead_variables.jazz
-  "fail/linter/dead_variables.jazz", line 5 (4) to line 7 (5)
-  warning: Instruction only assigns dead variables
   "fail/linter/dead_variables.jazz", line 6 (8-18)
   warning: Instruction only assigns dead variables
   "fail/linter/dead_variables.jazz", line 11 (2-8)
   warning: Instruction only assigns dead variables
   "fail/linter/dead_variables.jazz", line 23 (4-28)
-  warning: Instruction only assigns dead variables
+  warning: Variable “y” is affected but never used
   "fail/linter/dead_variables.jazz", line 32 (4-10)
-  warning: Instruction only assigns dead variables
-  "fail/linter/dead_variables.jazz", line 33 (4) to line 38 (5)
   warning: Instruction only assigns dead variables
   "fail/linter/dead_variables.jazz", line 37 (8-12)
   warning: Instruction only assigns dead variables
-  "fail/linter/dead_variables.jazz", line 45 (4-12)
-  warning: Instruction only assigns dead variables
-  "fail/linter/dead_variables.jazz", line 50 (4-12)
-  warning: Instruction only assigns dead variables
-  "fail/linter/dead_variables.jazz", line 58 (4) to line 64 (5)
-  warning: Instruction only assigns dead variables
-  "fail/linter/dead_variables.jazz", line 59 (8) to line 61 (9)
-  warning: Instruction only assigns dead variables
   "fail/linter/dead_variables.jazz", line 65 (4-10)
-  warning: Instruction only assigns dead variables
-  "fail/linter/dead_variables.jazz", line 74 (4) to line 79 (5)
-  warning: Instruction only assigns dead variables
-  "fail/linter/dead_variables.jazz", line 75 (8) to line 77 (9)
   warning: Instruction only assigns dead variables
   "fail/linter/dead_variables.jazz", line 76 (12-22)
   warning: Instruction only assigns dead variables
@@ -69,15 +53,13 @@
   warning: Variable x (declared at : "fail/linter/variables_initialisation.jazz", line 17 (12-13)) not initialized
   "fail/linter/variables_initialisation.jazz", line 25 (11-12)
   warning: Variable x (declared at : "fail/linter/variables_initialisation.jazz", line 22 (12-13)) not initialized
-  "fail/linter/variables_initialisation.jazz", line 3 (4-12)
-  warning: Instruction only assigns dead variables
   "fail/linter/variables_initialisation.jazz", line 8 (4-17)
   warning: Instruction only assigns dead variables
   "fail/linter/variables_initialisation.jazz", line 18 (4-18)
   warning: Instruction only assigns dead variables
-  "fail/linter/variables_initialisation.jazz", line 25 (4) to line 27 (5)
-  warning: Instruction only assigns dead variables
 
   $ ../jasminc -wall fail/linter/bug_1223.jazz
   "fail/linter/bug_1223.jazz", line 3 (2-21)
-  warning: Variable 'z' is affected but never used
+  warning: Variable “z” is affected but never used
+  "fail/linter/bug_1223.jazz", line 23 (2-22)
+  warning: Variable “c” is affected but never used


### PR DESCRIPTION
# Description

1. Instructions that do not assign any variable cannot raise a “dead assignment” warning.
2. Instructions that only assign dead variables are bogus only if they have no other “effect” (function call, memory store).

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
