### PR TITLE
Ignores useless zero-extensions of primitives

### DIFF
--- a/changes/03-other/1283-useless-extension.md
+++ b/changes/03-other/1283-useless-extension.md
@@ -1,0 +1,5 @@
+- Redundant zero-extensions of primitives (when the size of the extension
+  is the same as the size of the primitive output) are now accepted
+  instead of rejected.
+  The useless zero-extension is dropped, and a warning is emitted.
+  ([PR #1283](https://github.com/jasmin-lang/jasmin/pull/1283)).

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1725,8 +1725,14 @@ let cast_opn ~loc id ws =
   | Oasm (BaseOp (None, op)) ->
     begin match List.last id.tout with
       | Coq_sword from ->
-          if wsize_le ws from then rs_tyerror ~loc(InvalidZeroExtend (from, ws, name))
-          else Oasm (BaseOp (Some ws, op))
+          if not (wsize_le from ws) then rs_tyerror ~loc(InvalidZeroExtend (from, ws, name))
+          else if ws = from then begin
+            warning Always (L.i_loc0 loc)
+              "primitive operator %t already returns a value of size %a; the zero-extension is ignored"
+              name PrintCommon.pp_wsize ws;
+            Oasm (BaseOp (None, op))
+          end else
+            Oasm (BaseOp (Some ws, op))
       | _ -> invalid ()
   end
   | Oasm (BaseOp (Some _, _)) -> assert false

--- a/compiler/tests/warning/x86-64/ignored_zero_extension.jazz
+++ b/compiler/tests/warning/x86-64/ignored_zero_extension.jazz
@@ -1,0 +1,5 @@
+export fn main (reg u64 x) -> reg u64 {
+  reg u64 res = x;
+  ?{}, res = (64u)#AND_64(res, res);
+  return res;
+}

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -18,6 +18,10 @@
   "warning/x86-64/reg_const_ptr.jazz", line 2 (9-10)
   warning: no need to return a [reg const ptr] r
 
+  $ ../jasminc warning/x86-64/ignored_zero_extension.jazz
+  "warning/x86-64/ignored_zero_extension.jazz", line 3 (2-36)
+  warning: primitive operator AND_64 already returns a value of size 64; the zero-extension is ignored
+
   $ ../jasminc -wall -until_cstexp fail/linter/dead_variables.jazz
   "fail/linter/dead_variables.jazz", line 6 (8-18)
   warning: Instruction only assigns dead variables


### PR DESCRIPTION
# Description

We detect trivially useless zero-extensions of primitives (the size of the extension is the same as the size of the output of the primitive), drop them and produce a warning.

# Checklist

- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
