### PR TITLE
Pretyping: rewrite handling of #swap

### DIFF
--- a/compiler/tests/fail/x86-64/swap_type_mismatch.jazz
+++ b/compiler/tests/fail/x86-64/swap_type_mismatch.jazz
@@ -1,0 +1,3 @@
+export fn main(reg u64 x, reg ptr u8[8] y) {
+  x, y = #swap(y, x);
+}

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1498,6 +1498,10 @@ fail/x86-64/swap_int.jazz:
 
 "fail/x86-64/swap_int.jazz", line 6 (2-21): the swap primitive is not available at type int
 
+fail/x86-64/swap_type_mismatch.jazz:
+
+"fail/x86-64/swap_type_mismatch.jazz", line 2 (18-19): the expression has type u64 instead of u8[8]
+
 fail/x86-64/unaligned_slice_copy.jazz:
 
 "fail/x86-64/unaligned_slice_copy.jazz", line 6 (3-24):
@@ -1514,7 +1518,7 @@ Allowed args are:
 
 Statistics:
 	Annots:      0
-	Pretyping:  44
+	Pretyping:  45
 	Parsing:     4
 	Typing:      1
 	Compile:   189

--- a/compiler/tests/success/common/swap.jazz
+++ b/compiler/tests/success/common/swap.jazz
@@ -38,3 +38,16 @@ export fn main (reg u32 x y) -> reg u32 {
   x = x;
   return x;
 }
+
+export fn truncate(reg u32 x) -> reg u32, reg u16 {
+  reg u16 y;
+  reg u32 t = x;
+  x = x;
+  x, y = #swap(x, t);
+  x = x;
+  return x, y;
+}
+
+export fn nolhs(reg u32 x y) {
+  #keep _, _ = #swap(x, y);
+}


### PR DESCRIPTION
# Description

Pretyping rejects too much uses of `#swap`, for no reason.

# Checklist

- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
