### PR TITLE
Register allocation: changes in heuristics

### DIFF
--- a/changes/03-other/1295-regalloc-heuristic.md
+++ b/changes/03-other/1295-regalloc-heuristic.md
@@ -1,0 +1,2 @@
+- The heuristic for allocating register has been changed slightly
+  ([PR 1295](https://github.com/jasmin-lang/jasmin/pull/1295)).


### PR DESCRIPTION
# Description

This change makes it possible to compile more programs, e.g., all of libjade legacy (that currently relies on `-lazy-regalloc` in various implementations) and makes register allocation more robust: more registers are chosen as a result of a computation (that depends on the program) rather than based on internal implementation details of the data-structures.

Hoping there are not too many regressions.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [ ] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed
