### PR TITLE
ASM printing: change formatting of raw bytes

### DIFF
--- a/changes/03-other/1297-asm-bytes.md
+++ b/changes/03-other/1297-asm-bytes.md
@@ -1,0 +1,2 @@
+- Global variables in assembly listings are displayed in a more compact way
+  ([PR 1297](https://github.com/jasmin-lang/jasmin/pull/1297)).

--- a/compiler/src/printASM.ml
+++ b/compiler/src/printASM.ml
@@ -9,7 +9,7 @@ type asm_element =
 | Dwarf of string (* Debug info in std dwarf format*)
 | Instr of string * string list
 | Comment of string
-| Byte of string
+| Bytes of string list
 
 let iwidth = 4
 
@@ -31,8 +31,14 @@ let pp_instr fmt name params =
 let pp_comment fmt comment =
   Format.fprintf fmt "// %s" comment
 
-let pp_byte fmt byte =
-  Format.fprintf fmt "\t.byte\t%s" byte
+let pp_bytes fmt =
+  List.iteri (fun i byte ->
+      let pfx = i mod 16 == 0 in
+      Format.fprintf fmt "%s%s%s"
+        (if pfx && i > 0 then "\n" else "")
+        (if pfx then "\t.byte\t" else ", ")
+        byte
+    )
 
 let pp_dwarf fmt (dwarf: string) =
   Format.fprintf fmt "\t%s" dwarf
@@ -49,8 +55,8 @@ let pp_asm_element fmt asm_element =
     pp_instr fmt name params
   | Comment content ->
     pp_comment fmt content
-  | Byte data ->
-    pp_byte fmt data
+  | Bytes data ->
+    pp_bytes fmt data
 
 let pp_asm_line fmt =
   Format.fprintf fmt "%a\n%!" pp_asm_element

--- a/compiler/src/printASM.mli
+++ b/compiler/src/printASM.mli
@@ -1,18 +1,12 @@
-
-
-(**
-Assembly code type. Common interface produced by all existing architectures
+(** Assembly code type. Common interface produced by all existing architectures
 *)
-type asm_element = 
-| Header of string * string list
-| Label of string
-| Dwarf of string (* Debug info in std dwarf format*)
-| Instr of string * string list
-| Comment of string
-| Byte of string
+type asm_element =
+  | Header of string * string list
+  | Label of string
+  | Dwarf of string (* Debug info in std dwarf format*)
+  | Instr of string * string list
+  | Comment of string
+  | Bytes of string list
 
-
-(** 
-Pretty print assembly code 
-*)
 val pp_asm : Format.formatter -> asm_element list -> unit
+(** Pretty print assembly code *)


### PR DESCRIPTION
# Description

Printing of global data in assembly listings puts up to sixteen bytes per line. Each byte is expressed as a non-negative decimal integer.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [ ] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed
