### PR TITLE
Add support for shifts & negation in array sizes

### DIFF
--- a/changes/02-bugfix/1298-lsl-in-array-sizes.md
+++ b/changes/02-bugfix/1298-lsl-in-array-sizes.md
@@ -1,0 +1,3 @@
+- Arithmetic shifts (`<<`, `>>`) and negation are now allowed in array sizes
+  ([PR #1298](https://github.com/jasmin-lang/jasmin/pull/1298),
+  fixes [#1296](https://github.com/jasmin-lang/jasmin/issues/1296)).

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -712,25 +712,25 @@ fail/param_expansion/x86-64/expression_arg.jazz:
 
 "fail/param_expansion/x86-64/expression_arg.jazz", line 3 (24-25):
 compilation error in function f:
-param expansion: expression ((uint) ((64u) 3)) not allowed in array size (only constant arithmetic expressions are allowed)
+param expansion: unary operator (64u) not supported in array sizes
 
 fail/param_expansion/x86-64/expression_global.jazz:
 
 "fail/param_expansion/x86-64/expression_global.jazz", line 2 (7-8):
 compilation error:
-param expansion: expression ((uint) ((64u) 3)) not allowed in array size (only constant arithmetic expressions are allowed)
+param expansion: unary operator (64u) not supported in array sizes
 
 fail/param_expansion/x86-64/expression_global2.jazz:
 
 "fail/param_expansion/x86-64/expression_global2.jazz", line 2 (18-19):
 compilation error:
-param expansion: expression ((uint) ((64u) 2)) not allowed in array size (only constant arithmetic expressions are allowed)
+param expansion: unary operator (64u) not supported in array sizes
 
 fail/param_expansion/x86-64/expression_res.jazz:
 
 "fail/param_expansion/x86-64/expression_res.jazz", line 4 (13-14):
 compilation error in function f:
-param expansion: expression ((uint) ((64u) 3)) not allowed in array size (only constant arithmetic expressions are allowed)
+param expansion: unary operator (64u) not supported in array sizes
 
 fail/param_expansion/x86-64/global_array_not_constant.jazz:
 

--- a/compiler/tests/success/common/array_sizes.jazz
+++ b/compiler/tests/success/common/array_sizes.jazz
@@ -1,0 +1,14 @@
+param int one = 1;
+param int two = one << one;
+
+u8[one] a = { 0 };
+u8[one + one] b = { 1, 2 };
+u8[one * one] c = { 3 };
+u8[two - one] d = { 4 };
+u8[- - one] e = { 5 };
+u8[-(5 /s -two)] f = { 6, 7 };
+u8[(-5) /u -two] g = { 8, 9, 10 };
+u8[-((-5) %s -two)] h = { 11 };
+u8[(-5) %u -two] i = { 12 };
+u8[(one << two) << -one] j = { 13, 14 };
+u8[(two >> -one) >> two] k = { 15 };

--- a/compiler/tests/success/common/bug_1296.jazz
+++ b/compiler/tests/success/common/bug_1296.jazz
@@ -1,0 +1,7 @@
+param int x = 2;
+param int y = 1 << x;
+
+export fn load(reg ptr u8[y] v) -> reg u32 {
+  reg u32 r = v[:u32 0];
+  return r;
+}


### PR DESCRIPTION
# Description

Add support for left & right shifts in array sizes, as well as negation. This covers all operators that consume and produce integer values.

Fixes #1296

Done:

 - [x] add support for right shifts
 - [x] double-check what other operators are missing

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed
