### PR TITLE
Support spilling of variables with the same name

### DIFF
--- a/changes/02-bugfix/1299-spill-with-same-name.md
+++ b/changes/02-bugfix/1299-spill-with-same-name.md
@@ -1,0 +1,4 @@
+- No longer crashes when spilling several variables with the same name in a
+  single function
+  ([PR #1299](https://github.com/jasmin-lang/jasmin/pull/1299);
+  fixes [#1292](https://github.com/jasmin-lang/jasmin/issues/1292)).

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -58,11 +58,7 @@ let warn_extra_fd pd asmOp (_, fd) = List.iter (warn_extra_i pd asmOp) fd.f_body
 
 let do_spill_unspill asmop ?(debug = false) cp =
   let p = Conv.cuprog_of_prog cp in
-  match
-    Lower_spill.spill_uprog asmop
-      (fun k ii -> Conv.fresh_var_ident k ii (Uint63.of_int 0))
-      p
-  with
+  match Lower_spill.spill_uprog asmop Conv.fresh_var_ident p with
   | Utils0.Error msg -> Error (Conv.error_of_cerror (Printer.pp_err ~debug) msg)
   | Utils0.Ok p -> Ok (Conv.prog_of_cuprog p)
 

--- a/compiler/tests/success/common/bug_1292.jazz
+++ b/compiler/tests/success/common/bug_1292.jazz
@@ -1,0 +1,11 @@
+export fn f(reg u32 a) {
+  if a < 0 {
+    reg u32 x = 0;
+    () = #spill(x);
+    () = #unspill(x);
+  } else {
+    reg u32 x = 0;
+    () = #spill(x);
+    () = #unspill(x);
+  }
+}

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -264,7 +264,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: uprog) : cexec uprog :
 
   Let p :=
     spill_prog
-      (fun k ii => fresh_var_ident cparams k ii 0)
+      (fresh_var_ident cparams)
       p in
   let p := cparams.(print_uprog) LowerSpill p in
 

--- a/proofs/compiler/lower_spill.v
+++ b/proofs/compiler/lower_spill.v
@@ -1,6 +1,6 @@
 (* ** Imports and settings *)
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype.
-From Coq Require Import ZArith.
+From Coq Require Import ZArith Uint63.
 Require Import pseudo_operator expr compiler_util.
 
 Local Open Scope seq_scope.
@@ -26,7 +26,7 @@ End E.
 Section ASM_OP.
 
 Context `{asmop : asmOp}.
-Context (fresh_var_ident: v_kind -> instr_info -> string -> atype -> Ident.ident).
+Context (fresh_var_ident: v_kind -> instr_info -> int -> string -> atype -> Ident.ident).
 
 Definition is_spill_op o :=
   match o with
@@ -188,7 +188,7 @@ Section PROGT.
 Context {pT: progT}.
 
 Definition init_map (s:Sv.t) :=
-  Sv.fold (fun (x:var) m =>
+  Sv.fold (fun (x:var) '(m, count) =>
     let n := vname x in         
     let k :=
       match Ident.id_kind n with
@@ -199,8 +199,9 @@ Definition init_map (s:Sv.t) :=
       end in
     let ty := vtype x in
     let n := Ident.id_name n in
-    Mvar.set m x {| vname := fresh_var_ident k dummy_instr_info n ty; vtype := ty |})
-    s (Mvar.empty var).
+    (Mvar.set m x {| vname := fresh_var_ident k dummy_instr_info count n ty; vtype := ty |}
+    , succ count))
+    s (Mvar.empty var, 0%uint63).
 
 Definition get_spill (m:Mvar.t var) ii (x:var) :=
   match Mvar.get m x with
@@ -217,7 +218,7 @@ Definition spill_fd {eft} (fn:funname) (fd: _fundef eft) : cexec (_fundef eft) :
   let 'MkFun ii tyi params c tyo res ef := fd in
   let s := foldl to_spill_i (Sv.empty, false) c in
   if ~~s.2 then ok fd else
-  let m := init_map s.1 in
+  let: (m, _) := init_map s.1 in
   let X := Sv.union (vars_l params) (Sv.union (vars_l res) (vars_c c)) in
   let b := check_map m X in
   Let _ := assert b.1 (pp_internal_error E.pass (pp_s "invalid map")) in

--- a/proofs/compiler/lower_spill_proof.v
+++ b/proofs/compiler/lower_spill_proof.v
@@ -2,7 +2,7 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype.
 Require Import psem compiler_util.
 Require Export pseudo_operator lower_spill.
-Import Utf8.
+Import Utf8 Uint63.
 
 Local Open Scope seq_scope.
 
@@ -17,7 +17,7 @@ Context
   {sip : SemInstrParams asm_op syscall_state}
   {pT  : progT}
   {sCP : semCallParams}
-  (fresh_var_ident : v_kind -> instr_info -> string -> atype -> Ident.ident)
+  (fresh_var_ident : v_kind -> instr_info -> int -> string -> atype -> Ident.ident)
   (p p' : prog) (ev : extra_val_t)
   (spill_prog_ok : spill_prog fresh_var_ident p = ok p').
 
@@ -324,12 +324,13 @@ Proof.
   by rewrite hc /=; move/SvD.F.subset_iff: hsub2 => ->.
 Qed.
 
-Lemma init_map_ty toS :
-  forall x sx, Mvar.get (init_map fresh_var_ident toS) x = Some sx -> vtype x = vtype sx.
+Lemma init_map_ty toS x sx :
+  let: (m, _) := init_map fresh_var_ident toS in
+  Mvar.get m x = Some sx -> vtype x = vtype sx.
 Proof.
-  move=> x sx; rewrite /init_map Sv.fold_spec.
   have : Mvar.get (Mvar.empty var) x = Some sx -> vtype x = vtype sx by done.
-  elim: (Sv.elements toS) (Mvar.empty var) => [ | y ys hrec] //= m hm.
+  rewrite /init_map Sv.fold_spec.
+  elim: (Sv.elements toS) (Mvar.empty var) 0%uint63 => [ | y ys hrec] //= m count hm.
   by apply hrec; rewrite Mvar.setP; case: eqP => [-> [<-]| ] .
 Qed.
 
@@ -389,14 +390,16 @@ Proof.
   + by SvD.fsetdec. + by SvD.fsetdec.
 Qed.
 
-Lemma lower_get_spillP toS X :
-  let m := init_map fresh_var_ident toS in
+Lemma lower_get_spillP toS X m count :
+  init_map fresh_var_ident toS = (m, count) ->
   let get_spill := lower_spill.get_spill m in
   (check_map m X).1 ->
   ∀ (ii : instr_info) (x sx : var), get_spill ii x = ok sx → vtype x = vtype sx ∧ ¬ Sv.In sx X.
 Proof.
-  move=> /= /check_mapP [hget _] ii x sx; rewrite /lower_spill.get_spill.
-  by case: Mvar.get (@init_map_ty toS x) (hget x) => // sx' /(_ _ erefl) -> /(_ _ erefl) ? [<-].
+  move=> /= ok_m /check_mapP [hget _] ii x sx; rewrite /lower_spill.get_spill.
+  have := @init_map_ty toS x.
+  rewrite ok_m.
+  by case: Mvar.get (hget x) => // sx' /(_ _ erefl) ? /(_ _ erefl) -> /ok_inj <-.
 Qed.
 
 Lemma lower_get_spill_ii m :
@@ -404,13 +407,13 @@ Lemma lower_get_spill_ii m :
   ∀ (ii : instr_info) (x sx : var), get_spill ii x = ok sx → ∀ ii' : instr_info, get_spill ii' x = ok sx.
 Proof. by rewrite /lower_spill.get_spill => ii x sx hx ii'; case: Mvar.get hx. Qed.
 
-Lemma lower_get_spill_inj toS X :
-  let m := init_map fresh_var_ident toS in
+Lemma lower_get_spill_inj toS X m count :
+  init_map fresh_var_ident toS = (m, count) ->
   let get_spill := lower_spill.get_spill m in
   (check_map m X).1 ->
   ∀ (ii ii' : instr_info) (x x' sx : var), get_spill ii x = ok sx → get_spill ii' x' = ok sx → x = x'.
 Proof.
-  move=> /= /check_mapP [_ hget] ii ii' x x' sx.
+  move=> ok_m /= /check_mapP [_ hget] ii ii' x x' sx.
   rewrite /lower_spill.get_spill.
   have := hget x _ x' _.
   by case: Mvar.get => // sx1; case: Mvar.get => // sx2 /(_ _ _ erefl erefl) h [?] [?]; apply h; subst.
@@ -633,15 +636,15 @@ Proof.
     fi ft fp /= c f_tyout res fb hfun htra hinit hw hsc [hc_ hc] hres hfull hf'1 hf'2.
   case: ifP hf'1.
   + by move=> hX [?]; subst f'; econstructor; eauto => //=; rewrite -eq_p_extra.
-  t_xrbindP=> _ hcm [env' c'] hc' ?; subst f'.
-  pose m := init_map fresh_var_ident (foldl to_spill_i (Sv.empty, false) c).1.
+  case ok_m: init_map => [ m _count ].
+  t_xrbindP=> ? hcm [env' c'] hc' ?; subst f'.
   pose X := Sv.union (vars_l fp) (Sv.union (vars_l res) (vars_c c)).
   pose get_spill := lower_spill.get_spill m.
   pose S := {| get_spill     := get_spill;
                X             := X;
-               get_spillP    := lower_get_spillP hcm;
+               get_spillP    := lower_get_spillP ok_m hcm;
                get_spill_ii  := @lower_get_spill_ii m;
-               get_spill_inj := lower_get_spill_inj hcm |}.
+               get_spill_inj := lower_get_spill_inj ok_m hcm |}.
   case: (hc S _ _ _ (evm s1) hc').
   + by rewrite /= /X; SvD.fsetdec.
   + by split => // x /Sv_memP.
@@ -733,16 +736,16 @@ Proof.
     exists (st_eq tt), (st_eq tt); split => //.
     + by apply/wequiv_rec_st_eq/eq_globs.
     by apply st_eq_finalize.
+  case ok_m: init_map => [ m _count ].
   t_xrbindP => _.
-  set m := init_map _ _.
   set X' := Sv.union _ _.
   set get_spill' := lower_spill.get_spill m.
   move=> hcm [env c'] hcc' <- /=.
   set S := {| get_spill     := get_spill';
                X             := X';
-               get_spillP    := lower_get_spillP hcm;
+               get_spillP    := lower_get_spillP ok_m hcm;
                get_spill_ii  := @lower_get_spill_ii m;
-               get_spill_inj := lower_get_spill_inj hcm |}.
+               get_spill_inj := lower_get_spill_inj ok_m hcm |}.
   move=> s hinit; exists s.
   + by move: hinit; rewrite /initialize_funcall /= eq_p_extra.
   exists (st_ve S Sv.empty), (st_ve S env); split => //.
@@ -760,7 +763,7 @@ Proof.
   move: Sv.empty env c' hcc'.
   change get_spill' with (get_spill S).
   move: S => S.
-  clear hinit s hcm get_spill' X' m fb res f_tyout fp ft fi fd' spillok fs fn.
+  clear hinit s ok_m hcm get_spill' X' m fb res f_tyout fp ft fi fd' spillok fs fn.
   set Pi := fun i => forall env env' c', spill_i (get_spill S) env i = ok (env', c') ->
         Sv.Subset (vars_I i) (X S) → wequiv_rec p p' ev ev eq_spec (st_ve S env) [::i] c' (st_ve S env').
   set Pr := fun i => forall ii, Pi (MkI ii i).


### PR DESCRIPTION
# Description

Prior to this change, two different reg variables would be spilled to the same stack variable. This PR makes sure that all stack variables introduced by “lower-spill” are actually fresh.

Fixes #1292

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed
