### PR TITLE
Printing annotation strings escapes only \ and "

### DIFF
--- a/changes/03-other/1306-annotations-escape.md
+++ b/changes/03-other/1306-annotations-escape.md
@@ -1,0 +1,2 @@
+- Pretty-printing of annotation strings no longer escapes non-ASCII characters
+  ([PR #1306](https://github.com/jasmin-lang/jasmin/pull/1306)).

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -87,11 +87,18 @@ let pp_glvs ~debug pp_len pp_var fmt lvs =
   | _   -> F.fprintf fmt "(@[%a@])" (pp_list ",@ " (pp_glv ~debug pp_len pp_var)) lvs
 
 (* -------------------------------------------------------------------- *)
+let pp_escape_string fmt =
+  String.iter (function
+      | '\\' -> F.fprintf fmt "\\\\"
+      | '"' -> F.fprintf fmt "\\\""
+      | c -> F.fprintf fmt "%c" c
+    )
+
 let rec pp_simple_attribute fmt =
   function
   | Annotations.Aint z -> Z.pp_print fmt z
   | Aid s -> F.fprintf fmt "%s" s
-  | Astring s -> F.fprintf fmt "%S" s
+  | Astring s -> F.fprintf fmt "\"%a\"" pp_escape_string s
   | Aws ws -> F.fprintf fmt "%s" (string_of_ws ws)
   | Astruct a -> F.fprintf fmt "{%a}" pp_annotations a
 

--- a/compiler/tests/success/common/annotations.jazz
+++ b/compiler/tests/success/common/annotations.jazz
@@ -1,0 +1,7 @@
+#[test = "This
+is
+a
+multiline
+  annotation  with  tabs and \" special {| |} characters
+"]
+export fn noop() {}


### PR DESCRIPTION
# Description

Current behavior escapes any non-ascii character, which is not super convenient to read.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
