### PR TITLE
More assembler directives about function symbols

### DIFF
--- a/changes/01-feature/1307-asm-func-directives.md
+++ b/changes/01-feature/1307-asm-func-directives.md
@@ -1,0 +1,4 @@
+- Assembly listings have more precise meta-data about function symbols
+  ([PR #1307](https://github.com/jasmin-lang/jasmin/pull/1307);
+  fixes [#1302](https://github.com/jasmin-lang/jasmin/issues/1302)).
+

--- a/compiler/src/AsmTargetBuilder.ml
+++ b/compiler/src/AsmTargetBuilder.ml
@@ -16,6 +16,7 @@ module type AsmTarget = sig
 
     val headers             : asm_element list
     val data_segment_header : asm_element list
+    val function_directives : asm_element list
     val function_header     : asm_element list
     val function_tail       : asm_element list
     val pp_instr_r          : Name.t -> (reg, regx, xreg, rflag, cond, asm_op) Arch_decl.asm_i_r -> asm_element list
@@ -62,10 +63,14 @@ module Make(Target : AsmTarget) : S
 
     let pp_function_header (name:string) decl =
         if decl.asm_fd_export then
-            [
-                Label (mangle name);
-                Label name;
-            ] @ Target.function_header
+          let mname  = mangle name in
+          Target.function_directives
+          @ [
+            Header (".type", [mname; "%function"]);
+            Header (".type", [name; "%function"]);
+            Label mname;
+            Label name;
+          ] @ Target.function_header
         else []
 
     let pp_function_tail decl =

--- a/compiler/src/AsmTargetBuilder.mli
+++ b/compiler/src/AsmTargetBuilder.mli
@@ -1,3 +1,5 @@
+open PrintASM
+
 (**
 Module AsmTarget :
     This module defines the interface for generating assembly code for a target architecture.
@@ -19,6 +21,9 @@ module type AsmTarget = sig
 
     (* Data segment header*)
     val data_segment_header : PrintASM.asm_element list
+
+    val function_directives : asm_element list
+    (** Meta-data to print before the function definition *)
 
     (* Start of the function*)
     val function_header     : PrintASM.asm_element list

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -69,11 +69,6 @@ let pp_asm_arg (arg : (register, Arch_utils.empty, Arch_utils.empty, rflag, cond
 
 (* -------------------------------------------------------------------- *)
 
-(* TODO_ARM: Review. *)
-let headers = [ Instr (".thumb", []); Instr (".syntax unified", []) ]
-
-(* -------------------------------------------------------------------- *)
-
 let pp_set_flags opts = if opts.set_flags then "s" else ""
 
 (* We assume the only condition in the argument list is the one we need to
@@ -230,6 +225,10 @@ and type asm_op = arm_op
     (* TODO_ARM: Review. *)
     [ Instr ("pop", [ "{pc}" ]) ]
 
+  let function_directives =
+    [
+      Header (".thumb_func", [])
+    ]
 
   let function_header =
     [

--- a/compiler/src/pp_riscv.ml
+++ b/compiler/src/pp_riscv.ml
@@ -105,6 +105,8 @@ module RiscVTarget: AsmTarget
       Label global_datas_label
     ]
 
+  let function_directives = []
+
   let function_header =
     [
       Instr ("addi", [ pp_register SP; pp_register SP; "-4"]);

--- a/compiler/src/pp_x86.ml
+++ b/compiler/src/pp_x86.ml
@@ -399,6 +399,8 @@ and type asm_op = X86_instr_decl.x86_op
       let name = pp_name_ext pp in
       [Instr(name, (pp_asm_args pp.pp_aop_args))]
 
+  let function_directives = []
+
   let function_header = []
 
   let function_tail = [Instr ("ret", [])]


### PR DESCRIPTION
# Description

Add `.thumb_func` and `.type` directives before export functions in assembly listings.

Fixes #1302

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
