### PR TITLE
Safety checker: array offsets must be nonnegative

### DIFF
--- a/changes/02-bugfix/1313-safety-out-of-bounds.md
+++ b/changes/02-bugfix/1313-safety-out-of-bounds.md
@@ -1,0 +1,3 @@
+- Safety checker: correctly check that array offsets are nonnegative
+  ([PR 1313](https://github.com/jasmin-lang/jasmin/pull/1313);
+  fixes [#1310](https://github.com/jasmin-lang/jasmin/issues/1310)).

--- a/compiler/safety/fail/not_in_bounds.jazz
+++ b/compiler/safety/fail/not_in_bounds.jazz
@@ -1,0 +1,5 @@
+export fn f (reg ptr u64[2] t) -> reg ptr u64[2] {
+  t[-1] = 2;
+  t[2] = 2;
+  return t;
+}

--- a/compiler/safety/run.expected
+++ b/compiler/safety/run.expected
@@ -271,6 +271,25 @@ Bottom ⊥
 
 Program is not safe!
 
+File fail/not_in_bounds.jazz:
+Analyzing function f
+
+
+*** Possible Safety Violation(s):
+  "fail/not_in_bounds.jazz", line 2 (2-12): in_bound: t[(- 1)] (length 16 U8)
+  "fail/not_in_bounds.jazz", line 3 (2-11): in_bound: t[2] (length 16 U8)
+  
+Memory ranges:
+  mem_t: [0; 0]
+  
+* Rel:
+{mem_t = 0}
+mem_t ∊ [0; 0]
+
+
+
+Program is not safe!
+
 File fail/popcnt.jazz:
 Analyzing function off_by_one
 


### PR DESCRIPTION
# Description

The safety checker used not to check that array offsets are nonnegative. We fix that.

Fixes #1310 

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
