### PR TITLE
Remove spurious wequiv_f_rec assumption from wequiv_fun_ind

### DIFF
--- a/proofs/compiler/allocation_proof.v
+++ b/proofs/compiler/allocation_proof.v
@@ -791,12 +791,10 @@ Section PROOF.
   Proof. by move=> hincl; apply st_rel_weaken => >; apply: eq_alloc_incl. Qed.
 
   Lemma it_alloc_cP (f_body : cmd) (dead_vars_fd0 : instr_info → Sv.t) (r1 : M.t_) (r2 : M.t) (f_body0 : cmd) :
-    (∀ (ii1 ii2 : instr_info) (fn1 fn2 : funname),
-      wequiv_f_rec p1 p2 ev ev uincl_spec (rpreF (eS:=uincl_spec))ii1 ii2 fn1 fn2 (rpostF (eS:=uincl_spec))) →
     check_cmd dead_vars_fd0 f_body f_body0 r1 = ok r2 →
     wequiv_rec p1 p2 ev ev uincl_spec (st_eq_alloc r1) f_body f_body0 (st_eq_alloc r2).
   Proof.
-    move=> hrec. move: f_body dead_vars_fd0 r1 r2 f_body0.
+    move: f_body dead_vars_fd0 r1 r2 f_body0.
     apply (cmd_rect (Pr := Pi_r) (Pi:=Pi) (Pc:=Pc)) => //.
     + move=> i1 ii1 hi1 dead_vars r1 r2 [ii2 i2] /=; t_xrbindP => r2' /hi1 -/(_ ii1 ii2) + <-.
       apply wequiv_weaken => // -[scs mem vm1] [_ _ vm2] [/= <- <- hvm]; split => //.
@@ -865,14 +863,13 @@ Section PROOF.
     move=> xs f es ii dead_vars r1 r2 ii2 [] // xs2 f2 es2 /=.
     t_xrbindP => re /eqP <- hces hcxs.
     apply wequiv_call_rel_uincl with checker_alloc re => //.
-    by move=> s t h; apply hrec.
+    by move=> ???; apply: wequiv_fun_rec.
   Qed.
 
   Lemma it_alloc_callP fn :
     wiequiv_f p1 p2 ev ev (rpreF (eS:= uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
   Proof.
-    apply wequiv_fun_ind => hrec {fn}.
-    move=> fn _ fs ft [<- hfsu] fd hget.
+    apply wequiv_fun_ind => {}fn _ fs ft [<- hfsu] fd hget.
     have [fd2 [Hget2 /=]]:= all_checked hget.
     t_xrbindP => /and3P [] _ htyin htyout r0 Hcinit r1 /check_f_extraP[] Hcparams hinit hfinalize r2 Hcc r3 Hcres _.
     exists fd2 => // s11 Hi.
@@ -886,16 +883,16 @@ Section PROOF.
     move=> /(_ _ _ Hvm0 hall2) [vm3 /= Hw2 Hvm3].
     rewrite -(all2_convertible_eval_atype htyin) htr /= /estate0 -heq1 -heq2 (hinit _ _ _ _ Hi0) /=.
     rewrite (write_vars_lvals _ gd) Hw2.
-    exists (with_vm s11 vm3)=> //; exists (st_eq_alloc r1), (st_eq_alloc r2); split => //; last first.
+    exists (with_vm s11 vm3)=> //; exists (st_eq_alloc r1), (st_eq_alloc r2).
+    split => //; first exact: it_alloc_cP Hcc.
     (* FIXME: can we have a generic lemma for finialize_funcall based on check_es *)
-    + move=> s t fs' /st_relP [-> /=] hu'; rewrite /finalize_funcall.
-      t_xrbindP => vs.
-      have [Hr3] := check_esP (~~direct_call) Hcres hu'.
-      rewrite sem_pexprs_get_var => h {}/h [vres1' /= []].
-      rewrite sem_pexprs_get_var => -> H2 vs' Hcr <-.
-      have [vs3 /=]:= mapM2_dc_truncate_val Hcr H2.
-      by rewrite (all2_convertible_eval_atype htyout) => -> ? /=; eexists; eauto; split => //=.
-    by apply: it_alloc_cP Hcc.
+    move=> s t fs' /st_relP [-> /=] hu'; rewrite /finalize_funcall.
+    t_xrbindP => vs.
+    have [Hr3] := check_esP (~~direct_call) Hcres hu'.
+    rewrite sem_pexprs_get_var => h {}/h [vres1' /= []].
+    rewrite sem_pexprs_get_var => -> H2 vs' Hcr <-.
+    have [vs3 /=]:= mapM2_dc_truncate_val Hcr H2.
+    by rewrite (all2_convertible_eval_atype htyout) => -> ? /=; eexists; eauto; split => //=.
   Qed.
 
 End IT.

--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -1942,8 +1942,7 @@ Proof. apply checker_st_eq_exP => //. Qed.
 Lemma it_lower_callP fn :
   wiequiv_f p p' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs _ [<- <-] fd hget.
+  apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
   have [_ hfvres hfvc] := disj_fvars_get_fundef hget.
   rewrite get_map_prog hget /= /lower_fd.
   eexists; first reflexivity.
@@ -2026,7 +2025,7 @@ Opaque esem.
   (* Call *)
   move=> xs fn es ii /disj_fvars_vars_I_Ccall [hdisjx hdisje] /=.
   apply (wequiv_call_rel_eq (sip:=sip)) with checker_st_eq_ex fvars => //.
-  by move=> ???; apply hrec.
+  by move=> ???; apply: (wequiv_fun_rec (spec := eq_spec)).
 Qed.
 End IT.
 

--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -577,8 +577,7 @@ Proof. by move: Hp;rewrite /array_copy_prog; t_xrbindP => ??? <-. Qed.
 
 Lemma it_array_copy_fdP fn : wiequiv_f p1 p2 ev ev (rpreF (eS:= uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs ft [<- hfsu] fd1 hget.
+  apply wequiv_fun_ind => {}fn _ fs ft [<- hfsu] fd1 hget.
   have [fd2 hcopy ->] := all_checked hget; exists fd2 => //.
   move=> s1 hinit.
   have [hin hout hex hpar hbody hres] :
@@ -655,7 +654,7 @@ Proof.
   apply wequiv_call_rel_uincl with checker_st_uincl_on X => //.
   + by split => //; clear -hsub; SvD.fsetdec.
   + by split => //; clear -hsub; SvD.fsetdec.
-  by move=> ???; apply hrec.
+  by move=> ???; apply: wequiv_fun_rec.
 Qed.
 
 End IT.

--- a/proofs/compiler/array_expansion_proof.v
+++ b/proofs/compiler/array_expansion_proof.v
@@ -908,9 +908,6 @@ Section CMD.
 
 Context (m:t) (hwf : wf_t m).
 
-Context (hrec : forall ii1 ii2 fn1 fn2,
-   wequiv_f_rec p1 p2 ev ev exp_spec (rpreF (eS:=exp_spec)) ii1 ii2 fn1 fn2 (rpostF (eS:=exp_spec))).
-
 #[ local ]
 Definition Pi_ (i1 : instr) :=
   forall i2, expand_i fsigs m i1 = ok i2 ->
@@ -991,7 +988,7 @@ Proof.
   + move=> s t vs1 vs2 [?? _] [vs2' hvs ->]; split => //; split => //.
     eexists; first exact heq.
     by exists vs2' => //.
-  + by apply hrec.
+  + by move=> ???; apply: wequiv_fun_rec.
   move=> _ _ fr1 fr2 _ /=; apply upd_st_rel.
   move=> vs1 vs2 [_ _ [_ [expd]]]; rewrite heq => -[?]; subst expd => /=.
   move=> [vs' hvs' hflat] s t s' heqa hw; rewrite eq_globs hflat.
@@ -1003,8 +1000,8 @@ End CMD.
 Lemma it_expand_callP_aux fn :
   wiequiv_f p1 p2 ev ev (rpreF (eS:=exp_spec)) fn fn (rpostF (eS:=exp_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs1 fs2 [<-] [hscs hmem] [[expdin expdout] hexpd [vs /= hexpv hflat]] fd hget1.
+  apply wequiv_fun_ind => {}fn _ fs1 fs2 [<-] [hscs hmem] [[expdin expdout]
+    hexpd [vs /= hexpv hflat]] fd hget1.
   have [fd1 [fd2 [m [inout [hget2 hsigs /=]]]]]:= all_checked hget1.
   rewrite /expand_fsig; t_xrbindP => -[mt finf].
   case: fd hget1.
@@ -1034,8 +1031,8 @@ Proof.
     by move=> hin <- _ <- [<-].
   have [s1']:= expand_returnsP hwf heqae (expend_tyv_expand_return hparams) hw hexpv.
   rewrite map_comp -map_flatten -(write_vars_lvals false gd) => -> heqa1.
-  exists s1' => //; exists (eq_alloc m), (eq_alloc m); split => //.
-  + by apply expand_cP.
+  exists s1' => //; exists (eq_alloc m), (eq_alloc m).
+  split=> //; first exact: expand_cP.
   move=> s t fr1 heqa2; rewrite /finalize_funcall /=; t_xrbindP.
   move=> vres hgets vres' {}htr <-; have ? := mapM2_dc_truncate_id htr; subst vres'.
   rewrite -(sem_pexprs_get_var false gd) in hgets.

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -265,8 +265,7 @@ Proof. by apply checker_st_uinclP. Qed.
 
 Lemma it_remove_init_fdP fn : wiequiv_f p p' ev ev (rpreF (eS:= uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
 Proof.
- apply wequiv_fun_ind => hrec {fn}.
- move=> fn _ fs ft [<- hfsu] fd hget.
+ apply wequiv_fun_ind => {}fn _ fs ft [<- hfsu] fd hget.
  exists (remove_init_fd is_reg_array fd).
  + by rewrite get_map_prog hget.
  move=> s hinit.
@@ -311,7 +310,7 @@ Proof.
   + by move=> > hc ii; apply wequiv_for_rel_uincl with checker_st_uincl tt tt.
   + by move=> > ?? ii; apply wequiv_while_rel_uincl with checker_st_uincl tt.
   move=> xs fn es ii; apply wequiv_call_rel_uincl with checker_st_uincl tt => //.
-  by move=> ???; apply hrec.
+ move=> ???; exact/wequiv_fun_rec.
 Qed.
 
 End IT_REMOVE_INIT.
@@ -692,8 +691,7 @@ Qed.
 
 Lemma it_add_init_callP fn : wiequiv_f p p' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
 Proof.
- apply wequiv_fun_ind => hrec {fn}.
- move=> fn _ fs _ [<- <-] fd hget.
+ apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
  exists (add_init_fd fd).
  + by rewrite get_map_prog hget.
  move=> {hget}.

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -1451,8 +1451,7 @@ Qed.
 
 Lemma it_const_prop_callP fn : wiequiv_f p p' ev ev (rpreF (eS:= uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs ft [<- hfsu] fd hget.
+  apply wequiv_fun_ind => {}fn _ fs ft [<- hfsu] fd hget.
   exists (const_prop_fun (p_globs p) fd).
   + by rewrite get_map_prog hget.
   move=> {hget} s1 hinit.
@@ -1590,7 +1589,8 @@ Proof.
     by apply: remove_cpm_write1 hc' => //; rewrite write_i_while; SvD.fsetdec.
   move=> xs f es ii m /=.
   rewrite (surjective_pairing (const_prop_rvs _ _ _)) /=.
-  by apply wequiv_call_rel_uincl with checker_cp m => // ???; apply hrec.
+  apply wequiv_call_rel_uincl with checker_cp m => // ???.
+  exact: wequiv_fun_rec.
 Qed.
 
 End IT_PROOF.

--- a/proofs/compiler/dead_calls_proof.v
+++ b/proofs/compiler/dead_calls_proof.v
@@ -377,8 +377,7 @@ Section PROOF.
   Lemma it_dead_calls_callP fn :
     wiequiv_f p p' ev ev (rpreF (eS:= dc_spec)) fn fn (rpostF (eS:=dc_spec)).
   Proof.
-    apply wequiv_fun_ind => hrec {fn}.
-    move=> fn _ fs _ [<- <- hin] fd hfd; exists fd => //.
+    apply wequiv_fun_ind => {}fn _ fs _ [<- <- hin] fd hfd; exists fd => //.
     + by apply get_dead_calls.
     move=> s hinit.
     exists s=> //; exists (st_eq tt), (st_eq tt); split => //; last by apply st_eq_finalize.
@@ -401,7 +400,7 @@ Section PROOF.
       by apply hc'.
     + move=> >; rewrite !CallsE => hfin.
       apply wequiv_call_rel_eq with checker_st_eq tt => //.
-      move=> ???; apply hrec; split => //.
+      move=> ???; apply: wequiv_fun_rec; split => //.
       by move: hfin; rewrite /def_incl; SfD.fsetdec.
     move=> n hn; apply: pfxp.
     by apply: live_calls_in hfd n hn.

--- a/proofs/compiler/dead_code_proof.v
+++ b/proofs/compiler/dead_code_proof.v
@@ -603,8 +603,7 @@ Section PROOF.
   Lemma it_dead_code_callP fn :
     wiequiv_f p p' ev ev (rpreF (eS:= dc_spec)) fn fn (rpostF (eS:=dc_spec)).
   Proof.
-    apply wequiv_fun_ind => hrec {fn}.
-    move=> fn _ fs ft [<- hfsu] fd hget.
+    apply wequiv_fun_ind => {}fn _ fs ft [<- hfsu] fd hget.
     have dcok : map_cfprog_name (dead_code_fd is_move_op do_nop onfun) (p_funcs p) = ok (p_funcs p').
     + by move: dead_code_ok; rewrite /dead_code_prog_tokeep; t_xrbindP => ? ? <-.
     have [fd' hfd' hget'] := get_map_cfprog_name_gen dcok hget.
@@ -696,7 +695,7 @@ Section PROOF.
       (Rv:=List.Forall2 value_uincl) => //.
     + by rewrite -eq_globs; apply read_es_st_uincl_on; rewrite read_esE; SvD.fsetdec.
     + by move=> > [].
-    + by apply hrec.
+    + move=> >; exact: wequiv_fun_rec.
     move=> _ _ fr1 fr2 _ /=; apply upd_st_rel.
     move=> vs1 vs2 hall.
     apply wrequiv_weaken with (st_uincl_on I) (st_uincl_on O) => //.

--- a/proofs/compiler/direct_call_proof.v
+++ b/proofs/compiler/direct_call_proof.v
@@ -307,8 +307,8 @@ Lemma it_indirect_to_direct fn :
   wiequiv_f (dc1:=indirect_c) (dc2:=direct_c)
     p p ev ev (rpreF (eS:=uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs1 fs2 [<-] [hscs hmem hu] fd hget; exists fd => // s.
+  apply wequiv_fun_ind => {}fn _ fs1 fs2 [<-] [hscs hmem hu] fd hget.
+  exists fd => // s.
   rewrite /initialize_funcall; t_xrbindP => vs htra s0 hinit hw.
   have -> /= := mapM2_dc_truncate_weak hu htra.
   rewrite /estate0 -hscs -hmem hinit /=.
@@ -341,7 +341,7 @@ Proof.
   + by move=> > hc ii; apply wequiv_for_rel_uincl with checker_st_uincl tt tt.
   + by move=> > ?? ii; apply wequiv_while_rel_uincl with checker_st_uincl tt.
   move=> xs fn es ii; apply wequiv_call_rel_uincl with checker_st_uincl tt => //.
-  by move=> ???; apply hrec.
+  by move=> ???; apply: wequiv_fun_rec.
 Qed.
 
 End IT.

--- a/proofs/compiler/inline_proof.v
+++ b/proofs/compiler/inline_proof.v
@@ -663,7 +663,7 @@ Proof.
   move=> fs1 fs2 hpre.
   rewrite (isem_call_inline p1 ev do_inline).
   move: fs1 fs2 hpre.
-  apply wequiv_fun_ind => hrec fn1 _ fs1 fs2 [<- hu] fd1 hfd1.
+  apply wequiv_fun_ind => fn1 _ fs1 fs2 [<- hu] fd1 hfd1.
   have : if fn1 == fn then fd1 = fd /\ get_fundef (p_funcs p2) fn1 = Some fd' else get_fundef (p_funcs p2) fn1 = Some fd1.
   + move: hfd1; rewrite /p1 /p2 /get_fundef /= !assoc_cat.
     move: (uniq_funname); rewrite /pfuncs map_cat cat_uniq => /and3P [_ hhas _].
@@ -686,7 +686,7 @@ Proof.
                          (sem_fun (sem_Fun := sem_fun_rec E) p1 ev ii fn fs).
     + move=> ii fn2 fs /=; rewrite /do_inline; case: eqP => //= ?; reflexivity.
     rewrite (isem_cmd_ext h) => {h}.
-    by move: s t; apply it_sem_uincl_aux => // ii fn2 ???; apply hrec.
+    by move: s t; apply it_sem_uincl_aux => // ?????; apply: wequiv_fun_rec.
   (* Second it works for fn1 *)
   move=> ? [? ->]; subst fn1 fd1; exists fd' => //.
   have : exists2 Xc,
@@ -757,7 +757,7 @@ Proof.
     + by split => //; rewrite !read_writeE; clear; SvD.fsetdec.
     + by split => //; rewrite !read_writeE; clear; SvD.fsetdec.
     move=> i1 i2 h; rewrite /= /do_inline eqxx hinline /=.
-    by apply (hrec ii ii f f i1 i2).
+    exact/(wequiv_fun_rec (p1 := p1) (p2 := p2)).
   rewrite /check_rename.
   t_xrbindP => ffd /get_funP hffd.
   case: ifP => //; set ffd' := rename_fd ii f ffd.
@@ -807,7 +807,7 @@ Proof.
   rewrite -(convertible_assgn_tuple htyin) h.
   clear h => /=.
   rewrite ITree.Eq.Eqit.bind_ret_l isem_cmd_cat.
-  have := [elaborate it_alloc_cP (p1:=p1) (p2:=p2) erefl hrec hc].
+  have := [elaborate it_alloc_cP (p1 := p1) (p2 := p2) ev erefl hc ].
   move=> /wequiv_write2 -/(_ (with_vm s1 vm2)) h.
   apply xrutt_facts.xrutt_bind with
     (fun s2 s3 : estate => evm (with_vm s1 vm2) =[\write_c (f_body ffd')] evm s3 /\ st_eq_alloc r2 s2 s3).

--- a/proofs/compiler/load_constants_in_cond_proof.v
+++ b/proofs/compiler/load_constants_in_cond_proof.v
@@ -411,8 +411,7 @@ Proof. by apply checker_st_eq_onP; rewrite eq_globs. Qed.
 Lemma it_load_constants_progP_aux fn:
   wiequiv_f p p' ev ev (rpreF (eS:=eq_spec)) fn fn (rpostF (eS:=eq_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs _ [<-] <- fd hget.
+  apply wequiv_fun_ind => {}fn _ fs _ [<-] <- fd hget.
   move: Hp; rewrite /load_constants_prog; t_xrbindP => funcs Hmap hp'.
   case: (get_map_cfprog_gen Hmap hget) => fd' Hupdate hget'.
   rewrite -{1}hp' /= hget'.
@@ -481,7 +480,7 @@ Proof.
   apply wequiv_call_rel_eq with checker_st_eq_on X => //.
   + by split => //; SvD.fsetdec.
   + by split => //; SvD.fsetdec.
-  by move=> ???; apply hrec.
+  by move=> ???; apply: wequiv_fun_rec.
 Qed.
 
 End IT.
@@ -509,9 +508,8 @@ Lemma it_load_constants_progP p p' doit:
   ∀ (ev : extra_val_t) (fn : funname),
   wiequiv_f p p' ev ev (rpreF (eS:=eq_spec)) fn fn (rpostF (eS:=eq_spec)).
 Proof.
-  case: doit.
-  + by move=> ??? ; apply it_load_constants_progP_aux.
-  move=> [<-] ??; apply wiequiv_f_eq.
+case: doit; last by move=> [<-] ??; apply wiequiv_f_eq.
+by move=> ???; apply it_load_constants_progP_aux.
 Qed.
 
 End IT.

--- a/proofs/compiler/lower_spill_proof.v
+++ b/proofs/compiler/lower_spill_proof.v
@@ -722,8 +722,7 @@ Qed.
 Lemma it_alloc_callP fn :
   wiequiv_f p p' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs _ [<- <-] fd hget.
+  apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
   have spillok : map_cfprog_name (spill_fd fresh_var_ident) (p_funcs p) = ok (p_funcs p').
   + by move: spill_prog_ok; rewrite /spill_prog; t_xrbindP => ? ? <-.
   have [fd' hfd'1 hfd'2] := get_map_cfprog_name_gen spillok hget.
@@ -824,7 +823,7 @@ Proof.
   apply wequiv_call_rel_eq with (checker_st_ve S) env => //.
   + split => //; SvD.fsetdec.
   + split => //; SvD.fsetdec.
-  by move=> fs fs' <-; apply hrec.
+  move=> fs fs' <-; exact/wequiv_fun_rec.
 Qed.
 
 End IT.

--- a/proofs/compiler/makeReferenceArguments_proof.v
+++ b/proofs/compiler/makeReferenceArguments_proof.v
@@ -719,8 +719,7 @@ Context
   Lemma it_makeReferenceArguments_callP fn :
     wiequiv_f p p' ev ev (rpreF (eS:= mra_spec)) fn fn (rpostF (eS:=mra_spec)).
   Proof.
-    apply wequiv_fun_ind => hrec {fn}.
-    move=> fn _ fs _ [<- <-] fd hget.
+    apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
     move: Hp; rewrite /makereference_prog; t_xrbindP.
     move=> pfuncs' hmap heq.
     have [fd' hfd' hget'] := get_map_cfprog_gen hmap hget.
@@ -806,7 +805,8 @@ Context
     rewrite sem_pl /= Eqit.bind_ret_l.
     rewrite /isem_pexprs eval_args' /= Eqit.bind_ret_l Eqit.bind_bind.
     set fs1 := mk_fstate ves s; set fs2 := mk_fstate ves (with_vm s vmx).
-    apply xrutt_facts.xrutt_bind with (rpostF (eS:=mra_spec) f f fs1 fs2); first by apply (hrec ii ii).
+    apply xrutt_facts.xrutt_bind with (rpostF (eS:=mra_spec) f f fs1 fs2);
+      first exact/(wequiv_fun_rec (ev1 := ev) (ev2 := ev)).
     move=> fr _[<-]; rewrite heq => -[_ [<-] [vres' htr]].
     rewrite /upd_estate.
     case h3 : write_lvals => [s' | e /=]; last first.

--- a/proofs/compiler/propagate_inline_proof.v
+++ b/proofs/compiler/propagate_inline_proof.v
@@ -823,8 +823,7 @@ Section PROOF.
 
   Lemma it_pi_callP fn : wiequiv_f p1 p2 ev ev (rpreF (eS:= uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
   Proof.
-    apply wequiv_fun_ind => hrec {fn}.
-    move=> fn _ fs ft [<- hfsu] fd1 hget.
+    apply wequiv_fun_ind => {}fn _ fs ft [<- hfsu] fd1 hget.
     have [fd2 hfun ->] := all_checked hget.
     exists fd2 => // {hget}.
     have [hin hout hex hpar hres [dc_ hc hbody]] :
@@ -888,7 +887,7 @@ Section PROOF.
     + move=> > [] [h1 h2 h3] hval; split => //.
       by apply/valid_pi_with_scs/valid_pi_remove_m.
     + by rewrite /check_lvals /= /check_lvals_pi heq.
-    by move=> fs1 fs2 hpre; apply hrec.
+    by move=> ???; apply: wequiv_fun_rec.
   Qed.
 
   End IT.

--- a/proofs/compiler/remove_globals_proof.v
+++ b/proofs/compiler/remove_globals_proof.v
@@ -251,9 +251,8 @@ Module INCL. Section INCL.
 
   Lemma it_gd_incl_fun fn : wiequiv_f P1 P2 ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
   Proof.
-    apply wequiv_fun_ind => hrec {fn}.
-    move=> fn _ fs ft [<- <-] fd ->; exists fd => // s1 hinit.
-    exists s1 => //.
+    apply wequiv_fun_ind => {}fn _ fs ft [<- <-] fd ->.
+    exists fd => // s1 hinit; exists s1 => //.
     exists (st_equal tt), (st_equal tt); split => //; last by move=> s t vs /st_equalP <- ->; eexists; eauto.
     move: (f_body fd) => {fn fs ft fd s1 hinit}.
     apply (cmd_rect (Pr := Pi_r) (Pi:=Pi) (Pc:=Pc)) => //.
@@ -266,7 +265,7 @@ Module INCL. Section INCL.
     + by move=> > hc ii; apply wequiv_for_rel_eq with checker_equal tt tt.
     + by move=> > hc hc' ii; apply wequiv_while_rel_eq with checker_equal tt.
     move=> ????; apply wequiv_call_rel_eq with checker_equal tt => //.
-    by move=> ???; apply hrec.
+    by move=> ???; apply: wequiv_fun_rec.
   Qed.
 
   End IT.
@@ -911,8 +910,7 @@ Module RGP. Section PROOFS.
 
   Lemma it_remove_glob_call fn : wiequiv_f P P' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
   Proof.
-    apply wequiv_fun_ind => hrec {fn}.
-    move=> fn _ fs _ [<- <-] fd hget.
+    apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
     have [fd' [hget' hfd']]:= get_fundefP hget.
     exists fd' => //.
     move: hfd'; rewrite /remove_glob_fundef; t_xrbindP => _tt hparams res1 hres1 [m' c'] hrm ?;subst fd' => /=.
@@ -967,7 +965,7 @@ Module RGP. Section PROOFS.
     move=> xs fn es ii d dc_ /=; t_xrbindP => xs' hxs' es' hes' <- /=.
     apply wequiv_call_rel_eq_R with (checker_valid ii) d d => //.
     + by move=> > []. + by move=> > [?????].
-    by move=> ?? <-; apply hrec.
+    by move=> ?? <-; apply: wequiv_fun_rec.
   Qed.
 
   End IT.

--- a/proofs/compiler/riscv_lower_addressing_proof.v
+++ b/proofs/compiler/riscv_lower_addressing_proof.v
@@ -435,8 +435,7 @@ Proof. apply checker_st_eq_onP; apply eq_globs. Qed.
 Lemma it_lower_addressing_progP fn:
   wiequiv_f p p' ev ev (rpreF (eS:=eq_spec)) fn fn (rpostF (eS:=eq_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs _ [<-] <- fd hget.
+  apply wequiv_fun_ind => {}fn _ fs _ [<-] <- fd hget.
   move: ok_p'; rewrite /lower_addressing_prog.
   set tmp := {| v_var := _; v_info := _ |}.
   t_xrbindP=> funcs ok_funcs hp'.
@@ -503,7 +502,7 @@ Proof.
   apply (wequiv_call_rel_eq (sip:=sip)) with checker_st_eq_on X => //.
   + by split => //; SvD.fsetdec.
   + by split => //; SvD.fsetdec.
-  by move=> ???; apply hrec.
+  by move=> ???; apply: (wequiv_fun_rec (spec := eq_spec)).
 Qed.
 
 End IT.

--- a/proofs/compiler/riscv_lowering_proof.v
+++ b/proofs/compiler/riscv_lowering_proof.v
@@ -778,8 +778,7 @@ Proof. apply checker_st_eqP => //. Qed.
 Lemma it_lower_callP fn :
   wiequiv_f p p' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs _ [<- <-] fd hget.
+  apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
   rewrite get_map_prog hget /= /lower_fd.
   eexists; first reflexivity.
   move=> s.
@@ -822,7 +821,7 @@ Proof.
   (* Call *)
   move=> xs fn es ii /=.
   apply (wequiv_call_rel_eq (sip:=sip)) with checker_st_eq tt => //.
-  by move=> ???; apply hrec.
+  by move=> ???; apply: (wequiv_fun_rec (spec := eq_spec)).
 Qed.
 
 End IT.

--- a/proofs/compiler/slh_lowering_proof.v
+++ b/proofs/compiler/slh_lowering_proof.v
@@ -1415,12 +1415,9 @@ eapply wequiv_weaken;
 move=> ??; exact: env_le_st_eq hle2.
 Qed.
 
-Lemma lower_it_call xs fn es :
-  (forall ii1 ii2 fn1 fn2,
-      wequiv_f_rec p p' ev ev slh_spec rpreF ii1 ii2 fn1 fn2 rpostF) ->
-  Pi_r (Ccall xs fn es).
+Lemma lower_it_call xs fn es : Pi_r (Ccall xs fn es).
 Proof.
-move=> hind ii env env' /=; rewrite (surjective_pairing (fun_info _)).
+move=> ii env env' /=; rewrite (surjective_pairing (fun_info _)).
 t_xrbindP=> _ _ ? hchkes hchkxs <- <-; apply (
   wequiv_call
     (Pf := rpreF)
@@ -1430,22 +1427,19 @@ t_xrbindP=> _ _ ? hchkes hchkxs <- <-; apply (
 - rewrite hp_globs => s _ vs [<- hwf] hsemes /=; exists vs => //; split=> //.
   exact: check_f_argsP hwf hchkes hsemes.
 - by move=> s _ vs _ [<- _] [<- hvs].
-- exact: hind.
-  move=> fs _ fr _ [_ <- hpre] [<- hpos] s _ s' [<- [hmsf hvars]] hwrite.
-  exists s'; first (by rewrite hp_globs); split=> //.
-  apply: (check_f_lvsP _ hchkxs hpos hwrite); split=> //.
-  case: Env.cond hvars => [c|//] [hsemc hmem]; split=> //.
+- by move=> ???; apply: wequiv_fun_rec.
+move=> fs _ fr _ [_ <- hpre] [<- hpos] s _ s' [<- [hmsf hvars]] hwrite.
+exists s'; first (by rewrite hp_globs); split=> //.
+apply: (check_f_lvsP _ hchkxs hpos hwrite); split=> //.
+case: Env.cond hvars => [c|//] [hsemc hmem]; split=> //.
 by rewrite (use_memP _ (s2 := s) _ _ hmem).
 Qed.
 
 Lemma it_lower_code c c' env env' :
-  (forall ii1 ii2 fn1 fn2,
-      wequiv_f_rec p p' ev ev slh_spec rpreF ii1 ii2 fn1 fn2 rpostF) ->
   check_cmd fun_info env c = ok env' ->
   lower_cmd c = ok c' ->
   wequiv_rec p p' ev ev slh_spec (st_eq env) c c' (st_eq env').
 Proof.
-move=> hind.
 apply: (cmd_rect (Pr := Pi_r) (Pi := Pi) (Pc := Pc)) c env env' c' => //;
   [ | | |
   | exact: it_lower_opn
@@ -1453,7 +1447,7 @@ apply: (cmd_rect (Pr := Pi_r) (Pi := Pi) (Pc := Pc)) c env env' c' => //;
   | exact: lower_it_if
   | exact: lower_it_for
   | exact: lower_it_while
-  | move=> ???; exact: lower_it_call hind ].
+  | move=> ???; exact: lower_it_call ].
 
 (* MkI *)
 - move=> i ii hi env env' [ii' i'] hchecki hloweri. exact: hi hchecki hloweri.
@@ -1486,7 +1480,7 @@ Qed.
 
 Lemma it_lower_call {fn} : wiequiv_f p p' ev ev rpreF fn fn rpostF.
 Proof.
-apply: wequiv_fun_ind => hind {}fn _ fs _ [<- <- htin] fd
+apply: wequiv_fun_ind => {}fn _ fs _ [<- <- htin] fd
   /(get_map_cfprog_name_gen hp_body) [] fd' /lower_fdP [].
 rewrite /check_fd /= (surjective_pairing (fun_info _)).
 t_xrbindP=> env henv env' hchk htout _ _ htyin hparams hlower htyout hret hextra
@@ -1506,7 +1500,7 @@ exists (st_eq env), (st_eq env'); split => //.
   by have := size_mapM2 hargs; rewrite size_map => -[-> _].
 
 (* Body *)
-- exact: it_lower_code hind hchk hlower.
+- exact: it_lower_code hchk hlower.
 
 (* Finalize *)
 clear s hs fs htin; move=> s _ fs [<- hwf].

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -4257,11 +4257,8 @@ Proof.
   by apply: subset_vars_wft_DEF hvs'.(vs_wf_table).(wft_def).
 Qed.
 
-Lemma it_check_cP_aux :
-  (∀ ii1 ii2 fn1 fn2, wequiv_f_rec P P' tt rip sa_spec (rpreF (eS:=sa_spec)) ii1 ii2 fn1 fn2 (rpostF (eS:=sa_spec))) ->
-  forall c1, Pc c1.
+Lemma it_check_cP_aux : forall c1, Pc c1.
 Proof.
-  move=> hrec.
   apply (cmd_rect (Pr:=Pi_r) (Pi:=Pi) (Pc:=Pc)) => //; subst Pi_r Pc Pi => /=.
   + move=> table1 rmap1 table2 rmap2 vme _ [<- <- <-] _.
     by apply wequiv_nil; exists vme.
@@ -4439,7 +4436,7 @@ Proof.
     by exists vargs2 => //; rewrite P'_globs.
   + move=> _ _ vargs1 vargs2 [-> ->] [hargs heqinmems haddr hvarsz hclear] {Rv}.
     split => //; first by apply hvs.(vs_scs).
-  + by apply hrec.
+  + by move=> ???; apply: wequiv_fun_rec.
   (* after function call, we have [valid_state] for [rmap1] where all writable arguments
      have been cleared.
   *)
@@ -4555,7 +4552,7 @@ End CMD.
 
 Lemma it_check_cP fn : wiequiv_f P P' tt rip (rpreF (eS:=sa_spec)) fn fn (rpostF (eS:=sa_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {}fn _ [scs1 m1 vargs1] [_ m2 vargs2] [<- /= <-] hext hargs heqinmem_args hok fd hfd.
+  apply wequiv_fun_ind => {}fn _ [scs1 m1 vargs1] [_ m2 vargs2] [<- /= <-] hext hargs heqinmem_args hok fd hfd.
   have [fd2 halloc hfd2] := Halloc_fd hfd.
   exists fd2 => //.
 

--- a/proofs/compiler/unrolling_proof.v
+++ b/proofs/compiler/unrolling_proof.v
@@ -234,8 +234,8 @@ Section PROOF.
   Lemma it_unroll_callP fn :
     wiequiv_f p p' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
   Proof.
-    apply wequiv_fun_ind => hrec {fn}.
-    move=> fn _ fs _ [<- <-] fd hfd; exists (unroll_fun (fn, fd)).1.2.
+    apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hfd.
+    exists (unroll_fun (fn, fd)).1.2.
     + by apply: p'_get_fundef hfd.
     move=> s {hfd}.
     case: fd => /= finfo ftyin fparams fbody ftyout fres fextra.
@@ -277,7 +277,7 @@ Section PROOF.
       by apply wkequiv_bind with (st_eq tt).
     + by move=> > hc hc' ii /=; surjpairing; apply wequiv_while_rel_eq with checker_st_eq tt.
     move=> ???? /=; surjpairing; apply wequiv_call_rel_eq with checker_st_eq tt => //.
-    by move=> ??<-; apply hrec.
+    by move=> ???; apply: wequiv_fun_rec.
   Qed.
 
   End IT.

--- a/proofs/compiler/wint_word_proof.v
+++ b/proofs/compiler/wint_word_proof.v
@@ -429,8 +429,7 @@ Let Pc c :=
 Lemma it_wi2w_call_internalP fn :
   wiequiv_f p p' ev ev (rpreF (eS:= uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs ft [<- hfsu] fd hget.
+  apply wequiv_fun_ind => {}fn _ fs ft [<- hfsu] fd hget.
   exists (wi2w_fun fd).
   + by rewrite get_map_prog hget.
   move=> s hinit.
@@ -449,7 +448,7 @@ Proof.
   + by move=> v dir lo hi c hc ii; apply wequiv_for_rel_uincl with checker_wi2w tt tt.
   + by move=> a c e ii' c' hc hc' ii; apply wequiv_while_rel_uincl with checker_wi2w tt.
   move=> xs f es ii; apply wequiv_call_rel_uincl with checker_wi2w tt => //.
-  by move=> ?? hu; apply hrec.
+  by move=> ???; apply: wequiv_fun_rec.
 Qed.
 
 End IT.

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -2017,8 +2017,7 @@ Section PROOF.
   Lemma it_lower_callP fn :
     wiequiv_f p p' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
   Proof.
-    apply wequiv_fun_ind => hrec {fn}.
-    move=> fn _ fs _ [<- <-] fd hget.
+    apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
     have := fvars_fun hget.
     move=> /disjoint_union [Hdisjp /disjoint_union [Hdisjr Hdisjc]].
     rewrite get_map_prog hget /= /lower_fd.
@@ -2078,7 +2077,7 @@ Section PROOF.
     (* Call *)
     move=> xs fn es ii /disj_fvars_vars_I_Ccall [hdisjx hdisje] /=.
     apply (wequiv_call_rel_eq (sip:=sip)) with checker_st_eq_ex fvars => //.
-    by move=> ???; apply hrec.
+    by move=> ???; apply: (wequiv_fun_rec (spec := eq_spec)).
   Qed.
 
   End IT.

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -745,15 +745,13 @@ Proof.
   eexists; eauto.
 Qed.
 
-Lemma wiequiv_f_eq fn : wiequiv_f p p ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
+Lemma wiequiv_f_eq fn :
+  wiequiv_f p p ev ev (rpreF (eS := eq_spec)) fn fn (rpostF (eS := eq_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs _ [<- <-] fd hget.
-  exists fd => //.
-  move=> s1; exists s1 => //.
-  exists (st_eq tt), (st_eq tt); split => //.
-  + by apply wequiv_rec_st_eq.
-  by apply st_eq_finalize.
+apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
+exists fd => // s1 ?; exists s1 => //; exists (st_eq tt), (st_eq tt).
+split=> //; first exact/wequiv_rec_st_eq.
+exact/st_eq_finalize.
 Qed.
 
 Lemma wiequiv_st_eq c : wiequiv p p ev ev (st_eq tt) c c (st_eq tt).
@@ -1585,13 +1583,11 @@ Qed.
 Lemma it_sem_uincl_f fn :
   wiequiv_f p p ev ev (rpreF (eS:= uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
 Proof.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> {}fn _ fs1 fs2 [<-] hu fd ->; exists fd => //.
-  move=> s /(fs_uincl_initialize erefl erefl erefl erefl hu) [t] -> {}hu; exists t => //.
-  exists (st_uincl tt), (st_uincl tt); split => //.
-  + apply it_sem_uincl_aux => //.
-    by move=> ii fn' fs1' fs2' h; apply hrec.
-  by apply: fs_uincl_finalize.
+apply wequiv_fun_ind => {}fn _ fs1 fs2 [<-] hu fd ->.
+exists fd => // s /(fs_uincl_initialize erefl erefl erefl erefl hu) [t] -> {}hu.
+exists t => //; exists (st_uincl tt), (st_uincl tt); split=> //.
++ apply it_sem_uincl_aux => // ii fn' fs1' fs2' h; exact/wequiv_fun_rec.
+exact/fs_uincl_finalize.
 Qed.
 
 Lemma it_sem_uincl c :

--- a/proofs/lang/psem_of_sem_proof.v
+++ b/proofs/lang/psem_of_sem_proof.v
@@ -339,8 +339,7 @@ Lemma it_psem_call :
     wiequiv_f (wsw1:=nosubword) (wsw2:=withsubword) p p ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
 Proof.
   move=> hsyscall hinitstate hfinal fn.
-  apply wequiv_fun_ind => hrec {fn}.
-  move=> fn _ fs _ [<- <-] fd ->; exists fd => // s1 hinit.
+  apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd ->; exists fd => // s1 hinit.
   have : exists2 s2 : estate_s, initialize_funcall p ev fd fs = ok s2 & estate_sim s1 s2.
   + move: hinit; rewrite /initialize_funcall.
     t_xrbindP => > -> s1' /hinitstate [s2'] /= -> hs hw.
@@ -369,7 +368,7 @@ Proof.
   + by move=> > hc ii; apply wequiv_for_rel_eq with checker_st_eq tt tt.
   + by move=> > hc hc' ii; apply wequiv_while_rel_eq with checker_st_eq tt.
   move=> ????; apply wequiv_call_rel_eq with checker_st_eq tt => //.
-  by move=> ?? <-; apply hrec.
+  by move=> ?? <-; apply: wequiv_fun_rec.
 Qed.
 
 End IT_SEM.

--- a/proofs/lang/relational_logic.v
+++ b/proofs/lang/relational_logic.v
@@ -1802,15 +1802,16 @@ Notation isem_fun_def2 := (isem_fun_def (wsw:=wsw2) (dc:=dc2) (ep:=ep) (spp:=spp
 Notation wiequiv_f rpreF fn1 fn2 rpostF :=
    (wkequiv_io (rpreF fn1 fn2) (isem_fun_def1 p1 ev1 fn1) (isem_fun_def2 p2 ev2 fn2) (rpostF fn1 fn2)).
 
+Lemma wequiv_fun_rec ii1 ii2 fn1 fn2 :
+  wequiv_f_rec rpreF ii1 ii2 fn1 fn2 rpostF.
+Proof. move=> fs1' fs2' hpre'; exact/xrutt_trigger. Qed.
+
 Lemma wequiv_fun_ind :
-  ((forall ii1 ii2 fn1 fn2, wequiv_f_rec rpreF ii1 ii2 fn1 fn2 rpostF) ->
-   (forall fn1 fn2, wequiv_fun_body_hyp_rec rpreF fn1 fn2 rpostF)) ->
+  (forall fn1 fn2, wequiv_fun_body_hyp_rec rpreF fn1 fn2 rpostF) ->
   forall fn1 fn2,
   wiequiv_f rpreF fn1 fn2 rpostF.
 Proof.
-  have hrec : (forall ii1 ii2 fn1 fn2, wequiv_f_rec rpreF ii1 ii2 fn1 fn2 rpostF).
-  + by move=> ii1 ii2 fn1' fn2' fs1' fs2' hpre'; apply xrutt_trigger.
-  move=> /(_ hrec) hbody fn1 fn2 fs1 fs2 hpre.
+  move=> hbody fn1 fn2 fs1 fs2 hpre.
   apply interp_mrec_xrutt with (RPreInv := (@RPreD spec))
                                (RPostInv := (@RPostD spec)).
   + move=> {hpre fn1 fn2 fs1 fs2}.
@@ -1822,7 +1823,6 @@ Proof.
 Qed.
 
 End REC.
-
 
 Definition wequiv_rec P c1 c2 Q :=
   wequiv (rE0:=relEvent_recCall spec) p1 p2 ev1 ev2 P c1 c2 Q.
@@ -1864,6 +1864,8 @@ Qed.
 End WEQUIV_FUN.
 
 End RELATIONAL.
+
+Arguments wequiv_fun_rec {_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _}.
 
 (* Notation wiequiv_f := (wequiv_f (sem_F1 := sem_fun_full) (sem_F2 := sem_fun_full)). *)
 Notation wiequiv   := (wequiv (sem_F1 := sem_fun_full) (sem_F2 := sem_fun_full)).


### PR DESCRIPTION
# Description

In `relational_logic.v`, the hypothesis of `wequiv_fun_ind` was an implication, but the left-hand side of that was proven to always hold. I removed it and updated all the uses of `wequiv_fun_ind`.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed