### PR TITLE
CI: use EasyCrypt 2025.11

### DIFF
--- a/changes/01-feature/1319-easycrypt-2025.11.md
+++ b/changes/01-feature/1319-easycrypt-2025.11.md
@@ -1,0 +1,2 @@
+- Extraction as EasyCrypt code targets version 2025.11
+  ([PR #1319](https://github.com/jasmin-lang/jasmin/pull/1319)).

--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -140,6 +140,8 @@ let ec_keyword =
  ; "clear"
  ; "wlog"
 
+ ; "idassign"
+
  (* Auto tactics *)
  ; "apply"
  ; "rewrite"

--- a/scripts/easycrypt.nix
+++ b/scripts/easycrypt.nix
@@ -18,13 +18,13 @@ with {
   };
 
   "release" = rec {
-    version = "2025.10";
+    version = "2025.11";
     rev = "r${version}";
     src = fetchFromGitHub {
       owner = "easycrypt";
       repo = "easycrypt";
       inherit rev;
-      hash = "sha256-EF508JsM99lLIqTrWkV/gvlKYRSPQgaLfqxDoOkJbhU=";
+      hash = "sha256-BLyC8AB075Nyhb5heIKVkxnWWt4Zn8Doo10ShsACJ4g=";
     };
   };
 


### PR DESCRIPTION
# Description

Update to latest EasyCrypt (new keyword: `idassign`: https://github.com/EasyCrypt/easycrypt/pull/823).

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
