### PR TITLE
Tests: remove redundant script check-cct

### DIFF
--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -6,19 +6,19 @@ args   = -arch x86-64 -nolea
 kodirs = tests/fail/nolea/x86-64
 
 [test-CCT]
-bin    = ./scripts/check-cct
+bin    = ./jasmin-ct
 okdirs = CCT/success
 kodirs = CCT/fail
 exclude = CCT/success/doit CCT/fail/doit
 
 [test-CCT-DOIT]
-bin    = ./scripts/check-cct
+bin    = ./jasmin-ct
 args = --doit
 okdirs = CCT/success/doit
 kodirs = CCT/fail/doit
 
 [test-SCT]
-bin    = ./scripts/check-cct
+bin    = ./jasmin-ct
 args = --speculative --after=rmfunc
 okdirs = CCT/success/speculative
 

--- a/compiler/scripts/check-cct
+++ b/compiler/scripts/check-cct
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -ex
-
-exec $(dirname $0)/../jasmin-ct "$@"


### PR DESCRIPTION
Unless I’m mistaken, this file is not very useful…