### PR TITLE
Stack-alloc: turn dead-code into error

### DIFF
--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -1017,7 +1017,7 @@ Fixpoint alloc_e (e:pexpr) ty :=
     Let e1 := alloc_e e1 aint in
     Let vk := get_var_kind x in
     match vk with
-    | None => Let _ := check_diff xv in ok (Pget al aa ws x e1)
+    | None => Error (stk_ierror_basic xv "register array remains")
     | Some vpk =>
       Let: (sr, status) := get_gsub_region_status rmap xv vpk in
       Let _ := check_valid xv status in

--- a/proofs/compiler/stack_alloc_proof_1.v
+++ b/proofs/compiler/stack_alloc_proof_1.v
@@ -1525,9 +1525,7 @@ Section EXPR.
       t_xrbindP=> i' hv' ?; subst i'.
       have h0 : sem_pexpr true [::] s' e1' >>= to_int = ok i.
       + by rewrite he1' /= hv'.
-      move=> [vpk | ]; last first.
-      + t_xrbindP => h /check_diffP h1 <- /=.
-        by rewrite (get_var_kindP h h1 hget) /= h0 /= hw.
+      move=> [vpk | ]; last by [].
       t_xrbindP=> hgvk [sr status] hgsub.
       t_xrbindP=> hcvalid halign [xi ofsi] haddr [<-] /=.
       have hgvalid := get_gsub_region_statusP hgvk hgsub.


### PR DESCRIPTION
Minor cleaning.
