### PR TITLE
Warn when dead-vars finds duplicate i-locs

### DIFF
--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -342,7 +342,14 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       end;
       let (in_set, out_set) = i.i_info in
       let s = Conv.csv_of_sv (Sv.diff in_set out_set) in
-      Hashtbl.add hvars i.i_loc s
+      if Hashtbl.mem hvars i.i_loc then begin
+          (* If there is an entry already, the i_locs have duplicates:
+             this should not happen, hence the warning, but we can safely continue by
+             assuming that no variable dies here *)
+          Utils.warning Always i.i_loc "Bug! Please report.";
+          Hashtbl.replace hvars i.i_loc Var0.SvExtra.Sv.empty
+      end else
+        Hashtbl.add hvars i.i_loc s
     in
     List.iter analyze live.f_body;
 


### PR DESCRIPTION
The current implementation of `dead_vars_fd` relies on the fact that i-locs are unique (which is fine). If, due to a bug, there are duplicate i-locs, the behavior of the compiler becomes strange and error messages are unhelpful (usually the allocation checker discards useful information and then blames the program with a dogmatic “variable already set”).

This PR improves the situation in two complementary ways:

1. duplicate i-locs are detected, so that a bug can be filed
2. dead-vars-fd will be correct (but maybe less precise) in this situation, so that the compiler is still usable.
