### PR TITLE
Print less brackets

### DIFF
--- a/changes/03-other/1340-print-less-brackets.md
+++ b/changes/03-other/1340-print-less-brackets.md
@@ -1,0 +1,3 @@
+- Pretty-printing of Jasmin programs and expressions use less parentheses,
+  taking into account priority and associativity of operators
+  ([PR #1340](https://github.com/jasmin-lang/jasmin/pull/1340)).

--- a/compiler/safety/run.expected
+++ b/compiler/safety/run.expected
@@ -78,7 +78,7 @@ Analyzing function main
 
 
 *** Possible Safety Violation(s):
-  "fail/bad_align.jazz", line 6 (2-30): aligned pointer (pt +64u ((64u) 1)) u64
+  "fail/bad_align.jazz", line 6 (2-30): aligned pointer pt +64u (64u) 1 u64
   
 Memory ranges:
   mem_pt: [0; 9]
@@ -114,7 +114,7 @@ Analyzing function uninit
 
 
 *** Possible Safety Violation(s):
-  "fail/bounded_while.jazz", line 15 (2-17): is_init t[(4 - 1)]
+  "fail/bounded_while.jazz", line 15 (2-17): is_init t[4 - 1]
   
 Memory ranges:
   mem_bound: [0; 0]
@@ -276,7 +276,7 @@ Analyzing function f
 
 
 *** Possible Safety Violation(s):
-  "fail/not_in_bounds.jazz", line 2 (2-12): in_bound: t[(- 1)] (length 16 U8)
+  "fail/not_in_bounds.jazz", line 2 (2-12): in_bound: t[- 1] (length 16 U8)
   "fail/not_in_bounds.jazz", line 3 (2-11): in_bound: t[2] (length 16 U8)
   
 Memory ranges:
@@ -312,7 +312,7 @@ Analyzing function undefined
 
 
 *** Possible Safety Violation(s):
-  "fail/shld.jazz", line 2 (2-30): (((uint) ((8u) 17)) % 32) ∈ [0; 16]
+  "fail/shld.jazz", line 2 (2-30): (uint) (8u) 17 % 32 ∈ [0; 16]
   
 Memory ranges:
   mem_x: [0; 0]

--- a/compiler/src/printCommon.ml
+++ b/compiler/src/printCommon.ml
@@ -242,3 +242,74 @@ let pp_var fmt x =
   fprintf fmt "%s" y.v_name
 
 let pp_var_i fmt x = pp_var fmt x.E.v_var
+
+(* -------------------------------------------------------------------- *)
+type priority =
+  | OpPmin
+  | OpPternary
+  | OpPbor
+  | OpPband
+  | OpPeq
+  | OpPcmp
+  | OpPor
+  | OpPxor
+  | OpPand
+  | OpPshift
+  | OpPsum
+  | OpPprod
+  | OpPunary
+
+let priority_min = OpPmin
+let priority_ternary = OpPternary
+
+let priority_of_wop1 = function
+  | E.WIwint_of_int _ | WIint_of_wint _ | WIword_of_wint _ | WIwint_of_word _
+  | WIwint_ext _ ->
+      OpPunary
+  | WIneg _ -> OpPsum
+
+let priority_of_op1 = function
+  | E.Oword_of_int _ | Oint_of_word _ | Osignext _ | Ozeroext _ | Onot | Olnot _
+    ->
+      OpPunary
+  | Oneg _ -> OpPsum
+  | Owi1 (_, iop) -> priority_of_wop1 iop
+
+let priority_of_wop2 = function
+  | Expr.WIadd | WIsub -> OpPsum
+  | WImul | WIdiv | WImod -> OpPprod
+  | WIshl | WIshr -> OpPshift
+  | WIeq | WIneq -> OpPeq
+  | WIlt | WIle | WIgt | WIge -> OpPcmp
+
+let priority_of_op2 = function
+  | Expr.Obeq | Oeq _ | Oneq _ -> OpPeq
+  | Oand -> OpPband
+  | Oor -> OpPbor
+  | Oadd _ | Osub _ | Ovadd _ | Ovsub _ -> OpPsum
+  | Omul _ | Odiv _ | Omod _ | Ovmul _ -> OpPprod
+  | Oland _ -> OpPand
+  | Olor _ -> OpPor
+  | Olxor _ -> OpPxor
+  | Olsr _ | Olsl _ | Oasr _ | Oror _ | Orol _ | Ovlsr _ | Ovlsl _ | Ovasr _ ->
+      OpPshift
+  | Olt _ | Ole _ | Ogt _ | Oge _ -> OpPcmp
+  | Owi2 (_, _, iop) -> priority_of_wop2 iop
+
+type associativity = Left | NoAssoc | Right
+
+let associativity = function
+  | OpPmin | OpPternary -> NoAssoc
+  | OpPbor | OpPband | OpPeq | OpPcmp | OpPor | OpPxor | OpPand | OpPshift
+  | OpPsum | OpPprod ->
+      Left
+  | OpPunary -> Right
+
+let same_side a b =
+  match (a, b) with Left, Left | Right, Right -> true | _, _ -> false
+
+let optparent fmt ctxt side prio =
+  kdprintf (fun pp ->
+      if prio < ctxt || ((not (same_side (associativity ctxt) side)) && prio = ctxt)
+      then fprintf fmt "(%t)" pp
+      else pp fmt)

--- a/compiler/src/printCommon.mli
+++ b/compiler/src/printCommon.mli
@@ -61,3 +61,32 @@ val pp_ty : Format.formatter -> Prog.ty -> unit
 val pp_datas : Format.formatter -> Obj.t list -> unit
 val pp_var : Format.formatter -> Var0.Var.var -> unit
 val pp_var_i : Format.formatter -> Expr.var_i -> unit
+
+type priority
+(** Priority levels of operators *)
+
+type associativity = Left | NoAssoc | Right  (** Associativity of operators *)
+
+val associativity : priority -> associativity
+(** Associativity of a priority level *)
+
+val priority_min : priority
+(** Minimal priority level *)
+
+val priority_of_op1 : Expr.sop1 -> priority
+(** Priority level of unary operators *)
+
+val priority_of_op2 : Expr.sop2 -> priority
+(** Priority level of binary operators *)
+
+val priority_ternary : priority
+(** Priority level of the ternary “_ ? _ : _” operator *)
+
+val optparent :
+  Format.formatter ->
+  priority ->
+  associativity ->
+  priority ->
+  ('a, Format.formatter, unit) format ->
+  'a
+(** Print within optional enclosing parentheses. *)

--- a/compiler/src/printFexpr.ml
+++ b/compiler/src/printFexpr.ml
@@ -1,24 +1,27 @@
 open Fexpr
 open PrintCommon
 
-let rec pp_fexpr fmt = function
+let rec pp_fexpr side prio fmt = function
   | Fconst z -> Z.pp_print fmt (Conv.z_of_cz z)
   | Fvar x -> pp_var_i fmt x
   | Fapp1 (op, e) ->
+      let p = priority_of_op1 op in
       (* no casts left at this stage, so the value of [debug] has no impact *)
-      Format.fprintf fmt "(%s %a)" (string_of_op1 ~debug:false op) pp_fexpr e
-  | Fapp2 (op, e1, e2) -> Format.fprintf fmt "(%a %s %a)" pp_fexpr e1 (string_of_op2 op) pp_fexpr e2
-  | Fif (c, e1, e2) -> Format.fprintf fmt "(%a ? %a : %a)" pp_fexpr c pp_fexpr e1 pp_fexpr e2
+      let sop = string_of_op1 ~debug:false op in
+      optparent fmt prio side p "%s %a" sop (pp_fexpr NoAssoc p) e
+  | Fapp2 (op, e1, e2) ->
+      let p = priority_of_op2 op in
+      optparent fmt prio side p "%a %s %a" (pp_fexpr Left p) e1 (string_of_op2 op) (pp_fexpr Right p) e2
+  | Fif (c, e1, e2) ->
+      let p = priority_ternary in
+      optparent fmt prio side p "%a ? %a : %a" (pp_fexpr Left p) c (pp_fexpr NoAssoc p) e1 (pp_fexpr Right p) e2
 
-let pp_rexpr fmt =
-  function
+let pp_fexpr = pp_fexpr NoAssoc priority_min
+
+let pp_rexpr fmt = function
   | Rexpr e -> pp_fexpr fmt e
-  | Load (al, sz, e) ->
-    pp_mem_access pp_fexpr fmt al (Some sz) e
+  | Load (al, sz, e) -> pp_mem_access pp_fexpr fmt al (Some sz) e
 
-let pp_lexpr fmt =
-  function
+let pp_lexpr fmt = function
   | LLvar x -> pp_var_i fmt x
-  | Store (al, sz, e) ->
-    pp_mem_access pp_fexpr fmt al (Some sz) e
-
+  | Store (al, sz, e) -> pp_mem_access pp_fexpr fmt al (Some sz) e

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -48,7 +48,7 @@ fail/arm-m4/add_shift.jazz:
 
 "fail/arm-m4/add_shift.jazz", line 4 (2-20):
 compilation error in function main:
-asmgen: invalid rexpr for oprd (r1 <<32u ((8u) 50))
+asmgen: invalid rexpr for oprd r1 <<32u (8u) 50
         invalid rexpr for word
 
 fail/arm-m4/addw_set_flags.jazz:
@@ -116,7 +116,7 @@ fail/arm-m4/bug_667.jazz:
 "fail/arm-m4/bug_667.jazz", line 9 (2-16):
 compilation error in function main:
 asmgen: the address computation is too complex
-          (sp +32u ((((32u) 4) *32u r0) +32u ((32u) 4)))
+          sp +32u ((32u) 4 *32u r0 +32u (32u) 4)
         an intermediate variable might be needed
 
 fail/arm-m4/cmp_imm_too_large.jazz:
@@ -388,7 +388,7 @@ fail/array_expansion/x86-64/param_not_array.jazz:
 "fail/array_expansion/x86-64/param_not_array.jazz", line 19 (2-32):
 compilation error in function main:
 array expansion: cannot expand expression
-  (cf ? r[0 : 2] : r[1 : 2])
+  cf ? r[0 : 2] : r[1 : 2]
 Only variables and sub-arrays can be expanded in function arguments.
 
 fail/array_expansion/x86-64/sub_array.jazz:
@@ -456,7 +456,7 @@ fail/asmgen/arm-m4/address_too_complex.jazz:
 "fail/asmgen/arm-m4/address_too_complex.jazz", line 2 (2-23):
 compilation error in function f:
 asmgen: the address computation is too complex
-          (r0 +32u ((((32u) 4) *32u (r1 +32u ((32u) 2))) +32u ((32u) 0)))
+          r0 +32u ((32u) 4 *32u (r1 +32u (32u) 2) +32u (32u) 0)
         an intermediate variable might be needed
 
 fail/asmgen/x86-64/incompatible_args.jazz:
@@ -464,7 +464,7 @@ fail/asmgen/x86-64/incompatible_args.jazz:
 "fail/asmgen/x86-64/incompatible_args.jazz", line 4 (2-14):
 compilation error in function main:
 linearization: The following assignment remains:
-[#aligned :u128 (RSP +64u ((64u) 0))] = ((128u) 3000000)
+[#aligned :u128 RSP +64u (64u) 0] = (128u) 3000000
 Is there an instruction in the target architecture that can implement it?
 More information may be found online: https://jasmin-lang.readthedocs.io/en/stable/misc/faq.html#linearization
 
@@ -472,7 +472,7 @@ fail/asmgen/x86-64/invalid_scale.jazz:
 
 "fail/asmgen/x86-64/invalid_scale.jazz", line 2 (2-25):
 compilation error in function f:
-asmgen: Invalid address:  (RDI +64u ((((64u) 8) *64u ((((64u) 3) *64u RSI) +64u ((64u) 2))) +64u ((64u) 0)))
+asmgen: Invalid address:  RDI +64u ((64u) 8 *64u ((64u) 3 *64u RSI +64u (64u) 2) +64u (64u) 0)
         Invalid scale: 24 (should be 1, 2, 4, or 8)
 
 fail/asmgen/x86-64/uninit_flag.jazz:
@@ -855,7 +855,7 @@ fail/register_allocation/x86-64/conflicting_variables.jazz:
 compilation error:
 register allocation: conflicting variables “z” and “res” must be merged due to:
   at "fail/register_allocation/x86-64/conflicting_variables.jazz", line 3 (2-16):
-    ( _0,  _1,  _2,  _3,  _4, res) = #ADD_64(arg, ((64u) 3)); /*  */
+    ( _0,  _1,  _2,  _3,  _4, res) = #ADD_64(arg, (64u) 3); /*  */
   at "fail/register_allocation/x86-64/conflicting_variables.jazz", line 12 (2-11):
     ( _0,  _1,  _2,  _3,  _4, z) = #ADD_64(z, res); /*  */
   at "fail/register_allocation/x86-64/conflicting_variables.jazz", line 11 (2-14):
@@ -952,7 +952,7 @@ fail/slh/x86-64/if_wrong_update.jazz:
 
 "fail/slh/x86-64/if_wrong_update.jazz", line 10 (8-35):
 compilation error in function main:
-speculative execution lowering: Not able to prove that (! __zf__)
+speculative execution lowering: Not able to prove that ! __zf__
                                 evaluate to true,
                                 known expression __zf__
                                 Did you run the speculative constant time checker first?
@@ -990,7 +990,7 @@ fail/slh/x86-64/while_wrong_update.jazz:
 
 "fail/slh/x86-64/while_wrong_update.jazz", line 10 (8-35):
 compilation error in function main:
-speculative execution lowering: Not able to prove that (! __zf__)
+speculative execution lowering: Not able to prove that ! __zf__
                                 evaluate to true,
                                 known expression __zf__
                                 Did you run the speculative constant time checker first?
@@ -1016,7 +1016,7 @@ fail/stack_allocation/x86-64/array_access_too_complex.jazz:
 "fail/stack_allocation/x86-64/array_access_too_complex.jazz", line 6 (2-19):
 compilation error in function main:
 stack allocation: do not know how to compile this array access into a memory access,
-                  the expression ((uint) (i /64u (i +64u ((64u) 1))))
+                  the expression (uint) (i /64u (i +64u (64u) 1))
                   must contain only the operators “+” and “*”
 
 fail/stack_allocation/x86-64/bad_alignment.jazz:
@@ -1113,7 +1113,7 @@ source
     zone = [0:8] }
 and destination
   { region = { slot = s; align = u64; writable = true };
-    zone = [0:16][(8 * ((uint) i)):8] }
+    zone = [0:16][8 * (uint) i:8] }
 regions are not equal
 
 fail/stack_allocation/x86-64/merge_too_large_global.jazz:
@@ -1214,7 +1214,7 @@ compilation error in function main:
 stack allocation: the assignment to array s cannot be turned into a nop
 source
   { region = { slot = s; align = u64; writable = true };
-    zone = [0:16][(8 * ((uint) i)):16] }
+    zone = [0:16][8 * (uint) i:16] }
 and destination
   { region = { slot = s; align = u64; writable = true };
     zone = [0:16] }
@@ -1227,10 +1227,10 @@ compilation error in function main:
 stack allocation: the assignment to sub-array s cannot be turned into a nop
 source
   { region = { slot = s; align = u64; writable = true };
-    zone = [0:16][(8 * ((uint) i)):8] }
+    zone = [0:16][8 * (uint) i:8] }
 and destination
   { region = { slot = s; align = u64; writable = true };
-    zone = [0:16][(8 * ((uint) (i +64u ((64u) 1)))):8] }
+    zone = [0:16][8 * (uint) (i +64u (64u) 1):8] }
 regions are not equal
 
 fail/stack_allocation/x86-64/return_ptr_global.jazz:
@@ -1311,7 +1311,7 @@ compilation error in function main:
 stack allocation: the assignment to array s2 cannot be turned into a nop
 source
   { region = { slot = s; align = u32; writable = true };
-    zone = [0:40][(1 * ((uint) i)):20] }
+    zone = [0:40][1 * (uint) i:20] }
 and destination
   { region = { slot = s; align = u32; writable = true };
     zone = [0:20] }
@@ -1483,7 +1483,7 @@ fail/x86-64/shift.jazz:
 "fail/x86-64/shift.jazz", line 5 (4-12):
 compilation error in function main:
 linearization: The following assignment remains:
-RAX = (RAX <<64u RAX)
+RAX = RAX <<64u RAX
 Is there an instruction in the target architecture that can implement it?
 More information may be found online: https://jasmin-lang.readthedocs.io/en/stable/misc/faq.html#linearization
 

--- a/compiler/tests/printing.ml
+++ b/compiler/tests/printing.ml
@@ -173,13 +173,18 @@ let eq_pmod_item x y =
 let eq_pmod_items x y = List.for_all2 eq_pmod_item x y
 
 (* ---------------------------------------------------------------- *)
-let parse arch_info fname =
+let parse arch_info ctxt fname =
   try
     try
       let _env, pprog, _ast = Compile.parse_file arch_info fname in
       pprog
-    with Pretyping.TyError (loc, msg) ->
-      hierror ~loc:(Lone loc) ~kind:"typing error" "%a" Pretyping.pp_tyerror msg
+    with
+    | Pretyping.TyError (loc, msg) ->
+        hierror ~loc:(Lone loc) ~kind:"typing error" "%a" Pretyping.pp_tyerror
+          msg
+    | Syntax.ParseError (loc, msg) ->
+        hierror ~loc:(Lone loc) ~kind:"parsing" "%s: %s" ctxt
+          (Option.default "parse error" msg)
   with HiError err ->
     Format.eprintf "%a@." pp_hierror err;
     exit 1
@@ -199,14 +204,14 @@ let print (type reg) (type regx) (type xreg) (type rflag) (type cond)
 (* Increments its [errors] argument in case of failure. *)
 let parse_and_print fname errors arch =
   let module Arch = (val CoreArchFactory.get_arch_module arch Linux) in
-  let pprog = parse Arch.arch_info fname in
+  let pprog = parse Arch.arch_info fname fname in
   let printed =
     BatFile.with_temporary_out ~prefix:"test" ~suffix:".jazz" (fun oc fname ->
         let fmt = BatFormat.formatter_of_out_channel oc in
         print (module Arch) fmt pprog;
         fname)
   in
-  let reparsed = parse Arch.arch_info printed in
+  let reparsed = parse Arch.arch_info fname printed in
   if eq_pmod_items reparsed pprog then errors
   else (
     Format.eprintf "Failure: %s@." fname;

--- a/compiler/tests/sct-checker/reject.expected
+++ b/compiler/tests/sct-checker/reject.expected
@@ -5,7 +5,7 @@ Failed as expected missing_update_in_loop: "fail/basic.jazz", line 95 (2) to lin
                                             msf }
 Failed as expected missing_update_after_loop: "fail/basic.jazz", line 88 (18-21):
                                               speculative constant type checker: MSF is Trans
-                                              (! (x >u ((64u) 0)))
+                                              ! (x >u (64u) 0)
 Failed as expected outdated_msf: "fail/basic.jazz", line 78 (9-12):
                                  speculative constant type checker: the variable msf is not known to be a msf, only {
                                    } are
@@ -65,17 +65,14 @@ Failed as expected modmsf_trace: "fail/modmsf-trace.jazz", line 17 (2-8):
                                    the function kill_msf destroys MSFs at "fail/modmsf-trace.jazz", line 3 (4) to line 5 (5)
 File movmsf.jazz:
 Failed as expected overwrite2: "fail/movmsf.jazz", line 29 (4-5):
-                               speculative constant type checker: x cannot become an MSF as the current status depends on it (
-                               (x >u ((64u) 0)))
+                               speculative constant type checker: x cannot become an MSF as the current status depends on it (x >u (64u) 0)
 Failed as expected overwrite: "fail/movmsf.jazz", line 21 (4-5):
-                              speculative constant type checker: x cannot become an MSF as the current status depends on it (
-                              (x >u ((64u) 0)))
+                              speculative constant type checker: x cannot become an MSF as the current status depends on it (x >u (64u) 0)
 Failed as expected fail: "fail/movmsf.jazz", line 13 (29-32):
                          speculative constant type checker: MSF is not Trans
 File speculative-stack-leak.jazz:
 Failed as expected main: "fail/speculative-stack-leak.jazz", line 32 (2) to line 36 (3):
-                         speculative constant type checker: (pub >s
-                                                            ((32u) 0)) has type #secret but should be at most #public
+                         speculative constant type checker: pub >s (32u) 0 has type #secret but should be at most #public
 File spill.jazz:
 Failed as expected spill2: "fail/spill.jazz", line 13 (5-8):
                            speculative constant type checker: pub has type #transient but should be at most #public

--- a/compiler/tests/sct-checker/sct_errors.expected
+++ b/compiler/tests/sct-checker/sct_errors.expected
@@ -3,11 +3,11 @@ Failed as expected syscall: speculative constant type checker: syscalls destroy 
                              x } are required
 Failed as expected update_msf_not_trans: speculative constant type checker: MSF is not Trans
 Failed as expected update_msf_wrong_expr: speculative constant type checker: the expression false need to be equal to
-                                          (x ==64u ((64u) 0))
+                                          x ==64u (64u) 0
 Failed as expected update_msf_not_msf: speculative constant type checker: 
                                        the variables { x } need to be MSFs.
 Failed as expected msf_trans: speculative constant type checker: MSF is Trans
-                              (x ==64u ((64u) 0))
+                              x ==64u (64u) 0
 Failed as expected not_known_as_msf: speculative constant type checker: 
                                      the variables { x } need to be MSFs.
 Failed as expected msf_in_export: speculative constant type checker: 

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -2,13 +2,13 @@
   warning: support of the RISC-V architecture is experimental
   "warning/risc-v/load_constant_warning.jazz", line 3 (9-15)
   warning: extra assignment introduced:
-             ra = #LI(((32u) 10)); /* :r */
+             ra = #LI((32u) 10); /* :r */
 
   $ ../jasminc -wea warning/x86-64/extra_assignment.jazz
   "warning/x86-64/extra_assignment.jazz", line 9 (2-12)
   from line 15 (2-12)
   warning: extra assignment introduced:
-             RAX = #MOV_64(((64u) 0)); /* :r */
+             RAX = #MOV_64((64u) 0); /* :r */
 
   $ ../jasminc -wlea warning/x86-64/lea.jazz
   "warning/x86-64/lea.jazz", line 6 (2-18)


### PR DESCRIPTION
Pretty-printing of Jasmin programs and expressions use less parentheses, taking into account priority and associativity of operators.
