### PR TITLE
Enable wints as argument to #swap

### DIFF
--- a/changes/01-feature/1342-enable-wint-swap.md
+++ b/changes/01-feature/1342-enable-wint-swap.md
@@ -1,0 +1,2 @@
+- The `#swap` pseudo-operator can also be applied to word-sized integers
+  ([PR #1342](https://github.com/jasmin-lang/jasmin/pull/1342)).

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -2003,7 +2003,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((annot,pi) : S.pinstr) : 'asm E
                       (tyerror ~loc:(L.loc ey) (TypeMismatch (yty, xty))) in
            let () = match ty with
              | P.ETarr _ -> ()
-             | P.ETword(None, ws) when ws <= U64 -> ()
+             | P.ETword(_, ws) when ws <= U64 -> ()
              | _ ->
                 let w = match ty with P.ETword(w, ws) -> w | _ -> None in
                 let ty = match P.gty_of_gety ty with P.Bty ty -> ty | _ -> assert false in

--- a/compiler/tests/success/common/swap.jazz
+++ b/compiler/tests/success/common/swap.jazz
@@ -51,3 +51,10 @@ export fn truncate(reg u32 x) -> reg u32, reg u16 {
 export fn nolhs(reg u32 x y) {
   #[keep] _, _ = #swap(x, y);
 }
+
+export fn wint(reg ui32 a) -> reg ui32 {
+  reg ui32 b = 0;
+  a, b = #swap(a, b);
+  a += b;
+  return a;
+}

--- a/proofs/compiler/wint_int.v
+++ b/proofs/compiler/wint_int.v
@@ -22,10 +22,10 @@ Module Import E.
   Definition ierror := pp_internal_error pass.
 
   Definition ierror_e e :=
-    ierror (pp_nobox [:: pp_s "ill typed expression"; pp_e e]).
+    ierror (pp_nobox [:: pp_s "ill typed expression "; pp_e e]).
 
   Definition ierror_lv lv :=
-    ierror (pp_nobox [:: pp_s "ill typed left value"; pp_lv lv]).
+    ierror (pp_nobox [:: pp_s "ill typed left value "; pp_lv lv]).
 
 End E.
 
@@ -278,33 +278,44 @@ Fixpoint wi2i_ir (ir:instr_r) : cexec instr_r :=
     ok (Cassgn x tag ty e)
 
   | Copn xs t o es =>
-    Let es' := mapM wi2i_e es in
-    let xtys := map (to_etype None) (sopn_tout o) in
-    Let xs := mapM2 (E.ierror_s "invalid dest in Copn") wi2i_lv xtys xs in
-    Let o :=
-     (* TODO: do that for other operators ? maybe for swap ? *)
-     if sopn.is_spill_op o is Some (k, tys) then
-       (* We check that the operator is well-typed *)
-       let etys := map etype_of_expr es in
-       let tys' := map2 (fun ety ty => to_etype (sign_of_etype ety) ty) etys tys in
-       Let _ := assert (size tys == size es) (E.ierror_s "ill typed spill") in
-       Let _ := assert (all2 esubtype tys' etys) (E.ierror_s "ill typed spill (arguments)") in
-       (* We patch the type of the operator *)
-       let tys := map2 (fun ty e => wi2i_type (sign_of_expr e) ty) tys es in
-       ok (Opseudo_op (Ospill k tys))
-     else
-       Let _ := assert (all (fun e => sign_of_expr e == None) es)
-                    (E.ierror_s "invalid expr in Copn") in
-       ok o
-     in
-    ok (Copn xs t o es')
+      match o with
+      | Opseudo_op (Ospill k tys) =>
+          (* We check that the operator is well-typed *)
+          let etys := map etype_of_expr es in
+          let tys' := map2 (fun ety ty => to_etype (sign_of_etype ety) ty) etys tys in
+          Let _ := assert (size tys == size es) (E.ierror_s "ill typed spill") in
+          Let _ := assert (all2 esubtype tys' etys) (E.ierror_s "ill typed spill (arguments)") in
+          (* We patch the type of the operator *)
+          let tys := map2 (fun ty e => wi2i_type (sign_of_expr e) ty) tys es in
+          Let es := mapM wi2i_e es in
+          ok (Copn [::] t (Opseudo_op (Ospill k tys)) es)
+      | Opseudo_op (Oswap ty) =>
+          if es is [:: e1; e2 ] then
+            let ety := etype_of_expr e1 in
+            let sig := [:: ety; ety] in
+            Let _ := assert (all2 (fun ety e => esubtype ety (etype_of_expr e)) sig es)
+                       (E.ierror_s "invalid args in swap") in
+            Let es := mapM wi2i_e es in
+            Let xs := mapM2 (E.ierror_s "invalid dest in swap") wi2i_lv sig xs in
+            let ty := wi2i_type (sign_of_expr e1) ty in
+            ok (Copn xs t (Opseudo_op (Oswap ty)) es)
+          else Error (E.ierror_s "ill-typed swap")
+      | Opseudo_op (Ocopy _ _ | Onop | Omulu _ | Oaddcarry _ | Osubcarry _)
+      | Oslh _ | Oasm _ =>
+          Let _ := assert (all (fun e => sign_of_expr e == None) es)
+                          (E.ierror_s "invalid expr in Copn") in
+          Let es := mapM wi2i_e es in
+          let xtys := map (to_etype None) (sopn_tout o) in
+          Let xs := mapM2 (E.ierror_s "invalid dest in Copn") wi2i_lv xtys xs in
+          ok (Copn xs t o es)
+      end
 
   | Csyscall xs o es =>
     Let _ := assert (all (fun e => sign_of_expr e == None) es)
                     (E.ierror_s "invalid args in Csyscall") in
     Let es := mapM wi2i_e es in
     let xtys := map (to_etype None) (syscall_sig_u o).(scs_tout) in
-    Let xs := mapM2 (E.ierror_s "invalid dest in Copn") wi2i_lv xtys xs in
+    Let xs := mapM2 (E.ierror_s "invalid dest in Csyscall") wi2i_lv xtys xs in
     ok (Csyscall xs o es)
 
   | Cif b c1 c2 =>


### PR DESCRIPTION
# Description

Currently, pre-typing reject applications of `#swap` to word-sized integers (for no good reason, AFAICT).

Apart from relaxing a test in pre-typing, this PR adapts the wint-int pass to properly handle swap operators.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed