### PR TITLE
Deprecate annotations without square brackets

### DIFF
--- a/changes/03-other/1346-deprecate-open-annotations.md
+++ b/changes/03-other/1346-deprecate-open-annotations.md
@@ -1,0 +1,3 @@
+- Annotations must be enclosed within square brackets; syntax without square
+  brackets is now deprecated
+  ([PR 1346](https://github.com/jasmin-lang/jasmin/pull/1346)).

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -146,7 +146,9 @@ struct_annot:
   | a=separated_list(COMMA, annotation) { a }
 
 top_annotation:
-  | SHARP a=annotation    { [a] }
+  | SHARP a=loc(annotation)
+    { Utils.warning Deprecated Location.(i_loc0 (loc a)) "annotations should be enclosed within square brackets";
+      [Location.unloc a] }
   | SHARP LBRACKET a=struct_annot RBRACKET { a }
 
 annotations:


### PR DESCRIPTION
This will make it possible to easily distinguish instructions with a leading annotation (e.g., `#[inline] f();`) from intrinsics/pseudo-operators without an L-value (e.g., `#spill(x);`).