### PR TITLE
Fix detection of duplicate global variables

### DIFF
--- a/changes/02-bugfix/1348-fix-warn-duplicate-glob-var.md
+++ b/changes/02-bugfix/1348-fix-warn-duplicate-glob-var.md
@@ -1,0 +1,4 @@
+- Warn as expected when defining two (global) variables with the same name in
+  the same namespace
+  ([PR 1348](https://github.com/jasmin-lang/jasmin/pull/1346);
+  fixes [#1347](https://github.com/jasmin-lang/jasmin/issues/1347)).

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -461,15 +461,14 @@ end  = struct
     let find (x : A.symbol) (env : 'asm env) =
       find (fun b -> b.gb_vars) x env
 
-    let warn_double_decl v map =
-      let name = v.P.v_name in
+    let warn_double_decl name v map =
       match Map.find name map with
       | exception Not_found -> ()
       | v' -> warn_duplicate_var name (v, (), ()) v'
 
     let push_core (env : 'asm env) (name: P.Name.t) (v : P.pvar) (ty: P.epty) (s : E.v_scope)  =
       let doit m =
-        warn_double_decl v m.gb_vars;
+        warn_double_decl name v m.gb_vars;
         { m with gb_vars = Map.add name (v, ty, s) m.gb_vars }
       in
       let e_bindings =

--- a/compiler/tests/warning/common/bug_1347.jazz
+++ b/compiler/tests/warning/common/bug_1347.jazz
@@ -1,0 +1,9 @@
+namespace A {
+  u32 g = 0;
+  u64 g = 1;
+}
+
+namespace B {
+  namespace C { u32 x = 2; }
+  namespace C { u16 x = 3; }
+}

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -83,3 +83,9 @@
   warning: Variable “x” is affected but never used
 
   $ ../jasminc fail/linter/silent_dead.jazz
+
+  $ ../jasminc warning/common/bug_1347.jazz
+  "warning/common/bug_1347.jazz", line 3 (6-7)
+  warning: the variable g is already declared at "warning/common/bug_1347.jazz", line 2 (6-7)
+  "warning/common/bug_1347.jazz", line 8 (20-21)
+  warning: the variable C::x is already declared at "warning/common/bug_1347.jazz", line 7 (20-21)


### PR DESCRIPTION
# Description

The computation of the variable name is wrong…

Fixes #1347

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
