### PR TITLE
Only support annotations with delimiting square brackets

### DIFF
--- a/changes/03-other/1353-only-delimited-annotations.md
+++ b/changes/03-other/1353-only-delimited-annotations.md
@@ -1,0 +1,2 @@
+- Annotations without delimiting square brackets are no longer supported
+  ([PR #1353](https://github.com/jasmin-lang/jasmin/pull/1353)).

--- a/compiler/src/lexer.mll
+++ b/compiler/src/lexer.mll
@@ -183,6 +183,7 @@ rule main = parse
   | (vsize as r) (signletter as s) (gensize as g)
       { SVSIZE(mkvsizesign r s g)}
 
+  | "#["     { SHARPLBRACKET }
   | "#"     { SHARP      }
   | "["     { LBRACKET   }
   | "]"     { RBRACKET   }

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -20,6 +20,7 @@
 %token <Syntax.sign> T_INT_CAST
 
 %token SHARP
+%token SHARPLBRACKET
 %token ALIGNED
 %token AMP
 %token AMPAMP
@@ -146,10 +147,7 @@ struct_annot:
   | a=separated_list(COMMA, annotation) { a }
 
 top_annotation:
-  | SHARP a=loc(annotation)
-    { Utils.warning Deprecated Location.(i_loc0 (loc a)) "annotations should be enclosed within square brackets";
-      [Location.unloc a] }
-  | SHARP LBRACKET a=struct_annot RBRACKET { a }
+  | SHARPLBRACKET a=struct_annot RBRACKET { a }
 
 annotations:
   | l=list(top_annotation) { List.concat l }


### PR DESCRIPTION
# Description

Annotations must be enclosed within square brackets.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change

