### PR TITLE
Trusted automated spilling

### DIFF
--- a/changes/01-feature/1356-auto-spill.md
+++ b/changes/01-feature/1356-auto-spill.md
@@ -1,0 +1,3 @@
+- When one of the “auto-spill” flag is set on the command-line, automatically
+  insert spill and unspill operations in the program
+  ([PR #1356](https://github.com/jasmin-lang/jasmin/pull/1356)).

--- a/compiler/src/CLI_errors.ml
+++ b/compiler/src/CLI_errors.ml
@@ -50,6 +50,10 @@ let check_options () =
   then warning Experimental Location.i_dummy
       "support for windows calling-convention is experimental";
 
+  if !do_auto_spill <> None
+  then warning Experimental Location.i_dummy
+      "automatic spilling is experimental";
+
   if !target_arch = ARM_M4
     then warning Experimental Location.i_dummy
       "support of the ARMv7 architecture is experimental";

--- a/compiler/src/autoSpill.ml
+++ b/compiler/src/autoSpill.ml
@@ -1,0 +1,98 @@
+open Utils
+open Prog
+open Pseudo_operator
+
+(* **************************************************************** *)
+
+type strategy = OptIn | OptOut
+
+let has_nospill a =
+  Annotations.has_symbol "nospill" a || Annotations.has_symbol "msf" a
+
+let has_spill = Annotations.has_symbol "spill"
+let is_word = function Bty (U _) -> true | _ -> false
+
+(** Tells whether a variable [x] is spillable, according to the given
+    [strategy]. The variable must be of kind reg, of a type that is either word
+    or ptr array, and annotated depending to the strategy. *)
+let is_spillable strategy x =
+  is_reg_kind x.v_kind
+  && (is_ptr x.v_kind || is_word x.v_ty)
+  &&
+  match strategy with
+  | OptIn -> has_spill x.v_annot
+  | OptOut -> not (has_nospill x.v_annot)
+
+let spillable strategy (s : Sv.t) : Sv.t = Sv.filter (is_spillable strategy) s
+
+(* **************************************************************** *)
+
+let mk_spill o s =
+  let xs = Sv.elements s in
+  let tys = List.map (fun x -> Conv.cty_of_ty x.v_ty) xs in
+  let es = List.map (fun x -> Pvar (gkvar (L.mk_loc L._dummy x))) xs in
+  Copn ([], AT_none, Sopn.Opseudo_op (Ospill (o, tys)), es)
+
+let vars_lv = function
+  | Lnone _ | Lvar _ -> Sv.empty
+  | Lmem (_, _, _, e) | Laset (_, _, _, _, e) | Lasub (_, _, _, _, e) ->
+      vars_e e
+
+let vars_i = function
+  | Cassgn (x, _, _, e) -> Sv.union (vars_lv x) (vars_e e)
+  | Copn (xs, _, _, es) | Csyscall (xs, _, es) | Ccall (xs, _, es) ->
+      List.fold Sv.union (vars_es es) (List.map vars_lv xs)
+  | Cfor _ | Cif _ | Cwhile _ -> assert false
+
+let rec spill_all_i strategy i =
+  let wrap i_desc = { i with i_desc; i_annot = [] } in
+  let op o xs = xs |> spillable strategy |> mk_spill o |> wrap in
+  match i.i_desc with
+  | Cassgn _ | Copn _ | Csyscall _ | Ccall _ ->
+      [ op Unspill (vars_i i.i_desc); i; op Spill (assigns i.i_desc) ]
+  | Cif (e, c1, c2) ->
+      [
+        op Unspill (vars_e e);
+        {
+          i with
+          i_desc = Cif (e, spill_all_c strategy c1, spill_all_c strategy c2);
+        };
+      ]
+  | Cfor (x, (d, e1, e2), c) ->
+      [
+        op Unspill (vars_es [ e1; e2 ]);
+        { i with i_desc = Cfor (x, (d, e1, e2), spill_all_c strategy c) };
+      ]
+  | Cwhile (al, c1, e, ei, c2) ->
+      [
+        {
+          i with
+          i_desc =
+            Cwhile
+              ( al,
+                spill_all_c strategy c1 @ [ op Unspill (vars_e e) ],
+                e,
+                ei,
+                spill_all_c strategy c2 );
+        };
+      ]
+
+and spill_all_c strategy c = List.concat_map (spill_all_i strategy) c
+
+let spill_all_fd strategy fd =
+  if has_nospill fd.f_annot.f_user_annot then fd
+  else
+    let wrap i_desc =
+      { i_desc; i_loc = L.i_dummy; i_info = fd.f_info; i_annot = [] }
+    in
+    let op o xs =
+      xs |> Sv.of_list |> spillable strategy |> mk_spill o |> wrap
+    in
+    let f_body =
+      (op Spill fd.f_args :: spill_all_c strategy fd.f_body)
+      @ [ op Unspill (List.map L.unloc fd.f_ret) ]
+      |> refresh_i_loc_c
+    in
+    { fd with f_body }
+
+let doit strategy (gd, fds) = (gd, List.map (spill_all_fd strategy) fds)

--- a/compiler/src/autoSpill.mli
+++ b/compiler/src/autoSpill.mli
@@ -1,0 +1,31 @@
+(** Naive automatic spilling. The transformation implemented in this module
+    automatically inserts spill and unspill operators in a systematic way:
+    “spillable” variables are spilled after every definition (including
+    arguments on function entry) and unspilled before every use (including
+    returning results at the end of functions).
+
+    Which program variables are considered “spillable” (and therefore subject to
+    this transformation) depend on the “strategy”. There are two possible
+    strategies:
+    - either all reg variables are considered spillable, unless their
+      declaration are annotated with [#[nospill]];
+    - or only reg variables that are explicitly annotated with [#[spill]] are
+      considered spillable.
+
+    When a function is annotated [nospill], then it is preserved: no spill or
+    unspill operator are introduced in its body.
+
+    Note that an [msf] annotation implies [nospill].
+
+    This transformation is experimental (i.e., subject to change) and trusted
+    (i.e., not proved). *)
+
+(** The [strategy] controls which variables are subject to the spill/unspill
+    operators introduced by this transformation. *)
+type strategy =
+  | OptIn  (** reg variables explicitly annotated with [spill] *)
+  | OptOut  (** all reg variables, except the ones annotated with [nospill] *)
+
+val doit : strategy -> ('info, 'asm) Prog.prog -> ('info, 'asm) Prog.prog
+(** Insert spill and unspill operators in a program, according to the chosen
+    strategy. *)

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -50,6 +50,10 @@ let enable_all_warnings () =
   linting_level := 2;
   set_all_warnings ()
 
+let do_auto_spill = ref None
+let set_auto_spill () = do_auto_spill := Some AutoSpill.OptIn
+let set_auto_spill_all () = do_auto_spill := Some AutoSpill.OptOut
+
 let stack_zero_strategy = ref None
 let stack_zero_strategies =
   let open Stack_zero_strategy in
@@ -220,6 +224,8 @@ let options = [
     "-linting-level", Arg.Int set_linting_level, "[n] Set linting level to n (defaults to 1; disable linting when set to 0)";
     "-color", Arg.Symbol (["auto"; "always"; "never"], set_color), " Print messages with color";
     "-help-intrinsics", Arg.Set help_intrinsics, " List the set of intrinsic operators (and exit)";
+    "-auto-spill", Arg.Unit set_auto_spill, " Enable naive spilling of #[spill]-annotated variables";
+    "-auto-spill-all", Arg.Unit set_auto_spill_all, " Enable naive spilling of all reg variables";
     "-print-stack-alloc", Arg.Set print_stack_alloc, " Print the results of the stack allocation OCaml oracle";
     "-print-export-info-json", Arg.Set print_export_info_json, " Print information about exported functions in json";
     "-lazy-regalloc", Arg.Set lazy_regalloc, " Allocate variables to registers in program order";

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -201,6 +201,12 @@ let main () =
 
     visit_prog_after_pass ~debug:true Compiler.ParamsExpansion prog;
 
+    let prog =
+      match !Glob_options.do_auto_spill with
+      | None -> prog
+      | Some strategy -> AutoSpill.doit strategy prog
+    in
+
     (* Now call the coq compiler *)
     let cprog = Conv.cuprog_of_prog prog in
 

--- a/compiler/tests/success/common/autospill.jazz
+++ b/compiler/tests/success/common/autospill.jazz
@@ -1,0 +1,21 @@
+export
+fn main(reg u32 arg) -> reg ui32 {
+  arg &= 0x1f;
+  reg ui32 result = 1;
+  #[spill] reg u32 i = 0;
+  while (i < arg) {
+    result <<= 1;
+    i += 1;
+  }
+  return result;
+}
+
+export
+fn xor(reg ptr u32[2] arg) -> reg u32 {
+  #[nospill]
+  reg u32 x y z;
+  x = arg[0];
+  y = arg[1];
+  z = x ^ y;
+  return z;
+}

--- a/docs/source/compiler/passes/auto_spill.md
+++ b/docs/source/compiler/passes/auto_spill.md
@@ -1,0 +1,57 @@
+# Automated spilling
+
+This is an experimental feature of the `jasminc` command-line tool, enabled
+using either `-auto-spill` or `-auto-spill-all`. This trusted program
+transformation inserts unspill operations before every use of a variable and
+spill operations after every definition of a variable.
+
+Variables that are subject to this transformation are variables of kind `reg`
+and of machine-word type.
+
+When using `-auto-spill`, only variables that are declared with a `spill`
+annotation are subject to this transformation.
+
+For instance, in the following program, two spilling operations are introduced,
+after each write to the variable `i`: once before the loop and once at the end
+of the loop body. Moreover, two unspill operations are introduced, before each
+read from the variable `i`: once within the loop body before the increment and
+once before evaluating the loop guard.
+
+~~~
+export
+fn main(reg u32 arg) -> reg ui32 {
+  arg &= 0x1f;
+  reg ui32 result = 1;
+  #[spill] reg u32 i = 0;
+  while (i < arg) {
+    result <<= 1;
+    i += 1;
+  }
+  return result;
+}
+~~~
+
+When using `-auto-spill-all`, all such variables are spilled and unspilled,
+except the ones declared with an explicitly `nospill` annotation.
+
+In the example program below, when using `-auto-spill-all`, the pointer argument
+is spilled on function entry and unspilled before both accesses to its contents.
+The other local variables `x`, `y`, and `z` are annotated `nospill`: therefore
+no spill or unspill operation related to them is introduced.
+
+~~~
+export
+fn xor(reg ptr u32[2] arg) -> reg u32 {
+  #[nospill]
+  reg u32 x y z;
+  x = arg[0];
+  y = arg[1];
+  z = x ^ y;
+  return z;
+}
+~~~
+
+Automated spilling can be disabled in a whole function by annotating said
+function as `nospill`.
+
+A `msf` annotation is treated as a `nospill` annotation.


### PR DESCRIPTION
# Description

This adds a trusted auto-spill transformation, that is naive but systematic. It features two modes that can be fine-tuned using annotations.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [ ] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed
