### PR TITLE
introduce annotation #[stable_call_conv]

### DIFF
--- a/changes/01-feature/1361-stable-call-conv.md
+++ b/changes/01-feature/1361-stable-call-conv.md
@@ -1,0 +1,3 @@
+- New experimental `stable_call_conv` annotation for internal functions and
+  improved documentation of difficulties related to register allocation
+  ([PR 1361](https://github.com/jasmin-lang/jasmin/pull/1361)).

--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -44,6 +44,7 @@ module type Core_arch = sig
   val is_ct_asm_extra : extra_op -> bool
   val is_doit_asm_extra : extra_op -> bool
 
+  val internal_call_conv : (reg, regx, xreg, rflag, cond) internal_calling_convention
 end
 
 module type Arch = sig
@@ -81,6 +82,8 @@ module type Arch = sig
   val arch_info : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Pretyping.arch_info
 
   val is_ct_sopn : ?doit:bool -> extended_op -> bool
+
+  val internal_call_conv : (var, var, var, var, cond) internal_calling_convention
 end
 
 module Arch_from_Core_arch (A : Core_arch) :
@@ -213,4 +216,10 @@ module Arch_from_Core_arch (A : Core_arch) :
    | BaseOp (_, o) -> (if doit then is_doit_asm_op else is_ct_asm_op) o
    | ExtOp o -> (if doit then is_doit_asm_extra else is_ct_asm_extra) o
 
+  let internal_call_conv =
+    { icall_reg   = List.map var_of_reg  internal_call_conv.icall_reg
+    ; icall_regx  = List.map var_of_regx internal_call_conv.icall_regx
+    ; icall_xreg  = List.map var_of_xreg internal_call_conv.icall_xreg
+    ; icall_rflag = List.map var_of_flag internal_call_conv.icall_rflag
+    }
 end

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -46,6 +46,7 @@ module type Core_arch = sig
   val is_ct_asm_extra : extra_op -> bool
   val is_doit_asm_extra : extra_op -> bool
 
+  val internal_call_conv : (reg, regx, xreg, rflag, cond) internal_calling_convention
 end
 
 module type Arch = sig
@@ -83,6 +84,8 @@ module type Arch = sig
   val arch_info : (reg, regx, xreg, rflag, cond, asm_op, extra_op) Pretyping.arch_info
 
   val is_ct_sopn : ?doit:bool -> extended_op -> bool
+
+  val internal_call_conv : (var, var, var, var, cond) internal_calling_convention
 end
 
 module Arch_from_Core_arch (A : Core_arch) : Arch

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -122,4 +122,6 @@ module Arm (Lowering_params : Arm_input) : Arch_full.Core_arch
   let pp_asm = Pp_arm_m4.print_prog
 
   let callstyle = Arch_full.ByReg { call = Some LR; return = false }
+
+  let internal_call_conv = Arm_decl.arm_internal_call_conv
 end

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -125,7 +125,6 @@ let main () =
     let env, pprog, _ast =
       try Compile.parse_file Arch.arch_info ~idirs:!Glob_options.idirs infile
       with
-      | Annot.AnnotationError (loc, code) -> hierror ~loc:(Lone loc) ~kind:"annotation error" "%t" code
       | Pretyping.TyError (loc, code) -> hierror ~loc:(Lone loc) ~kind:"typing error" "%a" Pretyping.pp_tyerror code
       | Syntax.ParseError (loc, msg) ->
           let msg =
@@ -264,8 +263,11 @@ let main () =
           if !debug then Format.eprintf "assembly listing written@."
       end else if List.mem Compiler.Assembly !print_list then
           Format.printf "%a%!" Arch.pp_asm asm
+    | exception Annot.AnnotationError (loc, code) -> hierror ~loc:(Lone loc) ~kind:"annotation error" "%t" code
     end
   with
+
+
   | Utils.HiError e ->
     Format.eprintf "%a@." pp_hierror e;
     exit 1

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -749,6 +749,47 @@ module Regalloc (Arch : Arch_full.Arch)
           in
           cnf
 
+
+let stable_call_conv = "stable_call_conv"
+
+let is_stable_call_conv f =
+  Annotations.has_symbol stable_call_conv f.f_annot.f_user_annot
+
+type internal_max_use_reg =
+  { max_reg  : int;
+    max_regx : int;
+    max_xreg : int;
+    max_flag : int; }
+
+let default_max_use_reg =
+  let icc = Arch.internal_call_conv in
+  { max_reg  = List.length icc.icall_reg
+  ; max_regx = List.length icc.icall_regx
+  ; max_xreg = List.length icc.icall_xreg
+  ; max_flag = List.length icc.icall_rflag }
+
+let process_call_conv f =
+  Annot.ensure_uniq1 stable_call_conv
+    (Annot.on_attribute
+      ~on_empty:(fun _ _ _ -> default_max_use_reg)
+      ~on_struct:(fun loc _ s ->
+        let get n name = Annot.ensure_uniq1 name (Annot.int (Some (Z.of_int n))) s |> Option.default Z.zero |> Z.to_int in
+        let d = default_max_use_reg in
+        let max = { max_reg  = get d.max_reg "reg"
+                  ; max_regx = get d.max_regx "regx"
+                  ; max_xreg = get d.max_xreg "xreg"
+                  ; max_flag = get d.max_flag "flag" } in
+        let check_max_use name limit use =
+          if limit < use then Annot.error ~loc "%s = %i is too large, it should be at most %i" name use limit
+        in
+        check_max_use "reg"  d.max_reg  max.max_reg;
+        check_max_use "regx" d.max_regx max.max_regx;
+        check_max_use "xreg" d.max_xreg max.max_xreg;
+        check_max_use "flag" d.max_flag max.max_flag;
+        max)
+      (fun loc _nid -> Annot.error ~loc "no attribute or = {reg = <int>; regx = <int>; xreg = <int>; flag = <int> } expected after %s" stable_call_conv))
+  f.f_annot.f_user_annot
+
 let allocate_forced_registers return_addresses nv (vars: int Hv.t) tr (cnf: conflicts)
     (f: ('info, 'asm) func) (a: A.allocation) : conflicts =
   let split ~ctxt ~num =
@@ -758,37 +799,44 @@ let allocate_forced_registers return_addresses nv (vars: int Hv.t) tr (cnf: conf
        hierror_reg ~loc:(Lone f.f_loc) ~funname:f.f_name.fn_name "too many %s according to the ABI (only %d available on this architecture)"
          ctxt num
   in
-  let alloc_from_list loc ~ctxt rs xs q vs : unit =
+  let alloc_from_list ~ctxt get regs regxs xregs flags loc vs : unit =
     let f x = Hv.find vars x in
-    let num_rs = List.length rs in
-    let num_xs = List.length xs in
-    List.fold_left (fun (rs, xs) p ->
-        let p = q p in
+    let num_regs  = List.length regs in
+    let num_regxs = List.length regxs in
+    let num_xregs = List.length xregs in
+    let num_flags = List.length flags in
+    List.fold_left (fun (regs, regxs, xregs, flags) p ->
+        let p = get p in
         match f p with
         | i ->
-          let d, rs, xs =
+          let d, regs, regxs, xregs, flags =
             match kind_of_type Arch.reg_size p.v_kind p.v_ty with
-            | Word -> let d, rs = split ~ctxt ~num:num_rs rs in d, rs, xs
+            | Word -> let d, regs = split ~ctxt ~num:num_regs regs in d, regs, regxs, xregs, flags
             | Vector ->
                 let ctxt = "large " ^ ctxt in
-                let d, xs = split ~ctxt ~num:num_xs xs in d, rs, xs
+                let d, xregs = split ~ctxt ~num:num_xregs xregs in d, regs, regxs, xregs, flags
             | Extra ->
-               hierror_reg ~loc:(Lmore loc) "unexpected extra register %a" pp_var p
+                let ctxt = "extra " ^ ctxt in
+                let d, regxs = split ~ctxt ~num:num_regxs regxs in d, regs, regxs, xregs, flags
             | Flag ->
-               hierror_reg ~loc:(Lmore loc) "unexpected flag register %a" pp_var p
+                let ctxt = "flag " ^ ctxt in
+                let d, flags = split ~ctxt ~num:num_flags flags in d, regs, regxs, xregs, flags
             | Unknown ty ->
               hierror_reg ~loc:(Lmore loc) "unknown type %a for forced register %a"
                 PrintCommon.pp_ty ty (Printer.pp_var ~debug:true) p
           in
           allocate_one nv vars loc cnf p i d a;
-          (rs, xs)
-        | exception Not_found -> (rs, xs))
-      (rs, xs)
+          (regs, regxs, xregs, flags)
+        | exception Not_found -> (regs, regxs, xregs, flags))
+      (regs, regxs, xregs, flags)
       vs
-    |> (ignore : var list * var list -> unit)
+    |> (ignore : var list * var list * var list * var list -> unit)
   in
-  let alloc_args loc get = alloc_from_list loc ~ctxt:"parameters" Arch.argument_vars Arch.xmm_argument_vars get in
-  let alloc_ret loc get = alloc_from_list loc ~ctxt:"return values" Arch.ret_vars Arch.xmm_ret_vars get in
+
+  let alloc_args_gen get = alloc_from_list ~ctxt:"parameters" get in
+  let alloc_ret_gen get =  alloc_from_list ~ctxt:"return values" get in
+  let alloc_args get = alloc_args_gen get Arch.argument_vars [] Arch.xmm_argument_vars [] in
+  let alloc_ret get  = alloc_ret_gen get Arch.ret_vars [] Arch.xmm_ret_vars [] in
   let rec alloc_instr_r loc c =
     function
     | Cfor (_, _, s)
@@ -797,8 +845,8 @@ let allocate_forced_registers return_addresses nv (vars: int Hv.t) tr (cnf: conf
     | Csyscall(lvs, _, es) ->
        let get_a = function Pvar { gv ; gs = Slocal } -> L.unloc gv | _ -> assert false in
        let get_r = function Lvar gv -> L.unloc gv | _ -> assert false in
-       alloc_args loc get_a es;
-       alloc_ret loc get_r lvs;
+       alloc_args get_a loc es;
+       alloc_ret  get_r loc lvs;
        c
 
     | Cwhile (_, s1, _, _, s2)
@@ -822,8 +870,15 @@ let allocate_forced_registers return_addresses nv (vars: int Hv.t) tr (cnf: conf
     List.fold_left (fun c instr -> alloc_instr c instr) c s
   in
   let loc = L.i_loc0 f.f_loc in
-  if FInfo.is_export f.f_cc then alloc_args loc identity f.f_args;
-  if FInfo.is_export f.f_cc then alloc_ret loc L.unloc f.f_ret;
+  if FInfo.is_export f.f_cc then
+    (alloc_args identity loc f.f_args; alloc_ret L.unloc loc f.f_ret)
+  else
+    if is_stable_call_conv f then (
+      warning Experimental loc "support for %s annotation is experimental" stable_call_conv;
+      let icc = Arch.internal_call_conv in
+      alloc_args_gen identity icc.icall_reg icc.icall_regx icc.icall_xreg icc.icall_rflag loc f.f_args;
+      alloc_ret_gen L.unloc icc.icall_reg icc.icall_regx icc.icall_xreg icc.icall_rflag loc f.f_ret);
+
   let cnf = alloc_stmt f.f_body cnf in
   (match Arch.callstyle with
   | Arch_full.ByReg { call = Some r; return } ->
@@ -1207,32 +1262,51 @@ let global_allocation return_addresses (funcs: ('info, 'asm) func list) :
     - generate a fresh variable to hold the return address (if needed)
     - split live ranges (caveat: do not forget to remove φ-nodes at the end)
     - compute liveness information
-    - compute variables that are killed by a call to a function (including return addresses and extra registers)
-
+    - compute variables that are killed by a call to a function,
+      including return addresses and extra registers.
+      If the `stable_call_conv` is used then all
+      registers allowed to be used are also considered as killed.
+    - compute also the set of variables used by the function, including
+      the ones in the called functions
     Initial 'info are preserved in the result.
    *)
   let liveness_table : (Sv.t * Sv.t, 'asm) func Hf.t = Hf.create 17 in
   let killed_map : Sv.t Hf.t = Hf.create 17 in
   let killed fn = Hf.find killed_map fn in
+  let fn_vars_map : Sv.t Hf.t = Hf.create 17 in
+  let fn_vars fn = Hf.find fn_vars_map fn in
   let preprocess f =
     let f = f |> fill_in_missing_names |> Ssa.split_live_ranges false in
     Hf.add liveness_table f.f_name (Liveness.live_fd true f);
     let ra = Hf.find return_addresses f.f_name in
-    let written =
-      let written, cg = written_vars_fc f in
-      let written =
-        match f.f_cc with
-        | (Export | Internal) -> written
-        | Subroutine ->
-          Sv.union (vars_retaddr ra) written
-      in
-      let killed_by_calls =
-        Mf.fold (fun fn _locs acc -> Sv.union (killed fn) acc)
-          cg Sv.empty in
-      let killed_by_syscalls = if has_syscall f.f_body then Arch.syscall_kill else Sv.empty in
-      Sv.union (Sv.union written killed_by_calls) killed_by_syscalls
+    let written, cg = written_vars_fc f in
+    let ra =
+      match f.f_cc with
+      | (Export | Internal) -> Sv.empty
+      | Subroutine -> vars_retaddr ra
     in
+    (* If stable_call_conv is used then all allowed registers are considered as written *)
+    let written_call_conv =
+      match process_call_conv f with
+      | None -> Sv.empty
+      | Some mu ->
+        let icc = Arch.internal_call_conv in
+        [List.take mu.max_reg icc.icall_reg; List.take mu.max_regx icc.icall_regx;
+         List.take mu.max_xreg icc.icall_xreg; List.take mu.max_flag icc.icall_rflag]
+        |> List.flatten |> Sv.of_list in
+    let all_vars = Sv.union ra (vars_fc f) in
+    let all_vars =
+      Mf.fold (fun fn _locs acc -> Sv.union (fn_vars fn) acc)
+        cg all_vars in
+    let written = Sv.union ra (Sv.union written_call_conv written) in
+    let killed_by_calls =
+      Mf.fold (fun fn _locs acc -> Sv.union (killed fn) acc)
+        cg Sv.empty in
+    let killed_by_syscalls = if has_syscall f.f_body then Arch.syscall_kill else Sv.empty in
+    let written = Sv.union (Sv.union written killed_by_calls) killed_by_syscalls in
+
     Hf.add killed_map f.f_name written;
+    Hf.add fn_vars_map f.f_name all_vars;
     f
   in
   let funcs : (unit, 'asm) func list = funcs |> List.rev |> List.rev_map preprocess in
@@ -1292,6 +1366,26 @@ let global_allocation return_addresses (funcs: ('info, 'asm) func list) :
       liveness_table
       conflicts
   in
+  let conflicts =
+    (* If stable_call_conv is used then all variables used in f
+       are in conflict with the registers that are declared to be not modified by the
+       specified calling convention *)
+    let doit conflicts f =
+      match process_call_conv f with
+      | None -> conflicts
+      | Some mu ->
+        let icc = Arch.internal_call_conv in
+        let exclude =
+          List.flatten [List.drop mu.max_reg icc.icall_reg;
+                        List.drop mu.max_regx icc.icall_regx;
+                        List.drop mu.max_xreg icc.icall_xreg;
+                        List.drop mu.max_flag icc.icall_rflag ] in
+        let fv = fn_vars f.f_name in
+        List.fold_left (fun c x ->
+          Sv.fold (fun y c -> conflicts_add_one Arch.pointer_data Arch.reg_size Arch.asmOp vars tr Lnone x y c) fv c)
+          conflicts exclude in
+     List.fold_left doit conflicts funcs
+    in
 
   (* In-register return address conflicts with function arguments *)
   let conflicts =

--- a/compiler/src/riscv_arch_full.ml
+++ b/compiler/src/riscv_arch_full.ml
@@ -57,4 +57,6 @@ module Riscv (Lowering_params : Riscv_input) : Arch_full.Core_arch
   let pp_asm = Pp_riscv.print_prog
 
   let callstyle = Arch_full.ByReg { call = Some RA; return = true }
+
+  let internal_call_conv = Riscv_decl.riscv_internal_call_conv
 end

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -238,4 +238,5 @@ module X86 (Lowering_params : X86_input) :
 
   include Lowering_params
 
+  let internal_call_conv = X86_decl.x86_internal_call_conv
 end

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -909,8 +909,8 @@ register allocation: too many return values according to the ABI (only 2 availab
 fail/register_allocation/x86-64/unknown_type_register.jazz:
 
 "fail/register_allocation/x86-64/unknown_type_register.jazz", line 1 (0-28):
-compilation error:
-register allocation: unexpected flag register a
+compilation error in function f:
+register allocation: too many flag parameters according to the ABI (only 0 available on this architecture)
 
 fail/register_allocation/x86-64/var_unallocated.jazz:
 

--- a/compiler/tests/success/x86-64/stable_call_conv.jazz
+++ b/compiler/tests/success/x86-64/stable_call_conv.jazz
@@ -1,0 +1,43 @@
+#[stable_call_conv = {reg = 5, flag = 5}]
+fn f(reg u64 x1, reg u64 x2) -> reg u64 {
+   reg u64 x3 = x1;
+   x3 += x2;
+   reg u64 x4 = x2;
+   x4 += x3;
+
+   reg u64 x5 = x4;
+   x5 += x3;
+   x5 += x4;
+   x5 += x3;
+   x5 += x2;
+   x5 += x1;
+   x5 = x5;
+   return x5;
+}
+
+#[stable_call_conv = {reg = 5, flag}]
+fn g1(reg u64 x1, reg u64 x2) -> reg u64 {
+   #spill(x2);
+   x1 = f(x1, x2);
+   #unspill(x2);
+   x1 += x2;
+   return x1;
+}
+
+#[stable_call_conv = {reg = 6, flag}]
+fn g2(reg u64 x1, reg u64 x2) -> reg u64 {
+   reg u64 x3 = x2;
+   x1 = f(x1, x2);
+   x1 += x3;
+   return x1;
+}
+
+export fn h (reg u64 x, reg u64 y, reg u64 w) -> reg u64 {
+   reg u64 z;
+   #spill(y);
+   z = g1(x, y);
+   #unspill(y);
+   z = g2(z, y);
+   z += w;
+   return z;
+}

--- a/docs/source/compiler/harmony/index.md
+++ b/docs/source/compiler/harmony/index.md
@@ -1,0 +1,7 @@
+# Living in harmony with the Jasmin compiler
+
+:::{toctree}
+:maxdepth: 2
+
+regalloc.md
+:::

--- a/docs/source/compiler/harmony/regalloc.md
+++ b/docs/source/compiler/harmony/regalloc.md
@@ -1,0 +1,351 @@
+# Register allocation
+
+A big difference between the Jasmin compiler and more traditional compilers lies
+in **register allocation**. While traditional languages only manipulate
+variables abstractly, Jasmin allows the programmer to specify where variables
+are stored, either in memory (`stack`) or in registers (`reg`). Moreover, the
+compiler does not, in general, introduce any automatic spilling (saving
+registers to the stack) nor any additional register assignments. This design
+choice introduces strong constraints during register allocation. Some exceptions
+to this rule are the [Insert Renaming](../passes/insert_renaming.md) and
+[Automated spilling](../passes/auto_spill.md) passes.
+
+## Constraints imposed by the architecture
+
+During register allocation, the compiler must map every `reg` variable to a concrete hardware register.
+In addition, it must respect architectural constraints imposed by the instruction set.
+These constraints typically arise because certain assembly instructions:
+- Require specific registers, or
+- Impose equality constraints between source and destination registers.
+
+For example:
+```
+ (of, cf2, sf, pf, zf, x) = #ADC_64(y, z, cf1);
+```
+The `ADC_64` instruction forces:
+- The last argument `cf1` to be the carry flag `CF`,
+- The first results `of, cf2, sf, pf, zf` to be the flags `OF, CF, SF, PF, ZF`,
+- An additional constraint requiring the first source operand and the destination to use the same register;
+  hence `x` and `y` must be allocated to the same register.
+
+Due to these constraints, the following Jasmin program does not compile:
+```
+export fn fail(reg u64 y, reg u64 z) -> reg u64 {
+  reg u64 x;
+  x = y + z;
+  x = x + y;
+  return x;
+}
+```
+Compilation fails with the following error:
+```
+compilation error:
+register allocation: conflicting variables “y.230” and “x.237” must be merged due to:
+  at "test.jazz", line 2 (2-12):
+    ( _0.232,  _1.233,  _2.234,  _3.235,  _4.236, x.237) =
+      #ADD_64(y.230, z.231); /*  */
+  at "../test.jazz", line 3 (2-12):
+    ( _5.238,  _6.239,  _7.240,  _8.241,  _9.242, x.243) =
+      #ADD_64(x.237, y.230); /*  */
+```
+The first instruction enforces that `x.237` and `y.230` be merged into the same register.
+However, both variables are live during the second instruction, which creates a conflict and makes the merge impossible.
+
+To fix this, an explicit copy must be introduced:
+```
+export fn success(reg u64 y, reg u64 z) -> reg u64 {
+  reg u64 x;
+  x = y;
+  x = x + z;
+  x = x + y;
+  return x;
+}
+```
+
+## Finite number of registers
+
+Because the number of registers is finite, there exist valid Jasmin programs that cannot be translated into assembly.
+
+Consider the following example:
+```
+fn sum10 (reg u64 sum) -> reg u64 {
+  inline int i;
+  reg u64[14] t;
+  for i = 0 to 14 {
+    t[i] = i;
+  }
+  for i = 0 to 14 {
+    sum += t[i];
+  }
+  return sum;
+}
+
+export fn test1 () -> reg u64 {
+  reg u64 sum = 0;
+  sum = sum10(sum);
+  return sum;
+}
+```
+This code compiles successfully. The function `sum10` uses 15 registers: one for sum and fourteen for the array `t`.
+
+However, compilation may fail when sum10 is used in a different context:
+```
+fn sum10 (reg u64 sum) -> reg u64 {
+  inline int i;
+  reg u64[14] t;
+  for i = 0 to 14 {
+    t[i] = i;
+  }
+  for i = 0 to 14 {
+    sum += t[i];
+  }
+  return sum;
+}
+
+export fn test1 () -> reg u64 {
+  reg u64 sum = 0;
+  sum = sum10(sum);
+  return sum;
+}
+
+export fn test2() -> reg u64 {
+  reg u64 j = 0;
+  reg u64 sum = 0;
+  while (j < 5) {
+    sum = sum10(sum);
+    j += 1;
+  }
+  return sum;
+}
+```
+This results in the following error:
+```
+compilation error:
+register allocation: no more free register to allocate variable:
+    t#1.377 (defined at "../test.jazz", line 5 (4-5))
+```
+The issue arises because the variable `j` remains live throughout the execution of `sum10`, increasing register pressure.
+
+One solution is to reduce the number of registers used by `sum10`. Another is to temporarily spill `j` to the stack:
+
+```
+export fn test3() -> reg u64 {
+  stack u64 j_s;
+  reg u64 j = 0;
+  reg u64 sum = 0;
+
+  while (j < 5) {
+    j_s = j;
+    sum = sum10(sum);
+    j = j_s;
+    j += 1;
+  }
+  return sum;
+}
+```
+Here, the reg variable `j` is explicitly spilled to the stack variable `j_s` before the call to `sum10`, and unspilled afterward.
+
+The same behavior can be expressed using the #spill and #unspill primitives:
+
+the call to `sum10` and its value is recover (unspill) from memory after the call.
+```
+export fn test4() -> reg u64 {
+  reg u64 j = 0;
+  reg u64 sum = 0;
+
+  while (j < 5) {
+    #spill(j);
+    sum = sum10(sum);
+    #unspill(j);
+    j += 1;
+  }
+  return sum;
+}
+```
+
+## Constraints imposed by function calls
+
+Function calls introduce additional register allocation constraints:
+```
+fn incr (reg u64 x1) -> reg u64 {
+  x1 += 1;
+  return x1;
+}
+
+export fn test (reg u64 x, reg u64 y) -> reg u64 {
+  x = incr(x);
+  y = incr(y);
+  return y;
+}
+```
+Compilation fails with:
+```
+compilation error:
+register allocation: conflicting variables “x.237” and “y.238” must be merged due to:
+  at "../test.jazz", line 2 (2-10):
+    ( _0.232,  _1.233,  _2.234,  _3.235, x1.236) = #INC_64(x1.194); /*  */
+  at "../test.jazz", line 7 (2-14):
+    x.239 = incr(x.237);
+  at "../test.jazz", line 8 (2-14):
+    y.240 = incr(y.238);
+```
+
+Function calls introduce equality constraints between parameters (respectively
+results) and arguments (respectively destinations). In this example, these
+constraints force `x` and `y` to be allocated to the same register, which is
+impossible since they are alive simultaneously. More precisly instruction `x.239
+= incr(x.237)` generates constraints `x.239 == x1.236` and `x.237 == x1.194` and
+instruction `y.240 = incr(y.238)` generates `y.240 == x1.236` and `y.238 ==
+x1.194` (where `==` is to be read, in this paragraph, as “must be allocated to
+the same register as”). So `x.237` and `y.238` should be allocated to the same
+register but they are alive at the same time.
+
+A solution is to introduce an explicit copy of `y`:
+```
+export fn test (reg u64 x, reg u64 y) -> reg u64 {
+  x = incr(x);
+  y = y;
+  y = incr(y);
+  return y;
+}
+```
+
+## Using stable calling convention
+
+Jasmin provides an experimental feature allowing the use of a predefined calling convention, customizable via function annotations.
+This feature is only available for non-exported functions.
+
+The general syntax is:
+```
+#[stable_call_conv = {reg = <int>, regx = <int>, xreg = <int>, flag = <int>} ]
+```
+This annotation specifies how many registers of each category may be used or modified by the function:
+- `reg`  : general-purpose registers,
+- `flag` : flag registers (x86 and ARM only),
+- `regx` : MMX registers (x86 only),
+- `xreg` : XMM/YMM registers (x86 only).
+
+When `reg = n` is specified, the compiler conservatively assumes that the first `n` registers of that
+category are modified by the function. Register names and order are fixed.
+
+For x86 the four listes are
+```
+reg  ::= [RDI; RSI; RDX; RCX; R8; R9; RAX; RBX; RBP; R10; R11; R12; R13; R14; R15]
+regx ::= [MM0; MM1; MM2; MM3; MM4; MM5; MM6; MM7]
+xreg ::= [XMM0; XMM1; XMM2; XMM3; XMM4; XMM5; XMM6; XMM7; XMM8; XMM9; XMM10; XMM11; XMM12; XMM13; XMM14; XMM15]
+flag ::= [CF; PF; ZF; SF; OF]
+```
+For arm the listes are:
+```
+reg  ::= [R00; R01; R02; R03; R04; R05; R06; R07; R08; R09; R10; R11; R12]
+regx ::= []
+xreg ::= []
+flag ::= [CF; NF; ZF; VF ]
+ ```
+
+For riscv the listes are
+```
+reg  ::= [X10; X11; X12; X13; X14; X15; X16; X17; X5; X6; X7; X8; X9;
+          X18; X19; X20; X21; X22; X23; X24; X25; X26; X27; X28; X29; X30; X31 ]
+regx ::= []
+xreg ::= []
+flag ::= []
+```
+Function arguments are forced to use the first registers of each category, and the same applies to return values.
+
+The annotation can be partially specified, if only `#[stable_call_conv]` is
+provided this is equivalent to using all registers of all categories. Providing
+no integer arguments for a category means that all register of this category are
+used. When a category is not provided its means that no register of this
+category are used. For example, in x86:
+
+```
+#[stable_call_conv = {reg = 5, flag}]
+```
+is equivalent to
+```
+#[stable_call_conv = {reg = 5, flag = 5, regx = 0, xreg = 0}]
+```
+
+The following program uses a stable calling convention:
+```
+#[stable_call_conv = {reg = 5, flag = 5}]
+fn f(reg u64 x1, reg u64 x2) -> reg u64 {
+   reg u64 x3 = x1;
+   x3 += x2;
+   reg u64 x4 = x2;
+   x4 += x3;
+   reg u64 x5 = x4;
+   x5 += x3;
+   x5 += x4;
+   x5 += x3;
+   x5 += x2;
+   x5 += x1;
+   x5 = x5;
+   return x5;
+}
+
+#[stable_call_conv = {reg = 5, flag}]
+fn g1(reg u64 x1, reg u64 x2) -> reg u64 {
+   #spill(x2);
+   x1 = f(x1, x2);
+   #unspill(x2);
+   x1 += x2;
+   return x1;
+}
+
+#[stable_call_conv = {reg = 6, flag}]
+fn g2(reg u64 x1, reg u64 x2) -> reg u64 {
+   reg u64 x3 = x2;
+   x1 = f(x1, x2);
+   x1 += x3;
+   return x1;
+}
+
+export fn h (reg u64 x, reg u64 y, reg u64 w) -> reg u64 {
+   reg u64 z;
+   #spill(y);
+   z = g1(x, y);
+   #unspill(y);
+   z = g2(z, y);
+   z += w;
+   return z;
+}
+```
+Remark that the same program can be compiled without any need of spill or copy using the
+customize calling convention of Jasmin.
+```
+fn f(reg u64 x1, reg u64 x2) -> reg u64 {
+   reg u64 x3 = x1;
+   x3 += x2;
+   reg u64 x4 = x2;
+   x4 += x3;
+   reg u64 x5 = x4;
+   x5 += x3;
+   x5 += x4;
+   x5 += x3;
+   x5 += x2;
+   x5 += x1;
+   x5 = x5;
+   return x5;
+}
+
+fn g1(reg u64 x1, reg u64 x2) -> reg u64 {
+   x1 = f(x1, x2);
+   x1 += x2;
+   return x1;
+}
+
+export fn h (reg u64 x, reg u64 y, reg u64 w) -> reg u64 {
+   reg u64 z;
+   z = g1(x, y);
+   z = g1(z, y);
+   z += w;
+   return z;
+}
+```
+
+
+
+
+

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -16,6 +16,8 @@ language/semantics/index
 
 compiler/passes/index
 compiler/advanced/index
+compiler/harmony/index
+
 :::
 
 :::{toctree}

--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -678,6 +678,14 @@ Definition check_call_conv {call_conv:calling_convention} (fd:asm_fundef) :=
         check_list get_ARReg fd.(asm_fd_res) call_reg_ret &
         check_list get_AXReg fd.(asm_fd_res) call_xreg_ret].
 
+
+Class internal_calling_convention :=
+  { icall_reg   : seq reg_t
+  ; icall_regx  : seq regx_t
+  ; icall_xreg  : seq xreg_t
+  ; icall_rflag : seq rflag_t
+  }.
+
 End DECL.
 
 Section ENUM.

--- a/proofs/compiler/arm_decl.v
+++ b/proofs/compiler/arm_decl.v
@@ -317,3 +317,12 @@ Definition is_expandable_or_shift (n : Z) : bool :=
    | EI_byte | EI_pattern | EI_shift => true
    | EI_none => false
   end.
+
+
+
+Definition arm_internal_call_conv : internal_calling_convention :=
+  {| icall_reg   := [:: R00; R01; R02; R03; R04; R05; R06; R07; R08; R09; R10; R11; R12]
+   ; icall_regx  := [::]
+   ; icall_xreg  := [::]
+   ; icall_rflag := [:: CF; NF; ZF; VF ]
+  |}.

--- a/proofs/compiler/riscv_decl.v
+++ b/proofs/compiler/riscv_decl.v
@@ -177,3 +177,12 @@ Definition riscv_linux_call_conv : calling_convention :=
  ; call_xreg_ret  := [::]
  ; call_reg_ret_uniq := erefl true;
 |}.
+
+
+Definition riscv_internal_call_conv : internal_calling_convention :=
+  {| icall_reg   := [:: X10; X11; X12; X13; X14; X15; X16; X17; X5; X6; X7; X8; X9;
+                             X18; X19; X20; X21; X22; X23; X24; X25; X26; X27; X28; X29; X30; X31 ]
+   ; icall_regx  := [::]
+   ; icall_xreg  := [::]
+   ; icall_rflag := [::]
+  |}.

--- a/proofs/compiler/x86_decl.v
+++ b/proofs/compiler/x86_decl.v
@@ -328,3 +328,10 @@ Definition x86_windows_call_conv : calling_convention :=
    ; call_xreg_ret  := [:: XMM0 ]
    ; call_reg_ret_uniq := erefl true;
   |}.
+
+Definition x86_internal_call_conv : internal_calling_convention :=
+  {| icall_reg    := [:: RDI; RSI; RDX; RCX; R8; R9; RAX; RBX; RBP; R10; R11; R12; R13; R14; R15]
+   ; icall_regx  := [:: MM0; MM1; MM2; MM3; MM4; MM5; MM6; MM7]
+   ; icall_xreg   := [:: XMM0; XMM1; XMM2; XMM3; XMM4; XMM5; XMM6; XMM7; XMM8; XMM9; XMM10; XMM11; XMM12; XMM13; XMM14; XMM15]
+   ; icall_rflag := [:: CF; PF; ZF; SF; OF]
+  |}.


### PR DESCRIPTION
# Description

Add an experimental `stable_call_conv` annotation to local functions

Write some documentation about specific issues related to the Jasmin compiler and register allocation (and how the new annotation can help).

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed