### PR TITLE
x86: support zero-extension from u128 to u256

### DIFF
--- a/changes/03-other/1364-x86-u128-u256.md
+++ b/changes/03-other/1364-x86-u128-u256.md
@@ -1,0 +1,2 @@
+- Zero-extension from 128-bit to 256-bit is now supported on x86
+  ([PR #1364](https://github.com/jasmin-lang/jasmin/pull/1364)).

--- a/compiler/tests/success/x86-64/extend.jazz
+++ b/compiler/tests/success/x86-64/extend.jazz
@@ -60,16 +60,24 @@ x ^= y;
 
 
 export
-fn test_u256(reg u64 ptr_, reg u64 v, reg u32 w) {
-reg u256 x, y;
+fn test_u256(reg u64 p v, reg u32 w) {
+  reg u256 x y;
+  reg u128 z;
 
-x = #set0_256();
-y = (256u)v;
-x ^= y;
-y = (256u)w;
-x ^= y;
-[:u128 ptr_ + 0] = x;
-[:u256 ptr_ + 32] = x;
+  x = #set0_256();
+  y = (256u)v;
+  x ^= y;
+  y = (256u)w;
+  x ^= y;
+  y = (256u)[:u128 p];
+  z = y;
+  y = (256u)z;
+  x ^= y;
+  y = (256u)[:u256 p];
+  x ^= y;
+
+  [:u128 p] = x;
+  [:u256 p + 32] = x;
 }
 
 export

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -270,7 +270,12 @@ Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
         | U256 => kb true szo (LowerCopn (Oasm (BaseOp (Some szo, VMOV szi))) [:: a])
         | _ => LowerAssgn
         end
-    | _ => LowerAssgn
+    | U128 =>
+        match szo with
+        | U256 => kb (~~ is_lval_in_memory x) szo (LowerCopn (Oasm (BaseOp (Some szo, VMOVDQU szi))) [:: a ])
+        | _ => LowerAssgn
+        end
+    | U256 => LowerAssgn
     end
 
   | Papp2 op a b =>

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -606,11 +606,15 @@ Section PROOF.
           1-3: rewrite /= ok_x /exec_sopn /= truncate_word_le // {hle} /= zero_extend_u //.
           do 3 f_equal.
           exact: zero_extend_cut.
-        case: sz Hw hle' => // Hw hle'; case hc: convertible => //.
-        1-2: move: hty; rewrite -(convertible_eval_atype hc) => -[?]; subst sz'.
-        1-2: rewrite /= ok_x /exec_sopn /= truncate_word_le // {hle} /= zero_extend_u //.
-        do 3 f_equal.
-        exact: zero_extend_cut.
+        - case: sz Hw hle' => // Hw hle'; case hc: convertible => //.
+          1-2: move: hty; rewrite -(convertible_eval_atype hc) => -[?]; subst sz'.
+          1-2: rewrite /= ok_x /exec_sopn /= truncate_word_le // {hle} /= zero_extend_u //.
+          do 3 f_equal.
+          exact: zero_extend_cut.
+        case: sz Hw hle' => // Hw hle'; case: andP => // - [] _ hc.
+        move: (convertible_eval_atype hc).
+        rewrite hty; case => ?; subst sz'.
+        by rewrite /= ok_x /= /exec_sopn /= truncate_word_le // /= zero_extend_u.
       (* Olnot *)
       + rewrite /= /sem_sop1 /= => sz; t_xrbindP => w Hz z' /to_wordI' [sz' [z [Hsz ? ->]]] ?; subst.
         case: andP => // - [hsz] hc.


### PR DESCRIPTION
# Description

When targeting x86, a zero-extension from `u128` to `u256` now emits a `VMOVDQU` instruction (instead of failing during asm-gen).

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed
