### PR TITLE
Asm: remember Jasmin version

### DIFF
--- a/changes/03-other/1365-asm-jasmin-version.md
+++ b/changes/03-other/1365-asm-jasmin-version.md
@@ -1,0 +1,3 @@
+- The assembly output of the compiler features an `.ident` directive including
+  the version of the compiler
+  ([PR #1365](https://github.com/jasmin-lang/jasmin/pull/1365)).

--- a/compiler/src/AsmTargetBuilder.ml
+++ b/compiler/src/AsmTargetBuilder.ml
@@ -110,11 +110,13 @@ module Make(Target : AsmTarget) : S
         let functions_head = pp_functions_decl asm.asm_funcs in
         let functions_body = pp_functions asm.asm_funcs in
         let data_segment = pp_data_segment asm.asm_globs asm.asm_glob_names in
+        let compiler_ident = Header (".ident", [Format.asprintf "\"%s\"" Glob_options.version_string]) in
         let stack_note_segment =
           if is_target_system_macos () then [] else [
               Header (".section", [ "\".note.GNU-stack\""; "\"\""; "%progbits" ]);
             ]
         in
-        headers @ functions_head @ functions_body @ data_segment @ stack_note_segment
+        headers @ functions_head @ functions_body @ data_segment @
+        compiler_ident :: stack_note_segment
 
 end


### PR DESCRIPTION
# Description

This enriches the ASM output with some meta-data.

The `.ident` directive of GNU binutils is documented there: https://sourceware.org/binutils/docs/as/Ident.html

I’ve checked on an Apple OS that the compiler continues to work.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [ ] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed
