### PR TITLE
ARM: emit ADC when the out carry is discarded

### DIFF
--- a/changes/03-other/1369-arm-lowering-adc.md
+++ b/changes/03-other/1369-arm-lowering-adc.md
@@ -1,0 +1,4 @@
+- On arm-m4, the add-with-carry operation `_, r = a + b + c` is translated into
+  `ADC` (as opposed to `ADCS`) when the output carry is explicitly ignored
+  (i.e., written as an underscore)
+  ([PR #1369](https://github.com/jasmin-lang/jasmin/pull/1369)).

--- a/compiler/tests/success/arm-m4/addcarry.jazz
+++ b/compiler/tests/success/arm-m4/addcarry.jazz
@@ -1,0 +1,7 @@
+export fn add_carry(reg u32 a b) -> reg u32 {
+  reg bool c;
+  c, a = a + b;  // ADDS
+  _, a += b + c; // ADC
+  _, a += b + c; // `c` is still available here
+  return a;
+}

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -341,6 +341,8 @@ Definition lower_cassgn_bool (lv : lval) (tag: assgn_tag) (e : pexpr) : option (
 (* -------------------------------------------------------------------- *)
 (* Lowering of architecture-specific operations. *)
 
+Definition isLnone x : bool := if x is Lnone _ _ then true else false.
+
 Definition lower_add_carry
   (lvs : seq lval) (es : seq pexpr) : option copn_args :=
   match lvs, es with
@@ -352,11 +354,12 @@ Definition lower_add_carry
         | _ => None
         end
       in
+      let cf_not_none := ~~ isLnone cf in
       let opts :=
-        {| set_flags := true; is_conditional := false; has_shift := None; |}
+        {| set_flags := cf_not_none; is_conditional := false; has_shift := None; |}
       in
       let lnoneb := Lnone dummy_var_info abool in
-      let lvs' := [:: lnoneb; lnoneb; cf; lnoneb; r ] in
+      let lvs' := if cf_not_none then [:: lnoneb; lnoneb; cf; lnoneb; r ] else [:: r ] in
       Some (lvs', Oasm (BaseOp (None, ARM_op mn opts)), es')
   | _, _ =>
       None

--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -1378,6 +1378,15 @@ Proof.
   lia.
 Qed.
 
+Lemma write_Lnone wdb gd x v s s' :
+  isLnone x ->
+  write_lval wdb gd x v s = ok s' ->
+  s = s'.
+Proof.
+  case: x => // ii ty _ /=.
+  by rewrite /write_none /=; t_xrbindP.
+Qed.
+
 Lemma lower_add_carryP s0 s1 ii lvs tag es lvs' op' es' :
   esem_i p' ev (MkI ii (Copn lvs tag (sopn_addcarry U32) es)) s0 = ok s1
   -> lower_add_carry lvs es = Some (lvs', op', es')
@@ -1412,15 +1421,19 @@ Proof.
 
   2: rewrite hseme2 /= {hseme2}.
 
+  all: case no_carry: (isLnone _) => /=.
+
   all: rewrite /exec_sopn /=.
   all: rewrite !truncate_word_le // {hws hws'} /=.
   all: move: hwrite00 hwrite1.
   all: rewrite wunsigned_carry.
 
-  1: move: hseme2 => [?]; subst b.
-  1: rewrite /= Z.add_0_r wrepr0 GRing.addr0.
+  1, 2: move: hseme2 => [?]; subst b.
+  1, 2: rewrite /= Z.add_0_r wrepr0 GRing.addr0.
 
-  all: by move=> -> /= ->.
+  2, 4: by move=> -> /= ->.
+
+  1, 2: by move => /(write_Lnone no_carry) <- ->.
 Qed.
 
 Lemma lower_base_op s0 s1 ii lvs tag aop es lvs' op' es' :


### PR DESCRIPTION
# Description

The add-with-carry operation “c, r = a + b + c” is generally translated into an ADCS instruction. When the destination carry is “_” (Lnone), there is no need to set the flag and the compiler now emits an ADC instruction.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed
