### PR TITLE
No ring in extraction

### DIFF
--- a/compiler/src/asm_utils.mli
+++ b/compiler/src/asm_utils.mli
@@ -5,13 +5,13 @@ val pp_remote_label : Label.remote_label -> string
 val mangle : string -> string
 
 val format_glob_data :
-  Obj.t list ->
+  Word0.word list ->
   ((Var0.Var.var * Wsize.wsize) * BinNums.coq_Z) list ->
   PrintASM.asm_element list
 
 val hash_to_string : ('a -> string) -> 'a -> string
 val pp_imm : string -> Z.t -> string
-val pp_rip_address : Obj.t -> string
+val pp_rip_address : Word0.word -> string
 val pp_register : ('reg, _, _, _, _) Arch_decl.arch_decl -> 'reg -> string
 
 type parsed_reg_address = {

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -16,17 +16,17 @@ val z_of_pos : BinNums.positive -> Z.t
 val cz_of_z : Z.t -> BinNums.coq_Z
 val z_of_cz : BinNums.coq_Z -> Z.t
 
-val word_of_z : wsize -> Z.t -> Obj.t
-val int64_of_z : Z.t -> Obj.t
-val int32_of_z : Z.t -> Obj.t
-val z_of_int256 : Obj.t -> Z.t
-val z_of_int128 : Obj.t -> Z.t
-val z_of_int64 : Obj.t -> Z.t
-val z_of_int32 : Obj.t -> Z.t
-val z_of_int16 : Obj.t -> Z.t
-val z_of_int8 : Obj.t -> Z.t
-val z_of_word : wsize -> Obj.t -> Z.t
-val z_unsigned_of_word : wsize -> Obj.t -> Z.t
+val word_of_z : wsize -> Z.t -> Word0.word
+val int64_of_z : Z.t -> Word0.word
+val int32_of_z : Z.t -> Word0.word
+val z_of_int256 : Word0.word -> Z.t
+val z_of_int128 : Word0.word -> Z.t
+val z_of_int64 : Word0.word -> Z.t
+val z_of_int32 : Word0.word -> Z.t
+val z_of_int16 : Word0.word -> Z.t
+val z_of_int8 : Word0.word -> Z.t
+val z_of_word : wsize -> Word0.word -> Z.t
+val z_unsigned_of_word : wsize -> Word0.word -> Z.t
 
 (* -------------------------------------------------------------------- *)
 val cty_of_ty : Prog.ty -> Type.atype

--- a/compiler/src/printCommon.mli
+++ b/compiler/src/printCommon.mli
@@ -58,7 +58,7 @@ val pp_arr_slice :
 
 val pp_len : Format.formatter -> int -> unit
 val pp_ty : Format.formatter -> Prog.ty -> unit
-val pp_datas : Format.formatter -> Obj.t list -> unit
+val pp_datas : Format.formatter -> Word0.word list -> unit
 val pp_var : Format.formatter -> Var0.Var.var -> unit
 val pp_var_i : Format.formatter -> Expr.var_i -> unit
 

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -40,7 +40,7 @@ type stk_alloc_oracle_t =
   }
 
 type glob_alloc_oracle_t = 
-  { gao_data : Obj.t list 
+  { gao_data : Word0.word list 
   ; gao_slots  : (var * wsize * int) list 
   ; gao_align : wsize
   ; gao_size  : int               (* Not normalized with respect to sao_local_align *)

--- a/compiler/src/varalloc.mli
+++ b/compiler/src/varalloc.mli
@@ -28,7 +28,7 @@ type stk_alloc_oracle_t =
   }
 
 type glob_alloc_oracle_t = 
-  { gao_data : Obj.t list         (* word u8 *)
+  { gao_data : Word0.word list         (* word u8 *)
   ; gao_slots  : (var * wsize * int) list 
   ; gao_align : wsize
   ; gao_size  : int               (* Not normalized with respect to sao_local_align *)

--- a/proofs/arch/arm_expand_imm.v
+++ b/proofs/arch/arm_expand_imm.v
@@ -75,7 +75,7 @@ Definition check_wencoding we z :=
   | W16_encoding => is_w16_encoding z
   end.
 
-Definition check_ei_kind ewe sz (w: ssralg.GRing.ComRing.sort (word sz)) :=
+Definition check_ei_kind ewe sz (w: word sz) :=
   let z := wunsigned w in
   match ei_kind z with
   | EI_pattern | EI_byte => true

--- a/proofs/compiler/arm_extra.v
+++ b/proofs/compiler/arm_extra.v
@@ -42,7 +42,7 @@ Definition Oarm_add_large_imm_instr : instruction_desc :=
   let ty := aword arm_reg_size in
   let cty := eval_atype ty in
   let ctin := [:: cty; cty] in
-  let semi := fun (x y : word arm_reg_size) => (x + y)%R in
+  let semi := fun (x y : word arm_reg_size) => (x + y)%w in
   {| str    := (fun _ => "add_large_imm"%string)
    ; tin    := [:: ty; ty]
    ; i_in   := [:: E 1; E 2]

--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -346,7 +346,7 @@ Definition ad_nzcv : seq arg_desc := map F [:: NF; ZF; CF; VF ].
 (* Common flag definitions. *)
 
 Definition NF_of_word (ws : wsize) (w : word ws) := msb w.
-Definition ZF_of_word (ws : wsize) (w : word ws) := w == 0%R.
+Definition ZF_of_word (ws : wsize) (w : word ws) := w == 0%w.
 
 (* Compute the value of the flags for an arithmetic operation.
    For instance, for <+> a binary operation, this function should be called
@@ -705,7 +705,7 @@ Let string_of_arm_mnemonic mn :=
 Definition arm_ADD_semi (wn wm : ty_r) : ty_nzcv_r :=
   let x :=
     nzcv_w_of_aluop
-      (wn + wm)%R
+      (wn + wm)%w
       (wunsigned wn + wunsigned wm)%Z
       (wsigned wn + wsigned wm)%Z
   in
@@ -750,7 +750,7 @@ Definition arm_ADC_semi (wn wm : ty_r) (cf : bool) : ty_nzcv_r :=
   let c := Z.b2z cf in
   let x :=
     nzcv_w_of_aluop
-      (wn + wm + wrepr reg_size c)%R
+      (wn + wm + wrepr reg_size c)%w
       (wunsigned wn + wunsigned wm + c)%Z
       (wsigned wn + wsigned wm + c)%Z
   in
@@ -793,7 +793,7 @@ Definition arm_ADC_instr : instr_desc_t :=
   else drop_nzcv x.
 
 Definition arm_MUL_semi (wn wm : ty_r) : ty_nz_r :=
-  let res := (wn * wm)%R in
+  let res := (wn * wm)%w in
   (:: Some (NF_of_word res), Some (ZF_of_word res) & res).
 
 (* Registers that cannot be encoded using three bits and are therefore unusable with MULS *)
@@ -833,7 +833,7 @@ Definition arm_MUL_instr : instr_desc_t :=
   else drop_nz x.
 
 Definition arm_MLA_semi (wn wm wa: ty_r) : ty_r :=
-  (wn * wm + wa)%R.
+  (wn * wm + wa)%w.
 
 Definition arm_MLA_instr : instr_desc_t :=
   let mn := MLA in
@@ -859,7 +859,7 @@ Definition arm_MLA_instr : instr_desc_t :=
   |}.
 
 Definition arm_MLS_semi (wn wm wa: ty_r) : ty_r :=
-  (wa - wn * wm)%R.
+  (wa - wn * wm)%w.
 
 Definition arm_MLS_instr : instr_desc_t :=
   let mn := MLS in
@@ -916,7 +916,7 @@ Definition arm_SUB_semi (wn wm : ty_r) : ty_nzcv_r :=
   let wmnot := wnot wm in
   let x :=
     nzcv_w_of_aluop
-      (wn + wmnot + 1)%R
+      (wn + wmnot + 1)%w
       (wunsigned wn + wunsigned wmnot + 1)%Z
       (wsigned wn + wsigned wmnot + 1)%Z
   in
@@ -1250,7 +1250,7 @@ Definition arm_SMMULR_instr : instr_desc_t :=
 Definition get_hw (hw : halfword) (x : wreg) : u16 :=
   if split_vec 16 x is [:: lo; hi ]
   then if hw is HWT then hi else lo
-  else 0%R. (* Never happens. *)
+  else 0%w. (* Never happens. *)
 
 Definition arm_smul_hw_semi (hwn hwm : halfword) (wn wm : wreg) : wreg :=
   let n := get_hw hwn wn in
@@ -2080,7 +2080,7 @@ Definition arm_SBFX_instr : instr_desc_t :=
 Definition arm_CMP_semi (wn wm : ty_r) : ty_nzcv :=
   let wmnot := wnot wm in
   nzcv_of_aluop
-      (wn + wmnot + 1)%R
+      (wn + wmnot + 1)%w
       (wunsigned wn + wunsigned wmnot + 1)%Z
       (wsigned wn + wsigned wmnot + 1)%Z.
 

--- a/proofs/compiler/arm_lowering.v
+++ b/proofs/compiler/arm_lowering.v
@@ -253,8 +253,8 @@ Definition lower_Papp2_op
       else Some (ROR, e0, [:: e1 ])
   | Orol U32 =>
       let%opt c := is_wconst U8 e1 in
-      if c == 0%R then Some (MOV, e0, [::])
-      else Some (ROR, e0, [:: wconst (32 - c) ])
+      if c == 0%w then Some (MOV, e0, [::])
+      else Some (ROR, e0, [:: wconst (wrepr _ 32 - c)%w ])
   | _ =>
       None
   end.

--- a/proofs/compiler/arm_lowering_proof.v
+++ b/proofs/compiler/arm_lowering_proof.v
@@ -275,7 +275,7 @@ Proof.
    - by rewrite wltsE.
 
    (* Case [w0 <u w1]. *)
-   - by rewrite wleuE ltNge.
+   - by rewrite wleuE ltzE ltNge.
 
    (* Case [w0 <=s w1]. *)
    - by rewrite wlesE'.
@@ -284,16 +284,16 @@ Proof.
    - by rewrite wleuE'.
 
    (* Case [w0 >s w1]. *)
-   - by rewrite wlesE' ltNge.
+   - by rewrite wlesE' ltzE ltNge.
 
    (* Case [w0 >u w1]. *)
-   - by rewrite wleuE' ltNge.
+   - by rewrite wleuE' ltzE ltNge.
 
    (* Case [w0 >=s w1]. *)
-   - by rewrite wltsE leNgt.
+   - by rewrite wltsE lezE leNgt.
 
    (* Case [w0 >=u w1]. *)
-   by rewrite -word.wltuE leNgt.
+   by rewrite -word.wltuE lezE leNgt.
 
   case: op hcf hsemop h => // -[] //= _ [? ->] /(_ erefl) hsemop; subst cf.
   case hlower: lower_TST => [es'|//].
@@ -668,7 +668,7 @@ Proof.
   split; last by [].
   exists [:: v; @Vword U32 0 ].
   - by rewrite /= hseme wrepr0.
-  by rewrite /exec_sopn /= /sopn_sem ok_w' truncate_word_u /= GRing.add0r wnot1_wopp zero_extend_u.
+  by rewrite /exec_sopn /= /sopn_sem ok_w' truncate_word_u /= !add_wordE opp_wordE GRing.add0r wnot1_wopp zero_extend_u.
 Qed.
 
 Lemma mk_sem_divmodP si ws op (w0 w1 : word ws) w :
@@ -708,7 +708,7 @@ Ltac intro_opn_args :=
     match goal with
     | [ |- forall (_ : _ * _), _ ] => move=> []
     | [ |- forall (_ : option bool), _ ] => move=> ?
-    | [ |- forall (_ : _ (word _)), _ ] => move=> ?
+    | [ |- forall (_ : word _), _ ] => move=> ?
     end.
 
 #[local]
@@ -925,7 +925,7 @@ Proof.
     all: rewrite /=.
     4: rewrite (wadd_zero_extend _ _ hws).
     5: rewrite (wmul_zero_extend _ _ hws).
-    6,7: rewrite (wsub_zero_extend _ _ hws) wsub_wnot1.
+    6,7: rewrite !add_wordE !sub_wordE (wsub_zero_extend _ _ hws) wsub_wnot1.
     10: rewrite -(wand_zero_extend _ _ hws).
     11: rewrite -(wor_zero_extend _ _ hws).
     12: rewrite -(wxor_zero_extend _ _ hws).
@@ -936,7 +936,7 @@ Proof.
     1-3: rewrite /sem_sop2 /=; apply: rbindP => ? ->; apply: rbindP => ? -> /ok_inj/Vword_inj[] ??; subst => /=.
     1: have ? := cmp_le_antisym hws hws0; subst.
     2, 3: have ? := cmp_le_antisym hws hws1; subst.
-    2: rewrite GRing.addrC.
+    2: rewrite add_wordE GRing.addrC.
     1-3: by rewrite !zero_extend_u.
 
     all:
@@ -957,7 +957,7 @@ Proof.
     rewrite /sem_rol /sem_shift wrepr_unsigned -wror_opp.
     case: eqP => /= _; do 3 f_equal; apply: wror_m;
       change (wsize_bits _) with (wsize_size U256);
-      by rewrite wunsigned_sub_mod.
+      by rewrite sub_wordE wunsigned_sub_mod.
   }
 
   rewrite /arg_shift /=.

--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -276,7 +276,7 @@ Fixpoint assemble_cond ii (e : fexpr) : cexec condt :=
   end.
 
 Definition is_valid_address (addr : reg_address) :=
-  match addr.(ad_disp) != 0%R, isSome addr.(ad_offset), addr.(ad_scale) != 0 with
+  match addr.(ad_disp) != 0%w, isSome addr.(ad_offset), addr.(ad_scale) != 0 with
   | false, false, false => true
   | true, false, false => true
   | false, true, false => true

--- a/proofs/compiler/arm_params_core_proof.v
+++ b/proofs/compiler/arm_params_core_proof.v
@@ -85,7 +85,7 @@ Lemma sub_sem_fopn_args {s} {xi:var_i} {y} {wy : word Uptr} {z} {wz : word Uptr}
 Proof.
   move=> hc.
   rewrite /=; t_xrbindP => *; t_arm_op.
-  by rewrite /= wsub_wnot1 set_var_truncate // (convertible_eval_atype hc).
+  by rewrite /= !add_wordE wsub_wnot1 set_var_truncate // (convertible_eval_atype hc).
 Qed.
 
 Lemma subi_sem_fopn_args {s} {xi:var_i} {y imm wy} :
@@ -97,7 +97,7 @@ Lemma subi_sem_fopn_args {s} {xi:var_i} {y imm wy} :
 Proof.
   move=> hc.
   rewrite /=; t_xrbindP => *; t_arm_op.
-  by rewrite /= wsub_wnot1 set_var_truncate // (convertible_eval_atype hc).
+  by rewrite /= !add_wordE wsub_wnot1 set_var_truncate // (convertible_eval_atype hc).
 Qed.
 
 Lemma mov_sem_fopn_args {s} {xi:var_i} {y} {wy : word Uptr} :

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -118,6 +118,7 @@ Proof.
           /exec_sopn /= ok_wb ok_wo /=.
         have := shift_of_scaleP wo hshift.
         rewrite heq wrepr0 wunsigned0 wshl_sem //= wrepr1 GRing.mul1r => ->.
+        rewrite add_wordE.
         move: lea_sem; rewrite wrepr0 GRing.addr0 => ->.
         by rewrite hw /= with_vm_same.
       move=> [<-] hw.
@@ -125,6 +126,7 @@ Proof.
       rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb ok_vo /=
         /exec_sopn /= ok_wb ok_wo truncate_word_u /=.
       rewrite (shift_of_scaleP wo hshift).
+      rewrite add_wordE.
       move: lea_sem; rewrite wrepr0 GRing.addr0 => ->.
       by rewrite hw /= with_vm_same.
     move=> [?]; subst wo.
@@ -141,12 +143,14 @@ Proof.
       exists s2.(evm) => //.
       rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb /=
         /exec_sopn /= ok_wb truncate_word_u /=.
+        rewrite add_wordE.
       move: lea_sem; rewrite GRing.mulr0 GRing.addr0 => ->.
       by rewrite hw /= with_vm_same.
     move=> [<-] hw.
     exists s2.(evm) => //.
     rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb /=
       /exec_sopn /= ok_wb truncate_word_u /=.
+    rewrite add_wordE.
     move: lea_sem; rewrite GRing.mulr0 GRing.addr0 => ->.
     by rewrite hw /= with_vm_same.
   move=> al ws_ x_ e_; move: (Lmem al ws_ x_ e_) => {al ws_ x_ e_} x.
@@ -202,6 +206,7 @@ Proof.
   rewrite /= hget /=; t_arm_op.
   eexists; split; first reflexivity.
   + by move=> z hz; rewrite Vm.setP_neq //; apply /eqP; SvD.fsetdec.
+  rewrite !add_wordE.
   by rewrite Vm.setP_eq wsub_wnot1 vm_truncate_val_eq.
 Qed.
 

--- a/proofs/compiler/arm_stack_zeroization_proof.v
+++ b/proofs/compiler/arm_stack_zeroization_proof.v
@@ -302,7 +302,7 @@ Proof.
   apply: lsem_step2.
   + rewrite
       /lsem1 /step (find_instr_skip hbody) /= /eval_instr /=
-      /get_var hsr.(srl_off) /= /exec_sopn /= !truncate_word_u /= wsub_wnot1
+      /get_var hsr.(srl_off) /= /exec_sopn /= !truncate_word_u /= add_wordE wsub_wnot1
       /of_estate /= /lnext_pc /= -addnS.
     reflexivity.
   + rewrite /lsem1 /step (find_instr_skip hbody) /= -(addn1 2) addnA addn1.
@@ -398,7 +398,7 @@ Proof.
     exists s3; split.
     + apply: (lsem_step_end hsem3).
       by rewrite /lsem1 /step (find_instr_skip hbody) /= /eval_instr /=
-         /get_var /= hzf3 /= GRing.addrN /ZF_of_word /= eqxx /= /setpc /=
+         /get_var /= hzf3 /= GRing.addrN /ZF_of_word /= /setpc /=
          /lnext_pc /= -addnS.
     by move: hsr3; rewrite Z.sub_diag.
   have hlt3: (0 < n - wsize_size ws)%Z by nia.

--- a/proofs/compiler/constant_prop.v
+++ b/proofs/compiler/constant_prop.v
@@ -137,9 +137,9 @@ Definition sadd_int e1 e2 :=
 
 Definition sadd_w sz e1 e2 :=
   match is_wconst sz e1, is_wconst sz e2 with
-  | Some n1, Some n2 => wconst (n1 + n2)
-  | Some n, _ => if n == 0%R then e2 else Papp2 (Oadd (Op_w sz)) e1 e2
-  | _, Some n => if n == 0%R then e1 else Papp2 (Oadd (Op_w sz)) e1 e2
+  | Some n1, Some n2 => wconst (n1 + n2)%w
+  | Some n, _ => if n == 0%w then e2 else Papp2 (Oadd (Op_w sz)) e1 e2
+  | _, Some n => if n == 0%w then e1 else Papp2 (Oadd (Op_w sz)) e1 e2
   | _, _ => Papp2 (Oadd (Op_w sz)) e1 e2
   end.
 
@@ -159,8 +159,8 @@ Definition ssub_int e1 e2 :=
 
 Definition ssub_w sz e1 e2 :=
   match is_wconst sz e1, is_wconst sz e2 with
-  | Some n1, Some n2 => wconst (n1 - n2)
-  | _, Some n => if n == 0%R then e1 else Papp2 (Osub (Op_w sz)) e1 e2
+  | Some n1, Some n2 => wconst (n1 - n2)%w
+  | _, Some n => if n == 0%w then e1 else Papp2 (Osub (Op_w sz)) e1 e2
   | _, _ => Papp2 (Osub (Op_w sz)) e1 e2
   end.
 
@@ -186,14 +186,14 @@ Definition smul_int e1 e2 :=
 
 Definition smul_w sz e1 e2 :=
   match is_wconst sz e1, is_wconst sz e2 with
-  | Some n1, Some n2 => wconst (n1 * n2)
+  | Some n1, Some n2 => wconst (n1 * n2)%w
   | Some n, _ =>
-    if n == 0%R then @wconst sz 0
-    else if n == 1%R then e2
+    if n == 0%w then @wconst sz 0%w
+    else if n == 1%w then e2
     else Papp2 (Omul (Op_w sz)) (wconst n) e2
   | _, Some n =>
-    if n == 0%R then @wconst sz 0
-    else if n == 1%R then e1
+    if n == 0%w then @wconst sz 0%w
+    else if n == 1%w then e1
     else Papp2 (Omul (Op_w sz)) e1 (wconst n)
   | _, _ => Papp2 (Omul (Op_w sz)) e1 e2
   end.
@@ -486,7 +486,7 @@ Fixpoint const_prop_ir (m:cpm) ii (ir:instr_r) : cpm * cmd :=
     let ir :=
       if is_update_imm xs o es is Some (x, b, e) then
         if b then Copn [:: x ] AT_none (Oslh SLHmove) [:: e ]
-        else Cassgn x AT_none ty_msf (wconst (sz := msf_size) (-1))
+        else Cassgn x AT_none ty_msf (wconst (sz := msf_size) (-1%w)%w)
       else (Copn xs t o es)
     in
     (m, [:: MkI ii ir ])

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -177,6 +177,7 @@ Qed.
 
 Lemma sadd_wP sz e1 e2 : Papp2 (Oadd (Op_w sz)) e1 e2 =E sadd_w sz e1 e2.
 Proof.
+Local Opaque add_word.
 rewrite /sadd_w.
 case h1: (is_wconst sz e1) => [ n1 | ];
 case h2: (is_wconst sz e2) => [ n2 | ] //.
@@ -188,12 +189,13 @@ case h2: (is_wconst sz e2) => [ n2 | ] //.
   have! := (is_wconstP wdb gd s h1).
   t_xrbindP => ? k1 k2 ? k3 ? k4 ? k5 ? k6 <-; clarify.
   case: (to_wordI k6) => sz' [w' [? /truncate_word_uincl ?]]; subst.
-  by rewrite GRing.add0r k4;eauto.
+  by rewrite add_wordE GRing.add0r k4;eauto.
 case: eqP => // hz s v /=; rewrite /sem_sop2 /=.
 have! := (is_wconstP wdb gd s h2).
 t_xrbindP => ? k1 k2 ? k3 ? k4 ? k5 ? k6 <-; clarify.
 case: (to_wordI k5) => sz' [w' [? /truncate_word_uincl ?]]; subst.
-by rewrite GRing.addr0 k3;eauto.
+by rewrite add_wordE GRing.addr0 k3;eauto.
+Local Transparent add_word.
 Qed.
 
 Lemma saddP ty e1 e2 : Papp2 (Oadd ty) e1 e2 =E sadd ty e1 e2.
@@ -211,6 +213,7 @@ Qed.
 
 Lemma ssub_wP sz e1 e2 : Papp2 (Osub (Op_w sz)) e1 e2 =E ssub_w sz e1 e2.
 Proof.
+Local Opaque sub_word.
 rewrite /ssub_w.
 case h1: (is_wconst sz e1) => [ n1 | ];
 case h2: (is_wconst sz e2) => [ n2 | ] //.
@@ -222,7 +225,8 @@ case: eqP => // hz s v /=; rewrite /sem_sop2 /=.
 have! := (is_wconstP wdb gd s h2).
 t_xrbindP => ? k1 k2 ? k3 ? k4 ? k5 ? k6 <-; clarify.
 case: (to_wordI k5) => sz' [w' [? /truncate_word_uincl ?]]; subst.
-by rewrite GRing.subr0 k3;eauto.
+by rewrite sub_wordE GRing.subr0 k3;eauto.
+Local Transparent sub_word.
 Qed.
 
 Lemma ssubP ty e1 e2 : Papp2 (Osub ty) e1 e2 =E ssub ty e1 e2.
@@ -246,6 +250,7 @@ Qed.
 
 Lemma smul_wP sz e1 e2 : Papp2 (Omul (Op_w sz)) e1 e2 =E smul_w sz e1 e2.
 Proof.
+Local Opaque mul_word.
 rewrite /smul_w.
 case h1: (is_wconst sz e1) => [ n1 | ];
 case h2: (is_wconst sz e2) => [ n2 | ] //.
@@ -256,17 +261,18 @@ case h2: (is_wconst sz e2) => [ n2 | ] //.
 + case: eqP => hn1; [| case: eqP => hn2] => s v /=; rewrite /sem_sop2 /sem_sop1 /=;
   have! := (is_wconstP wdb gd s h1);
   t_xrbindP => ? k1 k2 ? k3 ? k4 ? k5 ? k6 ?; clarify.
-  - rewrite wrepr_unsigned GRing.mul0r;eauto.
+  - by rewrite wrepr0 mul_wordE GRing.mul0r;eauto.
   - case: (to_wordI k6) => {k6} sz' [w] [? /truncate_word_uincl]; subst.
-    by rewrite k4 GRing.mul1r; eauto.
+    by rewrite k4 mul_wordE GRing.mul1r; eauto.
   by rewrite k4 /= k6 /= wrepr_unsigned truncate_word_u /=;eexists;split;eauto => /=.
 case: eqP => hn1; [| case: eqP => hn2] => s v /=; rewrite /sem_sop2 /sem_sop1 /=;
 have! := (is_wconstP wdb gd s h2);
 t_xrbindP => ? k1 k2 ? k3 ? k4 ? k5 ? k6 ?; clarify.
-- by rewrite wrepr_unsigned GRing.mulr0;eauto.
+- by rewrite wrepr0 mul_wordE GRing.mulr0;eauto.
 - case: (to_wordI k5) => {k5} sz' [w] [? /truncate_word_uincl ?]; subst.
-  by rewrite k3 GRing.mulr1;eauto.
+  by rewrite k3 mul_wordE GRing.mulr1;eauto.
 by rewrite k3 /= k5 /= truncate_word_u wrepr_unsigned /=;eexists;split;eauto => /=.
+Local Transparent mul_word.
 Qed.
 
 Lemma smulP ty e1 e2 : Papp2 (Omul ty) e1 e2 =E smul ty e1 e2.
@@ -1448,6 +1454,7 @@ Qed.
 
 Lemma it_const_prop_callP fn : wiequiv_f p p' ev ev (rpreF (eS:= uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
 Proof.
+Local Opaque opp_word.
   apply wequiv_fun_ind => {}fn _ fs ft [<- hfsu] fd hget.
   exists (const_prop_fun (p_globs p) fd).
   + by rewrite get_map_prog hget.
@@ -1588,6 +1595,7 @@ Proof.
   rewrite (surjective_pairing (const_prop_rvs _ _ _)) /=.
   apply wequiv_call_rel_uincl with checker_cp m => // ???.
   exact: wequiv_fun_rec.
+Local Transparent opp_word.
 Qed.
 
 End IT_PROOF.

--- a/proofs/compiler/lea_proof.v
+++ b/proofs/compiler/lea_proof.v
@@ -145,7 +145,7 @@ Section PROOF.
     rewrite /sem_sop2 /=; t_xrbindP=> > + ? + ?
         /to_wordI' [? [? [hsz1 ? ->]]] ?
         /to_wordI' [? [? [hsz2 ? ->]]] ?.
-      subst=> h1 h2 [<-]; rewrite wsub_zero_extend // !zero_extend_idem //.
+      subst=> h1 h2 [<-]; rewrite sub_wordE wsub_zero_extend // !zero_extend_idem //.
     exact (lea_subP hsz (He1 _ _ _ (cmp_le_trans hsz' hsz1) Heq1 h1)
                            (He2 _ _ _ (cmp_le_trans hsz' hsz2) Heq2 h2) Hsub).
   Qed.

--- a/proofs/compiler/riscv_extra.v
+++ b/proofs/compiler/riscv_extra.v
@@ -36,7 +36,7 @@ Definition Oriscv_add_large_imm_instr : instruction_desc :=
   let ty := aword riscv_reg_size in
   let cty := eval_atype ty in
   let ctin := [:: cty; cty] in
-  let semi := fun (x y : word riscv_reg_size) => (x + y)%R in
+  let semi := fun (x y : word riscv_reg_size) => (x + y)%w in
   {| str    := (fun _ => "add_large_imm"%string)
    ; tin    := [:: ty; ty]
    ; i_in   := [:: E 1; E 2]

--- a/proofs/compiler/riscv_instr_decl.v
+++ b/proofs/compiler/riscv_instr_decl.v
@@ -170,7 +170,7 @@ Notation ty_rr := (sem_ltuple [:: lreg; lreg ]) (only parsing).
    instructions have a 32-bit output, this is irrelevant. *)
 
 (* Arithmetic *)
-Definition riscv_add_semi (wn wm : ty_r) : ty_r := (wn + wm)%R.
+Definition riscv_add_semi (wn wm : ty_r) : ty_r := (wn + wm)%w.
 
 Definition riscv_ADD_instr : instr_desc_t := RTypeInstruction riscv_add_semi "ADD" "add".
 Definition prim_ADD := ("ADD"%string, primM ADD).
@@ -179,14 +179,14 @@ Definition riscv_ADDI_instr : instr_desc_t := ITypeInstruction_12s riscv_add_sem
 Definition prim_ADDI := ("ADDI"%string, primM ADDI).
 
 
-Definition riscv_sub_semi (wn wm : ty_r) : ty_r := (wn - wm)%R.
+Definition riscv_sub_semi (wn wm : ty_r) : ty_r := (wn - wm)%w.
 
 Definition riscv_SUB_instr : instr_desc_t := RTypeInstruction riscv_sub_semi "SUB" "sub".
 Definition prim_SUB := ("SUB"%string, primM SUB).
 
 
 (* Set less *)
-Definition riscv_slt_semi (wn wm : ty_r) : ty_r := if (wlt Signed wn wm) then 1%R else 0%R.
+Definition riscv_slt_semi (wn wm : ty_r) : ty_r := if (wlt Signed wn wm) then 1%w else 0%w.
 
 Definition riscv_SLT_instr : instr_desc_t := RTypeInstruction riscv_slt_semi "SLT" "slt".
 Definition prim_SLT := ("SLT"%string, primM SLT).
@@ -195,7 +195,7 @@ Definition riscv_SLTI_instr : instr_desc_t := ITypeInstruction_12s riscv_slt_sem
 Definition prim_SLTI := ("SLTI"%string, primM SLTI).
 
 
-Definition riscv_sltu_semi (wn wm : ty_r) : ty_r := if (wlt Unsigned wn wm) then 1%R else 0%R.
+Definition riscv_sltu_semi (wn wm : ty_r) : ty_r := if (wlt Unsigned wn wm) then 1%w else 0%w.
 
 Definition riscv_SLTU_instr : instr_desc_t := RTypeInstruction riscv_sltu_semi "SLTU" "sltu".
 Definition prim_SLTU := ("SLTU"%string, primM SLTU).
@@ -378,7 +378,7 @@ Definition prim_NOT := ("NOT"%string, primM NOT).
 
 
 Definition riscv_NEG_semi (wn : ty_r) : ty_r :=
-  (- wn)%R.
+  (- wn)%w.
 
 Definition riscv_NEG_instr : instr_desc_t :=
   let tin := [:: lreg ] in
@@ -489,7 +489,7 @@ Definition prim_STORE := ("STORE"%string, primP STORE).
 
 
 (* RISC-V 32M Multiply instructions (operators). *)
-Definition riscv_mul_semi (wn wm: ty_r) : ty_r := (wn * wm)%R.
+Definition riscv_mul_semi (wn wm: ty_r) : ty_r := (wn * wm)%w.
 Definition riscv_MUL_instr : instr_desc_t := RTypeInstruction riscv_mul_semi "MUL" "mul".
 Definition prim_MUL := ("MUL"%string, primM MUL).
 
@@ -510,13 +510,13 @@ Definition prim_MULHSU := ("MULHSU"%string, primM MULHSU).
 
 (* Division by zero is specified, it must return all bits set *)
 Definition riscv_div_semi (wn wm: ty_r) : ty_r :=
-  if wm == 0%R then (-1)%R else wdivi wn wm.
+  if wm == 0%w then (-1%w)%w else wdivi wn wm.
 Definition riscv_DIV_instr : instr_desc_t := RTypeInstruction riscv_div_semi "DIV" "div".
 Definition prim_DIV := ("DIV"%string, primM DIV).
 
 (* Division by zero is specified, it must return all bits set *)
 Definition riscv_divu_semi (wn wm: ty_r) : ty_r :=
-  if wm == 0%R then (-1)%R else wdiv wn wm.
+  if wm == 0%w then (-1%w)%w else wdiv wn wm.
 Definition riscv_DIVU_instr : instr_desc_t := RTypeInstruction riscv_divu_semi "DIVU" "divu".
 Definition prim_DIVU := ("DIVU"%string, primM DIVU).
 

--- a/proofs/compiler/riscv_lowering_proof.v
+++ b/proofs/compiler/riscv_lowering_proof.v
@@ -437,12 +437,12 @@ Proof.
       + by rewrite ok_v1.
       + apply (minus_insertP h_insert).
         by rewrite ok_v2.
-      by rewrite /= wadd_zero_extend.
+      by rewrite /= sub_wordE wadd_zero_extend.
     move=> [<- <- <-].
     set op2' := Oasm _.
     have [hcmp [w1 [w2 [ok_w1 ok_w2 sem_correct]]]] :=
       Hassgn_op2 ok_v1 ok_v2 ok_v htrunc hwrite (op2' := op2') erefl erefl erefl.
-    by rewrite sem_correct //= wsub_zero_extend.
+    by rewrite sem_correct //= /semi_to_atype /= /riscv_sub_semi !sub_wordE wsub_zero_extend.
   + case => // -[] // [] //=.
     + rewrite /sem_sop2 /=.
       t_xrbindP=> w1 ok_w1 w2 ok_w2.

--- a/proofs/compiler/riscv_params.v
+++ b/proofs/compiler/riscv_params.v
@@ -229,7 +229,7 @@ Fixpoint assemble_cond ii (e : fexpr) : cexec condt :=
   end.
 
 Definition is_valid_address (addr : reg_address) :=
-  match addr.(ad_disp) != 0%R, isSome addr.(ad_offset), addr.(ad_scale) != 0 with
+  match addr.(ad_disp) != 0%w, isSome addr.(ad_offset), addr.(ad_scale) != 0 with
   | false, false, false => true
   | true, false, false => true
   | _, _, _ => false

--- a/proofs/compiler/riscv_params_core_proof.v
+++ b/proofs/compiler/riscv_params_core_proof.v
@@ -88,6 +88,7 @@ Lemma sub_sem_fopn_args {s} {xi:var_i} {y} {wy : word Uptr} {z} {wz : word Uptr}
 Proof.
   move=> hc.
   rewrite /=; t_xrbindP => *; t_riscv_op.
+  rewrite /= /riscv_sub_semi sub_wordE.
   by rewrite /= set_var_truncate // (convertible_eval_atype hc).
 Qed.
 

--- a/proofs/compiler/riscv_params_proof.v
+++ b/proofs/compiler/riscv_params_proof.v
@@ -104,6 +104,7 @@ Proof.
       exists (evm s2) => //.
       rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb ok_vo /=
         /exec_sopn /= ok_wb ok_wo /= /riscv_add_semi.
+      rewrite add_wordE.
       move: lea_sem; rewrite wrepr1 GRing.mul1r wrepr0 GRing.addr0 => ->.
       by rewrite hw /= with_vm_same.
     move=> [?]; subst wo.
@@ -120,12 +121,14 @@ Proof.
       exists s2.(evm) => //.
       rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb /=
         /exec_sopn /= ok_wb truncate_word_u /= /riscv_add_semi.
+      rewrite add_wordE.
       move: lea_sem; rewrite GRing.mulr0 GRing.addr0 => ->.
       by rewrite hw /= with_vm_same.
     move=> [<-] hw.
     exists s2.(evm) => //.
     rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb /=
       /exec_sopn /= ok_wb truncate_word_u /=.
+    rewrite add_wordE.
     move: lea_sem; rewrite GRing.mulr0 GRing.addr0 => ->.
     by rewrite hw /= with_vm_same.
   move=> al ws_ x_ e_; move: (Lmem al ws_ x_ e_) => {al ws_ x_ e_} x.

--- a/proofs/compiler/slh_lowering_proof.v
+++ b/proofs/compiler/slh_lowering_proof.v
@@ -960,7 +960,7 @@ Proof.
       case: lvs hwrite => //= x []; t_xrbindP => //= s1 hw [?]; subst s1.
       split; last by apply: wf_env_after_assign_vars1 hwf hw.
       do 2!constructor.
-      by rewrite /sem_sopn hsemes /exec_sopn /sopn_sem /sopn_sem_ /= hv1 truncate_word_u /se_protect_ptr_fail_sem /= eqxx /= hw.
+      by rewrite /sem_sopn hsemes /exec_sopn /sopn_sem /sopn_sem_ /= hv1 truncate_word_u /se_protect_ptr_fail_sem /= hw.
     case hlower: shp_lower => [[[lvs' op'] es']|] //= hcheck [<-] hexec.
     have [hs hw]:= lower_slhoP hshparams hwf hcheck hlower hsemes hexec hwrite.
     by split => //; do 2!constructor.
@@ -1353,7 +1353,7 @@ case: is_protect_ptrP hargs hchk hexec => {slho} [[ws sz]|slho] /=; t_xrbindP.
     hsemes (mapM_nth (Pconst 0%Z) (Vint 0) (n := 1) hsemes);
     last by rewrite (size_mapM hsemes).
   move=> [->] ?? /= -> /= ?.
-  rewrite truncate_word_u /= eqxx /= => - _ [->] ?; subst res.
+  rewrite truncate_word_u /= => - _ [->] ?; subst res.
   move: xs hwrite; rewrite /write_lvals; destruct_opn_args=> {}s' hwrite [<-].
   rewrite hwrite; exists s' => //; split=> //.
   exact: wf_env_after_assign_vars1 hwf hwrite.

--- a/proofs/compiler/stack_alloc_proof_1.v
+++ b/proofs/compiler/stack_alloc_proof_1.v
@@ -1505,7 +1505,7 @@ Section EXPR.
       have [ws'' [w [_ ?]]] := get_gvar_word htyx hget; subst v.
       case: hty' => ?; subst ws''.
       have ? := check_validP hcvalid; subst status.
-      rewrite -(GRing.addr0 (_+_)%R) -wrepr0.
+      rewrite add_wordE -(GRing.addr0 (_+_)%R) -wrepr0.
       rewrite (eq_sub_region_val_read_word _ hwf hread eq_addr (w:=zero_extend ws w)).
       + rewrite wrepr0 GRing.addr0.
         rewrite (check_alignP hwf eq_addr halign) /=.
@@ -1541,7 +1541,7 @@ Section EXPR.
       assert (heq := wfr_val hgvalid hget).
       case: heq => hread _.
       have ? := check_validP hcvalid; subst status.
-      rewrite wrepr_add (GRing.addrC (wrepr _ _)) GRing.addrA.
+      rewrite wrepr_add add_wordE (GRing.addrC (wrepr _ _)) GRing.addrA.
       rewrite (eq_sub_region_val_read_word _ hwf hread eq_addr (w:=w)).
       + case: al hw halign => //= hw halign.
         have {}halign := check_alignP hwf eq_addr halign.
@@ -3582,7 +3582,7 @@ Proof.
     apply: is_align_add; first by [].
     by rewrite WArray.arr_is_align.
   have /writeV -/(_ w) [mem2 hmem2] := hvp.
-  rewrite Z.add_comm wrepr_add GRing.addrA hmem2 /=; eexists; first by reflexivity.
+  rewrite Z.add_comm wrepr_add add_wordE GRing.addrA hmem2 /=; eexists; first by reflexivity.
   (* valid_state update array *)
   have hofs: 0 <= i1 * mk_scale aa ws /\ i1 * mk_scale aa ws + csize_of (cword ws) <= csize_of (eval_atype x.(vtype)).
   + by rewrite hty.
@@ -4785,6 +4785,7 @@ Proof.
     have /(_ (with_mem s2 mem2)) []:=
       mov_ofsP hsaparams rip ii P'_globs ok_wey ok_wofsy Hmov_ofs.
     + rewrite /= /get_gvar /get_var vs_rsp /= /sem_sop2 /= !truncate_word_u /= truncate_word_u /=.
+      rewrite add_wordE.
       move: hpaddr; rewrite (sub_region_addr_stkptr _ hlocal) => -[->].
       by rewrite hmem2.
     move=> /= vm2 hsem heq1.

--- a/proofs/compiler/wint_word_proof.v
+++ b/proofs/compiler/wint_word_proof.v
@@ -100,6 +100,7 @@ Section E.
       1-8: by case: k => /= > -> /= > -> /= > [->] <-; (eexists; first reflexivity).
       case: o; rewrite /= /mk_sem_wiop2 /=.
       1-3: by move=> > -> > -> /= > /wint_of_intP [-> _] <-; (eexists; first reflexivity);
+           rewrite (add_wordE, mul_wordE, sub_wordE);
            rewrite (wrepr_add, wrepr_mul, wrepr_sub) !wrepr_int_of_word.
       1-2: by move=> > -> > -> /= > -> <- /=; (eexists; first reflexivity) => /=.
       + move=> > -> w2 -> /= > /wint_of_intP /= [-> _] <-; (eexists; first reflexivity).

--- a/proofs/compiler/x86_decl.v
+++ b/proofs/compiler/x86_decl.v
@@ -285,7 +285,7 @@ Instance x86_fcp : FlagCombinationParams :=
 
 
 (* -------------------------------------------------------------------- *)
-Definition x86_check_CAimm (checker : caimm_checker_s) ws (w : ssralg.GRing.ComRing.sort(word ws)) : bool :=
+Definition x86_check_CAimm (checker : caimm_checker_s) ws (w : word ws) : bool :=
   match checker with
   | CAimmC_none => true
   | CAimmC_arm_shift_amout _ | CAimmC_arm_wencoding _ | CAimmC_arm_0_8_16_24

--- a/proofs/compiler/x86_extra.v
+++ b/proofs/compiler/x86_extra.v
@@ -75,13 +75,13 @@ Definition Oset0_instr sz  :=
              (map atype_of_ltype (b5w_ty sz)) (map sopn_arg_desc implicit_flags ++ [:: E 0])
              (let vf := Some false in
               let vt := Some true in
-              (::vf, vf, vf, vt, vt & (0%R: word sz)))
+              (::vf, vf, vf, vt, vt & (0%w: word sz)))
               true
   else
     mk_instr_desc_safe (pp_sz "set0" sz)
              [::] [::]
              (map atype_of_ltype (w_ty sz)) [::E 0]
-             (0%R: word sz) true.
+             (0%w: word sz) true.
 
 Definition Oconcat128_instr :=
   mk_instr_desc_safe (pp_s "concat_2u128")

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -456,8 +456,8 @@ Definition lower_cassgn (ii:instr_info) (x: lval) (tg: assgn_tag) (ty: atype) (e
   | LowerLea sz (MkLea d b sc o) =>
     let de := wconst (wrepr Uptr d) in
     let sce := wconst (wrepr Uptr sc) in
-    let b := oapp Plvar (@wconst sz 0) b in
-    let o := oapp Plvar (@wconst sz 0) o in
+    let b := oapp Plvar (@wconst sz 0%w) b in
+    let o := oapp Plvar (@wconst sz 0%w) o in
     let lea tt :=
       let ii := warning ii Use_lea in
       let add := Papp2 (Oadd (Op_w sz)) in
@@ -467,9 +467,9 @@ Definition lower_cassgn (ii:instr_info) (x: lval) (tg: assgn_tag) (ty: atype) (e
     if options.(use_lea) then lea tt
     (* d + b + sc * o *)
     else
-      if d == 0%R then
+      if d == 0%Z then
         (* b + sc * o *)
-        if sc == 1%R then
+        if sc == 1%Z then
           (* b + o *)
           [::MkI ii (Copn [:: f ; f ; f ; f ; f; x ] tg (Ox86 (ADD sz)) [:: b ; o])]
         else if is_zero sz b then

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -141,6 +141,7 @@ Proof.
   rewrite /= Hvm /= /eval_instr /= /sem_sopn /sem_sop2 /exec_sopn /= !truncate_word_u /= truncate_word_u /=.
   eexists; split; first reflexivity.
   + by move=> z hz; rewrite Vm.setP_neq //; apply /eqP; SvD.fsetdec.
+  rewrite sub_wordE.
   by rewrite Vm.setP_eq vm_truncate_val_eq.
 Qed.
 
@@ -171,7 +172,7 @@ Proof.
        (if sz != 0%Z then x86_allocate_stack_frame rsp None sz else [::]) = ok (with_vm s vm2).
   + rewrite /vm2; case: eqP => hsz //=.
     rewrite get_var_neq // hget /= /sem_sop2 /= !truncate_word_u /=.
-    by rewrite /exec_sopn /= truncate_word_u /=.
+    by rewrite /exec_sopn /= sub_wordE truncate_word_u /=.
   have -> /= : get_var true vm2 vrsp = ok (Vword (ts - wrepr U64 sz)).
   + rewrite /vm2; case: eqP => ? /=.
     + by subst sz; rewrite get_var_neq // hget wrepr0 GRing.subr0.
@@ -700,7 +701,7 @@ Proof.
     case: xs => // hargs _ [<-] <-; rewrite /se_init_sem.
     case: lvs => // x [] /=; t_xrbindP => // m1 hw ? <- /=; subst m1.
     t_xrbindP => z [op oargs] hass <- <- hlo /=.
-    by rewrite -(wrepr0 U64) in hw; apply (assemble_mov hlo hw hass).
+    by rewrite word0E -(wrepr0 U64) in hw; apply (assemble_mov hlo hw hass).
 
   (* SLHupdate *)
   + rewrite /exec_sopn /= /sopn_sem /sopn_sem_ /= /x86_se_update_sem /=; t_xrbindP.

--- a/proofs/compiler/x86_stack_zeroization_proof.v
+++ b/proofs/compiler/x86_stack_zeroization_proof.v
@@ -193,6 +193,7 @@ Proof.
     rewrite [get_var _ _ rspi]/get_var hsr.(sr_rsp) /=.
     rewrite /sem_sop2 /= (truncate_word_u top) /=.
     rewrite get_var_eq //= !truncate_word_u /= truncate_word_u /=.
+    rewrite add_wordE sub_wordE.
     rewrite hm' /=.
     rewrite /of_estate /= /lnext_pc /=.
     by rewrite -addnS; reflexivity.
@@ -281,7 +282,7 @@ Proof.
       rewrite (find_instr_skip hlinear) /=.
       rewrite /eval_instr /=.
       rewrite /get_var /= hzf3 /=.
-      rewrite GRing.addrN /ZF_of_word /= eqxx /=.
+      rewrite GRing.addrN /ZF_of_word /=.
       rewrite /lnext_pc /=.
       by rewrite -addnS.
     by move: hsr3; rewrite Z.sub_diag.
@@ -372,6 +373,7 @@ Local Opaque wsize_size.
   + rewrite Vm.setP_neq;
       last by apply /eqP => h; apply /rsp_nin /sv_of_listP;
       rewrite !in_cons /= -h eqxx /= ?orbT.
+    rewrite sub_wordE.
     by rewrite Vm.setP_eq.
   by lia.
 Local Transparent wsize_size.
@@ -500,6 +502,7 @@ Proof.
       rewrite !in_cons /= -h eqxx /= ?orbT.
      do 5 rewrite get_var_neq //.
     rewrite /get_var /= hsr.(sr_rsp) /sem_sop2 /= !truncate_word_u /= truncate_word_u /=.
+    rewrite add_wordE sub_wordE.
     rewrite hm' /=.
     rewrite /of_estate /= /lnext_pc.
     by rewrite -addnS; reflexivity.
@@ -590,7 +593,7 @@ Proof.
       rewrite (find_instr_skip hlinear) /=.
       rewrite /eval_instr /=.
       rewrite /get_var /= hzf3 /=.
-      rewrite GRing.addrN /ZF_of_word /= eqxx /=.
+      rewrite GRing.addrN /ZF_of_word /=.
       rewrite /lnext_pc /=.
       by rewrite -addnS.
     by move: hsr3; rewrite Z.sub_diag.
@@ -693,6 +696,7 @@ Local Opaque wsize_size.
   + rewrite Vm.setP_neq;
       last by apply /eqP => h; apply /rsp_nin /sv_of_listP;
       rewrite !in_cons /= -h eqxx /= ?orbT.
+    rewrite sub_wordE.
     by rewrite Vm.setP_eq.
   by lia.
 Local Transparent wsize_size.
@@ -973,7 +977,8 @@ Local Opaque wsize_size.
         apply /eqP => h; apply /rsp_nin /sv_of_listP;
           rewrite !in_cons /= -h eqxx /= ?orbT]).
     by rewrite Vm.setP_eq.
-  + by rewrite Vm.setP_eq.
+  + rewrite sub_wordE.
+    by rewrite Vm.setP_eq.
   by lia.
 Local Transparent wsize_size.
 Qed.
@@ -1239,7 +1244,8 @@ Local Opaque wsize_size.
         apply /eqP => h; apply /rsp_nin /sv_of_listP;
           rewrite !in_cons /= -h eqxx /= ?orbT]).
     by rewrite Vm.setP_eq.
-  + by rewrite Vm.setP_eq.
+  + rewrite sub_wordE.
+    by rewrite Vm.setP_eq.
   by lia.
 Local Transparent wsize_size.
 Qed.

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -9,7 +9,7 @@ From Coq Require ExtrOCamlInt63.
 (* This is a hack to force the extraction to keep the singleton here,
    This need should be removed if we add more constructor to syscall_t *)
 Extract Inductive syscall.syscall_t => "(Wsize.wsize * BinNums.positive) Syscall_t.syscall_t" ["Syscall_t.RandomBytes"].
-Set Extraction File Comment "This prelude is added at extraction time. See lang/extraction.v. *) [@@@ocaml.warning ""-9-27-32-33-34-37-39-50-67""] (* End of prelude. ".
+Set Extraction File Comment "This prelude is added at extraction time. See lang/extraction.v. *) [@@@ocaml.warning ""-9-20-27-32-33-34-37-39-50-67""] (* End of prelude. ".
 
 Extraction Inline ssrbool.is_left.
 Extraction Inline ssrbool.predT ssrbool.pred_of_argType.

--- a/proofs/lang/memory_example.v
+++ b/proofs/lang/memory_example.v
@@ -128,7 +128,7 @@ Module MemoryI : MemoryT.
 
   Definition get (m:mem) (p:pointer) := 
     Let _ := assert (is_alloc m p && is_init m p) ErrAddrInvalid in
-    ok (odflt 0%R (Mz.get m.(data) (wunsigned p))).
+    ok (odflt 0%w (Mz.get m.(data) (wunsigned p))).
 
   Definition set (m:mem) (p:pointer) (w:u8) :=
     Let _ := assert (is_alloc m p) ErrAddrInvalid in
@@ -455,7 +455,7 @@ Module MemoryI : MemoryT.
       ok
         {| data := Mz.empty _;
            alloc := init_mem_alloc s;
-           stk_limit := 0%R;
+           stk_limit := 0%w;
            stk_root := stk;
            frames := [::];
            framesP := init_mem_framesP stk;
@@ -556,6 +556,7 @@ Module MemoryI : MemoryT.
     wunsigned (stack_limit m) <= wunsigned (top_stack m')
     ∧ wunsigned (top_stack m') + sz + Z.max 0 sz' <= wunsigned (top_stack m).
   Proof.
+  Local Opaque GRing.add.
     rewrite /alloc_stack; case: Sumbool.sumbool_of_bool => // h [<-].
     rewrite /top_stack /=.
     rewrite !addE.
@@ -572,6 +573,7 @@ Module MemoryI : MemoryT.
     1, 3-4: lia.
     rewrite /f /footprint_of_frame /=.
     lia.
+  Local Transparent GRing.add.
   Qed.
 
   Lemma alloc_stack_ioff  m ws_stk sz ioff sz' m' :

--- a/proofs/lang/psem_facts.v
+++ b/proofs/lang/psem_facts.v
@@ -793,7 +793,7 @@ Proof.
   all: apply/andP; split; first by auto.
   - by rewrite wadd_zero_extend // !zero_extend_u wrepr_add.
   - by rewrite wmul_zero_extend // !zero_extend_u wrepr_mul.
-  by rewrite wsub_zero_extend // !zero_extend_u wrepr_sub.
+  by rewrite sub_wordE wsub_zero_extend // !zero_extend_u wrepr_sub.
 Qed.
 
 End WITH_PARAMS.

--- a/proofs/lang/sem_op_typed.v
+++ b/proofs/lang/sem_op_typed.v
@@ -38,7 +38,7 @@ Definition sem_sop1_typed (o : sop1) :
   | Onot => mk_sem_sop1 negb
   | Olnot sz => mk_sem_sop1 (@wnot sz)
   | Oneg Op_int => mk_sem_sop1 Z.opp
-  | Oneg (Op_w sz) => mk_sem_sop1 (-%R)%R
+  | Oneg (Op_w sz) => mk_sem_sop1 -%w
   | Owi1 sign o => sem_wiop1_typed sign o
   end.
 
@@ -61,9 +61,9 @@ Definition sem_shl {s} := @sem_shift (@wshl) s.
 Definition sem_ror {s} := @sem_shift (@wror) s.
 Definition sem_rol {s} := @sem_shift (@wrol) s.
 
-Definition sem_vadd (ve:velem) {ws:wsize} := (lift2_vec ve +%R ws).
-Definition sem_vsub (ve:velem) {ws:wsize} := (lift2_vec ve (fun x y => x - y)%R ws).
-Definition sem_vmul (ve:velem) {ws:wsize} := (lift2_vec ve *%R ws).
+Definition sem_vadd (ve:velem) {ws:wsize} := (lift2_vec ve +%w ws).
+Definition sem_vsub (ve:velem) {ws:wsize} := (lift2_vec ve (fun x y => x - y)%w ws).
+Definition sem_vmul (ve:velem) {ws:wsize} := (lift2_vec ve *%w ws).
 
 Definition sem_vshr (ve:velem) {ws:wsize} (v : word ws) (i: u128) :=
   lift1_vec ve (fun x => wshr x (wunsigned i)) ws v.
@@ -75,7 +75,7 @@ Definition sem_vshl (ve:velem) {ws:wsize} (v : word ws) (i: u128) :=
   lift1_vec ve (fun x => wshl x (wunsigned i)) ws v.
 
 Definition mk_sem_divmod (si: signedness) sz o (w1 w2: word sz) : exec (word sz) :=
-  if ((w2 == 0) || [&& si == Signed, wsigned w1 == wmin_signed sz & w2 == -1])%R then Error ErrArith
+  if ((w2 == 0) || [&& si == Signed, wsigned w1 == wmin_signed sz & w2 == -1%w])%w then Error ErrArith
   else ok (o w1 w2).
 
 Definition mk_sem_sop2 (t1 t2 t3: Type) (o:t1 -> t2 -> t3) v1 v2 : exec t3 :=
@@ -125,11 +125,11 @@ Definition sem_sop2_typed (o: sop2) :
   | Oor  => mk_sem_sop2 orb
 
   | Oadd Op_int     => mk_sem_sop2 Z.add
-  | Oadd (Op_w s)   => mk_sem_sop2 +%R
+  | Oadd (Op_w s)   => mk_sem_sop2 +%w
   | Omul Op_int     => mk_sem_sop2 Z.mul
-  | Omul (Op_w s)   => mk_sem_sop2 *%R
+  | Omul (Op_w s)   => mk_sem_sop2 *%w
   | Osub Op_int     => mk_sem_sop2 Z.sub
-  | Osub (Op_w s)   => mk_sem_sop2 (fun x y =>  x - y)%R
+  | Osub (Op_w s)   => mk_sem_sop2 (fun x y =>  x - y)%w
   | Odiv u Op_int   => mk_sem_sop2 (signed Z.div Z.quot u)
   | Odiv u (Op_w s) => @mk_sem_divmod u s (signed wdiv wdivi u)
   | Omod u Op_int   => mk_sem_sop2 (signed Z.modulo Z.rem u)

--- a/proofs/lang/sha256.v
+++ b/proofs/lang/sha256.v
@@ -3,7 +3,7 @@ Require Import word.
 Import Utf8 ZArith.
 Import utils.
 
-#[local] Open Scope ring_scope.
+#[local] Open Scope word_scope.
 
 Definition ch (e f g: u32) : u32 :=
   wxor (wand e f) (wand (wnot e) g).
@@ -56,4 +56,4 @@ Definition sha256rnds2 (x y z: u128) : u128 :=
     let a₂ := t₁ + maj a₁ a₀ b₀ + Σ₀ a₁ in
     let e₂ := t₁ + c₀ in
     make_vec U128 [:: e₁; e₂; a₁; a₂ ]
-  else 0 (* absurd case *).
+  else 0%w (* absurd case *).

--- a/proofs/lang/sopn.v
+++ b/proofs/lang/sopn.v
@@ -389,10 +389,10 @@ Definition pseudo_op_get_instr_desc (o : pseudo_operator) : instruction_desc :=
    Since at source level we do not take into account speculative execution,
    the protect/protect_ptr are simply the identity *)
 
-Definition se_init_sem : wmsf := 0%R.
+Definition se_init_sem : wmsf := 0%w.
 
 Definition se_update_sem (b : bool) (msf : wmsf) : wmsf :=
-  (if b then msf else (-1)%R).
+  (if b then msf else (-1%w)%w).
 
 Definition se_move_sem (w : wmsf) : wmsf := w.
 
@@ -401,7 +401,7 @@ Definition se_protect_sem {ws : wsize} (w : word ws) (msf : wmsf) : word ws := w
 Definition se_protect_ptr_sem {p:positive} (t: WArray.array p) (msf : wmsf) : WArray.array p := t.
 
 Definition se_protect_ptr_fail_sem {p:positive} (t: WArray.array p) (msf : wmsf) : exec (WArray.array p) :=
-  Let _ := assert (msf == 0%R) ErrSemUndef in
+  Let _ := assert (msf == 0%w) ErrSemUndef in
   ok t.
 
 Definition SLHinit_str := "init_msf"%string.
@@ -489,7 +489,7 @@ Proof.
   move=> [ | v1' [ | ]]; [ by t_xrbindP | | by t_xrbindP].
   move=> _ /List_Forall2_inv_l -[v2' [_ [-> [/of_value_uincl_te -/(_ cty_msf) /= hu' /List_Forall2_inv_l ->]]]].
   rewrite /se_protect_ptr_fail_sem; t_xrbindP => /= t a /hu [t' -> ha] w' /hu' -> /eqP -> <- <- /=.
-  by rewrite eqxx /=; exists [::Varr t'] => //; constructor.
+  by exists [::Varr t'] => //; constructor.
 Qed.
 
 Lemma protect_ptr_fail_errty p:

--- a/proofs/lang/warray_.v
+++ b/proofs/lang/warray_.v
@@ -87,7 +87,7 @@ Module WArray.
     Definition get8 (m:array s) (i:pointer) :=
       Let _ := assert (in_bound m i) ErrOob in
       Let _ := assert (is_init m i) ErrAddrUndef in
-      ok (odflt 0%R (Mz.get m.(arr_data) i)).
+      ok (odflt 0%w (Mz.get m.(arr_data) i)).
 
     Definition set8 (m:array s) (i:pointer) (v:u8) : result _ (array s):=
       Let _ := assert (in_bound m i) ErrOob in


### PR DESCRIPTION
# Description

Following changes in mathcomp (PR https://github.com/math-comp/math-comp/pull/1256, see https://github.com/jasmin-lang/jasmin/pull/1093 for discussions about it), extraction to OCaml fails when encountering a ring structure from mathcomp. In particular, Jasmin is not compatible with mathcomp 2.5.

This PR removes the ring structures from all the problematic places. Most of the removed instances involve the ring structure of words, but a few occurrences of the ring structure of `Z` are removed too.

This PR goes together with changes to coqword that I'm about to push. CI will tell if it works with the base version of coqword.

This is on top of https://github.com/jasmin-lang/jasmin/pull/1371, just to avoid the conflict between both PRs.