### PR TITLE
Doc: add archlinux aur packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ If you just want to install the Jasmin tools, here is a TL;DR:
 - with APT (debian, ubuntu), a package is available in a dedicated repository,
   see the [documentation](https://jasmin-lang.readthedocs.io/en/stable/misc/installation_guide.html#on-debian-and-related-linux-distributions)
 
+- from AUR (arch linux), a package is available in the Arch User Repository,
+  see the [documentation](https://jasmin-lang.readthedocs.io/en/stable/misc/installation_guide.html#on-arch-linux)
+
 - with nix
   ```
   nix-env -iA nixpkgs.jasmin-compiler

--- a/docs/source/misc/installation_guide.md
+++ b/docs/source/misc/installation_guide.md
@@ -53,6 +53,22 @@ Then update the list of available packages (`sudo apt update`) and install the p
 - **easycrypt** (Trixie only) has the proof assistant
 - **libjasmin-easycrypt** has the EasyCrypt libraries used for verifying Jasmin implementations
 
+#### On Arch Linux
+
+The packages are distributed through Arch User Repository (AUR), the relevant packages are:
+- [**jasmin-compiler-bin**](https://aur.archlinux.org/packages/jasmin-compiler-bin): the command-line tools
+- [**easycrypt-bin**](https://aur.archlinux.org/packages/easycrypt-bin): the proof assistant
+- [**libjasmin-easycrypt-bin**](https://aur.archlinux.org/packages/libjasmin-easycrypt-bin): the EasyCrypt libraries
+
+Install any of them with your AUR Helper with a command like the following:
+~~~
+# with yay
+yay -S jasmin-compiler-bin
+
+# with paru
+paru -S jasmin-compiler-bin
+~~~
+
 #### Using the nix (or lix) package manager, on linux, macos, wsl, etc.
 
 Assuming the package-manager is set up and working (see


### PR DESCRIPTION
# Description

I created a set of packages in Arch User Repository useful for Arch Linux users:
- [**jasmin-compiler-bin**](https://aur.archlinux.org/packages/jasmin-compiler-bin)
- [**easycrypt-bin**](https://aur.archlinux.org/packages/easycrypt-bin)
- [**libjasmin-easycrypt-bin**](https://aur.archlinux.org/packages/libjasmin-easycrypt-bin)

 I will maintain them.
In this PR I just updated the documentation by adding instructions for installing them using an AUR Helper (yay or paru).

I hope this may be useful.