### PR TITLE
CI: update EasyCrypt to 2026.02

### DIFF
--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -242,7 +242,7 @@ let ec_keyword =
  ; "section"
  ; "subtype"
  ; "type"
- ; "class"
+ ; "class" (* No longer a keyword since 2026.02 *)
  ; "instance"
  ; "print"
  ; "search"

--- a/scripts/easycrypt.nix
+++ b/scripts/easycrypt.nix
@@ -15,17 +15,17 @@ with {
     version = "main";
     rev = "????";
     src = builtins.fetchTarball "https://api.github.com/repos/easycrypt/easycrypt/tarball/main";
-    extraBuildInputs = [ ocamlPackages.markdown ];
+    extraBuildInputs = [];
   };
 
   "release" = rec {
-    version = "2025.11";
+    version = "2026.02";
     rev = "r${version}";
     src = fetchFromGitHub {
       owner = "easycrypt";
       repo = "easycrypt";
       inherit rev;
-      hash = "sha256-BLyC8AB075Nyhb5heIKVkxnWWt4Zn8Doo10ShsACJ4g=";
+      hash = "sha256-ii/msqNUPZ7jQXG2fEkEpsGXc4sw6DcyaTIw21lrl7M=";
     };
     extraBuildInputs = [];
   };
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
     batteries
     dune-build-info
     dune-site
+    markdown
     pcre2
     why3
     yojson


### PR DESCRIPTION
I think we can wait a bit before *removing* an entry for the black-list of identifiers of the EasyCrypt extraction.