### PR TITLE
fix typo in pretyping error message

### DIFF
--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -2204,7 +2204,7 @@ let tt_call_conv _loc params returns cc =
               Printer.pp_pvar x;
           let i = List.index_of x args in
           if i = None then
-            warning PedanticPretyping (L.i_loc0 loc) "%a should be one of the paramaters" Printer.pp_pvar x;
+            warning PedanticPretyping (L.i_loc0 loc) "%a should be one of the parameters" Printer.pp_pvar x;
           i
         | _ -> assert false) returns in
     let is_writable_ptr k =


### PR DESCRIPTION
I apologies for the nit contribution, but I can't stand little typos :). Thank you for the amazing tool.