### PR TITLE
Pretyping: remove redundant warning

### DIFF
--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -2202,10 +2202,7 @@ let tt_call_conv _loc params returns cc =
           if writable = Constant then
             warning Always (L.i_loc0 loc) "no need to return a [reg const ptr] %a"
               Printer.pp_pvar x;
-          let i = List.index_of x args in
-          if i = None then
-            warning PedanticPretyping (L.i_loc0 loc) "%a should be one of the paramaters" Printer.pp_pvar x;
-          i
+          List.index_of x args
         | _ -> assert false) returns in
     let is_writable_ptr k =
       match k with

--- a/compiler/tests/fail/typing/x86-64/res_wrong_type.jazz
+++ b/compiler/tests/fail/typing/x86-64/res_wrong_type.jazz
@@ -1,7 +1,5 @@
 /* The error should be that the type of "pt" is not compatible with the declared
    return type of function "init".
-   Currently, the error is about returning a "reg ptr" that is not given as
-   an argument.
 */
 fn init () -> stack u64[2] {
    stack u64[2] t;

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1394,7 +1394,7 @@ fail/typing/x86-64/only_param.jazz:
 
 fail/typing/x86-64/res_wrong_type.jazz:
 
-"fail/typing/x86-64/res_wrong_type.jazz", line 1 (0) to line 13 (1): In function “init”, return statement variable “pt” has storage type “reg mut ptr”, which differs from declared return storage type “stack”
+"fail/typing/x86-64/res_wrong_type.jazz", line 1 (0) to line 11 (1): In function “init”, return statement variable “pt” has storage type “reg mut ptr”, which differs from declared return storage type “stack”
 
 fail/typing/x86-64/subarray_non_const_len.jazz:
 

--- a/compiler/tests/negative.ml
+++ b/compiler/tests/negative.ml
@@ -42,12 +42,6 @@ let config path =
         ( "fail/register_allocation/x86-64/unknown_type_register.jazz",
           disable_warnings [ UnusedVar ] );
         ("fail/slh/x86-64/export_takes_msf.jazz", disable_renaming);
-        ( "fail/stack_allocation/x86-64/return_ptr_global.jazz",
-          disable_warnings [ PedanticPretyping ] );
-        ( "fail/stack_allocation/x86-64/return_ptr_local.jazz",
-          disable_warnings [ PedanticPretyping ] );
-        ( "fail/stack_allocation/x86-64/return_subslice.jazz",
-          disable_warnings [ PedanticPretyping ] );
         ( "fail/typing/x86-64/bug_488.jazz",
           disable_warnings [ SimplifyVectorSuffix ] );
         ( "fail/typing/x86-64/export_stack_array_res.jazz",
@@ -55,8 +49,6 @@ let config path =
         ("fail/typing/x86-64/export_stack_res.jazz", reset_warn_recoverable);
         ("fail/typing/x86-64/non_inline_stack_arg.jazz", reset_warn_recoverable);
         ("fail/typing/x86-64/non_inline_stack_res.jazz", reset_warn_recoverable);
-        ( "fail/typing/x86-64/res_wrong_type.jazz",
-          disable_warnings [ PedanticPretyping ] );
         ( "fail/typing/x86-64/write_constant_pointer_direct_array.jazz",
           reset_warn_recoverable );
         ( "fail/typing/x86-64/write_constant_pointer_subproc_array.jazz",


### PR DESCRIPTION
The issue reported by this warning are correctly handled by the following passes (type-checking, stack-allocation).