### PR TITLE
Array lengths are now integers in Z

### DIFF
--- a/changes/01-feature/1388-arrays-of-length-0.md
+++ b/changes/01-feature/1388-arrays-of-length-0.md
@@ -1,0 +1,3 @@
+- Arrays of length 0 are now supported. This is for the sake of uniformity
+  and is a preparatory stage for larger changes to arrays.
+  ([PR 1388](https://github.com/jasmin-lang/jasmin/pull/1388)).

--- a/compiler/linter/Analyser/BackwardAnalyser.ml
+++ b/compiler/linter/Analyser/BackwardAnalyser.ml
@@ -20,7 +20,7 @@ module type Logic = sig
   val syscall :
        Location.i_loc
     -> lvals
-    -> (Wsize.wsize * BinNums.positive) Syscall_t.syscall_t
+    -> (Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t
     -> exprs
     -> domain
     -> domain annotation

--- a/compiler/linter/Analyser/BackwardAnalyser.mli
+++ b/compiler/linter/Analyser/BackwardAnalyser.mli
@@ -94,7 +94,7 @@ module type Logic =
     val syscall :
       Jasmin.Location.i_loc ->
       Jasmin.Prog.lvals ->
-      (Jasmin.Wsize.wsize * Jasmin.BinNums.positive) Jasmin.Syscall_t.syscall_t ->
+      (Jasmin.Wsize.wsize * Jasmin.BinNums.coq_Z) Jasmin.Syscall_t.syscall_t ->
       Jasmin.Prog.exprs -> domain -> domain Annotation.annotation
 
     (**

--- a/compiler/linter/Analyser/ForwardAnalyser.ml
+++ b/compiler/linter/Analyser/ForwardAnalyser.ml
@@ -22,7 +22,7 @@ module type Logic = sig
   val syscall :
        Location.i_loc
     -> lvals
-    -> (Wsize.wsize * BinNums.positive) Syscall_t.syscall_t
+    -> (Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t
     -> exprs
     -> domain
     -> domain annotation

--- a/compiler/linter/Analyser/ForwardAnalyser.mli
+++ b/compiler/linter/Analyser/ForwardAnalyser.mli
@@ -116,7 +116,7 @@ module type Logic =
     val syscall :
       Jasmin.Location.i_loc ->
       Jasmin.Prog.lvals ->
-      (Jasmin.Wsize.wsize * Jasmin.BinNums.positive) Jasmin.Syscall_t.syscall_t ->
+      (Jasmin.Wsize.wsize * Jasmin.BinNums.coq_Z) Jasmin.Syscall_t.syscall_t ->
       Jasmin.Prog.exprs -> domain -> domain Annotation.annotation
 
     (**

--- a/compiler/linter/Analysis/Liveness/LivenessAnalyser.ml
+++ b/compiler/linter/Analysis/Liveness/LivenessAnalyser.ml
@@ -49,7 +49,7 @@ module LivenessDomain : BackwardAnalyser.Logic with type domain = Sv.t = struct
   let syscall
     (_ : Location.i_loc)
     (lvs : lvals)
-    (_ : (Wsize.wsize * BinNums.positive) Syscall_t.syscall_t)
+    (_ : (Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t)
     (exprs : exprs)
     (domain : domain) =
     Annotation (live_assigns domain lvs exprs)

--- a/compiler/safetylib/safetyAbsExpr.ml
+++ b/compiler/safetylib/safetyAbsExpr.ml
@@ -417,7 +417,7 @@ module AbsExpr (Arch : SafetyArch.SafetyArch) (AbsDom : AbsNumBoolType) = struct
   (*-------------------------------------------------------------------------*)
   let arr_full_range x =
     List.init
-      (arr_range x * size_of_ws (arr_size x))
+      (max 0 (arr_range x * size_of_ws (arr_size x)))
       (fun i -> AarraySlice (x, U8, i))
 
   (* let abs_arr_range_at abs x acc ws ei = match aeval_cst_int abs ei with
@@ -434,7 +434,7 @@ module AbsExpr (Arch : SafetyArch.SafetyArch) (AbsDom : AbsNumBoolType) = struct
   let sub_arr_range x acc ws len i =
     let init_offset = access_offset acc ws i in
     let wss = size_of_ws ws in
-    List.init len (fun j -> AarraySlice (x, ws, init_offset + wss * j))
+    List.init (max 0 len) (fun j -> AarraySlice (x, ws, init_offset + wss * j))
 
   let abs_sub_arr_range_at abs x acc ws len ei =
     match Option.map Z.to_int (aeval_cst_zint abs ei) with
@@ -657,7 +657,7 @@ module AbsExpr (Arch : SafetyArch.SafetyArch) (AbsDom : AbsNumBoolType) = struct
     | Pget(_, access,ws,x,ei) ->
       begin
         match abs_sub_arr_range abs (L.unloc x.gv,x.gs) access ws 1 ei with
-        | [] -> assert false
+        | [] -> (* nonpositive length *) top_linexpr abs ws_e
         | [mv] ->
           let lin = Mtexpr.var mv in
           wrap_if_overflow abs lin Unsigned (int_of_ws ws_e)
@@ -1052,7 +1052,7 @@ module AbsExpr (Arch : SafetyArch.SafetyArch) (AbsDom : AbsNumBoolType) = struct
     | Laset (_, acc, ws, x, ei) ->
       begin
         match abs_sub_arr_range abs (L.unloc x,Expr.Slocal) acc ws 1 ei with
-        | [] -> assert false
+        | [] -> (* nonpositive length *) MLnone
         | [mv] -> MLvar (loc, mv)
         | _ as mvs -> MLvars (loc, mvs)
       end
@@ -1162,7 +1162,7 @@ module AbsExpr (Arch : SafetyArch.SafetyArch) (AbsDom : AbsNumBoolType) = struct
         (* [rhs.ms_offset] is not to be scaled on the word size. *)
         let eiv = Mlocal (AarraySlice (rgv,ws,rhs.ms_offset + i)) in
         (vi, eiv)
-      ) (List.init len (fun i -> i)) in
+      ) (List.init (max 0 len) (fun i -> i)) in
 
     let ves = List.map (fun (v,eiv) ->
         let ei = sexpr_from_simple_expr (Mtexpr.var eiv) in

--- a/compiler/safetylib/safetyInterpreter.ml
+++ b/compiler/safetylib/safetyInterpreter.ml
@@ -433,7 +433,7 @@ let safe_opn pd asmOp safe opn es =
            | _ -> assert false
          in
            List.flatten
-             (List.init (Conv.int_of_cz n) (fun i -> init_get array aa ws (offset i) 1))
+             (List.init (max 0 (Conv.int_of_cz n)) (fun i -> init_get array aa ws (offset i) 1))
       | NotZero (sz, n) ->
         [ notZero(sz, List.nth es (Conv.int_of_nat n)) ]
 
@@ -1423,7 +1423,7 @@ end = struct
 
   let cells_of_array x ofs n =
     let x = L.unloc x in
-    List.init (Conv.int_of_cz n) (fun i -> SafetyVar.AarraySlice (x, U8, ofs + i))
+    List.init (max 0 (Conv.int_of_cz n)) (fun i -> SafetyVar.AarraySlice (x, U8, ofs + i))
 
   let aeval_syscall state sc lvs _es =
     match sc with

--- a/compiler/safetylib/safetyInterpreter.ml
+++ b/compiler/safetylib/safetyInterpreter.ml
@@ -422,7 +422,7 @@ let safe_opn pd asmOp safe opn es =
          let n = Papp1 (E.uint_of_word sz, n) in
          let n = Papp2 (Omod (Unsigned, Op_int), n, Pconst (Z.of_int 32)) in
          [ InRange(Pconst (Conv.z_of_cz lo), Pconst (Conv.z_of_cz hi), n) ]
-      | Wsize.AllInit(ws, p, i) ->
+      | Wsize.AllInit(ws, n, i) ->
          let array, aa, offset =
            match List.nth es (Conv.int_of_nat i) with
            | Pvar y -> y, Warray_.AAscale, icnst
@@ -433,7 +433,7 @@ let safe_opn pd asmOp safe opn es =
            | _ -> assert false
          in
            List.flatten
-             (List.init (Conv.int_of_pos p) (fun i -> init_get array aa ws (offset i) 1))
+             (List.init (Conv.int_of_cz n) (fun i -> init_get array aa ws (offset i) 1))
       | NotZero (sz, n) ->
         [ notZero(sz, List.nth es (Conv.int_of_nat n)) ]
 
@@ -1423,12 +1423,12 @@ end = struct
 
   let cells_of_array x ofs n =
     let x = L.unloc x in
-    List.init (Conv.int_of_pos n) (fun i -> SafetyVar.AarraySlice (x, U8, ofs + i))
+    List.init (Conv.int_of_cz n) (fun i -> SafetyVar.AarraySlice (x, U8, ofs + i))
 
   let aeval_syscall state sc lvs _es =
     match sc with
     | Syscall_t.RandomBytes (ws, len) ->
-       let n = BinInt.Z.to_pos (Type.arr_size ws len) in
+       let n = Type.arr_size ws len in
        let cells = match lvs with
          | [ Lnone _ ] -> []
          | [ Lvar x ] -> cells_of_array x 0 n

--- a/compiler/safetylib/safetyVar.ml
+++ b/compiler/safetylib/safetyVar.ml
@@ -179,7 +179,7 @@ let u8_blast_at ~blast_arrays scope at =
     | Aarray v ->
       if blast_arrays then
         let iws = size_of_ws (arr_size v) in
-        let r = arr_range v in
+        let r = max 0 (arr_range v) in
         let vi i = AarraySlice (v,U8,i) in
         List.init (r * iws) vi
       else [at]
@@ -212,7 +212,7 @@ let rec expand_arr_vars = function
       | Bty _ -> assert false
       | Arr (ws, n) ->
         let wsz = size_of_ws ws in
-        List.init n (fun i -> of_scope scope (AarraySlice (v,ws,wsz * i)))
+        List.init (max 0 n) (fun i -> of_scope scope (AarraySlice (v,ws,wsz * i)))
         @ expand_arr_vars t
     end
   | v :: t -> v :: expand_arr_vars t

--- a/compiler/src/AsmTargetBuilder.ml
+++ b/compiler/src/AsmTargetBuilder.ml
@@ -98,11 +98,14 @@ module Make(Target : AsmTarget) : S
     let pp_data_segment_body globs names = Asm_utils.format_glob_data globs names
 
     let pp_data_segment globs names =
-    if not (List.is_empty globs) then
+      (* If there are only global slots of length 0, [globs] is empty,
+         but we still need to print the global label.
+         We check [names] rather than [globs] to solve the issue. *)
+      if not (List.is_empty names) then
         let headers = Target.data_segment_header in
         let data = pp_data_segment_body globs names in
         headers @ data
-    else
+      else
         []
 
     let asm_of_prog (asm: (reg,regx,xreg,rflag,cond,asm_op) asm_prog) : asm_element list =

--- a/compiler/src/array_expand.ml
+++ b/compiler/src/array_expand.ml
@@ -8,7 +8,7 @@ let init_tbl fc =
     let ty = Bty (U ws) in
     let vi i =
       V.mk (v.v_name ^ "#" ^ string_of_int i) (Reg(reg_kind v.v_kind, Direct)) ty v.v_dloc v.v_annot in
-    let t = Array.init sz vi in
+    let t = Array.init (max 0 sz) vi in
     Hv.add tbl v (ws, t) in
   let fv = vars_fc fc in
   let arrs = Sv.filter is_reg_arr (vars_fc fc) in

--- a/compiler/src/asm_utils.ml
+++ b/compiler/src/asm_utils.ml
@@ -106,7 +106,7 @@ let pp_address (arch : ('a, 'b, 'c, 'd, 'e) arch_decl) = function
 
 
 let declassify_mem (arch : ('a, 'b, 'c, 'd, 'e) arch_decl) len a =
-  let s = Format.sprintf "declassify_mem %s [%s]" (Z.to_string (Conv.z_of_pos len)) (pp_address arch a) in
+  let s = Format.sprintf "declassify_mem %s [%s]" (Z.to_string (Conv.z_of_cz len)) (pp_address arch a) in
   [Comment s]
 
 let declassify_val pp_asm_arg_ty lty a =

--- a/compiler/src/asm_utils.mli
+++ b/compiler/src/asm_utils.mli
@@ -28,7 +28,7 @@ val parse_reg_address :
 
 val declassify_mem :
    ('a, 'b, 'c, 'd, 'e) Arch_decl.arch_decl ->
-   Label.label ->
+   BinNums.coq_Z ->
    ('a, 'f, 'g, 'h, 'i) Arch_decl.address ->
    PrintASM.asm
 

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -13,9 +13,6 @@ let z_of_nat n =
 let int_of_nat n = Z.to_int (z_of_nat n)
 let nat_of_int i = BinInt.Z.to_nat (cz_of_int i)
 
-let pos_of_int i = pos_of_z (Z.of_int i)
-let int_of_pos p = Z.to_int (z_of_pos p)
-
 let word_of_z sz z = Word0.wrepr sz (cz_of_z z)
 let int64_of_z z = word_of_z W.U64 z
 let int32_of_z z = word_of_z W.U32 z

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -37,13 +37,13 @@ let cty_of_ty = function
   | Bty Bool      -> T.Coq_abool
   | Bty Int       -> T.Coq_aint
   | Bty (U sz)   -> T.Coq_aword(sz)
-  | Arr (sz, len) -> T.Coq_aarr (sz, pos_of_int len)
+  | Arr (sz, len) -> T.Coq_aarr (sz, cz_of_int len)
 
 let ty_of_cty = function
   | T.Coq_abool  ->  Bty Bool
   | T.Coq_aint   ->  Bty Int
   | T.Coq_aword sz -> Bty (U sz)
-  | T.Coq_aarr (sz, len) -> Arr (sz, int_of_pos len)
+  | T.Coq_aarr (sz, len) -> Arr (sz, int_of_cz len)
 
 (* ------------------------------------------------------------------------ *)
 
@@ -85,11 +85,11 @@ let gvari_of_cgvari v =
 let rec cexpr_of_expr = function
   | Pconst z          -> C.Pconst (cz_of_z z)
   | Pbool  b          -> C.Pbool  b
-  | Parr_init (ws, n) -> C.Parr_init (ws, pos_of_int n)
+  | Parr_init (ws, n) -> C.Parr_init (ws, cz_of_int n)
   | Pvar x            -> C.Pvar (cgvari_of_gvari x)
   | Pget (al, aa,ws, x,e) -> C.Pget (al, aa, ws, cgvari_of_gvari x, cexpr_of_expr e)
   | Psub (aa,ws,len, x,e) ->
-    C.Psub (aa, ws, pos_of_int len, cgvari_of_gvari x, cexpr_of_expr e)
+    C.Psub (aa, ws, cz_of_int len, cgvari_of_gvari x, cexpr_of_expr e)
   | Pload (al, ws, e)  -> C.Pload(al, ws, cexpr_of_expr e)
   | Papp1 (o, e)      -> C.Papp1(o, cexpr_of_expr e)
   | Papp2 (o, e1, e2) -> C.Papp2(o, cexpr_of_expr e1, cexpr_of_expr e2)
@@ -102,10 +102,10 @@ let rec cexpr_of_expr = function
 let rec expr_of_cexpr = function
   | C.Pconst z          -> Pconst (z_of_cz z)
   | C.Pbool  b          -> Pbool  b
-  | C.Parr_init (ws, n) -> Parr_init (ws, int_of_pos n)
+  | C.Parr_init (ws, n) -> Parr_init (ws, int_of_cz n)
   | C.Pvar x            -> Pvar (gvari_of_cgvari x)
   | C.Pget (al, aa,ws, x,e) -> Pget (al, aa, ws, gvari_of_cgvari x, expr_of_cexpr e)
-  | C.Psub (aa,ws,len,x,e) -> Psub (aa, ws, int_of_pos len, gvari_of_cgvari x, expr_of_cexpr e)
+  | C.Psub (aa,ws,len,x,e) -> Psub (aa, ws, int_of_cz len, gvari_of_cgvari x, expr_of_cexpr e)
   | C.Pload (al, ws, e)  -> Pload(al, ws, expr_of_cexpr e)
   | C.Papp1 (o, e)      -> Papp1(o, expr_of_cexpr e)
   | C.Papp2 (o, e1, e2) -> Papp2(o, expr_of_cexpr e1, expr_of_cexpr e2)
@@ -123,7 +123,7 @@ let clval_of_lval = function
   | Lmem (al, ws, loc, e) -> C.Lmem (al, ws, loc, cexpr_of_expr e)
   | Laset(al, aa,ws,x,e)-> C.Laset (al, aa, ws, cvari_of_vari x, cexpr_of_expr e)
   | Lasub(aa,ws,len,x,e)->
-    C.Lasub (aa, ws, pos_of_int len, cvari_of_vari x, cexpr_of_expr e)
+    C.Lasub (aa, ws, cz_of_int len, cvari_of_vari x, cexpr_of_expr e)
 
 let lval_of_clval = function
   | C.Lnone(loc, ty)  -> Lnone (loc, ty_of_cty ty)
@@ -131,7 +131,7 @@ let lval_of_clval = function
   | C.Lmem(al,ws,loc,e)  -> Lmem (al, ws, loc, expr_of_cexpr e)
   | C.Laset(al, aa,ws,x,e) -> Laset (al, aa,ws, vari_of_cvari x, expr_of_cexpr e)
   | C.Lasub(aa,ws,len,x,e) ->
-    Lasub (aa,ws, int_of_pos len, vari_of_cvari x, expr_of_cexpr e)
+    Lasub (aa,ws, int_of_cz len, vari_of_cvari x, expr_of_cexpr e)
 
 (* ------------------------------------------------------------------------ *)
 
@@ -335,10 +335,10 @@ let prog_of_csprog p =
 
 
 (* ---------------------------------------------------------------------------- *)
-let to_array ty p t =
+let to_array ty len t =
   let ws, n = array_kind ty in
   let get i =
-    match Warray_.WArray.get p Aligned Warray_.AAscale ws t (cz_of_int i) with
+    match Warray_.WArray.get len Aligned Warray_.AAscale ws t (cz_of_int i) with
     | Utils0.Ok w -> z_of_word ws w
     | _    -> assert false in
   ws, Array.init n get

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -9,6 +9,7 @@ val nat_of_int : int -> Datatypes.nat
 val pos_of_int : int -> BinNums.positive
 val cz_of_int   : int -> BinNums.coq_Z
 val int_of_pos : BinNums.positive -> int
+val int_of_cz : BinNums.coq_Z -> int
 
 val pos_of_z : Z.t -> BinNums.positive
 val z_of_pos : BinNums.positive -> Z.t
@@ -57,7 +58,7 @@ val fdef_of_csfdef : Var0.funname * 'asm Expr._sfundef -> (unit, 'asm) sfundef
 val prog_of_csprog : 'asm Expr._sprog -> (unit, 'asm) sprog
 
 val to_array : 
-  Prog.ty -> BinNums.positive -> Warray_.WArray.array -> wsize * Z.t array
+  Prog.ty -> BinNums.coq_Z -> Warray_.WArray.array -> wsize * Z.t array
 
 val error_of_cerror :
   (Format.formatter -> Compiler_util.pp_error -> unit) ->

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -6,9 +6,7 @@ val z_of_nat  : Datatypes.nat -> Z.t
 val int_of_nat : Datatypes.nat -> int
 val nat_of_int : int -> Datatypes.nat
 
-val pos_of_int : int -> BinNums.positive
 val cz_of_int   : int -> BinNums.coq_Z
-val int_of_pos : BinNums.positive -> int
 val int_of_cz : BinNums.coq_Z -> int
 
 val pos_of_z : Z.t -> BinNums.positive

--- a/compiler/src/evaluator.ml
+++ b/compiler/src/evaluator.ml
@@ -226,19 +226,19 @@ let pp_val fmt v =
   match v with
   | Vbool b -> Format.fprintf fmt "%b" b
   | Vint z  -> Format.fprintf fmt "%a" Z.pp_print (Conv.z_of_cz z)
-  | Varr(p,t) ->
-    let ip = Conv.int_of_pos p in
+  | Varr(n,t) ->
+    let ni = Conv.int_of_cz n in
     let pp_res fmt = function
       | Ok w               -> pp_word fmt U8 w
       | Error ErrAddrUndef -> pp_undef fmt (Coq_cword U8)
       | Error _            -> assert false in
     Format.fprintf fmt "@[[";
-    for i = 0 to ip-2 do
+    for i = 0 to ni-2 do
       let i = Conv.cz_of_int i in
-      Format.fprintf fmt "%a;@ " pp_res (WArray.get p Aligned AAscale U8 t i);
+      Format.fprintf fmt "%a;@ " pp_res (WArray.get n Aligned AAscale U8 t i);
     done;
-    if 0 < ip then
-      pp_res fmt (WArray.get p Aligned AAscale U8 t (Conv.cz_of_int (ip-1)));
+    if 0 < ni then
+      pp_res fmt (WArray.get n Aligned AAscale U8 t (Conv.cz_of_int (ni-1)));
     Format.fprintf fmt "]@]";
   | Vword(ws, w) -> pp_word fmt ws w
   | Vundef ty -> pp_undef fmt ty

--- a/compiler/src/insert_copy_and_fix_length.ml
+++ b/compiler/src/insert_copy_and_fix_length.ml
@@ -38,7 +38,7 @@ let rec fix_length_eassert e =
   | PappN_safety (o, es) ->
     let e = List.hd es in
     let ty = Typing.type_of_expr e in
-    let len = Conv.pos_of_int (size_of ty) in
+    let len = Conv.cz_of_int (size_of ty) in
     let o = match o with Ois_arr_init _ -> Operators.Ois_arr_init len | Ois_barr_init _ -> Ois_barr_init len in
     PappN_safety(o, es)
   | Pis_var_init _ | Pis_mem_init _ -> e
@@ -56,7 +56,7 @@ and iac_instr_r pd loc ir =
          Typing.check_length loc n;
           warning IntroduceArrayCopy
             loc "an array copy is introduced";
-          let op = Pseudo_operator.Ocopy(ws, Conv.pos_of_int n) in
+          let op = Pseudo_operator.Ocopy(ws, Conv.cz_of_int n) in
           Copn([x], t, Sopn.Opseudo_op op, [e])
     else ir
   | Cif (b, th, el) -> Cif (b, iac_stmt pd th, iac_stmt pd el)
@@ -81,7 +81,7 @@ and iac_instr_r pd loc ir =
       else
         let len = xn / wsn in
         Typing.check_length loc len;
-        let op = Pseudo_operator.Ocopy (ws, Conv.pos_of_int len) in
+        let op = Pseudo_operator.Ocopy (ws, Conv.cz_of_int len) in
         Copn(xs,t,Sopn.Opseudo_op op, es)
     | Sopn.Opseudo_op(Ocopy _), _ -> assert false
     | Sopn.Opseudo_op(Pseudo_operator.Oswap _), x::_ ->
@@ -93,7 +93,7 @@ and iac_instr_r pd loc ir =
       (* Fix the size it is dummy for the moment *)
       let ws, len = array_kind (L.unloc x).v_ty in
       Typing.check_length loc len;
-      let op = Slh_ops.SLHprotect_ptr (ws, Conv.pos_of_int len) in
+      let op = Slh_ops.SLHprotect_ptr (ws, Conv.cz_of_int len) in
       Copn(xs,t, Sopn.Oslh op, es)
     | Sopn.Oslh (SLHprotect_ptr _), _ -> assert false
     | Sopn.Opseudo_op (Odeclassify _), _ ->
@@ -114,7 +114,7 @@ and iac_instr_r pd loc ir =
         | [x] -> Typing.ty_lval pd loc x
         | _ -> assert false in
       let ws, len = array_kind ty in
-      Csyscall(xs, Syscall_t.RandomBytes (ws, Conv.pos_of_int len), es)
+      Csyscall(xs, Syscall_t.RandomBytes (ws, Conv.cz_of_int len), es)
     end
   | Cassert (msg, e) ->
     Cassert (msg, fix_length_eassert e)

--- a/compiler/src/insert_copy_and_fix_length.ml
+++ b/compiler/src/insert_copy_and_fix_length.ml
@@ -53,7 +53,6 @@ and iac_instr_r pd loc ir =
       match is_array_copy x e with
       | None -> ir
       | Some (ws, n) ->
-         Typing.check_length loc n;
           warning IntroduceArrayCopy
             loc "an array copy is introduced";
           let op = Pseudo_operator.Ocopy(ws, Conv.cz_of_int n) in
@@ -80,7 +79,6 @@ and iac_instr_r pd loc ir =
           xn wsn
       else
         let len = xn / wsn in
-        Typing.check_length loc len;
         let op = Pseudo_operator.Ocopy (ws, Conv.cz_of_int len) in
         Copn(xs,t,Sopn.Opseudo_op op, es)
     | Sopn.Opseudo_op(Ocopy _), _ -> assert false
@@ -92,7 +90,6 @@ and iac_instr_r pd loc ir =
     | Sopn.Oslh (SLHprotect_ptr _), [Lvar x] ->
       (* Fix the size it is dummy for the moment *)
       let ws, len = array_kind (L.unloc x).v_ty in
-      Typing.check_length loc len;
       let op = Slh_ops.SLHprotect_ptr (ws, Conv.cz_of_int len) in
       Copn(xs,t, Sopn.Oslh op, es)
     | Sopn.Oslh (SLHprotect_ptr _), _ -> assert false

--- a/compiler/src/liveness.ml
+++ b/compiler/src/liveness.ml
@@ -101,7 +101,7 @@ let liveness weak prog =
   fst prog, fds
 
 let iter_call_sites (cbf: L.i_loc -> funname -> lvals -> Sv.t * Sv.t -> unit)
-                    (cbs: L.i_loc -> (Wsize.wsize * BinNums.positive) Syscall_t.syscall_t -> lvals -> Sv.t * Sv.t -> unit)
+                    (cbs: L.i_loc -> (Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t -> lvals -> Sv.t * Sv.t -> unit)
                     (f: (Sv.t * Sv.t, 'asm) func) : unit =
   iter_instr (fun i ->
       match i.i_desc with

--- a/compiler/src/liveness.mli
+++ b/compiler/src/liveness.mli
@@ -20,7 +20,7 @@ val liveness : bool -> ('info, 'asm) prog -> (Sv.t * Sv.t, 'asm) prog
 *)
 val iter_call_sites :
   (L.i_loc -> funname -> lvals -> Sv.t * Sv.t -> unit) ->
-  (L.i_loc -> (Wsize.wsize * BinNums.positive) Syscall_t.syscall_t -> lvals -> Sv.t * Sv.t -> unit) ->
+  (L.i_loc -> (Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t -> lvals -> Sv.t * Sv.t -> unit) ->
   (Sv.t * Sv.t, 'asm) func -> unit
 
 val pp_info : Format.formatter -> Sv.t * Sv.t -> unit

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -499,7 +499,7 @@ pparam:
 (* -------------------------------------------------------------------- *)
 pgexpr:
 | e=pexpr { GEexpr e }
-| LBRACE es = rtuple1(pexpr) RBRACE { GEarray es }
+| LBRACE es = rtuple(pexpr) RBRACE { GEarray es }
 
 pglobal:
 | pgd_type=ptype pgd_name=ident EQ pgd_val=pgexpr SEMICOLON

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1082,17 +1082,17 @@ let cast_int loc os e ety =
 
 
 (* -------------------------------------------------------------------- *)
-let conv_ty : BinNums.positive T.extended_type -> P.epty = function
+let conv_ty : BinNums.coq_Z T.extended_type -> P.epty = function
     | T.ETbool       -> P.etbool
     | T.ETint        -> P.etint
     | T.ETword(s,ws) -> P.ETword(s,ws)
-    | T.ETarr (ws, p) -> P.ETarr (ws, PE (P.cnst (Conv.z_of_pos p)))
+    | T.ETarr (ws, n) -> P.ETarr (ws, PE (P.cnst (Conv.z_of_cz n)))
 
 let conv_cty : T.atype -> P.epty = function
     | T.Coq_abool    -> P.etbool
     | T.Coq_aint     -> P.etint
     | T.Coq_aword ws -> P.etw ws
-    | T.Coq_aarr (ws, p) -> P.ETarr (ws, PE (P.cnst (Conv.z_of_pos p)))
+    | T.Coq_aarr (ws, n) -> P.ETarr (ws, PE (P.cnst (Conv.z_of_cz n)))
 
 let type_of_op2 op =
   let (ty1, ty2), tyo = E.etype_of_op2 op in
@@ -1392,8 +1392,8 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
 
   | S.PEstring s ->
      let es = array_of_string s in
-     let len = Conv.pos_of_int (List.length es) in
-     P.PappN (Oarray len, es), P.(ETarr (U8, PE (Pconst (Conv.z_of_pos len))))
+     let len = Z.of_int (List.length es) in
+     P.PappN (Oarray (Conv.cz_of_z len), es), P.(ETarr (U8, PE (Pconst len)))
 
   | S.PEIf (pe1, pe2, pe3) ->
     let e1, _ty1 = tt_expr ~mode pd env pe1 in
@@ -1994,7 +1994,7 @@ let create_is_arr_init _pd loc args =
     let e2 = cast_int loc None e2 t2 in
     let e3 = cast_int loc None e3 t3 in
     (* The size will be fixed later *)
-    P.PappN_safety (Ois_arr_init (Conv.pos_of_int 1) , [ e1; e2; e3])
+    P.PappN_safety (Ois_arr_init (Conv.cz_of_int 1) , [ e1; e2; e3])
   else
     rs_tyerror ~loc (InvalidArgCount(3, List.length args))
 
@@ -2090,7 +2090,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((pannot,pi) : S.pinstr) : 'asm 
             (string_error "only a single variable is allowed as destination of randombytes") in
       let _ = tt_as_array (loc, ty) in
       let es = tt_exprs_cast arch_info.pd env_rhs (L.loc pi) args [ty] in
-      [mk_i (P.Csyscall([x], Syscall_t.RandomBytes (U8, Conv.pos_of_int 1), es))]
+      [mk_i (P.Csyscall([x], Syscall_t.RandomBytes (U8, Conv.cz_of_int 1), es))]
 
   | (ls, xs), `Raw, { pl_desc = PEPrim (f, args) }, None when L.unloc f = "swap" ->
       let loc = L.loc pi in

--- a/compiler/src/printCommon.mli
+++ b/compiler/src/printCommon.mli
@@ -12,7 +12,7 @@ val pp_opn :
   Wsize.wsize ->
   Wsize.wsize -> 'asm Sopn.asmOp -> Format.formatter -> 'asm Sopn.sopn -> unit
 
-val pp_syscall : (Wsize.wsize * BinNums.positive) Syscall_t.syscall_t -> string
+val pp_syscall : (Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t -> string
 val pp_bool : Format.formatter -> bool -> unit
 val pp_kind : Format.formatter -> Wsize.v_kind -> unit
 val pp_btype : ?w:Wsize.signedness -> Format.formatter -> Prog.base_ty -> unit

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -66,7 +66,7 @@ let pp_ge_aux ~debug (pp_len: 'len pp) (pp_var: 'len gvar pp) : associativity ->
      begin match as_string es with
      | s -> F.fprintf fmt "%S" s
      | exception Not_found ->
-     F.fprintf fmt "/* %du8 */ @[{ %a }@]" (Conv.int_of_pos len) (pp_list ",@ " (pp_expr NoAssoc priority_min)) es
+     F.fprintf fmt "/* %au8 */ @[{ %a }@]" Z.pp_print (Conv.z_of_cz len) (pp_list ",@ " (pp_expr NoAssoc priority_min)) es
      end
   | Pif(_, e,e1,e2) ->
      let p = priority_ternary in

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -109,7 +109,7 @@ type ('len, 'info, 'asm) ginstr_r =
   | Cassgn of 'len glval * E.assgn_tag * 'len gty * 'len gexpr
   (* turn 'asm Sopn.sopn into 'sopn? could be useful to ensure that we remove things statically *)
   | Copn   of 'len glvals * E.assgn_tag * 'asm Sopn.sopn * 'len gexprs
-  | Csyscall of 'len glvals * (Wsize.wsize * BinNums.positive) Syscall_t.syscall_t * 'len gexprs
+  | Csyscall of 'len glvals * (Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t * 'len gexprs
   | Cassert of 'len assertion
   | Cif    of 'len gexpr * ('len, 'info, 'asm) gstmt * ('len, 'info, 'asm) gstmt
   | Cfor   of 'len gvar_i * 'len grange * ('len, 'info, 'asm) gstmt

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -73,7 +73,7 @@ type ('len, 'info, 'asm) ginstr_r =
   | Cassgn of 'len glval * E.assgn_tag * 'len gty * 'len gexpr
   (* turn 'asm Sopn.sopn into 'sopn? could be useful to ensure that we remove things statically *)
   | Copn   of 'len glvals * E.assgn_tag * 'asm Sopn.sopn * 'len gexprs
-  | Csyscall of 'len glvals * (Wsize.wsize * BinNums.positive) Syscall_t.syscall_t * 'len gexprs
+  | Csyscall of 'len glvals * (Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t * 'len gexprs
   | Cassert of 'len assertion
   | Cif    of 'len gexpr * ('len, 'info, 'asm) gstmt * ('len, 'info, 'asm) gstmt
   | Cfor   of 'len gvar_i * 'len grange * ('len, 'info, 'asm) gstmt

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -1311,7 +1311,7 @@ let global_allocation return_addresses (funcs: ('info, 'asm) func list) :
   (* Live variables at the end of each function, in addition to returned local variables *)
   let get_liveness, slive, liveness_per_callsite =
     let live : (L.i_loc list * Sv.t) list Hf.t = Hf.create 17 in
-    let slive : ((Wsize.wsize * BinNums.positive) Syscall_t.syscall_t, Sv.t) Hashtbl.t = Hashtbl.create 17 in
+    let slive : ((Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t, Sv.t) Hashtbl.t = Hashtbl.create 17 in
     List.iter (fun f ->
         let f_with_liveness = Hf.find liveness_table f.f_name in
         let live_when_calling_f = Hf.find_default live f.f_name [[], Sv.empty] in

--- a/compiler/src/subst.ml
+++ b/compiler/src/subst.ml
@@ -376,7 +376,7 @@ let remove_params (prog : ('info, 'asm) pprog) =
            (if m > 1 then "values" else "value")
            n
       | Arr (ws, n), GEarray es ->
-        let p = Conv.pos_of_int (n * size_of_ws ws) in
+        let len = Conv.cz_of_int (arr_size ws n) in
         let mk_word_i i e =
           try mk_word ws e
           with NotAConstantExpr ->
@@ -385,7 +385,7 @@ let remove_params (prog : ('info, 'asm) pprog) =
               i
         in
         let t = Warray_.WArray.of_list ws (List.mapi mk_word_i es) in
-        Global.Garr(p, t)
+        Global.Garr(len, t)
       | _, _ -> assert false in
     add_glob x gv;
     x, gv

--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -583,16 +583,23 @@ let check_array env x =
 (* ------------------------------------------------------------------- *)
 (* Formatting to string helpers *)
 
+(* we print negative lengths with a "m"-prefix to create valid module names *)
+let pp_length fmt i =
+  if i < 0 then
+    Format.fprintf fmt "m%d" (-i)
+  else
+    Format.fprintf fmt "%d" i
+
 let fmt_array_theory at = match at with
-  | Array n -> Format.sprintf "Array%i" n
-  | WArray n -> Format.sprintf "WArray%i" n
-  | ArrayWords aw -> Format.sprintf "ArrayWords%iW%i" aw.sizea (8*aw.sizew)
-  | SubArray x -> Format.sprintf "SubArray%i_%i" x.sizes x.sizeb
-  | SubArrayDirect x -> Format.sprintf "SubArrayDirect%i_%iW%i" x.sizes x.sizeb (8*x.sizew)
-  | SubArrayCast x -> Format.sprintf "SubArrayDirect%iW%i_%iW%i" x.sizes (8*x.sizews) x.sizeb (8*x.sizewb)
-  | ArrayAccessCast x -> Format.sprintf "ArrayAccessCastW%i_%iW%i" (8*x.sizews) x.sizeb (8*x.sizewb)
-  | ByteArray n -> Format.sprintf "BArray%i" n
-  | SubByteArray x -> Format.sprintf "SBArray%i_%i" x.sizeb x.sizes
+  | Array n -> Format.asprintf "Array%a" pp_length n
+  | WArray n -> Format.asprintf "WArray%a" pp_length n
+  | ArrayWords aw -> Format.asprintf "ArrayWords%aW%i" pp_length aw.sizea (8*aw.sizew)
+  | SubArray x -> Format.asprintf "SubArray%a_%a" pp_length x.sizes pp_length x.sizeb
+  | SubArrayDirect x -> Format.asprintf "SubArrayDirect%a_%aW%i" pp_length x.sizes pp_length x.sizeb (8*x.sizew)
+  | SubArrayCast x -> Format.asprintf "SubArrayDirect%aW%i_%aW%i" pp_length x.sizes (8*x.sizews) pp_length x.sizeb (8*x.sizewb)
+  | ArrayAccessCast x -> Format.asprintf "ArrayAccessCastW%i_%aW%i" (8*x.sizews) pp_length x.sizeb (8*x.sizewb)
+  | ByteArray n -> Format.asprintf "BArray%a" pp_length n
+  | SubByteArray x -> Format.asprintf "SBArray%a_%a" pp_length x.sizeb pp_length x.sizes
 
 let fmt_Wsz sz = Format.asprintf "W%i" (int_of_ws sz)
 
@@ -782,13 +789,21 @@ let pp_ec_prog fmt (prog:ec_prog) = Format.fprintf fmt "@[<v>%a@]" (pp_list "@ @
 (* ------------------------------------------------------------------- *)
 (* Array theory cloning *)
 
+(* For negative lengths, we need to import Int. We import it systematically. *)
+let pp_import_Int fmt () =
+  Format.fprintf fmt "require import Int.@ @ "
+
 let fmt_array_decl fmt i =
-  Format.fprintf fmt "@[<v>from Jasmin require import JArray.@ @ ";
-  Format.fprintf fmt "clone export PolyArray as Array%i  with op size <- %i.@]@." i i
+  Format.fprintf fmt "@[<v>";
+  pp_import_Int fmt ();
+  Format.fprintf fmt "from Jasmin require import JArray.@ @ ";
+  Format.fprintf fmt "clone export PolyArray as Array%a  with op size <- %i.@]@." pp_length i i
 
 let fmt_warray_decl fmt i =
-  Format.fprintf fmt "@[<v>from Jasmin require import JWord_array.@ @ ";
-  Format.fprintf fmt "clone export WArray as WArray%i  with op size <- %i.@]@." i i
+  Format.fprintf fmt "@[<v>";
+  pp_import_Int fmt ();
+  Format.fprintf fmt "from Jasmin require import JWord_array.@ @ ";
+  Format.fprintf fmt "clone export WArray as WArray%a  with op size <- %i.@]@." pp_length i i
 
 let fmt_op fmt (op_name, v) = Format.fprintf fmt "op %s <- %i" op_name v
 
@@ -797,8 +812,8 @@ let fmt_the fmt (th, v) = Format.fprintf fmt "theory %s <- %s" th v
 let fmt_th fmt (th, v) = Format.fprintf fmt "theory %s <= %s" th v
 
 let fmt_arraywords_decl fmt (aw: arraywords) =
-  let arrayn = Format.sprintf "Array%i" aw.sizea in
-  let warrayn = Format.sprintf "WArray%i" (aw.sizew*aw.sizea) in
+  let arrayn = Format.asprintf "Array%a" pp_length aw.sizea in
+  let warrayn = Format.asprintf "WArray%a" pp_length (aw.sizew*aw.sizea) in
   let fmt_insts fmt (aw: arraywords) =
     Format.fprintf fmt "%a,@ %a,@ %a,@ %a,@ %a"
     fmt_op ("sizeW", aw.sizew)
@@ -807,15 +822,16 @@ let fmt_arraywords_decl fmt (aw: arraywords) =
     fmt_th ("ArrayN", arrayn)
     fmt_th ("WArrayN", warrayn)
   in
-  Format.fprintf fmt "@[<v>from Jasmin require import JWord JWord_array.@ @ ";
-  Format.fprintf fmt "@[<v>require import %s %s.@ @ " arrayn warrayn;
+  Format.fprintf fmt "@[<v>";
+  pp_import_Int fmt ();
+  Format.fprintf fmt "require import %s %s.@ @ " arrayn warrayn;
   Format.fprintf fmt "clone export ArrayWords as %s  with @[%a@].@]@."
     (fmt_array_theory (ArrayWords aw))
     fmt_insts aw
 
 let fmt_subarray_decl fmt (s: subarray) =
-  let arrays = Format.sprintf "Array%i" s.sizes in
-  let arrayb = Format.sprintf "Array%i" s.sizeb in
+  let arrays = Format.asprintf "Array%a" pp_length s.sizes in
+  let arrayb = Format.asprintf "Array%a" pp_length s.sizeb in
   let fmt_insts fmt (s: subarray) =
     Format.fprintf fmt "%a,@ %a,@ %a,@ %a"
     fmt_op ("sizeS", s.sizes)
@@ -823,8 +839,10 @@ let fmt_subarray_decl fmt (s: subarray) =
     fmt_th ("ArrayS", arrays)
     fmt_th ("ArrayB", arrayb)
   in
-  Format.fprintf fmt "@[<v>from Jasmin require import JArray.@ @ ";
-  Format.fprintf fmt "@[<v>require import %s %s.@ @ " arrays arrayb;
+  Format.fprintf fmt "@[<v>";
+  pp_import_Int fmt ();
+  Format.fprintf fmt "from Jasmin require import JArray.@ @ ";
+  Format.fprintf fmt "require import %s %s.@ @ " arrays arrayb;
   Format.fprintf fmt "clone export SubArray as %s  with @[%a@].@]@."
     (fmt_array_theory (SubArray s))
     fmt_insts s
@@ -841,8 +859,10 @@ let fmt_subarraydirect_decl fmt (s: subarraydirect) =
     fmt_th ("ArrayWordsS", arrayws)
     fmt_th ("ArrayWordsB", arraywb)
   in
-  Format.fprintf fmt "@[<v>from Jasmin require import JWord JWord_array.@ @ ";
-  Format.fprintf fmt "@[<v>require import %s %s.@ @ " arrayws arraywb;
+  Format.fprintf fmt "@[<v>";
+  pp_import_Int fmt ();
+  Format.fprintf fmt "from Jasmin require import JWord JWord_array.@ @ ";
+  Format.fprintf fmt "require import %s %s.@ @ " arrayws arraywb;
   Format.fprintf fmt "clone export SubArrayDirect as %s  with @[%a@].@]@."
     (fmt_array_theory (SubArrayDirect s))
     fmt_insts s
@@ -861,8 +881,10 @@ let fmt_subarraycast_decl fmt (s: subarraycast) =
     fmt_th ("ArrayWordsS", arrayws)
     fmt_th ("ArrayWordsB", arraywb)
   in
-  Format.fprintf fmt "@[<v>from Jasmin require import JWord JWord_array.@ @ ";
-  Format.fprintf fmt "@[<v>require import %s %s.@ @ " arrayws arraywb;
+  Format.fprintf fmt "@[<v>";
+  pp_import_Int fmt ();
+  Format.fprintf fmt "from Jasmin require import JWord JWord_array.@ @ ";
+  Format.fprintf fmt "require import %s %s.@ @ " arrayws arraywb;
   Format.fprintf fmt "clone export SubArrayCast as %s  with @[%a@].@]@."
     (fmt_array_theory (SubArrayCast s))
     fmt_insts s
@@ -878,14 +900,18 @@ let fmt_arrayaccesscast_decl fmt (s: arrayaccesscast) =
     fmt_the ("WordB", Format.sprintf "W%i" (8*s.sizewb))
     fmt_th ("ArrayWordsB", arraywb)
   in
-  Format.fprintf fmt "@[<v>from Jasmin require import JWord JWord_array.@ @ ";
-  Format.fprintf fmt "@[<v>require import %s.@ @ " arraywb;
+  Format.fprintf fmt "@[<v>";
+  pp_import_Int fmt ();
+  Format.fprintf fmt "from Jasmin require import JWord JWord_array.@ @ ";
+  Format.fprintf fmt "require import %s.@ @ " arraywb;
   Format.fprintf fmt "clone export ArrayAccessCast as %s  with @[%a@].@]@."
     (fmt_array_theory (ArrayAccessCast s))
     fmt_insts s
 
 let fmt_bytearray_decl fmt n =
-  Format.fprintf fmt "@[<v>from Jasmin require import JByte_array.@ @ ";
+  Format.fprintf fmt "@[<v>";
+  pp_import_Int fmt ();
+  Format.fprintf fmt "from Jasmin require import JByte_array.@ @ ";
   Format.fprintf fmt "clone include ByteArray with op size <= %i.@]@." n
 
 let fmt_subbytearray_decl fmt (s:subarray) =
@@ -896,8 +922,10 @@ let fmt_subbytearray_decl fmt (s:subarray) =
     fmt_th ("Asmall", arrays)
     fmt_th ("Abig", arrayb)
   in
-  Format.fprintf fmt "@[<v>from Jasmin require import JByte_array.@ @ ";
-  Format.fprintf fmt "@[<v>require import %s %s.@ @ " arrays arrayb;
+  Format.fprintf fmt "@[<v>";
+  pp_import_Int fmt ();
+  Format.fprintf fmt "from Jasmin require import JByte_array.@ @ ";
+  Format.fprintf fmt "require import %s %s.@ @ " arrays arrayb;
   Format.fprintf fmt "clone SubByteArray as %s  with @[%t@].@]@."
     (fmt_array_theory (SubByteArray s))
     fmt_insts
@@ -944,15 +972,15 @@ let ec_zeroext_sz (szo, szi) e =
 let ec_zeroext (t_o, t_i) e =
   if t_o = t_i then e else ec_zeroext_sz (ws_of_ty t_o, ws_of_ty t_i) e
 
-let ec_Array env n = Env.add_Array env n; Format.sprintf "Array%i" n
+let ec_Array env n = Env.add_Array env n; Format.asprintf "Array%a" pp_length n
 
-let ec_WArray env n = Env.add_WArray env n; Format.sprintf "WArray%i" n
+let ec_WArray env n = Env.add_WArray env n; Format.asprintf "WArray%a" pp_length n
 
-let ec_BArray env n = Env.add_BArray env n; Format.sprintf "BArray%i" n
+let ec_BArray env n = Env.add_BArray env n; Format.asprintf "BArray%a" pp_length n
 
 let ec_SBArray env (s:subarray) =
   Env.add_SBArray env s;
-  Format.sprintf "SBArray%i_%i" s.sizeb s.sizes
+  Format.asprintf "SBArray%a_%a" pp_length s.sizeb pp_length s.sizes
 
 let toec_ty onarray env ty = match ty with
     | Bty Bool -> "bool"
@@ -1809,7 +1837,7 @@ struct
     | Syscall_t.RandomBytes (ws, n) ->
       let n = arr_size ws (Conv.int_of_cz n) in
       Env.add_randombytes env n;
-      Format.sprintf "%s.randombytes_%i" syscall_mod_arg n
+      Format.asprintf "%s.randombytes_%a" syscall_mod_arg pp_length n
 
   let ec_opn pd msfsz asmOp o =
     let s = Format.asprintf "%a" (pp_opn pd msfsz asmOp) o in
@@ -1959,7 +1987,7 @@ struct
       let randombytes_decl a n =
           let arr_ty = toec_ty env (Arr (U8, n)) in
           {
-              fname = Format.sprintf "randombytes_%i" n;
+              fname = Format.asprintf "randombytes_%a" pp_length n;
               args = [(a, arr_ty)];
               rtys = [arr_ty];
           }

--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -1305,8 +1305,8 @@ let ty_expr = function
 let ty_sopn pd msfsz asmOp op es =
   match op with
   (* Do a special case for copy since the Coq type loose information  *)
-  | Sopn.Opseudo_op (Pseudo_operator.Ocopy(ws, p)) ->
-    let l = [Arr(ws, Conv.int_of_pos p)] in
+  | Sopn.Opseudo_op (Pseudo_operator.Ocopy(ws, n)) ->
+    let l = [Arr(ws, Conv.int_of_cz n)] in
     l, l
   | Sopn.Opseudo_op (Pseudo_operator.Oswap _) ->
     let l = List.map ty_expr es in
@@ -1456,7 +1456,7 @@ module EcExpression(EA: EcArray): EcExpression = struct
               )
           | Oarray len ->
               Eapp (
-                  EA.of_list env U8 (Conv.int_of_pos len),
+                  EA.of_list env U8 (Conv.int_of_cz len),
                   [Elist (List.map (toec_expr env) es)]
               )
           end
@@ -1806,8 +1806,8 @@ struct
 
   let ec_syscall env o =
     match o with
-    | Syscall_t.RandomBytes (ws, p) ->
-      let n = arr_size ws (Conv.int_of_pos p) in
+    | Syscall_t.RandomBytes (ws, n) ->
+      let n = arr_size ws (Conv.int_of_cz n) in
       Env.add_randombytes env n;
       Format.sprintf "%s.randombytes_%i" syscall_mod_arg n
 

--- a/compiler/src/typing.ml
+++ b/compiler/src/typing.ml
@@ -20,9 +20,9 @@ let ty_var (x: var) =
   let ty = x.v_ty in
   begin match ty with
   | Arr(_, n) ->
-      if (n < 1) then
+      if (n < 0) then
         error (L.i_loc0 x.v_dloc)
-          "the variable %a has type %a, its array size should be positive"
+          "the variable %a has type %a, its array size must be non-negative"
           (Printer.pp_var ~debug:false) x PrintCommon.pp_ty ty
   | _ -> ()
   end;
@@ -59,8 +59,8 @@ let check_int loc e te = check_type loc e te tint
 let check_ptr pd loc e te = check_type loc e te (tu pd)
 
 let check_length loc len =
-  if len <= 0 then
-    error loc "the length should be strictly positive"
+  if len < 0 then
+    error loc "the length must be non-negative"
 
 (* -------------------------------------------------------------------- *)
 

--- a/compiler/src/typing.ml
+++ b/compiler/src/typing.ml
@@ -265,9 +265,9 @@ let check_global_decl (g, d) =
   | Global.Garr (len, _) ->
       if
         match ty with
-        | Arr (ws, len') -> Conv.int_of_pos len <> arr_size ws len'
+        | Arr (ws, len') -> Conv.int_of_cz len <> arr_size ws len'
         | _ -> true
-      then error (Arr (U8, Conv.int_of_pos len))
+      then error (Arr (U8, Conv.int_of_cz len))
   | Gword (ws, _) ->
       if match ty with Bty (U ws') -> not (wsize_le ws ws') | _ -> true then
         error (Bty (U ws))

--- a/compiler/src/typing.ml
+++ b/compiler/src/typing.ml
@@ -16,18 +16,7 @@ let error loc fmt =
     bfmt fmt
 
 (* -------------------------------------------------------------------- *)
-let ty_var (x: var) =
-  let ty = x.v_ty in
-  begin match ty with
-  | Arr(_, n) ->
-      if (n < 0) then
-        error (L.i_loc0 x.v_dloc)
-          "the variable %a has type %a, its array size must be non-negative"
-          (Printer.pp_var ~debug:false) x PrintCommon.pp_ty ty
-  | _ -> ()
-  end;
-  ty
-
+let ty_var (x: var) = x.v_ty
 
 let ty_gvar (x: int ggvar) = ty_var (L.unloc x.gv)
 
@@ -57,10 +46,6 @@ let check_type loc e te ty =
 let check_int loc e te = check_type loc e te tint
 
 let check_ptr pd loc e te = check_type loc e te (tu pd)
-
-let check_length loc len =
-  if len < 0 then
-    error loc "the length must be non-negative"
 
 (* -------------------------------------------------------------------- *)
 
@@ -162,7 +147,6 @@ and ty_get_set_sub pd loc ws len x e =
   let te = ty_expr pd loc e in
   check_array loc (Pvar x) tx;
   check_int loc e te;
-  check_length loc len;
   Arr(ws, len)
 
 (* -------------------------------------------------------------------- *)

--- a/compiler/src/typing.mli
+++ b/compiler/src/typing.mli
@@ -2,7 +2,6 @@ open Prog
 
 exception TyError of L.i_loc * string
 
-val check_length : L.i_loc -> int -> unit
 val ty_lval : Wsize.wsize -> L.i_loc -> lval -> ty
 val ty_expr : Wsize.wsize -> L.i_loc -> expr -> ty
 val error : Prog.L.i_loc -> ('a, Format.formatter, unit, 'b) format4 -> 'a

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -54,7 +54,7 @@ type glob_alloc_oracle_t =
 
 (* --------------------------------------------------- *)
 let incr_liverange r x d : liverange =
-  let s = size_of x.v_ty in
+  let s = max 0 (size_of x.v_ty) in
   let g = Mint.find_default Mv.empty s r in
   let i =
     match Mv.find x g with
@@ -230,7 +230,7 @@ let err_var_not_initialized x =
   hierror ~loc:Lnone "variable “%a” (declared at %a) may not be initialized" (Printer.pp_var ~debug:true) x Location.pp_loc x.v_dloc
 
 let get_slot ?var coloring x =
-  let sz = size_of x.v_ty in
+  let sz = max 0 (size_of x.v_ty) in
   try Mv.find x (Mint.find sz coloring)
   with Not_found -> err_var_not_initialized (Option.default x var)
 
@@ -380,7 +380,7 @@ let alloc_local_stack size slots atbl =
 
   let init_slot (x,ws) =
     let pos = round_ws ws !size in
-    let n = size_of x.v_ty in
+    let n = max 0 (size_of x.v_ty) in
     size := pos + n;
     (x,ws,pos) in
 

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -513,11 +513,11 @@ let alloc_mem (gtbl: wsize Hv.t) globs =
       let w = Memory_model.LE.encode ws w in
       List.iteri (fun i w -> t.(ofs + i) <- w) w
 
-    | Global.Garr(p, gt) ->
-      let ip = Conv.int_of_pos p in
-      for i = 0 to ip - 1 do
+    | Global.Garr(n, gt) ->
+      let ni = Conv.int_of_cz n in
+      for i = 0 to ni - 1 do
         let w =
-          match Warray_.WArray.get p Aligned Warray_.AAdirect U8 gt (Conv.cz_of_int i) with
+          match Warray_.WArray.get n Aligned Warray_.AAdirect U8 gt (Conv.cz_of_int i) with
           | Ok w -> w
           | _    -> assert false in
         t.(ofs + i) <- w

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -487,7 +487,9 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
   let sao_alloc = List.iter (Hv.remove lalloc) fd.f_args; lalloc in
 
   let sao_modify_rsp =
-    sao_size <> 0 || has_syscall fd.f_body ||
+    (* a slot can have size 0, so the condition on [sao_slots] is not redundant
+       with the condition on [sao_size] *)
+    sao_size <> 0 || List.length sao_slots <> 0 || has_syscall fd.f_body ||
       Sf.exists (fun fn -> (get_info fn).sao_modify_rsp) sao_calls in
   let sao = {
     sao_calls;

--- a/compiler/tests/fail/array_expansion/x86-64/default_scale_param_2.jazz
+++ b/compiler/tests/fail/array_expansion/x86-64/default_scale_param_2.jazz
@@ -1,0 +1,11 @@
+fn f (reg u64[2] r) -> reg u64[2] {
+  return r;
+}
+
+export fn main () -> reg u64 {
+  reg u64[2] z k;
+  z[0] = 0; z[1] = 1;
+  k = f(z[:u32 0:4]); // we do not use the default scale for z
+  reg u64 res = k[0];
+  return res;
+}

--- a/compiler/tests/fail/array_expansion/x86-64/default_scale_return_2.jazz
+++ b/compiler/tests/fail/array_expansion/x86-64/default_scale_return_2.jazz
@@ -1,0 +1,11 @@
+fn f (reg u64[2] r) -> reg u64[2] {
+  return r;
+}
+
+export fn main () -> reg u64 {
+  reg u64[2] z k;
+  z[0] = 0; z[1] = 1;
+  k[:u32 0:4] = f(z); // we do not use the default scale for k
+  reg u64 res = k[0];
+  return res;
+}

--- a/compiler/tests/fail/array_expansion/x86-64/sub_array_param_overflow.jazz
+++ b/compiler/tests/fail/array_expansion/x86-64/sub_array_param_overflow.jazz
@@ -1,0 +1,11 @@
+fn f (reg u64[2] r) -> reg u64[2] {
+  return r;
+}
+
+export fn main () -> reg u64 {
+  reg u64[2] z k;
+  z[0] = 0; z[1] = 1;
+  k = f(z[1:2]); // the subarray overflows
+  reg u64 res = k[0];
+  return res;
+}

--- a/compiler/tests/fail/array_expansion/x86-64/sub_array_param_overflow_2.jazz
+++ b/compiler/tests/fail/array_expansion/x86-64/sub_array_param_overflow_2.jazz
@@ -1,0 +1,11 @@
+fn f (reg u64[2] r) -> reg u64[2] {
+  return r;
+}
+
+export fn main () -> reg u64 {
+  reg u64[2] z k;
+  z[0] = 0; z[1] = 1;
+  k = f(z[-1:2]); // the offset is negative!
+  reg u64 res = k[0];
+  return res;
+}

--- a/compiler/tests/fail/array_expansion/x86-64/sub_array_return_overflow.jazz
+++ b/compiler/tests/fail/array_expansion/x86-64/sub_array_return_overflow.jazz
@@ -1,0 +1,11 @@
+fn f (reg u64[2] r) -> reg u64[2] {
+  return r;
+}
+
+export fn main () -> reg u64 {
+  reg u64[2] z k;
+  z[0] = 0; z[1] = 1;
+  k[1:2] = f(z); // the subarray overflows
+  reg u64 res = k[0];
+  return res;
+}

--- a/compiler/tests/fail/array_expansion/x86-64/sub_array_return_overflow_2.jazz
+++ b/compiler/tests/fail/array_expansion/x86-64/sub_array_return_overflow_2.jazz
@@ -1,0 +1,11 @@
+fn f (reg u64[2] r) -> reg u64[2] {
+  return r;
+}
+
+export fn main () -> reg u64 {
+  reg u64[2] z k;
+  z[0] = 0; z[1] = 1;
+  k[-1:2] = f(z); // the offset is negative!
+  reg u64 res = k[0];
+  return res;
+}

--- a/compiler/tests/fail/x86-64/randombytes_length_neg.jazz
+++ b/compiler/tests/fail/x86-64/randombytes_length_neg.jazz
@@ -1,0 +1,13 @@
+param int N = -1;
+
+export fn main (reg ptr u64[N] r) -> reg ptr u64[N], reg u64 {
+  r = #randombytes(r);
+  reg u64 res i;
+  res = 0;
+  i = 0;
+  while (i <s N) {
+    res += r[i];
+    i += 1;
+  }
+  return r, res;
+}

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -333,11 +333,23 @@ fail/array_expansion/x86-64/default_scale_param.jazz:
 compilation error in function main:
 array expansion: cannot expand variable r (the default scale must be used)
 
+fail/array_expansion/x86-64/default_scale_param_2.jazz:
+
+"fail/array_expansion/x86-64/default_scale_param_2.jazz", line 8 (8-9):
+compilation error in function main:
+array expansion: cannot expand variable z (the default scale must be used)
+
 fail/array_expansion/x86-64/default_scale_return.jazz:
 
 "fail/array_expansion/x86-64/default_scale_return.jazz", line 16 (2-3):
 compilation error in function main:
 array expansion: cannot expand variable r (the default scale must be used)
+
+fail/array_expansion/x86-64/default_scale_return_2.jazz:
+
+"fail/array_expansion/x86-64/default_scale_return_2.jazz", line 8 (2-3):
+compilation error in function main:
+array expansion: cannot expand variable k (the default scale must be used)
 
 fail/array_expansion/x86-64/export_param.jazz:
 
@@ -413,11 +425,23 @@ fail/array_expansion/x86-64/sub_array_param_not_reg.jazz:
 compilation error in function main:
 array expansion: cannot expand variable s (not a reg array)
 
+fail/array_expansion/x86-64/sub_array_param_overflow.jazz:
+
+"fail/array_expansion/x86-64/sub_array_param_overflow.jazz", line 8 (8-9):
+compilation error in function main:
+array expansion: cannot expand variable z (the sub-array overflows)
+
 fail/array_expansion/x86-64/sub_array_return_not_reg.jazz:
 
 "fail/array_expansion/x86-64/sub_array_return_not_reg.jazz", line 16 (2-3):
 compilation error in function main:
 array expansion: cannot expand variable s (not a reg array)
+
+fail/array_expansion/x86-64/sub_array_return_overflow.jazz:
+
+"fail/array_expansion/x86-64/sub_array_return_overflow.jazz", line 8 (2-3):
+compilation error in function main:
+array expansion: cannot expand variable k (the sub-array overflows)
 
 fail/array_expansion/x86-64/type_mismatch_param.jazz:
 
@@ -1653,4 +1677,4 @@ Statistics:
 	Pretyping:  47
 	Parsing:     4
 	Typing:      5
-	Compile:   204
+	Compile:   208

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -431,6 +431,12 @@ fail/array_expansion/x86-64/sub_array_param_overflow.jazz:
 compilation error in function main:
 array expansion: cannot expand variable z (the sub-array overflows)
 
+fail/array_expansion/x86-64/sub_array_param_overflow_2.jazz:
+
+"fail/array_expansion/x86-64/sub_array_param_overflow_2.jazz", line 8 (8-9):
+compilation error in function main:
+array expansion: cannot expand variable z (the sub-array overflows)
+
 fail/array_expansion/x86-64/sub_array_return_not_reg.jazz:
 
 "fail/array_expansion/x86-64/sub_array_return_not_reg.jazz", line 16 (2-3):
@@ -440,6 +446,12 @@ array expansion: cannot expand variable s (not a reg array)
 fail/array_expansion/x86-64/sub_array_return_overflow.jazz:
 
 "fail/array_expansion/x86-64/sub_array_return_overflow.jazz", line 8 (2-3):
+compilation error in function main:
+array expansion: cannot expand variable k (the sub-array overflows)
+
+fail/array_expansion/x86-64/sub_array_return_overflow_2.jazz:
+
+"fail/array_expansion/x86-64/sub_array_return_overflow_2.jazz", line 8 (2-3):
 compilation error in function main:
 array expansion: cannot expand variable k (the sub-array overflows)
 
@@ -1635,6 +1647,12 @@ asmgen: instruction POR is given incompatible args.
 Allowed args are:
   [[regx]; [regx; mem (glob allowed)]]
 
+fail/x86-64/randombytes_length_neg.jazz:
+
+"fail/x86-64/randombytes_length_neg.jazz", line 4 (2-22):
+compilation error in function main:
+stack allocation: randombytes: the requested size is negative
+
 fail/x86-64/shift.jazz:
 
 "fail/x86-64/shift.jazz", line 5 (4-12):
@@ -1677,4 +1695,4 @@ Statistics:
 	Pretyping:  47
 	Parsing:     4
 	Typing:      5
-	Compile:   208
+	Compile:   211

--- a/compiler/tests/safety/success/x86-64/array_length_neg.jazz
+++ b/compiler/tests/safety/success/x86-64/array_length_neg.jazz
@@ -1,0 +1,16 @@
+param int N = -1;
+param int M = -3;
+
+export fn main (reg ptr u64[N] a) -> reg ptr u64[N] {
+  return a;
+}
+
+export fn main2 (reg ptr u64[N] a) -> reg ptr u64[N] {
+  reg ptr u64[M] b = a[0:M];
+  reg u64 i = 0;
+  while (i <s M) {
+    b[i] = i;
+  }
+  a[0:M] = b;
+  return a;
+}

--- a/compiler/tests/safety/success/x86-64/randombytes_length_neg.jazz
+++ b/compiler/tests/safety/success/x86-64/randombytes_length_neg.jazz
@@ -1,0 +1,13 @@
+param int N = -1;
+
+export fn main (reg ptr u64[N] r) -> reg ptr u64[N], reg u64 {
+  r = #randombytes(r);
+  reg u64 res i;
+  res = 0;
+  i = 0;
+  while (i <s N) {
+    res += r[i];
+    i += 1;
+  }
+  return r, res;
+}

--- a/compiler/tests/success/x86-64/array_length_neg.jazz
+++ b/compiler/tests/success/x86-64/array_length_neg.jazz
@@ -1,0 +1,16 @@
+param int N = -1;
+param int M = -3;
+
+export fn main (reg ptr u64[N] a) -> reg ptr u64[N] {
+  return a;
+}
+
+export fn main2 (reg ptr u64[N] a) -> reg ptr u64[N] {
+  reg ptr u64[M] b = a[0:M];
+  reg u64 i = 0;
+  while (i <s M) {
+    b[i] = i;
+  }
+  a[0:M] = b;
+  return a;
+}

--- a/compiler/tests/success/x86-64/bug_1106.jazz
+++ b/compiler/tests/success/x86-64/bug_1106.jazz
@@ -1,0 +1,10 @@
+// A subarray of length 0 is ok
+
+export fn main () -> reg u32 {
+  stack u32[1] a b;
+  a[0] = 1;
+  b[0] = 2;
+  a[0:0] = b[0:0];
+  reg u32 res = b[0];
+  return res;
+}

--- a/compiler/tests/success/x86-64/bug_1158.jazz
+++ b/compiler/tests/success/x86-64/bug_1158.jazz
@@ -1,0 +1,16 @@
+param int T = 0;
+export fn test1(reg ptr u8[10] t) {
+  reg u8[0] r = #copy(t[0:T]);
+}
+
+inline
+fn test2(reg u8[T] t) {
+  reg u8[T] r = t;
+}
+
+param int N = 0;
+fn test3(reg ptr u8[10] p, reg u64 msf) -> reg ptr u8[10] {
+  reg ptr u8[N] r = #protect_ptr(p[0:N], msf);
+  p[0:N] = r;
+  return p;
+}

--- a/compiler/tests/success/x86-64/copy_length_0.jazz
+++ b/compiler/tests/success/x86-64/copy_length_0.jazz
@@ -1,0 +1,8 @@
+param int N = 0;
+
+export fn main (reg ptr u64[N] a) -> reg ptr u64[N] {
+  reg u64[N] r1;
+  r1 = #copy(a);
+  a = #copy(r1);
+  return a;
+}

--- a/compiler/tests/success/x86-64/copy_length_neg.jazz
+++ b/compiler/tests/success/x86-64/copy_length_neg.jazz
@@ -1,0 +1,8 @@
+param int N = -1;
+
+export fn main (reg ptr u64[N] a) -> reg ptr u64[N] {
+  reg u64[N] r1;
+  r1 = #copy(a);
+  a = #copy(r1);
+  return a;
+}

--- a/compiler/tests/success/x86-64/empty_string.jazz
+++ b/compiler/tests/success/x86-64/empty_string.jazz
@@ -1,0 +1,9 @@
+// passing an empty string is ok
+
+param int N = 0;
+
+inline fn f(inline u8[N] a) {}
+
+export fn test() {
+  f("");
+}

--- a/compiler/tests/success/x86-64/global_length_0.jazz
+++ b/compiler/tests/success/x86-64/global_length_0.jazz
@@ -1,0 +1,16 @@
+// a global array of length 0 is ok
+
+param int N = 0;
+
+u64[N] g = {};
+
+export fn main () -> reg u64 {
+  reg u64 res = 0;
+  reg ptr u64[N] r = g;
+  reg u64 i = 0;
+  while (i < N) {
+    res += r[i];
+    i += 1;
+  }
+  return res;
+}

--- a/compiler/tests/success/x86-64/randombytes_length_0.jazz
+++ b/compiler/tests/success/x86-64/randombytes_length_0.jazz
@@ -1,0 +1,13 @@
+param int N = 0;
+
+export fn main (reg ptr u64[N] r) -> reg ptr u64[N], reg u64 {
+  r = #randombytes(r);
+  reg u64 res i;
+  res = 0;
+  i = 0;
+  while (i <s N) {
+    res += r[i];
+    i += 1;
+  }
+  return r, res;
+}

--- a/compiler/tests/success/x86-64/reg_array_length_0.jazz
+++ b/compiler/tests/success/x86-64/reg_array_length_0.jazz
@@ -1,0 +1,12 @@
+param int N = 0;
+
+export fn main () -> reg u64 {
+  reg u64[N] r;
+  reg u64 res = 0;
+  inline int i;
+  for i = 0 to N {
+    r[i] = 0;
+    res += r[i];
+  }
+  return res;
+}

--- a/compiler/tests/success/x86-64/reg_array_length_neg.jazz
+++ b/compiler/tests/success/x86-64/reg_array_length_neg.jazz
@@ -1,0 +1,12 @@
+param int N = -1;
+
+export fn main () -> reg u64 {
+  reg u64[N] r;
+  reg u64 res = 0;
+  inline int i;
+  for i = 0 to N {
+    r[i] = 0;
+    res += r[i];
+  }
+  return res;
+}

--- a/compiler/tests/success/x86-64/stack_length_0.jazz
+++ b/compiler/tests/success/x86-64/stack_length_0.jazz
@@ -1,0 +1,15 @@
+// a stack array of length 0 is ok
+
+param int N = 0;
+
+export fn main () -> reg u64 {
+  stack u64[N] s;
+  reg u64 res = 0;
+  reg u64 i = 0;
+  while (i <s N) {
+    s[i] = i;
+    res += s[i];
+    i += 1;
+  }
+  return res;
+}

--- a/compiler/tests/success/x86-64/stack_length_neg.jazz
+++ b/compiler/tests/success/x86-64/stack_length_neg.jazz
@@ -1,0 +1,13 @@
+param int N = -1;
+
+export fn main () -> reg u64 {
+  stack u64[N] s;
+  reg u64 res = 0;
+  reg u64 i = 0;
+  while (i <s N) {
+    s[i] = i;
+    res += s[i];
+    i += 1;
+  }
+  return res;
+}

--- a/eclib/JArray.ec
+++ b/eclib/JArray.ec
@@ -12,8 +12,6 @@ abstract theory MonoArray.
 
   op size: int.
 
-  axiom ge0_size : 0 <= size.
-
   type t.
 
   op "_.[_]"  : t -> int -> elem.
@@ -128,8 +126,8 @@ abstract theory MonoArray.
     mkseq (fun i => t.[i]) size
   axiomatized by to_listE.
 
-  lemma size_to_list (t:t): size (to_list t) = size.
-  proof. rewrite to_listE size_mkseq /max; smt (ge0_size). qed.
+  lemma size_to_list (t:t): size (to_list t) = max 0 size.
+  proof. by rewrite to_listE size_mkseq. qed.
 
   lemma get_of_list (l:elem list) i : 0 <= i < size =>
     (of_list l).[i] = nth dfl l i.
@@ -144,9 +142,9 @@ abstract theory MonoArray.
   lemma of_listK (l : elem list) : size l = size =>
     to_list (of_list l) = l.
   proof.
-    move=> h; apply (eq_from_nth dfl); 1:by rewrite size_to_list h.
+    move=> h; apply (eq_from_nth dfl); 1:by rewrite size_to_list h; smt(size_ge0).
     move=> i; rewrite size_to_list => hi.
-    by rewrite get_to_list // get_of_list.
+    by rewrite get_to_list // get_of_list; 1:smt(size_ge0).
   qed.
 
   lemma to_listK : cancel to_list of_list.
@@ -229,13 +227,13 @@ abstract theory MonoArray.
     rewrite to_listE map2E map2_zip init_of_list /=;congr.
     apply (eq_from_nth dfl).
     + rewrite !size_map size_zip !size_map StdOrder.IntOrder.minrE /=.
-      smt (size_iota ge0_size).
+      smt (size_iota).
     move=> i; rewrite size_map => hi.
     rewrite (nth_map 0) 1:// (nth_map (dfl,dfl)).
     + rewrite size_zip StdOrder.IntOrder.minrE /= !size_map.
-      smt (size_iota ge0_size).
-    rewrite /= nth_zip ?size_map //=; 1: smt (size_iota ge0_size).
-    rewrite !(nth_map 0) // !nth_iota //; smt (ge0_size size_iota).
+      smt (size_iota).
+    rewrite /= nth_zip ?size_map //=; 1: smt (size_iota).
+    rewrite !(nth_map 0) // !nth_iota //; smt (size_iota).
   qed.
 
   hint simplify (map2iE, map2_of_list)@0.
@@ -296,8 +294,6 @@ end MonoArray.
 abstract theory PolyArray.
 
   op size: int.
-
-  axiom ge0_size : 0 <= size.
 
   type 'a t.
 
@@ -455,8 +451,8 @@ abstract theory PolyArray.
   op to_list (t:'a t) =
     mkseq (fun i => t.[i]) size.
 
-  lemma size_to_list (t:'a t): size (to_list t) = size.
-  proof. rewrite size_mkseq /max; smt (ge0_size). qed.
+  lemma size_to_list (t:'a t): size (to_list t) = max 0 size.
+  proof. by rewrite size_mkseq. qed.
 
   lemma get_of_list (dfl:'a) (l:'a list) i : 0 <= i < size =>
     (of_list dfl l).[i] = nth dfl l i.
@@ -476,17 +472,16 @@ abstract theory PolyArray.
   lemma of_listK (dfl:'a) (l : 'a list) : size l = size =>
     to_list (of_list dfl l) = l.
   proof.
-    move=> h; apply (eq_from_nth witness); 1:by rewrite size_to_list h.
+    move=> h; apply (eq_from_nth witness); 1:by rewrite size_to_list h; smt(size_ge0).
     move=> i; rewrite size_to_list => hi.
-    rewrite get_to_list // get_of_list //.
-    by rewrite nth_onth (onth_nth witness) // h.
+    rewrite get_to_list // get_of_list; 1:smt(size_ge0).
+    by rewrite nth_onth (onth_nth witness); 1:smt(size_ge0).
   qed.
 
   lemma to_listK (dfl:'a) : cancel to_list (of_list dfl).
   proof.
     move=> t; apply ext_eq => i hi.
-    by rewrite get_of_list // nth_onth (onth_nth witness) ?size_to_list //=
-      get_to_list.
+    by rewrite get_of_list // nth_onth (onth_nth witness) ?size_to_list //=; smt().
   qed.
 
   lemma to_list_inj ['a] : injective (to_list<:'a>).
@@ -550,20 +545,16 @@ end PolyArray.
 (* Array slicing *)
 abstract theory SubArray.
   op sizeS: int.
-  axiom gt0_sizeS: 0 < sizeS.
 
   op sizeB: int.
-  axiom gt0_sizeB: 0 < sizeB.
 
   (* Sub-array *)
   clone import PolyArray as ArrayS with
-    op size <- sizeS
-    proof ge0_size by rewrite ltzW gt0_sizeS.
+    op size <- sizeS.
 
   (* Base array *)
   clone import PolyArray as ArrayB with
-    op size <- sizeB
-    proof ge0_size by rewrite ltzW gt0_sizeB.
+    op size <- sizeB.
 
   op get_sub (a: 'a ArrayB.t) (i: int) = ArrayS.init (fun j => a.[i + j]).
 

--- a/eclib/JWord.ec
+++ b/eclib/JWord.ec
@@ -50,6 +50,9 @@ abstract theory BitWord.
 
 op size : {int | 0 < size} as gt0_size.
 
+lemma ge0_size : 0 <= size.
+proof. by apply ltzW; apply gt0_size. qed.
+
 clone FinType as Alphabet with
   type t    <- bool,
   op   enum <- [true; false],
@@ -62,8 +65,7 @@ clone include MonoArray with
   rename "of_list"  as "bits2w"
          "to_list"  as "w2bits"
          "^tP$"     as "wordP"
-         "sub"      as "bits"
-  proof ge0_size by (apply ltzW; apply gt0_size).
+         "sub"      as "bits".
 
 (* -------------------------------------------------------------------- *)
 abbrev modulus = 2 ^ size.
@@ -113,9 +115,12 @@ axiomatized by to_sintE.
 abbrev zero = of_int 0.
 abbrev one  = of_int 1.
 
+lemma size_w2bits' x : size (w2bits x) = size.
+proof. done. qed.
+
 lemma to_uint_cmp (x : t) : 0 <= to_uint x < modulus.
 proof.
-  by rewrite to_uintE bs2int_ge0 -(size_w2bits x) bs2int_le2Xs.
+  by rewrite to_uintE bs2int_ge0 -(size_w2bits' x) bs2int_le2Xs.
 qed.
 
 lemma to_sint_cmp (x : t) : min_sint <= to_sint x <= max_sint.
@@ -132,8 +137,8 @@ lemma to_uintK : cancel to_uint of_int.
 proof.
   move=> w; rewrite to_uintE of_intE.
   rewrite modz_small.
-  + by rewrite bs2int_ge0 ger0_norm // -(size_w2bits w) bs2int_le2Xs.
-  by rewrite -(size_w2bits w) bs2intK w2bitsK.
+  + by rewrite bs2int_ge0 ger0_norm // -(size_w2bits' w) bs2int_le2Xs.
+  by rewrite -(size_w2bits' w) bs2intK w2bitsK.
 qed.
 
 lemma to_uintK' (x: t) : of_int (to_uint x) = x.
@@ -1198,7 +1203,7 @@ move=> H; have H0: to_uint (w1 `&` w2) = 0 by smt(to_uint0).
 rewrite to_uintD_small //.
 move: H0; rewrite !to_uintE.
 rewrite andE => H0.
-apply bs2int_add_disjoint; rewrite ?size_w2bits //.
+apply bs2int_add_disjoint; rewrite ?size_w2bits ?max_size //.
 by rewrite -H0 map2_w2bits_w2bits.
 qed.
 
@@ -2178,6 +2183,9 @@ abstract theory W_WS.
   axiom gt0_r : 0 < r.
   axiom sizeBrS : sizeB = r * sizeS.
 
+  lemma ge0_size : 0 <= r.
+  proof. by smt (gt0_r). qed.
+
   clone import WT as WS with op size <- sizeS.
   clone import WT as WB with op size <- sizeB.
 
@@ -2186,7 +2194,6 @@ abstract theory W_WS.
 
     op dfl <- WS.of_int 0,
     op size <- r
-    proof ge0_size by smt (gt0_r)
     rename [type] "t" as "pack_t"
            [lemma] "tP" as "packP".
 

--- a/eclib/JWord_array.ec
+++ b/eclib/JWord_array.ec
@@ -273,20 +273,17 @@ abstract theory ArrayWords.
 
   (* size of the array in words *)
   op sizeA: int.
-  axiom gt0_sizeA: 0 < sizeA.
 
   clone WT as Word with
     op size <- 8 * sizeW
     proof gt0_size by rewrite pmulr_rgt0 // gt0_sizeW.
 
   clone import PolyArray as ArrayN with
-    op size <- sizeA
-    proof ge0_size by rewrite ltzW gt0_sizeA.
+    op size <- sizeA.
 
   (* Equivalent array of bytes *)
   clone import WArray as WArrayN with
-    op size <- sizeW * sizeA
-    proof ge0_size by rewrite pmulr_rge0 1:gt0_sizeW ltzW gt0_sizeA.
+    op size <- sizeW * sizeA.
 
   (* Conversion between WArrayN.t and Word.t ArrayN.t *)
   clone W_WS as Wu8 with
@@ -320,10 +317,8 @@ abstract theory SubArrayCast.
   axiom gt0_sizeWB: 0 < sizeWB.
 
   op sizeS: int.
-  axiom gt0_sizeS: 0 < sizeS.
 
   op sizeB: int.
-  axiom gt0_sizeB: 0 < sizeB.
 
   clone WT as WordS with
     op size <- 8 * sizeWS
@@ -335,11 +330,11 @@ abstract theory SubArrayCast.
 
   clone ArrayWords as ArrayWordsS with
     op sizeW <- sizeWS, op sizeA <- sizeS, theory Word <- WordS
-    proof gt0_sizeW by apply gt0_sizeWS, gt0_sizeA by apply gt0_sizeS.
+    proof gt0_sizeW by apply gt0_sizeWS.
 
   clone ArrayWords as ArrayWordsB with
     op sizeW <- sizeWB, op sizeA <- sizeB, theory Word <- WordB
-    proof gt0_sizeW by apply gt0_sizeWB, gt0_sizeA by apply gt0_sizeB.
+    proof gt0_sizeW by apply gt0_sizeWB.
 
   op get_sub_direct (a: WordB.t ArrayWordsB.ArrayN.t) (i: int) =
     ArrayWordsS.to_word_array (
@@ -391,7 +386,6 @@ abstract theory ArrayAccessCast.
   axiom gt0_sizeWB: 0 < sizeWB.
 
   op sizeB: int.
-  axiom gt0_sizeB: 0 < sizeB.
 
   clone WT as WordS with
     op size <- 8 * sizeWS
@@ -403,7 +397,7 @@ abstract theory ArrayAccessCast.
 
   clone ArrayWords as ArrayWordsB with
     op sizeW <- sizeWB, op sizeA <- sizeB, theory Word <- WordB
-    proof gt0_sizeW by apply gt0_sizeWB, gt0_sizeA by apply gt0_sizeB.
+    proof gt0_sizeW by apply gt0_sizeWB.
 
   clone W_WS as WSu8 with
     op sizeS <= W8.size, op sizeB <= W8.size*sizeWS, op r <= sizeWS,

--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -585,7 +585,7 @@ Variant asm_i_r : Type :=
   | AsmOp  of asm_op_t' & asm_args
   | SysCall of syscall_t
   | Declassify_val of ltype & asm_arg
-  | Declassify_mem of positive & address.
+  | Declassify_mem of Z & address.
 
 Record asm_i : Type := MkAI { asmi_ii : instr_info; asmi_i : asm_i_r }.
 

--- a/proofs/arch/arch_extra.v
+++ b/proofs/arch/arch_extra.v
@@ -317,8 +317,8 @@ Proof.
   case: ty1; case: ty2; try (right; discriminate).
   + by left; reflexivity.
   + by left; reflexivity.
-  + move=> p1 p2.
-    case: (Pos.eq_dec p1 p2).
+  + move=> n1 n2.
+    case: (Z.eq_dec n1 n2).
     + by left; congruence.
     + by right; congruence.
   move=> ws1 ws2.

--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -543,7 +543,7 @@ Definition assemble_sopn rip ii (op: sopn) (outx : lexprs) (inx : rexprs) :=
 
 Variant declassify_op :=
   | Odeclassify of atype
-  | Odeclassify_mem of positive.
+  | Odeclassify_mem of Z.
 
 Definition is_declassify (op: sopn) :=
   match op with

--- a/proofs/compiler/array_copy.v
+++ b/proofs/compiler/array_copy.v
@@ -58,7 +58,7 @@ Definition indirect_copy ws x y i :=
 Definition needs_temporary x y : bool :=
   is_var_in_memory x && is_var_in_memory y.
 
-Definition array_copy ii (x: var_i) (ws: wsize) (n: positive) (y: gvar) :=
+Definition array_copy ii (x: var_i) (ws: wsize) (n: Z) (y: gvar) :=
   let i_name := fresh_counter fi in
   let i := {| v_var := {| vtype := aint ; vname := i_name |}; v_info := v_info x |} in
   let ei := Pvar (mk_lvar i) in

--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -130,7 +130,7 @@ Proof.
   by rewrite /get_gvar /= /get_var /= Vm.setP_eq /= eqxx.
 Qed.
 
-Lemma array_copyP ii (dst: var_i) ws n src s vm1 (t t': WArray.array (Z.to_pos (arr_size ws n))) :
+Lemma array_copyP ii (dst: var_i) ws n src s vm1 (t t': WArray.array (arr_size ws n)) :
   convertible (vtype dst) (aarr ws n) →
   not_tmp (read_gvar src) →
   evm s <=[X] vm1 →
@@ -138,12 +138,12 @@ Lemma array_copyP ii (dst: var_i) ws n src s vm1 (t t': WArray.array (Z.to_pos (
   WArray.copy t = ok t' →
   ∃ vm2, [/\
     evm s <=[Sv.remove dst X] vm2,
-    (exists2 a : WArray.array (Z.to_pos (arr_size ws n)), vm2.[dst] = Varr a & WArray.uincl t' a) &
+    (exists2 a : WArray.array (arr_size ws n), vm2.[dst] = Varr a & WArray.uincl t' a) &
     esem p2 ev (array_copy fresh_var_ident fi ii dst ws n src) (with_vm s vm1) = ok (with_vm s vm2)
   ].
 Proof.
   move: t t'.
-  set len := Z.to_pos _.
+  set len := arr_size _ _.
 Opaque esem.
   case: dst => -[] ty dst dsti t t' /convertible_eval_atype /= hty hsub hvm ok_t hcopy.
   set x := {| vtype := _ |}.
@@ -169,15 +169,21 @@ Opaque esem.
   move: hcopy; rewrite /WArray.copy -/len => /(WArray.fcopy_uincl (WArray.uincl_empty tx0 erefl))
     => -[tx'] hcopy hutx.
   have :
-    forall (j:Z), 0 <= j -> j <= n ->
+    forall (j:Z), j <= n ->
       forall vm1' (tx0:WArray.array len),
       vm1 <=[Sv.union (read_gvar src) (Sv.remove x X)] vm1' ->
       vm1'.[x] = Varr tx0 ->
-      WArray.fcopy ws t tx0 (Zpos n - j) j = ok tx' ->
+      WArray.fcopy ws t tx0 (n - j) j = ok tx' ->
       exists2 vm2,
         (vm1 <=[Sv.union (read_gvar src) (Sv.remove x X)]  vm2 /\ vm2.[x] = Varr tx') &
-        esem_for p2 ev i c (with_vm s vm1') (ziota (Zpos n - j) j) = ok (with_vm s vm2).
+        esem_for p2 ev i c (with_vm s vm1') (ziota (n - j) j) = ok (with_vm s vm2).
   + clear -fresh_counter fresh_temporary ok_t Hp freshX hsub ok_t hty.
+    move=> j.
+    have [hneg|hpos] := Z.nonpos_nonneg_cases j.
+    + move=> _ vm1' tx hvm1' hx.
+      rewrite /WArray.fcopy ziota_neg //= => -[<-].
+      by exists vm1'.
+    move: j hpos.
     apply: natlike_ind => [ | j hj hrec] hjn vm1' tx hvm1' hx.
     + by rewrite /WArray.fcopy ziota0 /= => -[?]; subst tx; exists vm1'.
     Opaque Z.sub esem_for.
@@ -242,7 +248,7 @@ Transparent esem.
     rewrite /= get_var_neq; last by move=> [? _]; subst ty.
     rewrite /= /get_var hx /= truncate_word_u /=.
     by rewrite hset /= write_var_eq_type.
-  move=> /(_ n _ _ vm1' tx0 hvm1' htx0) [] => //;first by lia.
+  move=> /(_ n _ vm1' tx0 hvm1' htx0) [] //; first by lia.
   + by rewrite Z.sub_diag.
   rewrite Z.sub_diag => vm2 [] hvm2 htx' hfor; exists vm2; split.
   + apply: uincl_onT.

--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -178,14 +178,9 @@ Opaque esem.
         (vm1 <=[Sv.union (read_gvar src) (Sv.remove x X)]  vm2 /\ vm2.[x] = Varr tx') &
         esem_for p2 ev i c (with_vm s vm1') (ziota (n - j) j) = ok (with_vm s vm2).
   + clear -fresh_counter fresh_temporary ok_t Hp freshX hsub ok_t hty.
-    move=> j.
-    have [hneg|hpos] := Z.nonpos_nonneg_cases j.
-    + move=> _ vm1' tx hvm1' hx.
-      rewrite /WArray.fcopy ziota_neg //= => -[<-].
+    apply: natlike_ind_full => [ j hneg | j hj hrec] hjn vm1' tx hvm1' hx.
+    + rewrite /WArray.fcopy ziota_neg //= => -[<-].
       by exists vm1'.
-    move: j hpos.
-    apply: natlike_ind => [ | j hj hrec] hjn vm1' tx hvm1' hx.
-    + by rewrite /WArray.fcopy ziota0 /= => -[?]; subst tx; exists vm1'.
     Opaque Z.sub esem_for.
     rewrite /WArray.fcopy ziotaS_cons //=; have -> : n - Z.succ j + 1 = n - j by ring.
     t_xrbindP => tx1 w hget hset hcopy.

--- a/proofs/compiler/array_expansion.v
+++ b/proofs/compiler/array_expansion.v
@@ -95,7 +95,7 @@ Definition init_array_info (x : varr_info) (svm:Sv.t * Mvar.t array_info) :=
   let vars := map (fun id => {| vtype := ty; vname := id |}) x.(vi_n) in
   Let svelems := foldM init_elems (sv,0%Z) vars in
   let '(sv, len) := svelems in
-  Let _ := assert [&& (0 <? len)%Z & convertible (vtype (vi_v x)) (aarr x.(vi_s) (Z.to_pos len))]
+  Let _ := assert [&& (0 <? len)%Z & convertible (vtype (vi_v x)) (aarr x.(vi_s) len)]
              (reg_ierror_no_var "init_array_info") in
   ok (sv, Mvar.set m x.(vi_v) {| ai_ty := x.(vi_s); ai_len := len; ai_elems := vars |}).
 

--- a/proofs/compiler/array_expansion.v
+++ b/proofs/compiler/array_expansion.v
@@ -95,8 +95,7 @@ Definition init_array_info (x : varr_info) (svm:Sv.t * Mvar.t array_info) :=
   let vars := map (fun id => {| vtype := ty; vname := id |}) x.(vi_n) in
   Let svelems := foldM init_elems (sv,0%Z) vars in
   let '(sv, len) := svelems in
-  Let _ := assert [&& (0 <=? len)%Z & convertible (vtype (vi_v x)) (aarr x.(vi_s) len)]
-             (reg_ierror_no_var "init_array_info") in
+  Let _ := assert (is_aarr (vtype (vi_v x))) (reg_ierror_no_var "init_array_info") in
   ok (sv, Mvar.set m x.(vi_v) {| ai_ty := x.(vi_s); ai_len := len; ai_elems := vars |}).
 
 Definition init_map (fi : expand_info) := 
@@ -210,10 +209,12 @@ Definition expand_param (m : t) ex (e : pexpr) : cexec _ :=
       let vi := v_info (gv x) in
       ok (map (fun v => Pvar (mk_lvar (VarI v vi))) (ai_elems ai))
     | Psub aa ws' len' x e =>
-      Let _ := assert (aa == AAscale) (reg_error (gv x) "(the default scale must be used)") in
       Let i := o2r (reg_error (gv x) "(the index is not a constant)") (is_const e) in
       Let ai := o2r (reg_error (gv x) "(not a reg array)") (Mvar.get m.(sarrs) (gv x)) in
-      Let _ := assert [&& ws == ai_ty ai, ws' == ws, len == len' & is_lvar x]
+      Let _ := assert (aa == AAscale) (reg_error (gv x) "(the default scale must be used)") in
+      Let _ := assert (ai.(ai_ty) == ws') (reg_error (gv x) "(the default scale must be used)") in
+      Let _ := assert ((0 <=? i) && (i + len' <=? ai.(ai_len)))%Z (reg_error (gv x) "(the sub-array overflows)") in
+      Let _ := assert [&& ws' == ws, len == len' & is_lvar x]
                       (reg_error (gv x) "(type mismatch)") in
       let elems := take (Z.to_nat len) (drop (Z.to_nat i) (ai_elems ai)) in
       let vi := v_info (gv x) in
@@ -236,10 +237,12 @@ Definition expand_return m ex x :=
       let vi := v_info x in
       ok (map (fun v => Lvar (VarI v vi)) (ai_elems ai))
     | Lasub aa ws' len' x e =>
-      Let _ := assert (aa == AAscale) (reg_error x "(the default scale must be used)") in
       Let i := o2r (reg_error x "(the index is not a constant)") (is_const e) in
       Let ai := o2r (reg_error x "(not a reg array)") (Mvar.get m.(sarrs) x) in
-      Let _ := assert [&& ws == ai_ty ai, ws' == ws & len == len']
+      Let _ := assert (aa == AAscale) (reg_error x "(the default scale must be used)") in
+      Let _ := assert (ai.(ai_ty) == ws') (reg_error x "(the default scale must be used)") in
+      Let _ := assert ((0 <=? i) && (i + len' <=? ai.(ai_len)))%Z (reg_error x "(the sub-array overflows)") in
+      Let _ := assert [&& ws' == ws & len == len']
                       (reg_error x "(type mismatch)") in
       let vi := v_info x in
       let elems := take (Z.to_nat len) (drop (Z.to_nat i) (ai_elems ai)) in

--- a/proofs/compiler/array_expansion.v
+++ b/proofs/compiler/array_expansion.v
@@ -95,7 +95,7 @@ Definition init_array_info (x : varr_info) (svm:Sv.t * Mvar.t array_info) :=
   let vars := map (fun id => {| vtype := ty; vname := id |}) x.(vi_n) in
   Let svelems := foldM init_elems (sv,0%Z) vars in
   let '(sv, len) := svelems in
-  Let _ := assert [&& (0 <? len)%Z & convertible (vtype (vi_v x)) (aarr x.(vi_s) len)]
+  Let _ := assert [&& (0 <=? len)%Z & convertible (vtype (vi_v x)) (aarr x.(vi_s) len)]
              (reg_ierror_no_var "init_array_info") in
   ok (sv, Mvar.set m x.(vi_v) {| ai_ty := x.(vi_s); ai_len := len; ai_elems := vars |}).
 

--- a/proofs/compiler/array_expansion_proof.v
+++ b/proofs/compiler/array_expansion_proof.v
@@ -13,7 +13,7 @@ Record wf_ai (m : t) (x:var) ai := {
   x_nin : ~ Sv.In x m.(svars);
   len_pos : (0 < ai.(ai_len))%Z;
   len_def : ai_len ai = Z.of_nat (size (ai_elems ai));
-  x_ty    : convertible (vtype x) (aarr ai.(ai_ty) (Z.to_pos ai.(ai_len)));
+  x_ty    : convertible (vtype x) (aarr ai.(ai_ty) ai.(ai_len));
   xi_nin  : forall xi, xi \in ai_elems ai -> ~ Sv.In xi m.(svars);
   xi_ty   : forall xi, xi \in ai_elems ai -> xi.(vtype) = aword ai.(ai_ty);
   el_uni  : uniq (ai_elems ai);
@@ -83,11 +83,14 @@ Qed.
 
 Lemma wf_take_drop dfl m x ai i len :
   wf_ai m x ai ->
-  (0 <= i)%Z -> (i + len <= ai_len ai)%Z -> (0 <= len)%Z ->
+  (0 <= i)%Z -> (i + len <= ai_len ai)%Z ->
   take (Z.to_nat len) (drop (Z.to_nat i) (ai_elems ai)) =
   map (fun j => znth dfl (ai_elems ai) (i + j)) (ziota 0 len).
 Proof.
-  move=> vai h0i hilen h0len.
+  have [hneg|hpos] := Z.nonpos_nonneg_cases len.
+  + move=> _ _ _.
+    by rewrite Z_to_nat_le0 // take0 ziota_neg //.
+  move=> vai h0i hilen.
   have heq : size (take (Z.to_nat len) (drop (Z.to_nat i) (ai_elems ai))) = Z.to_nat len.
   + rewrite size_takel // size_drop; apply/ZNleP.
     rewrite Nat2Z.n2zB.
@@ -106,8 +109,7 @@ Lemma wf_ai_elems dfl m x ai :
 Proof.
   move=> vai.
   have /= := @wf_take_drop dfl m x ai 0 ai.(ai_len) vai (Z.le_refl _) (Z.le_refl _).
-  rewrite vai.(len_def) => /(_ (Zle_0_nat _)) <-.
-  by rewrite drop0 Nat2Z.id take_size.
+  by rewrite drop0 vai.(len_def) Nat2Z.id take_size.
 Qed.
 
 Lemma expand_vP n a ws l :
@@ -339,6 +341,7 @@ Lemma expand_paramsP (s1 s2 : estate) e expdin :
     exists2 vs', expand_vs expdin vs = ok vs' &
       sem_pexprs false gd s2 (flatten es2) = ok (flatten vs').
 Proof.
+Local Opaque wsize_size.
   move=> h ?? + /mapM2_Forall3 H; elim: H => [?[<-]|]; first by eexists.
   move=> [] /=; last first.
   + by t_xrbindP => > /(expand_eP h) {}h <- ?
@@ -374,26 +377,21 @@ Proof.
   have := WArray.get_sub_bound hst.
   rewrite /arr_size /=.
   move: t st hgx hst.
-  set wsaty := (X in (X * len')%positive).
-  set wsaty' := (X in (X * _)%positive).
-  have -> : wsaty' = wsaty by done.
-  have -> : Zpos (wsaty * len') = (wsize_size (ai_ty a) * Zpos len')%Z by done.
-  have -> : Zpos (wsaty * Z.to_pos (ai_len a))%positive = (wsize_size (ai_ty a) * ai_len a)%Z.
-  + by have ? := vai.(len_pos); rewrite Pos2Z.inj_mul Z2Pos.id.
-  move=> {wsaty'} t st hgx hst hi.
+  move=> t st hgx hst hi.
   have ? := wsize_size_pos (ai_ty a).
-  rewrite -Z2Nat.inj_pos (wf_take_drop (v_var (gv g)) vai) //. 2,3: by nia.
+  rewrite (wf_take_drop (v_var (gv g)) vai) //. 2,3: by nia.
   rewrite -map_comp; apply eq_in_map => j; rewrite in_ziota /comp /= => /andP [] /ZleP ? /ZltP ?.
   have hbound : (0 <=? i + j)%Z && (i + j <? ai_len a)%Z.
   + by apply /andP; split; [apply/ZleP|apply/ZltP]; nia.
   case: h => _ _ -[_ /(_ _ _ _ hga){hga}hgai].
   move/hgai: (wf_mem (v_var (gv g)) vai hbound); rewrite -hgx /= => -[<-].
   by rewrite (wf_index _ vai hbound) (WArray.get_sub_get _ hst).
+Local Transparent wsize_size.
 Qed.
 
-Lemma wf_write_get s (x:var_i) ai (a : WArray.array (Z.to_pos (arr_size (ai_ty ai) (Z.to_pos (ai_len ai))))) i len :
+Lemma wf_write_get s (x:var_i) ai (a : WArray.array (arr_size (ai_ty ai) (ai_len ai))) i len :
   wf_ai m x ai ->
-  (0 <= i)%Z -> (i + len <= ai_len ai)%Z -> (0 <= len)%Z ->
+  (0 <= i)%Z -> (i + len <= ai_len ai)%Z ->
   exists2 vm,
     write_lvals false gd s [seq Lvar {| v_var := znth (v_var x) (ai_elems ai) x0; v_info := v_info x |} | x0 <- ziota i len]
       [seq rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Unaligned AAscale (ai_ty ai) a i)) | i <- ziota i len] = ok (with_vm s vm) &
@@ -404,7 +402,7 @@ Lemma wf_write_get s (x:var_i) ai (a : WArray.array (Z.to_pos (arr_size (ai_ty a
            rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Unaligned AAscale (ai_ty ai) a j))
         else (evm s).[y].
 Proof.
-  move => hva h0i hilen h0l.
+  move => hva h0i hilen.
   have : uniq (ziota i len).
   + rewrite ziotaE map_inj_uniq ?iota_uniq //.
     by move=> j1 j2 h; apply Nat2Z.inj; lia.
@@ -457,7 +455,7 @@ Proof.
     move=> /write_varP [-> _]. rewrite (convertible_eval_atype hva.(x_ty)) => /vm_truncate_valEl [] a -> _.
     rewrite expand_vP => -[?]; subst vs'.
     rewrite (wf_ai_elems (v_var x) hva) -map_comp /comp.
-    have [vm2 -> hvm2 ]:= wf_write_get s2 a hva (Z.le_refl _) (Z.le_refl _) (Z.lt_le_incl _ _ (len_pos hva)).
+    have [vm2 -> hvm2 ]:= wf_write_get s2 a hva (Z.le_refl _) (Z.le_refl _).
     eexists; eauto.
     case heqa => ?? heqv; split => //; split => /=.
     + move=> y hin; rewrite hvm2 /= Vm.setP_neq; last by apply/eqP=> ?; subst y; apply (x_nin hva hin).
@@ -479,11 +477,11 @@ Proof.
   rewrite expand_vP => -[?]; subst vs'.
   have := WArray.set_sub_bound hra.
   have [ltws lt0len]:= (wsize_size_pos (ai_ty ai), len_pos hva).
-  rewrite /arr_size /mk_scale {1}(Z2Pos.id _ lt0len) Z2Pos.id; last by nia.
+  rewrite /arr_size /mk_scale.
   move=> hb; have [{hb} h0i hilen'] : (0 <= i /\ i + len' <= ai_len ai)%Z by nia.
-  have -> := wf_take_drop (v_var x) hva h0i hilen' (Zle_0_pos _).
+  have -> := wf_take_drop (v_var x) hva h0i hilen'.
   rewrite -map_comp /comp.
-  have [vm2 ] := wf_write_get s2 ra hva h0i hilen' (Zle_0_pos _).
+  have [vm2 ] := wf_write_get s2 ra hva h0i hilen'.
   rewrite {1 2}(ziota_shift i len') -!map_comp /comp.
   have -> :
    [seq rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Unaligned AAscale (ai_ty ai) ra (i + x0))) | x0 <- ziota 0 len'] =

--- a/proofs/compiler/array_expansion_proof.v
+++ b/proofs/compiler/array_expansion_proof.v
@@ -11,7 +11,7 @@ Local Open Scope seq_scope.
 
 Record wf_ai (m : t) (x:var) ai := {
   x_nin : ~ Sv.In x m.(svars);
-  len_pos : (0 < ai.(ai_len))%Z;
+  len_pos : (0 <= ai.(ai_len))%Z;
   len_def : ai_len ai = Z.of_nat (size (ai_elems ai));
   x_ty    : convertible (vtype x) (aarr ai.(ai_ty) ai.(ai_len));
   xi_nin  : forall xi, xi \in ai_elems ai -> ~ Sv.In xi m.(svars);
@@ -376,8 +376,7 @@ Local Opaque wsize_size.
   rewrite mapM_map /comp /= /get_gvar /get_var /= mapM_ok /=; do 2!f_equal.
   have := WArray.get_sub_bound hst.
   rewrite /arr_size /=.
-  move: t st hgx hst.
-  move=> t st hgx hst hi.
+  move=> hi.
   have ? := wsize_size_pos (ai_ty a).
   rewrite (wf_take_drop (v_var (gv g)) vai) //. 2,3: by nia.
   rewrite -map_comp; apply eq_in_map => j; rewrite in_ziota /comp /= => /andP [] /ZleP ? /ZltP ?.
@@ -476,7 +475,7 @@ Proof.
   t_xrbindP => sa /to_arrI -> ra hra /write_varP [] -> _ _.
   rewrite expand_vP => -[?]; subst vs'.
   have := WArray.set_sub_bound hra.
-  have [ltws lt0len]:= (wsize_size_pos (ai_ty ai), len_pos hva).
+  have [ltws le0len]:= (wsize_size_pos (ai_ty ai), len_pos hva).
   rewrite /arr_size /mk_scale.
   move=> hb; have [{hb} h0i hilen'] : (0 <= i /\ i + len' <= ai_len ai)%Z by nia.
   have -> := wf_take_drop (v_var x) hva h0i hilen'.
@@ -600,7 +599,7 @@ Proof.
     + apply /andP; split => //; apply /negP => hin.
       by apply (hdis x); [clear; SvD.fsetdec | apply /sv_of_listP/map_f].
     have /= -> := Nat2Z.inj_succ (size elems); ring.
-  move=> [heq /disjointP hdis huni hlen] /andP [] /ZltP h0len hty <-.
+  move=> [heq /disjointP hdis huni hlen] /andP [] /ZleP h0len hty <-.
   case: hwf => /= hwf hincl hget.
   split => /=.
   + move=> x ai /=; rewrite Mvar.setP; case: eqP.

--- a/proofs/compiler/array_expansion_proof.v
+++ b/proofs/compiler/array_expansion_proof.v
@@ -11,9 +11,8 @@ Local Open Scope seq_scope.
 
 Record wf_ai (m : t) (x:var) ai := {
   x_nin : ~ Sv.In x m.(svars);
-  len_pos : (0 <= ai.(ai_len))%Z;
   len_def : ai_len ai = Z.of_nat (size (ai_elems ai));
-  x_ty    : convertible (vtype x) (aarr ai.(ai_ty) ai.(ai_len));
+  x_ty    : is_aarr (vtype x);
   xi_nin  : forall xi, xi \in ai_elems ai -> ~ Sv.In xi m.(svars);
   xi_ty   : forall xi, xi \in ai_elems ai -> xi.(vtype) = aword ai.(ai_ty);
   el_uni  : uniq (ai_elems ai);
@@ -352,7 +351,8 @@ Local Opaque wsize_size.
     rewrite /get_gvar /=hloc{hloc} /get_var /=.
     move=> + hrec _ _ [<-] z0 /hrec{hrec}+ <- => + [? ->] /= => <-.
     have vai := (valid hga); case: h => _ _ -[_ /(_ _ _ _ hga){hga}hgai].
-    have := Vm.getP (evm s1) (gv g). rewrite (convertible_eval_atype vai.(x_ty)) /compat_val /=.
+    have /is_aarrP [xws [xlen hxty]] := vai.(x_ty).
+    have := Vm.getP (evm s1) (gv g). rewrite hxty /= /compat_val /=.
     move => /compat_ctypeE /type_of_valI [x2 /[dup] hg ->].
     rewrite /sem_pexprs mapM_cat -/(sem_pexprs _ _ _ (flatten _)) => -> /=.
     rewrite expand_vP /=; eexists; eauto.
@@ -363,13 +363,13 @@ Local Opaque wsize_size.
     by rewrite (wf_index _ vai hbound).
 
   move=> aa ws' len' g ei es >.
-  t_xrbindP=> /eqP ?; subst aa.
-  case: is_constP=> // i ? [<-].
+  t_xrbindP; case: is_constP=> // i ? [<-].
   move=> a hga.
-  move=> /and4P [] /eqP ? /eqP ? /eqP ? hloc ? _ hrec vs z; subst ws ws' len es => /=.
+  move=> /eqP ? /eqP ? hb /and3P [] /eqP ? /eqP ? hloc ? _ hrec vs z; subst aa ws ws' len es => /=.
+  move: hb; rewrite !zify => hb.
   have vai := valid hga.
 
-  apply: on_arr_gvarP; rewrite (convertible_eval_atype vai.(x_ty)) => len1 t [?]; subst len1.
+  apply: on_arr_gvarP => len1 t _.
   rewrite /get_gvar hloc => /get_varP [hgx _ _]; t_xrbindP => st hst ?; subst z.
   move=> ? /hrec[? hex +] <-; rewrite /sem_pexprs mapM_cat hex /= => -> /=.
   rewrite expand_vP /=; eexists; eauto.
@@ -388,7 +388,7 @@ Local Opaque wsize_size.
 Local Transparent wsize_size.
 Qed.
 
-Lemma wf_write_get s (x:var_i) ai (a : WArray.array (arr_size (ai_ty ai) (ai_len ai))) i len :
+Lemma wf_write_get s (x:var_i) ai lena (a : WArray.array lena) i len :
   wf_ai m x ai ->
   (0 <= i)%Z -> (i + len <= ai_len ai)%Z ->
   exists2 vm,
@@ -451,7 +451,8 @@ Proof.
   + move=> x xs2.
     t_xrbindP=> ai hga; have hva:= valid hga.
     move=> /andP[/eqP? /eqP?] hmap va vs' s1'; subst.
-    move=> /write_varP [-> _]. rewrite (convertible_eval_atype hva.(x_ty)) => /vm_truncate_valEl [] a -> _.
+    have /is_aarrP [xws [xlen hxty]] := hva.(x_ty).
+    move=> /write_varP [-> _]. rewrite hxty => /vm_truncate_valEl [] a -> _.
     rewrite expand_vP => -[?]; subst vs'.
     rewrite (wf_ai_elems (v_var x) hva) -map_comp /comp.
     have [vm2 -> hvm2 ]:= wf_write_get s2 a hva (Z.le_refl _) (Z.le_refl _).
@@ -467,17 +468,18 @@ Proof.
       rewrite in_ziota /= (zindex_bound _ hva) => ?.
       have /(_ xi):= xi_disj hva hne hga'; elim => //.
     subst y; rewrite hga => -[<-] hin.
-    by rewrite in_ziota (zindex_bound _ hva) hin (convertible_eval_atype (x_ty hva)) vm_truncate_val_eq.
-  move => aa ws' len' x e xs2; t_xrbindP => /eqP ?; subst aa.
-  case: is_constP => // i _ [<-] ai hga; have hva:= valid hga.
-  move=> /and3P []/eqP ? /eqP ? /eqP ? <- va vs' s1'; subst a ws' len.
-  have /= := Vm.getP (evm s1) x; rewrite (convertible_eval_atype hva.(x_ty)) => /compat_valEl [a heqx]; rewrite heqx.
+    by rewrite in_ziota (zindex_bound _ hva) hin hxty vm_truncate_val_eq.
+  move => aa ws' len' x e xs2.
+  t_xrbindP; case: is_constP => // i _ [<-] ai hga; have hva:= valid hga.
+  move=> /eqP ? /eqP ? hb /andP [] /eqP ? /eqP ? <- va vs' s1'; subst aa a ws' len.
+  move: hb; rewrite !zify => hb.
+  have /is_aarrP [xws [xlen hxty]] := hva.(x_ty).
+  have /= := Vm.getP (evm s1) x; rewrite hxty => /compat_valEl [a heqx]; rewrite heqx.
   t_xrbindP => sa /to_arrI -> ra hra /write_varP [] -> _ _.
   rewrite expand_vP => -[?]; subst vs'.
   have := WArray.set_sub_bound hra.
-  have [ltws le0len]:= (wsize_size_pos (ai_ty ai), len_pos hva).
   rewrite /arr_size /mk_scale.
-  move=> hb; have [{hb} h0i hilen'] : (0 <= i /\ i + len' <= ai_len ai)%Z by nia.
+  move=> hb'; have [{hb'} h0i hilen'] : (0 <= i /\ i + len' <= ai_len ai)%Z by nia.
   have -> := wf_take_drop (v_var x) hva h0i hilen'.
   rewrite -map_comp /comp.
   have [vm2 ] := wf_write_get s2 ra hva h0i hilen'.
@@ -505,7 +507,7 @@ Proof.
     rewrite in_ziota /= => /hybound ?.
     have /(_ xi):= xi_disj hva hne hga'; elim => //.
   subst y; rewrite hga => -[<-] hin.
-  rewrite in_ziota (convertible_eval_atype (x_ty hva)); case: ifP => //=; rewrite eqxx //.
+  rewrite in_ziota hxty; case: ifP => //=; rewrite eqxx //.
   move: (hin); rewrite -(zindex_bound _ hva) => /andP [] /ZleP ? /ZltP ? hn.
   rewrite /= (WArray.set_sub_get _ hra).
   by rewrite hn; have [_ /(_ _ _ _ hga hin)]:= heqv; rewrite heqx.
@@ -599,7 +601,7 @@ Proof.
     + apply /andP; split => //; apply /negP => hin.
       by apply (hdis x); [clear; SvD.fsetdec | apply /sv_of_listP/map_f].
     have /= -> := Nat2Z.inj_succ (size elems); ring.
-  move=> [heq /disjointP hdis huni hlen] /andP [] /ZleP h0len hty <-.
+  move=> [heq /disjointP hdis huni hlen] hty <-.
   case: hwf => /= hwf hincl hget.
   split => /=.
   + move=> x ai /=; rewrite Mvar.setP; case: eqP.
@@ -610,7 +612,7 @@ Proof.
       + by move=> xi /mapP [id ? ->].
       move=> x' ai' xi /eqP ?. rewrite Mvar.setP_neq // => /hget -/(_ xi) h [].
       by rewrite -(map_id elems) => /sv_of_listP -/hdis h1 /h.
-    move=> hne /[dup] /hget h1 /hwf [/= ??????? xi_disj]; constructor => //=.
+    move=> hne /[dup] /hget h1 /hwf [/= ?????? xi_disj]; constructor => //=.
     move=> x' ai' xi hxx'; rewrite Mvar.setP; case: eqP => [? | hne']; last by apply xi_disj.
     by move=> [<-] [] /= /h1 /hdis h2; rewrite -(map_id elems) => /sv_of_listP.
   + by clear -heq hincl; SvD.fsetdec.
@@ -625,7 +627,8 @@ Lemma eq_alloc_empty m scs mem :
 Proof.
   move=> hwf; split => //; split => //=.
   move=> x ai xi /hwf hva hin.
-  rewrite !Vm.initP (convertible_eval_atype (x_ty hva)) (xi_ty hva hin) /=.
+  have /is_aarrP [xws [xlen hxty]] := hva.(x_ty).
+  rewrite !Vm.initP hxty (xi_ty hva hin) /=.
   case heq : WArray.get => [w | /=]; last first.
   + by rewrite /undef_v (undef_x_vundef (_ _)).
   have []:= WArray.get_bound heq; rewrite /mk_scale => ???.

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -432,7 +432,7 @@ Section ADD_INIT.
     set i' := MkI _ _.
     have [vm2 heq2 hi']: exists2 vm2, evm s1 =1 vm2 & sem_I p' ev (with_vm s1 vm1) i' (with_vm s1 vm2).
     + rewrite /i'; have := hu x; rewrite in_cons eq_refl /= => /(_ erefl) {hu i'} hx.
-      exists (vm1.[x <- Varr (WArray.empty (Z.to_pos (arr_size ws len)))]).
+      exists (vm1.[x <- Varr (WArray.empty (arr_size ws len))]).
       + move: hu1; rewrite !vm_eq_vm_rel => hu1; apply vm_rel_set_r.
         + by move=> _ /=; rewrite hx heq /= eqxx.
         by apply: vm_relI hu1.

--- a/proofs/compiler/dead_calls.v
+++ b/proofs/compiler/dead_calls.v
@@ -1,7 +1,6 @@
 (* -------------------------------------------------------------------- *)
 From mathcomp Require Import ssreflect ssrfun ssrbool.
 (* ------- *) Require Import expr compiler_util gen_map.
-(* ------- *) (* - *) Import PosSet.
 Import  Utf8.
 
 Module Import E.

--- a/proofs/compiler/dead_calls_proof.v
+++ b/proofs/compiler/dead_calls_proof.v
@@ -1,7 +1,6 @@
 (* -------------------------------------------------------------------- *)
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype.
 (* ------- *) Require Import expr compiler_util psem gen_map dead_calls.
-(* ------- *) (* - *) Import PosSet.
 Import Utf8 xseq.
 
 Section WITH_PARAMS.

--- a/proofs/compiler/makeReferenceArguments_proof.v
+++ b/proofs/compiler/makeReferenceArguments_proof.v
@@ -321,7 +321,7 @@ Context
         DB true va & is_defined va].
       + move=> {haX hX}; case: a E hva => //=.
         + move=> xe; case: ifP => // /and4P=> -[ _ /is_aarrP [ws [len hlen]] hc _] [<-] hget /=.
-          have : type_of_val va = carr (Z.to_pos (arr_size ws len)).
+          have : type_of_val va = carr (arr_size ws len).
           + by rewrite (type_of_get_gvar_not_word _ hget) hlen.
           by move=> /type_of_valI [t ->]; rewrite (convertible_eval_atype hc) hlen /truncate_val /= WArray.castK.
         move=> a ws len xe e; case: ifP => // /andP [_ hc] [<-] /=.

--- a/proofs/compiler/remove_globals.v
+++ b/proofs/compiler/remove_globals.v
@@ -86,7 +86,7 @@ Section REMOVE.
       else Error (rm_glob_error_gen ii x [:: pp_s "a cell has a non-constant value"; pp_e pe ])
     ).
 
-  Definition array_from_cells ii x (len: positive) (cells: pexprs) : result pp_error_loc (WArray.array len) :=
+  Definition array_from_cells ii x (len: Z) (cells: pexprs) : result pp_error_loc (WArray.array len) :=
     Let bytes := evaluate_bytes ii x cells in
     match sem_opN (Oarray len) bytes >>= to_arr len with
     | Ok array => Ok _ array

--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -1654,7 +1654,10 @@ Definition alloc_syscall ii rmap rs o es :=
   | RandomBytes ws n =>
     let len := arr_size ws n in
     (* per the semantics, we have [len <= wbase Uptr], but we need [<] *)
-    Let _ := assert ((0 <=? len) && (len <? wbase Uptr))%Z
+    Let _ := assert (0 <=? len)%Z
+                    (stk_error_no_var "randombytes: the requested size is negative")
+    in
+    Let _ := assert (len <? wbase Uptr)%Z
                     (stk_error_no_var "randombytes: the requested size is too large")
     in
     match rs, es with

--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -1654,7 +1654,7 @@ Definition alloc_syscall ii rmap rs o es :=
   | RandomBytes ws n =>
     let len := arr_size ws n in
     (* per the semantics, we have [len <= wbase Uptr], but we need [<] *)
-    Let _ := assert (len <? wbase Uptr)%Z
+    Let _ := assert ((0 <=? len) && (len <? wbase Uptr))%Z
                     (stk_error_no_var "randombytes: the requested size is too large")
     in
     match rs, es with
@@ -1713,7 +1713,7 @@ Definition alloc_declassify_array rmap es :=
     if get_local xv is Some pk then
       Let: (p, ofs) := addr_from_pk xv pk in
       let e := add (Plvar p) (cast_const ofs) in
-      let len := Z.to_pos (size_of xv.(vtype)) in
+      let len := size_of xv.(vtype) in
       ok (Copn [::] AT_keep (Opseudo_op (pseudo_operator.Odeclassify_mem len)) [:: e ])
     else Error (stk_ierror_basic xv "register array remains")
   else Error (stk_ierror_no_var "declassify: invalid args").
@@ -1828,12 +1828,14 @@ Definition init_stack_layout (mglob : Mvar.t (Z * wsize)) sao :=
     else
       if (p <= ofs)%CMP then
         let len := size_slot x in
-        if (ws <= sao.(sao_align))%CMP then
-          if (Z.land ofs (wsize_size ws - 1) == 0)%Z then
-            let stack := Mvar.set stack x (ofs, ws) in
-            ok (stack, (ofs + len)%Z)
-          else Error (stk_ierror_no_var "bad stack region alignment")
-        else Error (stk_ierror_no_var "bad stack alignment")
+        if (0 <? len)%Z then
+          if (ws <= sao.(sao_align))%CMP then
+            if (Z.land ofs (wsize_size ws - 1) == 0)%Z then
+              let stack := Mvar.set stack x (ofs, ws) in
+              ok (stack, (ofs + len)%Z)
+            else Error (stk_ierror_no_var "bad stack region alignment")
+          else Error (stk_ierror_no_var "bad stack alignment")
+        else Error (stk_ierror_no_var "a slot has negative size")
       else Error (stk_ierror_no_var "stack region overlap") in
   Let _ := assert (0 <=? sao.(sao_ioff))%Z (stk_ierror_no_var "negative initial stack offset") in
   Let sp := foldM add (Mvar.empty _, sao.(sao_ioff)) sao.(sao_slots) in
@@ -2112,7 +2114,7 @@ Definition check_glob data gv :=
 Definition size_glob gv :=
   match gv with
   | @Gword ws _ => wsize_size ws
-  | @Garr p _ => Zpos p
+  | @Garr len _ => len
   end.
 
 Definition init_map (l:list (var * wsize * Z)) data (gd:glob_decls) : cexec (Mvar.t (Z*wsize)) :=
@@ -2122,20 +2124,22 @@ Definition init_map (l:list (var * wsize * Z)) data (gd:glob_decls) : cexec (Mva
     if (pos <=? p)%Z then
       if Z.land p (wsize_size ws - 1) == 0%Z then
         let s := size_slot v in
-        match ztake (p - pos) data with
-        | None => Error (stk_ierror_no_var "bad data 1")
-        | Some (_, data) =>
-        match ztake s data with
-        | None =>  Error (stk_ierror_no_var "bad data 2")
-        | Some (vdata, data) =>
-          match assoc gd v with
-          | None => Error (stk_ierror_no_var "unknown var")
-          | Some gv =>
-            Let _ := assert (s == size_glob gv) (stk_ierror_no_var "bad size") in
-            Let _ := check_glob vdata gv in
-            ok (Mvar.set mvar v (p,ws), p + s, data)%Z
-          end
-        end end
+        if (0 <? s)%Z then
+          match ztake (p - pos) data with
+          | None => Error (stk_ierror_no_var "bad data 1")
+          | Some (_, data) =>
+          match ztake s data with
+          | None =>  Error (stk_ierror_no_var "bad data 2")
+          | Some (vdata, data) =>
+            match assoc gd v with
+            | None => Error (stk_ierror_no_var "unknown var")
+            | Some gv =>
+              Let _ := assert (s == size_glob gv) (stk_ierror_no_var "bad size") in
+              Let _ := check_glob vdata gv in
+              ok (Mvar.set mvar v (p,ws), p + s, data)%Z
+            end
+          end end
+        else Error (stk_ierror_no_var "a global slot has negative size")
       else Error (stk_ierror_no_var "bad global alignment")
     else Error (stk_ierror_no_var "global overlap") in
   Let globals := foldM add (Mvar.empty (Z*wsize), 0%Z, data) l in

--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -1828,7 +1828,7 @@ Definition init_stack_layout (mglob : Mvar.t (Z * wsize)) sao :=
     else
       if (p <= ofs)%CMP then
         let len := size_slot x in
-        if (0 <? len)%Z then
+        if (0 <=? len)%Z then
           if (ws <= sao.(sao_align))%CMP then
             if (Z.land ofs (wsize_size ws - 1) == 0)%Z then
               let stack := Mvar.set stack x (ofs, ws) in
@@ -2124,7 +2124,7 @@ Definition init_map (l:list (var * wsize * Z)) data (gd:glob_decls) : cexec (Mva
     if (pos <=? p)%Z then
       if Z.land p (wsize_size ws - 1) == 0%Z then
         let s := size_slot v in
-        if (0 <? s)%Z then
+        if (0 <=? s)%Z then
           match ztake (p - pos) data with
           | None => Error (stk_ierror_no_var "bad data 1")
           | Some (_, data) =>

--- a/proofs/compiler/stack_alloc_proof_1.v
+++ b/proofs/compiler/stack_alloc_proof_1.v
@@ -17,7 +17,7 @@ Local Open Scope Z_scope.
 Definition csize_of (ty : ctype) :=
   match ty with
   | cword sz => wsize_size sz
-  | carr n => Zpos n
+  | carr n => n
   | cbool | cint => 1%Z
   end.
 
@@ -25,12 +25,9 @@ Lemma csize_of_eval_atype ty :
   csize_of (eval_atype ty) = size_of ty.
 Proof. by case: ty. Qed.
 
-Lemma csize_of_gt0 ty : 0 < csize_of ty.
-Proof. by case: ty. Qed.
-
 Lemma csize_of_le ty ty' : subctype ty ty' -> csize_of ty <= csize_of ty'.
 Proof.
-  case: ty => [||p|ws]; case:ty' => [||p'|ws'] //.
+  case: ty => [||n|ws]; case:ty' => [||n'|ws'] //.
   + by move=> /= /eqP [->]; lia.
   move=> /= /wsize_size_le.
   by apply Z.divide_pos_le.
@@ -39,11 +36,14 @@ Qed.
 (* Size of a value. *)
 Notation size_val v := (csize_of (type_of_val v)).
 
-Lemma size_of_gt0 ty : 0 < size_of ty.
-Proof. by case: ty. Qed.
+(* Slots with non-positive sizes can be ignored.
+   We require disjointness only if both slots are of positive sizes. *)
+Definition disjoint_zrange {pd:PointerData} (p: pointer) (s: Z) (p': pointer) (s': Z) :=
+  0 < s -> 0 < s' ->
+  memory_model.disjoint_zrange p s p' s'.
 
-Lemma size_slot_gt0 s : 0 < size_slot s.
-Proof. by apply size_of_gt0. Qed.
+Definition disjoint_range {pd:PointerData} p s p' s' :=
+  disjoint_zrange p (wsize_size s) p' (wsize_size s').
 
 Section WITH_PARAMS.
 
@@ -86,11 +86,11 @@ Hypothesis disjoint_writable : forall s1 s2,
 
 (* The address [Addr s] of a slot [s] is aligned w.r.t. [Align s]. *)
 Hypothesis slot_align :
-  forall s, Sv.In s Slots -> is_align (Addr s) (Align s).
+  forall s, Sv.In s Slots -> 0 < size_slot s -> is_align (Addr s) (Align s).
 
 (* Writable slots are disjoint from globals. *)
 Hypothesis writable_not_glob : forall s, Sv.In s Slots -> Writable s ->
-  0 < glob_size -> disjoint_zrange rip glob_size (Addr s) (size_slot s).
+  disjoint_zrange rip glob_size (Addr s) (size_slot s).
 
 (* All pointers valid in memory [m0] are valid in memory [m].
    It is supposed to be applied with [m0] the initial target memory
@@ -812,15 +812,14 @@ Proof.
   by exists cs1, cs2.
 Qed.
 
-(* Lemmas about wf_zone *)
-(* -------------------------------------------------------------------------- *)
-
-Lemma wf_concrete_slice_len_gt0 cs ty sl :
-  wf_concrete_slice cs ty sl -> 0 < cs.(cs_len).
-Proof. by move=> [? _]; have := csize_of_gt0 ty; lia. Qed.
-
 (* Lemmas about wf_sub_region *)
 (* -------------------------------------------------------------------------- *)
+
+Lemma wf_sub_region_size_slot_gt0 vme sr ty :
+  wf_sub_region vme sr ty ->
+  0 < csize_of ty ->
+  0 < size_slot sr.(sr_region).(r_slot).
+Proof. by move=> [_ [cs _ [??]]]; lia. Qed.
 
 (* TODO: move this closer to alloc_array_moveP? Before, this was used everywhere
    but not anymore. *)
@@ -869,9 +868,8 @@ Proof.
   rewrite /sub_concrete_slice /=.
   case: ifPn.
   + move=> _.
-    eexists; split; first by reflexivity.
-    move=> /=.
-    by lia.
+    eexists; first by reflexivity.
+    by split=> /=; lia.
   rewrite !zify.
   by lia.
 Qed.
@@ -1005,17 +1003,17 @@ Qed.
 
 Lemma wunsigned_sub_region_addr vme sr ty cs :
   wf_sub_region vme sr ty ->
+  0 < csize_of ty ->
   sem_zone vme sr.(sr_zone) = ok cs ->
   exists2 w,
     sub_region_addr vme sr = ok w &
     wunsigned w = wunsigned (Addr sr.(sr_region).(r_slot)) + cs.(cs_ofs).
 Proof.
-  move=> [hwf [cs2 ok_cs wf_cs]]; rewrite ok_cs => -[?]; subst cs2.
+  move=> [hwf [cs2 ok_cs wf_cs]] hpos; rewrite ok_cs => -[?]; subst cs2.
   rewrite /sub_region_addr; rewrite ok_cs /=.
   eexists; first by reflexivity.
   apply wunsigned_add.
-  have hlen := wf_concrete_slice_len_gt0 wf_cs.
-  have hofs := wfcs_ofs wf_cs.
+  have [hlen hofs] := wf_cs.
   have /ZleP hno := addr_no_overflow (wfr_slot hwf).
   have ? := wunsigned_range (Addr (sr.(sr_region).(r_slot))).
   by lia.
@@ -1023,13 +1021,14 @@ Qed.
 
 Lemma zbetween_sub_region_addr vme sr ty ofs :
   wf_sub_region vme sr ty ->
+  0 < csize_of ty ->
   sub_region_addr vme sr = ok ofs ->
   zbetween (Addr sr.(sr_region).(r_slot)) (size_slot sr.(sr_region).(r_slot))
     ofs (csize_of ty).
 Proof.
-  move=> hwf haddr.
+  move=> hwf hpos haddr.
   have [cs ok_cs wf_cs] := hwf.(wfsr_zone).
-  have := wunsigned_sub_region_addr hwf ok_cs.
+  have := wunsigned_sub_region_addr hwf hpos ok_cs.
   rewrite haddr => -[_ [<-] heq].
   rewrite /zbetween !zify heq.
   have hofs := wf_cs.(wfcs_ofs).
@@ -1043,7 +1042,11 @@ Lemma no_overflow_sub_region_addr vme sr ty ofs :
   no_overflow ofs (csize_of ty).
 Proof.
   move=> hwf haddr.
-  apply (no_overflow_incl (zbetween_sub_region_addr hwf haddr)).
+  case: (Z.nonpos_pos_cases (csize_of ty)) => [hneg|hpos].
+  + rewrite /no_overflow zify.
+    have := wunsigned_range ofs.
+    by lia.
+  apply (no_overflow_incl (zbetween_sub_region_addr hwf hpos haddr)).
   by apply (addr_no_overflow hwf.(wfr_slot)).
 Qed.
 
@@ -1258,19 +1261,20 @@ Section EXPR.
 
   Lemma check_alignP x sr ty w al ws tt :
     wf_sub_region vme sr ty ->
+    0 < csize_of ty ->
     sub_region_addr vme sr = ok w ->
     check_align al x sr ws = ok tt ->
     is_aligned_if al w ws.
   Proof.
-    move=> hwf ok_w; rewrite /check_align; t_xrbindP.
+    move=> hwf hpos ok_w; rewrite /check_align; t_xrbindP.
     case: al => //= halign halign2.
     have: is_align (Addr sr.(sr_region).(r_slot)) ws.
     + apply (is_align_m halign).
       rewrite -hwf.(wfr_align).
-      by apply (slot_align hwf.(wfr_slot)).
+      by apply (slot_align hwf.(wfr_slot) (wf_sub_region_size_slot_gt0 hwf hpos)).
     rewrite !is_alignE !p_to_zE.
     have [cs ok_cs _] := hwf.(wfsr_zone).
-    have := wunsigned_sub_region_addr hwf ok_cs.
+    have := wunsigned_sub_region_addr hwf hpos ok_cs.
     rewrite ok_w => -[_ [<-] ->].
     rewrite Z.add_mod //.
     move=> /eqP -> /=.
@@ -1510,7 +1514,7 @@ Section EXPR.
       rewrite add_wordE -(GRing.addr0 (_+_)%R) -wrepr0.
       rewrite (eq_sub_region_val_read_word _ hwf hread eq_addr (w:=zero_extend ws w)).
       + rewrite wrepr0 GRing.addr0.
-        rewrite (check_alignP hwf eq_addr halign) /=.
+        rewrite (check_alignP hwf _ eq_addr halign) /=; last by rewrite htyx.
         eexists; split; first by reflexivity.
         move: htr; rewrite /truncate_val /=.
         t_xrbindP=> ? /truncate_wordP [_ ->] <-.
@@ -1546,7 +1550,12 @@ Section EXPR.
       rewrite wrepr_add add_wordE (GRing.addrC (wrepr _ _)) GRing.addrA.
       rewrite (eq_sub_region_val_read_word _ hwf hread eq_addr (w:=w)).
       + case: al hw halign => //= hw halign.
-        have {}halign := check_alignP hwf eq_addr halign.
+        have hpos: 0 < csize_of (eval_atype x.(gv).(vtype)).
+        + rewrite htyx /=.
+          have [] := WArray.get_bound hw.
+          have := WArray.mk_scale_bound aa sz.
+          by lia.
+        have {}halign := check_alignP hwf hpos eq_addr halign.
         rewrite (is_align_addE halign) WArray.arr_is_align.
         by have [_ _ /= ->] := WArray.get_bound hw.
       have [_ hread8] := (read_read8 hw).
@@ -2357,7 +2366,8 @@ Lemma disjoint_source_word table rmap vme m0 s1 s2 :
 Proof.
   move=> hvs s al p ws hin /validwP [] hal hd i i' /hd.
   rewrite (validw8_alignment Aligned) !addE => hi hi'.
-  case: (vs_disjoint hin hi).
+  case: (vs_disjoint hin hi) => //.
+  + by lia.
   rewrite /wsize_size /= => /ZleP hs _ D K.
   move: D.
   have -> : wunsigned (p + wrepr _ i) = wunsigned (Addr s + wrepr _ i') by rewrite K.
@@ -2378,9 +2388,13 @@ Proof.
   move: ok_w; rewrite ok_ofs => -[?]; subst w.
   rewrite -(hread _ _ _ ok_ofs hoff hget).
   apply hreadeq.
-  apply (disjoint_zrange_byte hd).
-  rewrite -hty.
-  by apply (get_val_byte_bound hget).
+  have hbound := get_val_byte_bound hget.
+  have hpos: 0 < csize_of ty.
+  + rewrite -hty.
+    by lia.
+  move=> hsz _.
+  apply (disjoint_zrange_byte (hd hsz hpos)).
+  by rewrite -hty.
 Qed.
 
 Lemma wf_region_slot_inj r1 r2 :
@@ -2405,13 +2419,15 @@ Lemma distinct_regions_disjoint_zrange vme sr1 sr2 ty1 ty2 ofs1 ofs2 :
   sr1.(sr_region).(r_writable) ->
   disjoint_zrange ofs1 (csize_of ty1) ofs2 (csize_of ty2).
 Proof.
-  move=> hwf1 haddr1 hwf2 haddr2 hneq hw.
-  have hb1 := zbetween_sub_region_addr hwf1 haddr1.
-  have hb2 := zbetween_sub_region_addr hwf2 haddr2.
+  move=> hwf1 haddr1 hwf2 haddr2 hneq hw hpos1 hpos2.
+  have hb1 := zbetween_sub_region_addr hwf1 hpos1 haddr1.
+  have hb2 := zbetween_sub_region_addr hwf2 hpos2 haddr2.
   apply (disjoint_zrange_incl hb1 hb2).
-  apply (disjoint_writable hwf1.(wfr_slot) hwf2.(wfr_slot));
-    last by rewrite hwf1.(wfr_writable).
-  by move=> /(wf_region_slot_inj hwf1 hwf2).
+  apply: (disjoint_writable hwf1.(wfr_slot) hwf2.(wfr_slot)).
+  + by move=> /(wf_region_slot_inj hwf1 hwf2).
+  + by rewrite hwf1.(wfr_writable).
+  + by apply (wf_sub_region_size_slot_gt0 hwf1 hpos1).
+  by apply (wf_sub_region_size_slot_gt0 hwf2 hpos2).
 Qed.
 
 Lemma eq_sub_region_val_distinct_regions vme sr ty ofs sry ty' s2 mem2 status v :
@@ -2940,10 +2956,9 @@ Proof.
   move=> hwf haddr hsry hwfy hr hreadeq hwfsy [hread hty'].
   split=> // off ofsy w haddry hvalid /[dup] /get_val_byte_bound; rewrite hty' => hoff hget.
   have [cs ok_cs wf_cs] := hwf.(wfsr_zone).
-  have := wunsigned_sub_region_addr hwf ok_cs.
-  rewrite haddr => -[_ [<-] ok_ofs].
   have [csy ok_csy wf_csy] := hwfy.(wfsr_zone).
-  have := wunsigned_sub_region_addr hwfy ok_csy.
+  have hposy: 0 < csize_of ty' by lia.
+  have := wunsigned_sub_region_addr hwfy hposy ok_csy.
   rewrite haddry => -[_ [<-] ok_ofsy].
   have hoff': 0 <= off < csy.(cs_len).
   + have := wf_csy.(wfcs_len).
@@ -2952,6 +2967,7 @@ Proof.
     valid_offset_clear_status_map_aux hwfsy hsry ok_csy ok_cs hoff' hvalid.
   rewrite -(hread _ _ _ haddry hvalid hget).
   apply hreadeq.
+  move=> hpos _.
   apply not_between_U8_disjoint_zrange.
   + by apply (no_overflow_sub_region_addr hwf haddr).
   rewrite /between /zbetween wsize8 !zify.
@@ -2960,6 +2976,8 @@ Proof.
     rewrite /no_overflow zify.
     have := wunsigned_range ofsy.
     by lia.
+  have := wunsigned_sub_region_addr hwf hpos ok_cs.
+  rewrite haddr => -[_ [<-] ok_ofs].
   rewrite ok_ofs ok_ofsy -hr => hb.
   apply off_nin.
   rewrite /offset_in_concrete_slice !zify.
@@ -2980,7 +2998,11 @@ Proof.
   apply: is_align_add hlocal.(wfs_offset_align).
   apply (is_align_m hlocal.(wfs_align_ptr)).
   rewrite -hlocal.(wfs_align).
-  by apply (slot_align (sub_region_stkptr_wf vme hlocal).(wfr_slot)).
+  apply (slot_align (sub_region_stkptr_wf vme hlocal).(wfr_slot)) => /=.
+  have := hlocal.(wfs_size).
+  have := hlocal.(wfs_zone).
+  have := [elaborate wsize_size_pos Uptr].
+  by lia.
 Qed.
 
 Lemma check_writableP x r tt :
@@ -2988,16 +3010,14 @@ Lemma check_writableP x r tt :
   r.(r_writable).
 Proof. by rewrite /check_writable; t_xrbindP. Qed.
 
-Lemma set_wordP vme sr (x:var_i) ofs rmap al status ws rmap2 :
-  wf_sub_region vme sr (eval_atype x.(vtype)) ->
-  sub_region_addr vme sr = ok ofs ->
+Lemma set_wordP sr (x:var_i) rmap al status ws rmap2 :
   set_word rmap al sr x status ws = ok rmap2 ->
   [/\ sr.(sr_region).(r_writable),
-      is_aligned_if al ofs ws &
+      check_align al x sr ws = ok tt &
       rmap2 = set_word_pure rmap sr x status].
 Proof.
-  move=> hwf ok_ofs; rewrite /set_word.
-  by t_xrbindP=> /check_writableP hw /(check_alignP hwf ok_ofs) hal <-.
+  rewrite /set_word.
+  by t_xrbindP=> /check_writableP hw hal <-.
 Qed.
 
 Lemma get_status_map_setP rv r r' sm :
@@ -3076,7 +3096,7 @@ Lemma check_gvalid_set_word vme sr (x:var_i) rmap al status ws rmap2 y sry statu
 Proof.
   move=> hsr hwf hset.
   have [ofs haddr] := wf_sub_region_sub_region_addr hwf.
-  have [hw _ ->] := set_wordP hwf haddr hset.
+  have [hw _ ->] := set_wordP hset.
   rewrite /check_gvalid /=.
   case: (@idP (is_glob y)) => hg.
   + case heq: Mvar.get => [[ofs' ws']|//] [<- <-] /=.
@@ -3110,9 +3130,11 @@ Proof.
   move=> hwf haddr hwritable hreadeq hunch p hvalid1 hvalid2 hdisj.
   rewrite (hunch _ hvalid1 hvalid2 hdisj).
   symmetry; apply hreadeq.
-  apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf haddr)).
-  apply (hdisj _ hwf.(wfr_slot)).
-  by rewrite hwf.(wfr_writable).
+  move=> hpos _.
+  apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf hpos haddr)).
+  apply (hdisj _ hwf.(wfr_slot)) => //.
+  + by rewrite hwf.(wfr_writable).
+  by apply (wf_sub_region_size_slot_gt0 hwf hpos).
 Qed.
 
 (* This lemma is used both for [set_word] and [set_stack_ptr]. *)
@@ -3182,7 +3204,7 @@ Proof.
   rewrite get_gvar_neq //; move=> /(wfr_val hgvalid).
   assert (hwfy := check_gvalid_wf wfr_wf hgvalid).
   apply: (eq_sub_region_val_distinct_regions hwf haddr hwfy hneqr _ hreadeq).
-  by case: (set_wordP hwf haddr hset).
+  by case: (set_wordP hset).
 Qed.
 
 Lemma var_region_not_new rmap vme s2 x sr :
@@ -3218,10 +3240,11 @@ Proof.
   move=> hvalid pofs ofsy haddrp haddry.
   rewrite -(hpk hvalid _ _ haddrp haddry).
   apply hreadeq.
+  move=> hpos _.
   apply disjoint_zrange_sym.
   have /wfr_wf hwf := hsr.
   have hwfp := sub_region_stkptr_wf vme hlocal.
-  apply: (distinct_regions_disjoint_zrange hwfp haddrp hwf haddr _ erefl).
+  apply: (distinct_regions_disjoint_zrange hwfp haddrp hwf haddr _ erefl) => //.
   by apply not_eq_sym.
 Qed.
 
@@ -3236,8 +3259,7 @@ Lemma wfr_PTR_set_sub_region vars rmap vme s1 s2 (x:var_i) sr ofs mem2 al status
   wfr_PTR rmap2 vme (with_mem s2 mem2).
 Proof.
   move=> hwfr hsr haddr hreadeq hset y sry.
-  have /wfr_wf hwf := hsr.
-  have [_ _ ->] /= := set_wordP hwf haddr hset.
+  have [_ _ ->] /= := set_wordP hset.
   move=> /wfr_ptr [pky [hly hpky]].
   exists pky; split=> //.
   have /wfr_ptr [_ [/wf_vnew hnnew _]] := hsr.
@@ -3257,8 +3279,10 @@ Proof.
   move=> hvs hwf haddr hreadeq p hvp.
   rewrite (vs_eq_mem hvp).
   symmetry; apply hreadeq.
-  apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf haddr)).
-  by apply (vs_disjoint hwf.(wfr_slot) hvp).
+  move=> hpos _.
+  apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf hpos haddr)).
+  apply (vs_disjoint hwf.(wfr_slot) hvp) => //.
+  by apply (wf_sub_region_size_slot_gt0 hwf hpos).
 Qed.
 
 (* We show that, under the right hypotheses, [set_word] preserves
@@ -3289,21 +3313,21 @@ Proof.
   + by move=> ??; rewrite hvalideq; apply hvalid.
   + by move=> ??; rewrite hvalideq; apply hincl.
   + by move=> ??; rewrite hvalideq; apply hincl2.
-  + have [hwritable _ _] := set_wordP hwf haddr hset.
+  + have [hwritable _ _] := set_wordP hset.
     rewrite -csize_of_eval_atype in hreadeq.
     by apply (mem_unchanged_write_slot hwf haddr hwritable hreadeq hunch).
   + move=> y hget; rewrite Vm.setP_neq /=; first by apply heqvm.
     by apply /eqP; rewrite /get_local in hlx; congruence.
   + by apply: wf_table_set_var hwft.
   + case: (hwfr) => hwfsr hwfst hvarsz hvarss hval hptr; split.
-    + have [_ _ ->] := set_wordP hwf haddr hset.
+    + have [_ _ ->] := set_wordP hset.
       by move=> ?? /=; apply hwfsr.
     + have [addr ok_addr] := wf_sub_region_sub_region_addr hwf.
-      have [_ _ ->] /= := set_wordP hwf ok_addr hset.
+      have [_ _ ->] /= := set_wordP hset.
       by apply (wfr_STATUS_set_word_status _ hwfsr hwf hwfs hwfst).
-    + have [_ _ ->] := set_wordP hwf haddr hset.
+    + have [_ _ ->] := set_wordP hset.
       by apply hvarsz.
-    + have [_ _ ->] /= := set_wordP hwf haddr hset.
+    + have [_ _ ->] /= := set_wordP hset.
       by apply (wfr_VARS_STATUS_set_word_status _ (hvarsz _ _ hsr) hvars hvarsz hvarss).
     + by apply (wfr_VAL_set_word hwfr hsr haddr hreadeq hset htr heqval).
     by apply (wfr_PTR_set_sub_region hwfr hsr haddr hreadeq hset).
@@ -3362,10 +3386,10 @@ Proof.
   move=> hwf haddr hofs.
   rewrite /zbetween !zify.
   rewrite wunsigned_add; first by lia.
+  have ? := wsize_size_pos ws.
   have := no_overflow_sub_region_addr hwf haddr.
   rewrite /no_overflow zify.
   have := wunsigned_range addr.
-  have := wsize_size_pos ws.
   by lia.
 Qed.
 
@@ -3381,10 +3405,13 @@ Proof.
   have /vs_slot_valid hptr := hwf.(wfr_slot).
   apply /validwP; split=> //.
   move=> k hk; rewrite (validw8_alignment Aligned); apply hptr; move: hk.
+  have hpos: 0 < csize_of ty.
+  + have := wsize_size_pos ws.
+    by lia.
   apply: between_byte.
   + apply: no_overflow_incl (no_overflow_sub_region_addr hwf haddr).
     by apply (zbetween_sub_region_addr_ofs hwf haddr hbound).
-  apply (zbetween_trans (zbetween_sub_region_addr hwf haddr)).
+  apply (zbetween_trans (zbetween_sub_region_addr hwf hpos haddr)).
   by apply (zbetween_sub_region_addr_ofs hwf haddr hbound).
 Qed.
 
@@ -3483,20 +3510,22 @@ Proof.
     have := htr; rewrite {1}hty =>
       /(vm_truncate_val_subctype_word hdb htyv) [w htrw -> /=].
     have hofs: 0 <= 0 /\ wsize_size ws <= csize_of (eval_atype x.(vtype)) by rewrite hty /=; lia.
+    have hpos: 0 < csize_of (eval_atype (vtype x)).
+    + by rewrite hty.
     have hvp: validw (emem s2) Aligned (wi + wrepr _ ofsi)%R ws.
-    + have [_ halign _] := set_wordP hwf haddr hsetw.
+    + have [_ /(check_alignP hwf hpos haddr) halign _] := set_wordP hsetw.
       have := validw_sub_region_addr_ofs hvs hwf haddr hofs.
       rewrite wrepr0 GRing.addr0.
       by apply.
     have /writeV -/(_ w) [mem2 hmem2] := hvp.
     rewrite hmem2 /=; eexists; first by reflexivity.
     (* valid_state update word *)
-    have [_ _ hset] := set_wordP hwf haddr hsetw.
+    have [_ _ hset] := set_wordP hsetw.
     apply: (valid_state_set_word hvs hsr haddr _ _ _ _ _ hsetw) => //.
     + by apply (Memory.write_mem_stable hmem2).
     + by move=> ??; apply (write_validw_eq hmem2).
     + move=> al p ws''.
-      rewrite hty => /disjoint_range_alt.
+      rewrite hty => /(_ erefl erefl) /disjoint_range_alt.
       exact: (writeP_neq _ hmem2).
     rewrite hty htrw; split => //.
     rewrite /eq_sub_region_val_read haddr.
@@ -3536,8 +3565,10 @@ Proof.
         have hreadeq := writeP_neq _ hmem2.
         have [ofsy haddry] := wf_sub_region_sub_region_addr hwfy.
         apply: (eq_sub_region_val_disjoint_zrange_ovf hreadeq haddry _ (hval _ _ _ _ hgvalid hgy)).
+        case: (Z.nonpos_pos_cases (csize_of (eval_atype y.(gv).(vtype)))) => [hneg|hpos].
+        + by rewrite /disjoint_zrange_ovf; lia.
         have := disjoint_source_word hvs hwfy.(wfr_slot) hvp1.
-        have := zbetween_sub_region_addr hwfy haddry.
+        have := zbetween_sub_region_addr hwfy hpos haddry.
         exact: zbetween_disjoint_zrange_ovf.
       move=> y sry hgy.
       have [pk [hgpk hvpk]] := hptr _ _ hgy; exists pk; split => //.
@@ -3546,7 +3577,7 @@ Proof.
       apply: (writeP_neq _ hmem2).
       assert (hwf' := sub_region_stkptr_wf vme (wf_locals hgpk)).
       have := disjoint_source_word hvs hwf'.(wfr_slot) hvp1.
-      have := zbetween_sub_region_addr hwf' haddrp.
+      have := zbetween_sub_region_addr hwf' erefl haddrp.
       exact: zbetween_disjoint_zrange_ovf.
     + move=> p; rewrite (write_validw_eq hmem1) => hv.
       apply: read_write_any_mem hmem1 hmem2.
@@ -3577,9 +3608,13 @@ Proof.
   rewrite /get_gvar /= h /= /sem_sop2 /= hto.
   rewrite (mk_ofsP aa ws ofsi he1) /= truncate_word_u /= hvw /= truncate_word_u /=.
   have [hge0 hlen haa] := WArray.set_bound htt'.
+  have hpos: (0 < csize_of (eval_atype (vtype x))).
+  + rewrite hty /=.
+    have := WArray.mk_scale_bound aa ws.
+    by lia.
   have hvp: validw (emem s2) al (wx + wrepr Uptr ofsi + wrepr _ (i1 * mk_scale aa ws))%R ws.
   + apply (validw_sub_region_addr_ofs hvs hwf haddr); first by rewrite hty.
-    have [_ hal _] := set_wordP hwf haddr hset.
+    have [_ /(check_alignP hwf hpos haddr) hal _] := set_wordP hset.
     case: al haa hal {htt' hset} => //= haa hal.
     apply: is_align_add; first by [].
     by rewrite WArray.arr_is_align.
@@ -3594,8 +3629,7 @@ Proof.
   + move=> al' p ws' hdisj.
     apply (writeP_neq _ hmem2).
     apply: disjoint_range_alt.
-    apply: disjoint_zrange_incl_l hdisj.
-    rewrite -csize_of_eval_atype.
+    apply: disjoint_zrange_incl_l (hdisj _ _) => //; rewrite -csize_of_eval_atype //.
     by apply (zbetween_sub_region_addr_ofs hwf haddr).
   + by apply wfr_status.
   + by apply wfr_vars_status.
@@ -4468,7 +4502,7 @@ Proof.
         + by rewrite wrepr_sub -GRing.addrA (GRing.addrC (wrepr _ _)) GRing.subrK.
         apply hread.
         + have hbound:
-            0 <= i * mk_scale aa ws /\ i * mk_scale aa ws + csize_of (carr (Z.to_pos (arr_size ws len))) <= csize_of (eval_atype x.(vtype)).
+            0 <= i * mk_scale aa ws /\ i * mk_scale aa ws + csize_of (carr (arr_size ws len)) <= csize_of (eval_atype x.(vtype)).
           + rewrite htyx /=.
             by apply (WArray.set_sub_bound ok_ax').
           rewrite (sub_region_status_at_ofs_addr _ _ hwfx ok_ofsi hbound).
@@ -4699,16 +4733,15 @@ Proof.
       sem_sexpr vme' (mk_ofs_int aa ws e1) >>= to_int = ok (i * mk_scale aa ws).
     + by rewrite (mk_ofs_intP aa ws ok_i'').
     have hbound:
-      0 <= i * mk_scale aa ws /\ i * mk_scale aa ws + csize_of (carr (Z.to_pos (arr_size ws len))) <= csize_of (eval_atype y.(gv).(vtype)).
-    + rewrite hyty /= Z2Pos.id //.
+      0 <= i * mk_scale aa ws /\ i * mk_scale aa ws + csize_of (carr (arr_size ws len)) <= csize_of (eval_atype y.(gv).(vtype)).
+    + rewrite hyty /=.
       by apply (WArray.get_sub_bound ok_a).
     have haddry': sub_region_addr vme' sry'' = ok (wey + wrepr Uptr (i * mk_scale aa ws + ofsy'))%R.
     + have := sub_region_addr_offset hwfy hint hbound haddry.
-      rewrite -(sub_region_status_at_ofs_addr y.(gv) statusy' hwfy hint hbound) /= Z2Pos.id // hsub.
+      rewrite -(sub_region_status_at_ofs_addr y.(gv) statusy' hwfy hint hbound) /= hsub.
       by rewrite -GRing.addrA -wrepr_add Z.add_comm.
     exists vme', wey, (wrepr Uptr (i * mk_scale aa ws + ofsy')); split=> //.
-    + move: hsub; rewrite -{1}(Z2Pos.id (arr_size ws len)) // => hsub.
-      by apply (sub_region_status_at_ofs_wf hwfy hint hbound hsub).
+    + by apply (sub_region_status_at_ofs_wf hwfy hint hbound hsub).
     + by apply (sub_region_status_at_ofs_wf_status hwfsy hsub).
     + apply: sub_region_status_at_ofs_wf_vars_zone hsub.
       + by apply (check_gvalid_wf_vars_zone wfr_vars_zone hgvalidy).
@@ -4727,8 +4760,7 @@ Proof.
     apply (hread _ _ _ haddry).
     + apply: (valid_offset_sub_region_status_at_ofs (leni:=arr_size ws len)
         hwfsy hint _ _ hsub off_valid) => //.
-      have /get_val_byte_bound := ok_w.
-      by rewrite /= Z2Pos.id.
+      by apply (get_val_byte_bound ok_w).
     move: ok_w; rewrite /= (WArray.get_sub_get8 ok_a) /=.
     by case: ifP.
 
@@ -4796,10 +4828,10 @@ Proof.
     apply: (valid_state_set_stack_ptr hvs hwfy haddry hwfsy hvarszy hvarssy hlx hpaddr _ _ _ _ h heqvaly).
     + by apply (Memory.write_mem_stable hmem2).
     + by move=> ??; apply (write_validw_eq hmem2).
-    + by move=> ??? /disjoint_range_alt; apply (writeP_neq _ hmem2).
+    + by move=> ??? /(_ erefl erefl) /disjoint_range_alt; apply (writeP_neq _ hmem2).
     by rewrite (writeP_eq hmem2).
 
-  (* interestingly, we can prove that n = Z.to_pos len = Z.to_pos (arr_size ws len2)
+  (* interestingly, we can prove that n = arr_size ws len2
      but it does not seem useful
   *)
   move=> aa ws len2 x e' hw.
@@ -5118,7 +5150,7 @@ Qed.
 (* TODO: We use va (arg in the source) only to know the size of the argument.
    Would it make sense to use the type instead? Is there a benefit? *)
 Record wf_arg_pointer m1 m2 (wptrs:seq (option bool)) vargs vargs' (writable:bool) align va p i := {
-  wap_align             : is_align p align;
+  wap_align             : 0 < size_val va -> is_align p align;
     (* [p] is aligned *)
   wap_no_overflow       : no_overflow p (size_val va);
     (* [p + size_val va - 1] does not overflow *)
@@ -5126,7 +5158,7 @@ Record wf_arg_pointer m1 m2 (wptrs:seq (option bool)) vargs vargs' (writable:boo
     (* the bytes in [p ; p + size_val va - 1] are valid *)
     wap_fresh             : forall w, validw m1 Aligned w U8 -> disjoint_zrange p (size_val va) w (wsize_size U8);
     (* the bytes in [p ; p + size_val va - 1] are disjoint from the valid bytes of [m1] *)
-  wap_writable_not_glob : writable -> (0 < glob_size)%Z -> disjoint_zrange rip glob_size p (size_val va);
+  wap_writable_not_glob : writable -> disjoint_zrange rip glob_size p (size_val va);
     (* if the reg ptr is marked as writable, the associated zone in the target
        memory is disjoint from the globals *)
   wap_writable_disjoint : writable ->
@@ -6066,24 +6098,31 @@ Proof.
   rewrite /wf_arg hwptr haddr.
   eexists; split; first by reflexivity.
   split.
-  + rewrite hal.
-    by apply (halign _ ok_addr).
+  + rewrite hty => hpos.
+    rewrite hal.
+    by apply (halign _ hpos ok_addr).
   + have /= := no_overflow_sub_region_addr hwf ok_addr.
     by rewrite hty.
-  + move=> w hb.
+  + rewrite hty => w hb.
     apply (vs_slot_valid hwf.(wfr_slot)).
-    apply (zbetween_trans (zbetween_sub_region_addr hwf ok_addr)).
-    by rewrite -hty.
+    case: (Z.nonpos_pos_cases (csize_of (eval_atype x.(vtype)))) => [hneg|hpos].
+    + exfalso; move: hb; rewrite /between /zbetween wsize8 !zify.
+      by clear -hneg; lia.
+    by apply (zbetween_trans (zbetween_sub_region_addr hwf hpos ok_addr)).
   + move=> w hvalid.
-    apply: disjoint_zrange_incl_l (vs_disjoint hwf.(wfr_slot) hvalid).
-    rewrite hty.
-    by apply (zbetween_sub_region_addr hwf ok_addr).
-  + move=> hw hgsize.
+    rewrite /disjoint_zrange hty => hpos _.
+    apply:
+      disjoint_zrange_incl_l
+        (vs_disjoint hwf.(wfr_slot) hvalid (wf_sub_region_size_slot_gt0 hwf hpos) erefl).
+    by apply (zbetween_sub_region_addr hwf hpos ok_addr).
+  + move=> hw.
+    rewrite /disjoint_zrange hty => hgsize hpos.
     move: hclear; rewrite hw => /set_clearP [hwritable _].
-    apply: disjoint_zrange_incl_r (writable_not_glob hwf.(wfr_slot) _ hgsize);
+    apply:
+      disjoint_zrange_incl_r
+        (writable_not_glob hwf.(wfr_slot) _ hgsize (wf_sub_region_size_slot_gt0 hwf hpos));
       last by rewrite hwf.(wfr_writable).
-    rewrite hty.
-    by apply (zbetween_sub_region_addr hwf ok_addr).
+    by apply (zbetween_sub_region_addr hwf hpos ok_addr).
   by move=> *; (eapply hdisj; first by congruence); try eassumption; reflexivity.
 Qed.
 
@@ -6393,17 +6432,17 @@ Lemma disjoint_symbolic_zone_disjoint_zrange vme sr1 ty1 sr2 ty2 addr1 addr2 :
   disjoint_symbolic_zone vme sr1.(sr_zone) sr2.(sr_zone) ->
   disjoint_zrange addr1 (csize_of ty1) addr2 (csize_of ty2).
 Proof.
-  move=> hwf1 ok_addr1 hwf2 ok_addr2 heq hdisj.
+  move=> hwf1 ok_addr1 hwf2 ok_addr2 heq hdisj hpos1 hpos2.
   have [cs1 ok_cs1 wf_cs1] := hwf1.(wfsr_zone).
-  have := wunsigned_sub_region_addr hwf1 ok_cs1.
+  have := wunsigned_sub_region_addr hwf1 hpos1 ok_cs1.
   rewrite ok_addr1 => -[_ [<-] haddr1].
   have [cs2 ok_cs2 wf_cs2] := hwf2.(wfsr_zone).
-  have := wunsigned_sub_region_addr hwf2 ok_cs2.
+  have := wunsigned_sub_region_addr hwf2 hpos2 ok_cs2.
   rewrite ok_addr2 => -[_ [<-] haddr2].
   have := addr_no_overflow (wfr_slot hwf1).
   have := addr_no_overflow (wfr_slot hwf2).
   have := hdisj _ _ ok_cs1 ok_cs2.
-  rewrite /disjoint_concrete_slice /disjoint_zrange /no_overflow !zify /=.
+  rewrite /disjoint_concrete_slice /memory_model.disjoint_zrange /no_overflow !zify /=.
   rewrite haddr1 haddr2.
   have := wf_cs1.(wfcs_len).
   have := wf_cs2.(wfcs_len).
@@ -6539,8 +6578,9 @@ Proof.
   have /List.Forall_forall -/(_ _ hin) [hwf hw] := hlwf.
   have [addr ok_addr] := wf_sub_region_sub_region_addr hwf.
   rewrite ok_addr => _ [<-].
-  apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf ok_addr)).
-  apply (hdisj _ hwf.(wfr_slot)).
+  move=> hpos _.
+  apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwf hpos ok_addr)).
+  apply: (hdisj _ hwf.(wfr_slot) _ (wf_sub_region_size_slot_gt0 hwf hpos) erefl).
   by rewrite hwf.(wfr_writable).
 Qed.
 
@@ -6565,18 +6605,20 @@ Lemma eq_read_holed_rmap table rmap vme m0 s1 s2 mem2 l sr ty addr off :
   read mem2 Aligned (addr + wrepr _ off)%R U8 = read (emem s2) Aligned (addr + wrepr _ off)%R U8.
 Proof.
   move=> hvs hlwf hlunch hldisj hwf haddr hoff off_valid.
+  have hpos: 0 < csize_of ty.
+  + by clear -hoff; lia.
   case:(hvs) => hscs hvalid hdisj hincl hincl2 hunch hrip hrsp heqvm hwfr hwft heqmem hglobv htop.
   apply hlunch.
   + apply (hvalid _ _ hwf.(wfr_slot)).
     apply: between_byte hoff.
     + by apply (no_overflow_sub_region_addr hwf haddr).
-    by apply (zbetween_sub_region_addr hwf haddr).
+    by apply (zbetween_sub_region_addr hwf hpos haddr).
   + move=> hvalid'.
-    have := hdisj _ _ hwf.(wfr_slot) hvalid'.
+    have := hdisj _ _ hwf.(wfr_slot) hvalid' (wf_sub_region_size_slot_gt0 hwf hpos) erefl.
     apply zbetween_not_disjoint_zrange => //.
     apply: between_byte hoff.
     + by apply (no_overflow_sub_region_addr hwf haddr).
-    by apply (zbetween_sub_region_addr hwf haddr).
+    by apply (zbetween_sub_region_addr hwf hpos haddr).
   apply List.Forall_forall => -[sr2 ty2] hin2 addr2 haddr2.
   have /List.Forall_forall -/(_ _ hin2) hdisj2 := hldisj.
   have /List.Forall_forall -/(_ _ hin2) [hwf2 hw2] := hlwf.
@@ -6797,7 +6839,7 @@ Proof.
   exists (with_vm s2 (evm s2).[p <- vp]).
   have : type_of_val vp = eval_atype (vtype p) by rewrite (convertible_eval_atype hlocal.(wfr_rtype)).
   split; first by apply write_var_eq_type => //; rewrite /DB /= orbT.
-  have : type_of_val vres1 = carr (Z.to_pos (arr_size wsx nx)).
+  have : type_of_val vres1 = carr (arr_size wsx nx).
   + by move/vm_truncate_valEl_wdb: h; rewrite hty /= => -[a ->].
   move=> /type_of_valI -[a' ?]; subst vres1.
   have /vm_truncate_valE_wdb [? heq]:= h.
@@ -7170,7 +7212,7 @@ Proof.
   move=> halloc hvs.
   move: halloc; rewrite /alloc_syscall; move=> /add_iinfoP.
   case: o => [ws len].
-  t_xrbindP=> /ZltP hlen.
+  t_xrbindP=> /andP[] /ZleP hlen0 /ZltP hlen.
   case: rs => // -[] // x [] //.
   case: es => // -[] // g [] //.
   t_xrbindP=> pg /get_regptrP hlg px /get_regptrP hlx srg /get_sub_regionP hsrg {}rmap2 hrmap2 <- <-{c}.
@@ -7183,8 +7225,8 @@ Proof.
   set i1 := (X in [:: X; _]).
   set i2 := (X in [:: _; X]).
 
-  (* write [Z.to_pos (arr_size ws len)] in register [vxlen] *)
-  have := sap_immediateP hsaparams P' rip s2 (x := with_var (gv g) (vxlen pmap)) dummy_instr_info (Z.to_pos (arr_size ws len)) (@wt_len wf_pmap0).
+  (* write [arr_size ws len] in register [vxlen] *)
+  have := sap_immediateP hsaparams P' rip s2 (x := with_var (gv g) (vxlen pmap)) dummy_instr_info (arr_size ws len) (@wt_len wf_pmap0).
   set s2' := with_vm s2 _ => hsem1.
   have hvs': valid_state table rmap vme m0 s1 s2'.
   + apply (valid_state_distinct_reg _ hvs).
@@ -7215,30 +7257,36 @@ Proof.
   have [addrg ok_addrg] := wf_sub_region_sub_region_addr hwfg.
   have [m2 hfillm] := fill_fill_mem hvs hwfg ok_addrg hfill.
   have hvs2': valid_state table rmap2 vme m0 s1 (with_mem s2' m2).
-  + rewrite -(with_mem_same s1).
+  + case: (Z.nonpos_pos_cases (arr_size ws len)) => [hneg|hpos].
+    + (* if [arr_size ws len <= 0], nothing was written *)
+      have hsize: size (get_random (escs s1) (arr_size ws len)).2 = 0%nat.
+      + by have := WArray.fill_size hfill; clear -hneg; lia.
+      by move: hfillm; rewrite /fill_mem (size0nil hsize) /= => -[<-].
+    rewrite -(with_mem_same s1).
     apply (valid_state_holed_rmap
-            (l:=[::(srg, carr (Z.to_pos (arr_size ws len)))])
+            (l:=[::(srg, carr (arr_size ws len))])
             hvs2 (λ _ _ _, erefl) (fill_mem_stack_stable hfillm)
             (fill_mem_validw_eq hfillm)).
     + move=> p hvalid.
       rewrite (fill_mem_disjoint hfillm); first by apply vs_eq_mem.
-      rewrite -(WArray.fill_size hfill) positive_nat_Z.
-      apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwfg ok_addrg)).
-      apply vs_disjoint => //.
-      by apply hwfg.(wfr_slot).
+      rewrite -(WArray.fill_size hfill) (Z2Nat.id _ (Z.lt_le_incl _ _ hpos)).
+      apply (disjoint_zrange_incl_l (zbetween_sub_region_addr hwfg hpos ok_addrg)).
+      apply (vs_disjoint hwfg.(wfr_slot)) => //.
+      by apply (wf_sub_region_size_slot_gt0 hwfg hpos).
     + constructor; last by constructor.
       split=> //.
       by move: hrmap2 => /set_clearP [? _].
     + move=> p hvalid1 hvalid2 /List_Forall_inv [/(_ _ ok_addrg) hdisj _].
       rewrite (fill_mem_disjoint hfillm) //.
-      by rewrite -(WArray.fill_size hfill) positive_nat_Z.
+      rewrite -(WArray.fill_size hfill) (Z2Nat.id _ (Z.lt_le_incl _ _ hpos)).
+      by apply (hdisj hpos erefl).
     constructor; last by constructor.
     have /set_clearP [_ ->] /= := hrmap2.
     by apply (set_clear_pure_sub_region_cleared wfr_wf wfr_status hwfg).
 
   (* update the [scs] component *)
-  set s1'' := with_scs s1 (get_random (escs s1) (Z.to_pos (arr_size ws len))).1.
-  set s2'' := with_scs (with_mem s2' m2) (get_random (escs s1) (Z.to_pos (arr_size ws len))).1.
+  set s1'' := with_scs s1 (get_random (escs s1) (arr_size ws len)).1.
+  set s2'' := with_scs (with_mem s2' m2) (get_random (escs s1) (arr_size ws len)).1.
   have hvs2'': valid_state table rmap2 vme m0 s1'' s2''.
   + by apply valid_state_scs.
 
@@ -7251,9 +7299,8 @@ Proof.
     apply: (valid_state_set_move_regptr hvs2'' hwfg ok_addrg _ srg_vars _ hlx h) => //.
     rewrite htreq; split=> // off addrg' w ok_addrg' off_valid /[dup] /get_val_byte_bound /= hoff.
     move: ok_addrg'; rewrite ok_addrg => -[?]; subst addrg'.
-    rewrite Z2Pos.id // in hoff.
     rewrite (WArray.fill_get8 hfill) (fill_mem_read8_no_overflow _ hfillm)
-            -?(WArray.fill_size hfill) ?positive_nat_Z /=;
+            -?(WArray.fill_size hfill) ?Z2Nat.id /=;
       try (clear -hlen hoff; lia).
     by case: andb.
 
@@ -7262,13 +7309,11 @@ Proof.
   move: hsem1 => /= -> /=; rewrite LetK.
   rewrite /sem_syscall.
   rewrite /= /get_gvar /= /get_var.
-  rewrite Z2Pos.id //.
   have /wfr_ptr := hsrg; rewrite /get_local hlg => -[_ [[<-] /= hpk]].
   rewrite (hpk _ ok_addrg) /=.
   rewrite Vm.setP_eq wt_len vm_truncate_val_eq //=.
   rewrite /fexec_syscall /= /exec_syscall_s /= !truncate_word_u /=.
-  rewrite /exec_getrandom_s_core wunsigned_repr_small;
-    last by clear -hlen; have := gt0_arr_size ws len; lia.
+  rewrite /exec_getrandom_s_core wunsigned_repr_small //.
   rewrite -vs_scs hfillm /=.
   rewrite /upd_estate /= LetK.
   by apply write_var_eq_type; rewrite // (convertible_eval_atype hlocal.(wfr_rtype)).

--- a/proofs/compiler/stack_alloc_proof_1.v
+++ b/proofs/compiler/stack_alloc_proof_1.v
@@ -7171,7 +7171,7 @@ Lemma wfr_VARS_ZONE_alloc_syscall ii rmap rs o es rmap2 c vars :
 Proof.
   rewrite /alloc_syscall => /add_iinfoP.
   case: o => [ws len].
-  t_xrbindP=> _.
+  t_xrbindP=> _ _.
   case: rs => // -[] // x [] //.
   case: es => // -[] // g [] //.
   t_xrbindP=> _ _ _ _ srg /get_sub_regionP hsrg _ /set_clearP [_ ->] <- _.
@@ -7188,7 +7188,7 @@ Lemma wfr_VARS_STATUS_alloc_syscall ii rmap rs o es rmap2 c vars :
 Proof.
   rewrite /alloc_syscall => /add_iinfoP.
   case: o => [ws len].
-  t_xrbindP=> _.
+  t_xrbindP=> _ _.
   case: rs => // -[] // x [] //.
   case: es => // -[] // g [] //.
   t_xrbindP=> _ _ _ _ srg /get_sub_regionP hsrg _ /set_clearP [_ ->] <- _.
@@ -7212,7 +7212,7 @@ Proof.
   move=> halloc hvs.
   move: halloc; rewrite /alloc_syscall; move=> /add_iinfoP.
   case: o => [ws len].
-  t_xrbindP=> /andP[] /ZleP hlen0 /ZltP hlen.
+  t_xrbindP=> /ZleP hlen0 /ZltP hlen.
   case: rs => // -[] // x [] //.
   case: es => // -[] // g [] //.
   t_xrbindP=> pg /get_regptrP hlg px /get_regptrP hlx srg /get_sub_regionP hsrg {}rmap2 hrmap2 <- <-{c}.

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -95,7 +95,7 @@ Proof.
   move=> {z hf }; elim => [ | w data' hrec] i l z /=.
   + rewrite cats0 => _ <- <- h k w hr.
     have /= ? := @get_val_byte_bound (Varr t) k _ hr.
-    by apply h => //; rewrite hsz positive_nat_Z.
+    by apply h => //; rewrite hsz Z2Nat.id //; lia.
   rewrite {2}/test; t_xrbindP => i'.
   case heq: read => [ wp | ] //.
   case: eqP => [? | //] [?] h heq' hi hr; subst wp i' i.
@@ -111,6 +111,7 @@ Qed.
 Lemma init_mapP : forall x1 ofs1 ws1,
   Mvar.get mglob x1 = Some (ofs1, ws1) -> [/\
     ofs1 mod wsize_size ws1 = 0,
+    0 < size_slot x1,
     0 <= ofs1 /\ ofs1 + size_slot x1 <= glob_size,
     (forall gv, get_global_value gd x1 = Some gv ->
                 forall k w, get_val_byte (gv2val gv) k = ok w ->
@@ -129,6 +130,7 @@ Proof.
     forall x1 ofs1 ws1,
     Mvar.get (Mvar.empty (Z * wsize), 0, global_data).1.1 x1 = Some (ofs1, ws1) -> [/\
     ofs1 mod wsize_size ws1 = 0,
+    0 < size_slot x1,
     0 <= ofs1 /\ ofs1 + size_slot x1 <= (Mvar.empty (Z * wsize), 0, global_data).1.2,
     (forall gv, get_global_value gd x1 = Some gv ->
                 forall k w, get_val_byte (gv2val gv) k = ok w ->
@@ -139,13 +141,14 @@ Proof.
   + by split => //; exists [::].
   elim: global_alloc (Mvar.empty _, 0, global_data).
   + move=> [[mglob0 size0] data0] /= [] ? [l [hsize heq]] hbase2 [???]; subst mglob0 size0 data0.
-    move=> ??? /hbase2 [????]; split=> //.
+    move=> ??? /hbase2 [?????]; split=> //.
     rewrite /glob_size heq size_cat hsize Nat2Z.inj_add Z2Nat.id //.
     by lia.
   move=> [[x wsx] ofsx] l ih [[mglob0 size0] data0] /= [hbase1 [l0 [heqsz heq]] hbase2].
   t_xrbindP=> -[[mglob1 size1] data1].
   case: ZleP => [h1|//].
   case: eqP => [h2|//].
+  case: ZltP => [h3|//].
   case heqt : (ztake (ofsx - size0) data0) => [[rdata ldata] | //].
   case heqt' : (ztake (size_slot x) ldata) => [[vdata data] | //].
   rewrite -/(get_global_value gd x).
@@ -155,18 +158,17 @@ Proof.
   have [? hsz1] := ztakeP heqt; subst data0.
   have [? hsz2] := ztakeP heqt'; subst ldata.
   split=> /=.
-  + by have := size_slot_gt0 x; lia.
+  + by lia.
   + exists (l0 ++ rdata ++ vdata).
     rewrite heq -!catA; split => //.
-    have slot_x_gt0 := size_slot_gt0 x.
-    rewrite !size_cat hsz1 hsz2 heqsz; clear -hbase1 h1 slot_x_gt0.
+    rewrite !size_cat hsz1 hsz2 heqsz; clear -hbase1 h1 h3.
     do 2![rewrite -Z2Nat.z2nD /GRing.zero/=; [|by apply/ZleP; lia..]].
     lia.
   move=> x1 ofs1 ws1.
   rewrite Mvar.setP.
   case: eqP => [|_].
   + move=> <- [<- <-].
-    split.
+    split=> //.
     + by rewrite -Zland_mod.
     + by lia.
     + rewrite heqg => _ [<-].
@@ -189,9 +191,9 @@ Proof.
     move=> x2 ofs2 ws2.
     rewrite Mvar.setP.
     case: eqP => [//|_].
-    by move=> /hbase2 [_ ? _] _; right; lia.
-  move=> /hbase2 [???]; split=> //.
-  + by have := size_slot_gt0 x; lia.
+    by move=> /hbase2 [_ _ ? _ _] _; right; lia.
+  move=> /hbase2 [?????]; split=> //.
+  + by lia.
   move=> x2 ofs2 ws2.
   rewrite Mvar.setP.
   case: eqP; last by eauto.
@@ -200,12 +202,17 @@ Qed.
 
 Lemma init_map_align x1 ofs1 ws1 :
   Mvar.get mglob x1 = Some (ofs1, ws1) -> ofs1 mod wsize_size ws1 = 0.
-Proof. by move=> /init_mapP [? _ _]. Qed.
+Proof. by move=> /init_mapP [? _ _ _ _]. Qed.
+
+Lemma init_map_size_slot_pos x1 ofs1 ws1 :
+  Mvar.get mglob x1 = Some (ofs1, ws1) ->
+  0 < size_slot x1.
+Proof. by move=> /init_mapP [_ ? _ _ _]. Qed.
 
 Lemma init_map_bounded x1 ofs1 ws1 :
   Mvar.get mglob x1 = Some (ofs1, ws1) ->
   0 <= ofs1 /\ ofs1 + size_slot x1 <= glob_size.
-Proof. by move=> /init_mapP [_ ? _]. Qed.
+Proof. by move=> /init_mapP [_ _ ? _ _]. Qed.
 
 Lemma init_map_full : forall x gv,
   get_global_value gd x = Some gv ->
@@ -222,6 +229,7 @@ Proof.
   + by move=> p [] // [ofs [ws ?]] [?]; subst p; exists ofs, ws.
   move=> [[ x1 ws] z] glob_alloc ih [[mvar pos] data] hx1.
   t_xrbindP => -[[mvar1 pos1] data1]; case: ZleP => // ?.
+  case: ifP => // ?.
   case: ifP => // ?.
   case: ztake => // -[_ data0].
   case: ztake => // -[vdata data2].
@@ -243,7 +251,7 @@ Lemma check_globsP g gv :
 Proof.
   move=> h; move: (h) => /init_map_full [ofs [ws hget]].
   exists ofs, ws; split => //.
-  have [_ _ h1 _] := init_mapP hget.
+  have [_ _ _ h1 _] := init_mapP hget.
   apply (h1 _ h).
 Qed.
 
@@ -261,6 +269,7 @@ Lemma init_stack_layoutP :
         Mvar.get stack x1 = Some (ofs1, ws1) -> [/\
           (ws1 <= sao.(sao_align))%CMP,
           ofs1 mod wsize_size ws1 = 0,
+          0 < size_slot x1,
           sao.(sao_ioff) <= ofs1 /\ ofs1 + size_slot x1 <= sao.(sao_size),
           (forall x2 ofs2 ws2,
             Mvar.get stack x2 = Some (ofs2, ws2) -> x1 <> x2 ->
@@ -275,6 +284,7 @@ Proof.
     forall x1 ofs1 ws1,
     Mvar.get stack x1 = Some (ofs1, ws1) -> [/\
       (ws1 ≤ sao_align sao)%CMP, ofs1 mod wsize_size ws1 = 0,
+      0 < size_slot x1,
       sao.(sao_ioff) <= ofs1 /\ ofs1 + size_slot x1 <= size,
       (forall x2 ofs2 ws2,
         Mvar.get stack x2 = Some (ofs2, ws2) -> x1 <> x2 ->
@@ -289,6 +299,7 @@ Proof.
     Mvar.get (Mvar.empty (Z * wsize), sao.(sao_ioff)).1 x1 = Some (ofs1, ws1) -> [/\
       (ws1 <= sao.(sao_align))%CMP,
       ofs1 mod wsize_size ws1 = 0,
+      0 < size_slot x1,
       sao.(sao_ioff) <= ofs1 /\ ofs1 + size_slot x1 <= (Mvar.empty (Z * wsize), sao.(sao_ioff)).2,
       (forall x2 ofs2 ws2,
         Mvar.get (Mvar.empty (Z * wsize), sao.(sao_ioff)).1 x2 = Some (ofs2, ws2) -> x1 <> x2 ->
@@ -302,12 +313,13 @@ Proof.
   case: Mvar.get => //.
   case heq: Mvar.get => //.
   case: ifP => [|//]; rewrite zify => /ZleP h1.
-  case: ifP => [h2|//].
-  case: eqP => [h3|//].
+  case: ZltP => [h2|//].
+  case: ifP => [h3|//].
+  case: eqP => [h4|//].
   move=> [<- <-].
   apply ih.
   split=> /=.
-  + by have := size_slot_gt0 x; lia.
+  + by lia.
   move=> x1 ofs1 ws1.
   rewrite Mvar.setP.
   case: eqP => [|_].
@@ -318,9 +330,9 @@ Proof.
     move=> x2 ofs2 ws2.
     rewrite Mvar.setP.
     case: eqP => [|_]; first by congruence.
-    by move=> /hbase2 [_ _ ? _]; lia.
-  move=> /hbase2 /= [????]; split=> //.
-  + by have := size_slot_gt0 x; lia.
+    by move=> /hbase2 [_ _ _ ? _ _]; lia.
+  move=> /hbase2 /= [??????]; split=> //.
+  + by lia.
   move=> x2 ofs2 ws2.
   rewrite Mvar.setP.
   case: eqP; last by eauto.
@@ -332,47 +344,50 @@ Proof. by have [? ? _] := init_stack_layoutP; lia. Qed.
 
 Lemma init_stack_layout_stack_align x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) -> (ws1 <= sao.(sao_align))%CMP.
-Proof. by have [_ _ h] := init_stack_layoutP => /h [? _ _ _ _]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [? _ _ _ _ _]. Qed.
 
 Lemma init_stack_layout_align x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) -> ofs1 mod wsize_size ws1 = 0.
-Proof. by have [_ _ h] := init_stack_layoutP => /h [_ ? _ _ _]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [_ ? _ _ _ _]. Qed.
+
+Lemma init_stack_layout_size_slot_pos x1 ofs1 ws1 :
+  Mvar.get stack x1 = Some (ofs1, ws1) -> 0 < size_slot x1.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ ? _ _ _]. Qed.
 
 Lemma init_stack_layout_bounded_ioff x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) ->
   sao.(sao_ioff) <= ofs1 /\ ofs1 + size_slot x1 <= sao.(sao_size).
-Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ ? _ _]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ ? _ _]. Qed.
 
 Lemma init_stack_layout_bounded x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) ->
   0 <= ofs1 /\ ofs1 + size_slot x1 <= sao.(sao_size).
-Proof. have [? _ h] := init_stack_layoutP => /h [_ _ ? _ _]; lia. Qed.
+Proof. have [? _ h] := init_stack_layoutP => /h [_ _ _ ? _ _]; lia. Qed.
 
 Lemma init_stack_layout_disjoint x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) ->
   forall x2 ofs2 ws2,
     Mvar.get stack x2 = Some (ofs2, ws2) -> x1 <> x2 ->
     ofs1 + size_slot x1 <= ofs2 \/ ofs2 + size_slot x2 <= ofs1.
-Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ ? _]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ _ ? _]. Qed.
 
 Lemma init_stack_layout_not_glob x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) -> Mvar.get mglob x1 = None.
-Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ _ ?]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ _ _ ?]. Qed.
 
 (* We pack the hypotheses about slots in a record for the sake of simplicity. *)
 Record wf_Slots (Slots : Sv.t) Addr (Writable:slot-> bool) Align := {
   wfsl_no_overflow : forall s, Sv.In s Slots -> no_overflow (Addr s) (size_slot s);
   wfsl_disjoint : forall s1 s2, Sv.In s1 Slots -> Sv.In s2 Slots -> s1 <> s2 ->
     Writable s1 -> disjoint_zrange (Addr s1) (size_slot s1) (Addr s2) (size_slot s2);
-  wfsl_align : forall s, Sv.In s Slots -> is_align (Addr s) (Align s);
+  wfsl_align : forall s, Sv.In s Slots -> 0 < size_slot s -> is_align (Addr s) (Align s);
   wfsl_not_glob : forall s, Sv.In s Slots -> Writable s ->
-    0 < glob_size -> disjoint_zrange rip glob_size (Addr s) (size_slot s)
+    disjoint_zrange rip glob_size (Addr s) (size_slot s)
 }.
 
 Variable rsp : pointer.
 Hypothesis no_overflow_size : no_overflow rsp sao.(sao_size).
 Hypothesis disjoint_zrange_globals_locals :
-  0 < glob_size -> 0 < sao.(sao_size) ->
   disjoint_zrange rip glob_size rsp sao.(sao_size).
 Hypothesis rip_align : is_align rip U256.
   (* could be formulated [forall ws, is_align rip ws] (cf. extend_mem) *)
@@ -499,7 +514,7 @@ Proof.
   have hbound := init_map_bounded hget.
   move: no_overflow_glob_size; rewrite /no_overflow zify => hover.
   have := wunsigned_range rip.
-  have := size_slot_gt0 s.
+  have := init_map_size_slot_pos hget.
   by lia.
 Qed.
 
@@ -526,7 +541,7 @@ Proof.
   have hbound := init_stack_layout_bounded hget.
   move: no_overflow_size; rewrite /no_overflow zify => hover.
   have := wunsigned_range rsp.
-  have := size_slot_gt0 s.
+  have := init_stack_layout_size_slot_pos hget.
   by lia.
 Qed.
 
@@ -765,15 +780,17 @@ Qed.
 
 Lemma disjoint_zrange_globals_params :
   forall s, Sv.In s Slots_params -> Writable_params s ->
-  0 < glob_size -> disjoint_zrange rip glob_size (Addr_params s) (size_slot s).
+  disjoint_zrange rip glob_size (Addr_params s) (size_slot s).
 Proof.
-  move=> s hin hw hgsize.
+  move=> s hin hw hgsize hpos.
   have /in_Slots_params := hin.
   case hpi: get_pi => [[pi [varg1 varg2]]|//] _.
   rewrite /Addr_params hpi.
   have [i [p [? hargp]]] := get_pi_wf_arg hpi; subst varg2.
   move: hw; rewrite /Writable_params hpi => hw.
-  have := hargp.(wap_writable_not_glob) hw hgsize.
+  have {}hpos: 0 < size_val varg1.
+  + by have := get_pi_size_le hpi; clear -hpos; lia.
+  have := hargp.(wap_writable_not_glob) hw hgsize hpos.
   apply disjoint_zrange_incl_r.
   rewrite eq_refl zero_extend_u.
   by apply: zbetween_le (get_pi_size_le hpi).
@@ -783,14 +800,13 @@ Hypothesis Hdisjoint_zrange_locals :
   Forall3 (fun opi varg1 varg2 =>
     forall pi, opi = Some pi ->
     forall (p:pointer), varg2 = Vword p ->
-    0 < sao.(sao_size) ->
     disjoint_zrange rsp sao.(sao_size) p (size_val varg1)) sao.(sao_params) vargs1 vargs2.
 
 Lemma disjoint_zrange_locals_params :
-  forall s, Sv.In s Slots_params -> 0 < sao.(sao_size) ->
+  forall s, Sv.In s Slots_params ->
   disjoint_zrange rsp sao.(sao_size) (Addr_params s) (size_slot s).
 Proof.
-  move=> s hin hlt.
+  move=> s hin hlt hpos.
   have /in_Slots_params := hin.
   case hpi: get_pi => [[pi [varg1 varg2]]|//] _.
   rewrite /Addr_params hpi.
@@ -800,8 +816,10 @@ Proof.
   have [k [hnth1 hnth2 hnth3 hnth4]] := get_pi_nth hpi.
   rewrite -hnth3.
   rewrite eq_refl zero_extend_u.
+  have {}hpos: 0 < size_val (nth (Vbool true) vargs1 k).
+  + by rewrite hnth3; clear -hpos hle; lia.
   by apply (Forall3_nth Hdisjoint_zrange_locals None (Vbool true) (Vbool true)
-    (nth_not_default hnth2 ltac:(discriminate)) _ hnth2 _ hnth4 hlt).
+    (nth_not_default hnth2 ltac:(discriminate)) _ hnth2 _ hnth4 hlt hpos).
 Qed.
 
 Lemma wf_Slots_params :
@@ -831,20 +849,24 @@ Proof.
     rewrite -hnth14 hp1 -hnth24 hp2 eq_refl 2!zero_extend_u.
     have hle1 := get_pi_size_le hpi1.
     have hle2 := get_pi_size_le hpi2.
+    move=> hpos1 hpos2.
     apply (disjoint_zrange_incl_l (zbetween_le _ hle1)).
     apply (disjoint_zrange_incl_r (zbetween_le _ hle2)).
     rewrite -hnth13 -hnth23.
     apply (hargp1.(wap_writable_disjoint) hw1 (j:=i2)) => //.
     + congruence.
-    rewrite (nth_map None);
-      last by apply (nth_not_default hnth22 ltac:(discriminate)).
-    by rewrite hnth22.
-  + move=> s /in_Slots_params.
+    + rewrite (nth_map None);
+        last by apply (nth_not_default hnth22 ltac:(discriminate)).
+      by rewrite hnth22.
+    + by rewrite hnth13; clear -hle1 hpos1; lia.
+    by rewrite hnth23; clear -hle2 hpos2; lia.
+  + move=> s /in_Slots_params + hpos.
     case hpi: get_pi => [[pi [v1 v2]]|//] _.
     have [i [p [? hargp]]] := get_pi_wf_arg hpi; subst v2.
     rewrite /Addr_params /Align_params hpi.
     rewrite eq_refl zero_extend_u.
-    by apply hargp.(wap_align).
+    apply hargp.(wap_align).
+    by have := get_pi_size_le hpi; clear -hpos; lia.
   by apply disjoint_zrange_globals_params.
 Qed.
 
@@ -869,7 +891,8 @@ Proof.
   have hover2 := Haddr_no_overflow hin2.
   move /in_Slots : hin1 => [hin1|[hin1|hin1]].
   + by move: hw; rewrite /Writable (pick_slot_globals hin1).
-  + move /in_Slots : hin2 => [hin2|[hin2|hin2]].
+  + move=> hpos1 hpos2.
+    move /in_Slots : hin2 => [hin2|[hin2|hin2]].
     + apply disjoint_zrange_sym.
       apply: disjoint_zrange_incl (disjoint_zrange_globals_locals _ _).
       + rewrite /Addr (pick_slot_globals hin2).
@@ -879,12 +902,10 @@ Proof.
       + move /in_Slots_slots : hin2.
         case heq: Mvar.get => [[ofs ws]|//] _.
         have := init_map_bounded heq.
-        have := size_slot_gt0 sl2.
         by lia.
       move /in_Slots_slots : hin1.
       case heq: Mvar.get => [[ofs ws]|//] _.
       have := init_stack_layout_bounded heq.
-      have := size_slot_gt0 sl1.
       by lia.
     + split=> //.
       rewrite /Addr (pick_slot_locals hin1) (pick_slot_locals hin2).
@@ -897,41 +918,40 @@ Proof.
       have := init_stack_layout_disjoint heq1 heq2 hneq.
       by lia.
     rewrite /Addr (pick_slot_locals hin1) (pick_slot_params hin2).
-    apply: disjoint_zrange_incl_l (disjoint_zrange_locals_params hin2 _).
+    apply: disjoint_zrange_incl_l (disjoint_zrange_locals_params hin2 _ hpos2).
     + by apply (zbetween_Addr_locals hin1).
     move /in_Slots_slots : hin1.
     case heq: Mvar.get => [[ofs ws]|//] _.
     have := init_stack_layout_bounded heq.
-    have := size_slot_gt0 sl1.
     by lia.
   move /in_Slots : hin2 => [hin2|[hin2|hin2]].
   + rewrite /Addr (pick_slot_params hin1) (pick_slot_globals hin2).
+    move=> hpos1 hpos2.
     rewrite /Writable (pick_slot_params hin1) in hw.
     apply disjoint_zrange_sym.
-    apply: disjoint_zrange_incl_l (disjoint_zrange_globals_params hin1 hw _).
+    apply: disjoint_zrange_incl_l (disjoint_zrange_globals_params hin1 hw _ hpos1).
     + by apply (zbetween_Addr_globals hin2).
     move /in_Slots_slots : hin2.
     case heq: Mvar.get => [[ofs ws]|//] _.
     have := init_map_bounded heq.
-    have := size_slot_gt0 sl2.
     by lia.
   + rewrite /Addr (pick_slot_params hin1) (pick_slot_locals hin2).
+    move=> hpos1 hpos2.
     apply disjoint_zrange_sym.
-    apply: disjoint_zrange_incl_l (disjoint_zrange_locals_params hin1 _).
+    apply: disjoint_zrange_incl_l (disjoint_zrange_locals_params hin1 _ hpos1).
     + by apply (zbetween_Addr_locals hin2).
     move /in_Slots_slots : hin2.
     case heq: Mvar.get => [[ofs ws]|//] _.
     have := init_stack_layout_bounded heq.
-    have := size_slot_gt0 sl2.
     by lia.
   rewrite /Addr (pick_slot_params hin1) (pick_slot_params hin2).
   rewrite /Writable (pick_slot_params hin1) in hw.
   by apply wf_Slots_params.
 Qed.
 
-Lemma Hslot_align : forall s, Sv.In s Slots -> is_align (Addr s) (Align s).
+Lemma Hslot_align : forall s, Sv.In s Slots -> 0 < size_slot s -> is_align (Addr s) (Align s).
 Proof.
-  move=> s /in_Slots [hin|[hin|hin]].
+  move=> s /in_Slots [hin|[hin|hin]] hpos.
   + rewrite /Addr /Align !(pick_slot_globals hin).
     move /in_Slots_slots : hin.
     case heq: Mvar.get => [[ofs ws]|//] _.
@@ -956,18 +976,17 @@ Qed.
 
 Lemma Hwritable_not_glob :
   forall s, Sv.In s Slots -> Writable s ->
-  0 < glob_size -> disjoint_zrange rip glob_size (Addr s) (size_slot s).
+  disjoint_zrange rip glob_size (Addr s) (size_slot s).
 Proof.
   move=> s /in_Slots [hin|[hin|hin]].
   + by rewrite /Writable (pick_slot_globals hin).
-  + move=> _ hlt.
+  + move=> _ hlt hpos.
     apply: disjoint_zrange_incl_r (disjoint_zrange_globals_locals _ _) => //.
     + rewrite /Addr (pick_slot_locals hin).
       by apply (zbetween_Addr_locals hin).
     move /in_Slots_slots : hin.
     case heq: Mvar.get => [[ofs ws]|//] _.
     have := init_stack_layout_bounded heq.
-    have := size_slot_gt0 s.
     by lia.
   rewrite /Writable /Addr !(pick_slot_params hin).
   by apply wf_Slots_params.
@@ -1463,7 +1482,7 @@ Proof.
   set sr := sub_region_full _ _.
   have hin: Sv.In sr.(sr_region).(r_slot) Slots_params.
   + by apply in_Slots_params => /=; congruence.
-  have hwf: wf_sub_region Slots Writable Align vme sr (carr (Z.to_pos (arr_size ws n))).
+  have hwf: wf_sub_region Slots Writable Align vme sr (carr (arr_size ws n)).
   + split.
     + split=> /=.
       + by apply in_Slots; right; right.
@@ -1789,9 +1808,15 @@ Proof.
   + move=> s w hin hvalid.
     case /in_Slots : hin => [hin|[hin|hin]].
     + rewrite /Addr (pick_slot_globals hin).
+      move=> hpos _.
       apply (disjoint_zrange_incl_l (zbetween_Addr_globals hin)).
-      by apply: hext.(em_fresh) hvalid.
+      apply: (hext.(em_fresh) hvalid) => //.
+      move /in_Slots_slots : hin.
+      case heq: Mvar.get => [[??]|//] _.
+      have := init_map_bounded heq.
+      by lia.
     + rewrite /Addr (pick_slot_locals hin).
+      move=> _ _.
       apply: (disjoint_zrange_incl_l (zbetween_Addr_locals hin)).
       have hvalid2: validw m2 Aligned w U8.
       + apply hext.(em_valid).
@@ -1804,7 +1829,10 @@ Proof.
     have /in_Slots_params := hin.
     case hpi: get_pi => [[pi [v1 v2]]|//] _.
     have [i [p [? hargp]]] := get_pi_wf_arg hpi; subst v2.
-    apply: disjoint_zrange_incl_l (hargp.(wap_fresh) hvalid).
+    move=> hpos _.
+    have {}hpos: 0 < size_val v1.
+    + by have := get_pi_size_le hpi; clear -hpos; lia.
+    apply: disjoint_zrange_incl_l (hargp.(wap_fresh) hvalid hpos erefl).
     rewrite /Addr (pick_slot_params hin) /Addr_params hpi.
     rewrite eq_refl zero_extend_u.
     by apply (zbetween_le _ (get_pi_size_le hpi)).
@@ -1861,16 +1889,19 @@ Proof.
   case hpi: get_pi => [[pi [v1 v2]]|//] _.
   have [_ [p2 [? _]]] := get_pi_wf_arg hpi; subst v2.
   rewrite /Writable_params /Addr_params hpi => hw.
+  move=> hpos _.
   have [i [hnth1 hnth2 hnth3 hnth4]] := get_pi_nth hpi.
   have hi := nth_not_default hnth2 ltac:(discriminate).
   have := Forall3_nth hdisj None (Vbool true) (Vbool true);
     rewrite size_map => /(_ _ hi).
   rewrite (nth_map None) //.
-  rewrite hnth2 /= hw hnth4 => /(_ _ refl_equal refl_equal).
+  rewrite hnth2 /= hw hnth3 hnth4.
+  have {}hpos: 0 < size_val v1.
+  + by have := get_pi_size_le hpi; clear -hpos; lia.
+  move=> /(_ _ refl_equal refl_equal hpos erefl).
   apply disjoint_zrange_incl_l.
   rewrite eq_refl zero_extend_u.
   apply: zbetween_le.
-  rewrite hnth3.
   by apply: get_pi_size_le hpi.
 Qed.
 
@@ -1888,7 +1919,13 @@ Proof.
   case /in_Slots : hin => [hin|[hin|hin]].
   + by move: hw; rewrite /Writable (pick_slot_globals hin).
   + rewrite /Addr (pick_slot_locals hin).
-    by apply (disjoint_zrange_incl_l (zbetween_Addr_locals hin)).
+    move=> hpos _.
+    apply (disjoint_zrange_incl_l (zbetween_Addr_locals hin)).
+    apply hdisj2 => //.
+    move /in_Slots_slots : hin.
+    case heq: Mvar.get => [[??]|//] _.
+    have := init_stack_layout_bounded heq.
+    by clear -hpos; lia.
   rewrite /Writable (pick_slot_params hin) in hw.
   rewrite /Addr (pick_slot_params hin).
   by apply (disjoint_from_writable_params_param_slots hdisj1).
@@ -1918,16 +1955,17 @@ Proof.
     by apply zbetween_refl.
   have hvalid0: validw m0 Aligned (rip + wrepr _ i)%R U8.
   + exact: vs_glob_valid.
+  have hlt: 0 < glob_size.
+  + by clear -hi; lia.
   have hnvalid1: ~ validw (emem s1) Aligned (rip + wrepr _ i)%R U8.
-  + move=> /hfresh.
+  + move=> /hfresh /(_ hlt erefl).
     by apply zbetween_not_disjoint_zrange.
   have hdisjoint: forall s, Sv.In s Slots -> Writable s ->
     disjoint_zrange (Addr s) (size_slot s) (rip + wrepr Uptr i) (wsize_size U8).
-  + move=> s hin hw.
+  + move=> s hin hw hpos _.
     apply disjoint_zrange_sym.
     apply (disjoint_zrange_incl_l hb).
-    apply hwf.(wfsl_not_glob) => //.
-    by lia.
+    by apply hwf.(wfsl_not_glob).
   rewrite -hnew // -vs_unchanged //; last by rewrite -hvalideq1.
   exact: vs_unchanged.
 Qed.
@@ -3044,17 +3082,25 @@ Proof.
         (Vbool true) (Vbool true) hi1'.
     by apply (csize_of_le (value_uincl_subctype hincl)).
   split=> //.
+  + move=> hpos.
+    apply halign.
+    by clear -hle hpos; lia.
   + by apply (no_overflow_incl (zbetween_le _ hle)).
   + move=> w hb; apply hvalid.
     apply: zbetween_trans hb.
     by apply zbetween_le.
-  + move=> w /hfresh.
+  + move=> w + hpos _.
+    have {}hpos: 0 < size_val (nth (Vbool true) vargs1 i).
+    + by clear -hle hpos; lia.
+    move=> /hfresh /(_ hpos erefl).
     apply disjoint_zrange_incl_l.
     by apply zbetween_le.
-  + move=> hw hgsize.
-    apply: disjoint_zrange_incl_r (hwnglob hw hgsize).
+  + move=> hw hgsize hpos.
+    have {}hpos: 0 < size_val (nth (Vbool true) vargs1 i).
+    + by clear -hle hpos; lia.
+    apply: disjoint_zrange_incl_r (hwnglob hw hgsize hpos).
     by apply zbetween_le.
-  move=> hw j vaj pj neq_ij ok_writablej ok_vaj ok_pj.
+  move=> hw j vaj pj neq_ij ok_writablej ok_vaj ok_pj hposi hposj.
   have hj2' := nth_not_default ok_pj ltac:(discriminate).
   apply (disjoint_zrange_incl_l (zbetween_le _ hle)).
   have hle':
@@ -3068,6 +3114,10 @@ Proof.
     by apply (csize_of_le (value_uincl_subctype hincl)).
   rewrite -ok_vaj.
   apply (disjoint_zrange_incl_r (zbetween_le _ hle')).
+  have {}hposi : 0 < size_val (nth (Vbool true) vargs1 i).
+  + by clear -hle hposi; lia.
+  have {}hposj : 0 < size_val (nth (Vbool true) vargs1 j).
+  + by rewrite ok_vaj in hle'; clear -hle' hposj; lia.
   apply (hdisj hw j) => //.
   move /isSomeP: ok_writablej => [writablej ok_writablej].
   have := nth_not_default ok_writablej ltac:(discriminate); rewrite size_map => hj.
@@ -3325,8 +3375,11 @@ Proof.
   move=> _ /List_Forall2_inv_r [varg1' [vargs1' [-> [hincl /ih{}ih]]]].
   constructor=> //.
   move=> p2; apply: obindP => pi ? [hw] ?; subst opi varg2'.
+  move=> hpos _.
+  have {}hpos: 0 < size_val varg1.
+  + by have := csize_of_le (value_uincl_subctype hincl); lia.
   apply (disjoint_zrange_incl_l (zbetween_le _ (csize_of_le (value_uincl_subctype hincl)))).
-  apply hdisj.
+  apply: hdisj hpos erefl.
   + by rewrite /= hw.
   by apply hptreq.
 Qed.
@@ -3496,7 +3549,7 @@ Proof.
     t_xrbindP => a1 a ha wmsf /to_wordI [sz' [w']] [? hwmsf] /eqP ???; subst wmsf a1 vs vmsf.
     move: hw => /=; t_xrbindP => s2' hwr ?; subst s2'.
     have := alloc_protect_ptrP hwf.(wfsl_no_overflow) hwf.(wfsl_align) hpmap P'_globs (ii:=ii1) hshparams hvs hve hvmsf _ _ hwr hi.
-    move=> /(_ (Z.to_pos (arr_size ws len))); rewrite /truncate_val /= hwmsf /= ha => -[] // s2' [] hsem hvs2.
+    move=> /(_ (arr_size ws len)); rewrite /truncate_val /= hwmsf /= ha => -[] // s2' [] hsem hvs2.
     by exists s2', vme; split=> //; rewrite LetK.
   case: is_swap_arrayP => {heq} [[ws [len heq]] | _]; t_xrbindP.
   + subst o => -[{}rmap2 i] halloc /=
@@ -3977,7 +4030,7 @@ Proof.
   have heqinmem_args'' := alloc_stack_spec_value_eq_or_in_mem heqinmem_args' hass.
   have hext' := alloc_stack_spec_extend_mem hext hass.
 
-  have hdisj_glob_locals: 0 < glob_size -> 0 < (local_alloc fn).(sao_size) ->
+  have hdisj_glob_locals:
     disjoint_zrange rip glob_size rsp (sao_size (local_alloc fn)).
   + move=> hlt1 hlt2.
     apply disjoint_zrange_sym.
@@ -3995,17 +4048,16 @@ Proof.
     by apply: (no_overflow_incl hb).
   have hdisj_locals_params:
     Forall3 (fun opi varg1 varg2 => forall pi, opi = Some pi ->
-      forall (p:pointer), varg2 = Vword p -> 0 < (local_alloc fn).(sao_size) -> disjoint_zrange rsp (local_alloc fn).(sao_size) p (size_val varg1))
+      forall (p:pointer), varg2 = Vword p -> disjoint_zrange rsp (local_alloc fn).(sao_size) p (size_val varg1))
     (sao_params (local_alloc fn)) vargs1' vargs2'.
   + apply (nth_Forall3 None (Vbool true) (Vbool true)).
     + by have [? _] := Forall3_size heqinmem_args'.
     + by have [_ ?] := Forall3_size heqinmem_args'.
-    move=> i hi pi hpi p hp hlt.
+    move=> i hi pi hpi p hp hlt hpos.
     move: (hargs' i); rewrite /wf_arg.
     rewrite (nth_map None) // hpi /=.
     rewrite hp => -[_ [[<-] hargp]].
     apply disjoint_zrange_U8 => //.
-    + by apply csize_of_gt0.
     + by apply hargp.(wap_no_overflow).
     move=> k hk.
     have hb: between p (size_val (nth (Vbool true) vargs1' i)) (p + wrepr _ k) U8.
@@ -4633,7 +4685,7 @@ Proof.
   have heqinmem_args'' := alloc_stack_spec_value_eq_or_in_mem heqinmem_args' hass.
   have hext' := alloc_stack_spec_extend_mem hext hass.
 
-  have hdisj_glob_locals: 0 < glob_size -> 0 < (local_alloc fn).(sao_size) ->
+  have hdisj_glob_locals:
     disjoint_zrange rip glob_size rsp (sao_size (local_alloc fn)).
   + move=> hlt1 hlt2.
     apply disjoint_zrange_sym.
@@ -4651,17 +4703,17 @@ Proof.
     by apply: (no_overflow_incl hb).
   have hdisj_locals_params:
     Forall3 (fun opi varg1 varg2 => forall pi, opi = Some pi ->
-      forall (p:pointer), varg2 = Vword p -> 0 < (local_alloc fn).(sao_size) -> disjoint_zrange rsp (local_alloc fn).(sao_size) p (size_val varg1))
+      forall (p:pointer), varg2 = Vword p ->
+      disjoint_zrange rsp (local_alloc fn).(sao_size) p (size_val varg1))
     (sao_params (local_alloc fn)) vargs1' vargs2'.
   + apply (nth_Forall3 None (Vbool true) (Vbool true)).
     + by have [? _] := Forall3_size heqinmem_args'.
     + by have [_ ?] := Forall3_size heqinmem_args'.
-    move=> i hi pi hpi p hp hlt.
+    move=> i hi pi hpi p hp hlt hpos.
     move: (hargs' i); rewrite /wf_arg.
     rewrite (nth_map None) // hpi /=.
     rewrite hp => -[_ [[<-] hargp]].
     apply disjoint_zrange_U8 => //.
-    + by apply csize_of_gt0.
     + by apply hargp.(wap_no_overflow).
     move=> k hk.
     have hb: between p (size_val (nth (Vbool true) vargs1' i)) (p + wrepr _ k) U8.

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -111,7 +111,6 @@ Qed.
 Lemma init_mapP : forall x1 ofs1 ws1,
   Mvar.get mglob x1 = Some (ofs1, ws1) -> [/\
     ofs1 mod wsize_size ws1 = 0,
-    0 < size_slot x1,
     0 <= ofs1 /\ ofs1 + size_slot x1 <= glob_size,
     (forall gv, get_global_value gd x1 = Some gv ->
                 forall k w, get_val_byte (gv2val gv) k = ok w ->
@@ -130,7 +129,6 @@ Proof.
     forall x1 ofs1 ws1,
     Mvar.get (Mvar.empty (Z * wsize), 0, global_data).1.1 x1 = Some (ofs1, ws1) -> [/\
     ofs1 mod wsize_size ws1 = 0,
-    0 < size_slot x1,
     0 <= ofs1 /\ ofs1 + size_slot x1 <= (Mvar.empty (Z * wsize), 0, global_data).1.2,
     (forall gv, get_global_value gd x1 = Some gv ->
                 forall k w, get_val_byte (gv2val gv) k = ok w ->
@@ -141,14 +139,14 @@ Proof.
   + by split => //; exists [::].
   elim: global_alloc (Mvar.empty _, 0, global_data).
   + move=> [[mglob0 size0] data0] /= [] ? [l [hsize heq]] hbase2 [???]; subst mglob0 size0 data0.
-    move=> ??? /hbase2 [?????]; split=> //.
+    move=> ??? /hbase2 [????]; split=> //.
     rewrite /glob_size heq size_cat hsize Nat2Z.inj_add Z2Nat.id //.
     by lia.
   move=> [[x wsx] ofsx] l ih [[mglob0 size0] data0] /= [hbase1 [l0 [heqsz heq]] hbase2].
   t_xrbindP=> -[[mglob1 size1] data1].
   case: ZleP => [h1|//].
   case: eqP => [h2|//].
-  case: ZltP => [h3|//].
+  case: ZleP => [h3|//].
   case heqt : (ztake (ofsx - size0) data0) => [[rdata ldata] | //].
   case heqt' : (ztake (size_slot x) ldata) => [[vdata data] | //].
   rewrite -/(get_global_value gd x).
@@ -191,8 +189,8 @@ Proof.
     move=> x2 ofs2 ws2.
     rewrite Mvar.setP.
     case: eqP => [//|_].
-    by move=> /hbase2 [_ _ ? _ _] _; right; lia.
-  move=> /hbase2 [?????]; split=> //.
+    by move=> /hbase2 [_ ? _ _] _; right; lia.
+  move=> /hbase2 [????]; split=> //.
   + by lia.
   move=> x2 ofs2 ws2.
   rewrite Mvar.setP.
@@ -202,17 +200,12 @@ Qed.
 
 Lemma init_map_align x1 ofs1 ws1 :
   Mvar.get mglob x1 = Some (ofs1, ws1) -> ofs1 mod wsize_size ws1 = 0.
-Proof. by move=> /init_mapP [? _ _ _ _]. Qed.
-
-Lemma init_map_size_slot_pos x1 ofs1 ws1 :
-  Mvar.get mglob x1 = Some (ofs1, ws1) ->
-  0 < size_slot x1.
-Proof. by move=> /init_mapP [_ ? _ _ _]. Qed.
+Proof. by move=> /init_mapP [? _ _ _]. Qed.
 
 Lemma init_map_bounded x1 ofs1 ws1 :
   Mvar.get mglob x1 = Some (ofs1, ws1) ->
   0 <= ofs1 /\ ofs1 + size_slot x1 <= glob_size.
-Proof. by move=> /init_mapP [_ _ ? _ _]. Qed.
+Proof. by move=> /init_mapP [_ ? _ _]. Qed.
 
 Lemma init_map_full : forall x gv,
   get_global_value gd x = Some gv ->
@@ -251,7 +244,7 @@ Lemma check_globsP g gv :
 Proof.
   move=> h; move: (h) => /init_map_full [ofs [ws hget]].
   exists ofs, ws; split => //.
-  have [_ _ _ h1 _] := init_mapP hget.
+  have [_ _ h1 _] := init_mapP hget.
   apply (h1 _ h).
 Qed.
 
@@ -269,7 +262,6 @@ Lemma init_stack_layoutP :
         Mvar.get stack x1 = Some (ofs1, ws1) -> [/\
           (ws1 <= sao.(sao_align))%CMP,
           ofs1 mod wsize_size ws1 = 0,
-          0 < size_slot x1,
           sao.(sao_ioff) <= ofs1 /\ ofs1 + size_slot x1 <= sao.(sao_size),
           (forall x2 ofs2 ws2,
             Mvar.get stack x2 = Some (ofs2, ws2) -> x1 <> x2 ->
@@ -284,7 +276,6 @@ Proof.
     forall x1 ofs1 ws1,
     Mvar.get stack x1 = Some (ofs1, ws1) -> [/\
       (ws1 ≤ sao_align sao)%CMP, ofs1 mod wsize_size ws1 = 0,
-      0 < size_slot x1,
       sao.(sao_ioff) <= ofs1 /\ ofs1 + size_slot x1 <= size,
       (forall x2 ofs2 ws2,
         Mvar.get stack x2 = Some (ofs2, ws2) -> x1 <> x2 ->
@@ -299,7 +290,6 @@ Proof.
     Mvar.get (Mvar.empty (Z * wsize), sao.(sao_ioff)).1 x1 = Some (ofs1, ws1) -> [/\
       (ws1 <= sao.(sao_align))%CMP,
       ofs1 mod wsize_size ws1 = 0,
-      0 < size_slot x1,
       sao.(sao_ioff) <= ofs1 /\ ofs1 + size_slot x1 <= (Mvar.empty (Z * wsize), sao.(sao_ioff)).2,
       (forall x2 ofs2 ws2,
         Mvar.get (Mvar.empty (Z * wsize), sao.(sao_ioff)).1 x2 = Some (ofs2, ws2) -> x1 <> x2 ->
@@ -313,7 +303,7 @@ Proof.
   case: Mvar.get => //.
   case heq: Mvar.get => //.
   case: ifP => [|//]; rewrite zify => /ZleP h1.
-  case: ZltP => [h2|//].
+  case: ZleP => [h2|//].
   case: ifP => [h3|//].
   case: eqP => [h4|//].
   move=> [<- <-].
@@ -330,8 +320,8 @@ Proof.
     move=> x2 ofs2 ws2.
     rewrite Mvar.setP.
     case: eqP => [|_]; first by congruence.
-    by move=> /hbase2 [_ _ _ ? _ _]; lia.
-  move=> /hbase2 /= [??????]; split=> //.
+    by move=> /hbase2 [_ _ ? _ _]; lia.
+  move=> /hbase2 /= [?????]; split=> //.
   + by lia.
   move=> x2 ofs2 ws2.
   rewrite Mvar.setP.
@@ -344,36 +334,32 @@ Proof. by have [? ? _] := init_stack_layoutP; lia. Qed.
 
 Lemma init_stack_layout_stack_align x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) -> (ws1 <= sao.(sao_align))%CMP.
-Proof. by have [_ _ h] := init_stack_layoutP => /h [? _ _ _ _ _]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [? _ _ _ _]. Qed.
 
 Lemma init_stack_layout_align x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) -> ofs1 mod wsize_size ws1 = 0.
-Proof. by have [_ _ h] := init_stack_layoutP => /h [_ ? _ _ _ _]. Qed.
-
-Lemma init_stack_layout_size_slot_pos x1 ofs1 ws1 :
-  Mvar.get stack x1 = Some (ofs1, ws1) -> 0 < size_slot x1.
-Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ ? _ _ _]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [_ ? _ _ _]. Qed.
 
 Lemma init_stack_layout_bounded_ioff x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) ->
   sao.(sao_ioff) <= ofs1 /\ ofs1 + size_slot x1 <= sao.(sao_size).
-Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ ? _ _]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ ? _ _]. Qed.
 
 Lemma init_stack_layout_bounded x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) ->
   0 <= ofs1 /\ ofs1 + size_slot x1 <= sao.(sao_size).
-Proof. have [? _ h] := init_stack_layoutP => /h [_ _ _ ? _ _]; lia. Qed.
+Proof. have [? _ h] := init_stack_layoutP => /h [_ _ ? _ _]; lia. Qed.
 
 Lemma init_stack_layout_disjoint x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) ->
   forall x2 ofs2 ws2,
     Mvar.get stack x2 = Some (ofs2, ws2) -> x1 <> x2 ->
     ofs1 + size_slot x1 <= ofs2 \/ ofs2 + size_slot x2 <= ofs1.
-Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ _ ? _]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ ? _]. Qed.
 
 Lemma init_stack_layout_not_glob x1 ofs1 ws1 :
   Mvar.get stack x1 = Some (ofs1, ws1) -> Mvar.get mglob x1 = None.
-Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ _ _ ?]. Qed.
+Proof. by have [_ _ h] := init_stack_layoutP => /h [_ _ _ _ ?]. Qed.
 
 (* We pack the hypotheses about slots in a record for the sake of simplicity. *)
 Record wf_Slots (Slots : Sv.t) Addr (Writable:slot-> bool) Align := {
@@ -504,55 +490,59 @@ Definition Align := pick_slot Align_globals Align_locals Align_params.
 
 Lemma wunsigned_Addr_globals s ofs ws :
   Mvar.get mglob s = Some (ofs, ws) ->
+  0 < size_slot s ->
   wunsigned (Addr_globals s) = wunsigned rip + ofs.
 Proof.
   clear rsp_align rip_align.
   clear disjoint_zrange_globals_locals.
-  move=> hget.
+  move=> hget hpos.
   rewrite /Addr_globals /Offset_slots hget.
   rewrite wunsigned_add //.
   have hbound := init_map_bounded hget.
   move: no_overflow_glob_size; rewrite /no_overflow zify => hover.
   have := wunsigned_range rip.
-  have := init_map_size_slot_pos hget.
   by lia.
 Qed.
 
 Lemma zbetween_Addr_globals s :
   Sv.In s Slots_globals ->
+  0 < size_slot s ->
   zbetween rip glob_size (Addr_globals s) (size_slot s).
 Proof.
   clear rsp_align rip_align.
   move=> /in_Slots_slots.
   case heq: Mvar.get => [[ofs ws]|//] _.
-  rewrite /zbetween !zify (wunsigned_Addr_globals heq).
+  move=> hpos.
+  rewrite /zbetween !zify (wunsigned_Addr_globals heq hpos).
   have hbound := init_map_bounded heq.
   by lia.
 Qed.
 
 Lemma wunsigned_Addr_locals s ofs ws :
   Mvar.get stack s = Some (ofs, ws) ->
+  0 < size_slot s ->
   wunsigned (Addr_locals s) = wunsigned rsp + ofs.
 Proof.
   clear disjoint_zrange_globals_locals rsp_align rip_align.
-  move=> hget.
+  move=> hget hpos.
   rewrite /Addr_locals /Offset_slots hget.
   rewrite wunsigned_add //.
   have hbound := init_stack_layout_bounded hget.
   move: no_overflow_size; rewrite /no_overflow zify => hover.
   have := wunsigned_range rsp.
-  have := init_stack_layout_size_slot_pos hget.
   by lia.
 Qed.
 
 Lemma zbetween_Addr_locals s :
   Sv.In s Slots_locals ->
+  0 < size_slot s ->
   zbetween rsp sao.(sao_size) (Addr_locals s) (size_slot s).
 Proof.
   clear rsp_align rip_align.
   move=> /in_Slots_slots.
   case heq: Mvar.get => [[ofs ws]|//] _.
-  rewrite /zbetween !zify (wunsigned_Addr_locals heq).
+  move=> hpos.
+  rewrite /zbetween !zify (wunsigned_Addr_locals heq hpos).
   have hbound := init_stack_layout_bounded heq.
   by lia.
 Qed.
@@ -560,12 +550,14 @@ Qed.
 Lemma zbetween_Addr_locals_ioff s :
   wunsigned (rsp + wrepr _ sao.(sao_ioff)) = wunsigned rsp + sao.(sao_ioff) ->
   Sv.In s Slots_locals ->
+  0 < size_slot s ->
   zbetween (rsp + wrepr _ sao.(sao_ioff)) (sao.(sao_size) - sao.(sao_ioff)) (Addr_locals s) (size_slot s).
 Proof.
   clear rsp_align rip_align.
   move=> hadd /in_Slots_slots.
   case heq: Mvar.get => [[ofs ws]|//] _.
-  rewrite /zbetween !zify (wunsigned_Addr_locals heq).
+  move=> hpos.
+  rewrite /zbetween !zify (wunsigned_Addr_locals heq hpos).
   have hbound := init_stack_layout_bounded_ioff heq.
   rewrite hadd.
   by lia.
@@ -872,7 +864,12 @@ Qed.
 
 Lemma Haddr_no_overflow : forall s, Sv.In s Slots -> no_overflow (Addr s) (size_slot s).
 Proof.
-  move=> s /in_Slots [hin|[hin|hin]].
+  move=> s hin.
+  case: (Z.nonpos_pos_cases (size_slot s)) => [hneg|hpos].
+  + rewrite /no_overflow zify.
+    have := wunsigned_range (Addr s).
+    by clear -hneg; lia.
+  move: hin => /in_Slots [hin|[hin|hin]].
   + rewrite /Addr (pick_slot_globals hin).
     apply: no_overflow_incl no_overflow_glob_size.
     by apply zbetween_Addr_globals.
@@ -913,8 +910,8 @@ Proof.
       case heq1 : Mvar.get => [[ofs1 ws1]|//] _.
       move /in_Slots_slots : hin2.
       case heq2 : Mvar.get => [[ofs2 ws2]|//] _.
-      rewrite (wunsigned_Addr_locals heq1).
-      rewrite (wunsigned_Addr_locals heq2).
+      rewrite (wunsigned_Addr_locals heq1 hpos1).
+      rewrite (wunsigned_Addr_locals heq2 hpos2).
       have := init_stack_layout_disjoint heq1 heq2 hneq.
       by lia.
     rewrite /Addr (pick_slot_locals hin1) (pick_slot_params hin2).
@@ -1782,6 +1779,8 @@ Proof.
   move=> hext hass hrsp hneq /=.
   constructor=> //=.
   + move=> s w hin hb.
+    case: (Z.nonpos_pos_cases (size_slot s)) => [hneg|hpos].
+    + by exfalso; move: hb; rewrite /between /zbetween wsize8 !zify; clear -hneg; lia.
     rewrite hass.(ass_valid); apply /orP.
     case /in_Slots : hin => [hin|[hin|hin]].
     + left.
@@ -1789,12 +1788,12 @@ Proof.
       apply /orP; right.
       apply: zbetween_trans hb.
       rewrite /Addr (pick_slot_globals hin).
-      by apply (zbetween_Addr_globals hin).
+      by apply (zbetween_Addr_globals hin hpos).
     + right.
       apply: zbetween_trans hb.
       rewrite /Addr (pick_slot_locals hin).
       have := (ass_add_ioff hass). rewrite -{1 2}hrsp => hadd.
-      have := zbetween_Addr_locals_ioff hadd hin.
+      have := zbetween_Addr_locals_ioff hadd hin hpos.
       by rewrite hrsp.
     left.
     have /in_Slots_params := hin.
@@ -1809,15 +1808,15 @@ Proof.
     case /in_Slots : hin => [hin|[hin|hin]].
     + rewrite /Addr (pick_slot_globals hin).
       move=> hpos _.
-      apply (disjoint_zrange_incl_l (zbetween_Addr_globals hin)).
+      apply (disjoint_zrange_incl_l (zbetween_Addr_globals hin hpos)).
       apply: (hext.(em_fresh) hvalid) => //.
       move /in_Slots_slots : hin.
       case heq: Mvar.get => [[??]|//] _.
       have := init_map_bounded heq.
       by lia.
     + rewrite /Addr (pick_slot_locals hin).
-      move=> _ _.
-      apply: (disjoint_zrange_incl_l (zbetween_Addr_locals hin)).
+      move=> hpos _.
+      apply: (disjoint_zrange_incl_l (zbetween_Addr_locals hin hpos)).
       have hvalid2: validw m2 Aligned w U8.
       + apply hext.(em_valid).
         by rewrite hvalid.
@@ -1920,7 +1919,7 @@ Proof.
   + by move: hw; rewrite /Writable (pick_slot_globals hin).
   + rewrite /Addr (pick_slot_locals hin).
     move=> hpos _.
-    apply (disjoint_zrange_incl_l (zbetween_Addr_locals hin)).
+    apply (disjoint_zrange_incl_l (zbetween_Addr_locals hin hpos)).
     apply hdisj2 => //.
     move /in_Slots_slots : hin.
     case heq: Mvar.get => [[??]|//] _.

--- a/proofs/compiler/wint_int.v
+++ b/proofs/compiler/wint_int.v
@@ -206,12 +206,12 @@ Fixpoint wi2i_e (e0:pexpr) : cexec (safety_cond * pexpr) :=
 
   end.
 
-Definition wi2i_lvar (ety : extended_type positive) (x : var_i) : cexec var_i :=
+Definition wi2i_lvar (ety : extended_type Z) (x : var_i) : cexec var_i :=
   Let _ := assert (esubtype (etype_of_var m x) ety)
                   (E.ierror_lv (Lvar x)) in
   wi2i_vari x.
 
-Definition wi2i_lv (ety : extended_type positive) (lv : lval) : cexec (safety_cond * lval) :=
+Definition wi2i_lv (ety : extended_type Z) (lv : lval) : cexec (safety_cond * lval) :=
   let s := sign_of_etype ety in
   match lv with
   | Lnone vi ty =>
@@ -279,7 +279,7 @@ Definition wi2i_a_and (a : assertion) :=
   Let e := wi2i_eassert a.2 in
   ok (a.1, aands (rcons (map Pexpr e.1) e.2)).
 
-Context (sigs : funname -> option (list (extended_type positive) * list (extended_type positive))).
+Context (sigs : funname -> option (list (extended_type Z) * list (extended_type Z))).
 
 Definition get_sig f :=
   match sigs f with

--- a/proofs/lang/expr.v
+++ b/proofs/lang/expr.v
@@ -204,7 +204,7 @@ Definition type_of_opN (op: opN) : seq atype * atype :=
   | Opack ws p =>
     let n := nat_of_wsize ws %/ nat_of_pelem p in
     (nseq n aint, aword ws)
-  | Oarray len => (nseq (Pos.to_nat len) (aword U8), aarr U8 len)
+  | Oarray len => (nseq (Z.to_nat len) (aword U8), aarr U8 len)
   | Ocombine_flags c => (tin_combine_flags, abool)
   end.
 
@@ -262,10 +262,10 @@ Definition is_glob (x:gvar) := x.(gs) == Sglob.
 Inductive pexpr : Type :=
 | Pconst :> Z -> pexpr
 | Pbool  :> bool -> pexpr
-| Parr_init : wsize -> positive → pexpr
+| Parr_init : wsize -> Z → pexpr
 | Pvar   :> gvar -> pexpr
 | Pget   : aligned -> arr_access -> wsize -> gvar -> pexpr -> pexpr
-| Psub   : arr_access -> wsize -> positive -> gvar -> pexpr -> pexpr
+| Psub   : arr_access -> wsize -> Z -> gvar -> pexpr -> pexpr
 | Pload  : aligned -> wsize -> pexpr -> pexpr
 | Papp1  : sop1 -> pexpr -> pexpr
 | Papp2  : sop2 -> pexpr -> pexpr -> pexpr
@@ -315,7 +315,7 @@ Variant lval : Type :=
 | Lvar  `(var_i)
 | Lmem  of aligned & wsize & var_info & pexpr
 | Laset of aligned & arr_access & wsize & var_i & pexpr
-| Lasub of arr_access & wsize & positive & var_i & pexpr.
+| Lasub of arr_access & wsize & Z & var_i & pexpr.
 
 Coercion Lvar : var_i >-> lval.
 

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -8,7 +8,7 @@ From Coq Require ExtrOCamlInt63.
 
 (* This is a hack to force the extraction to keep the singleton here,
    This need should be removed if we add more constructor to syscall_t *)
-Extract Inductive syscall.syscall_t => "(Wsize.wsize * BinNums.positive) Syscall_t.syscall_t" ["Syscall_t.RandomBytes"].
+Extract Inductive syscall.syscall_t => "(Wsize.wsize * BinNums.coq_Z) Syscall_t.syscall_t" ["Syscall_t.RandomBytes"].
 Set Extraction File Comment "This prelude is added at extraction time. See lang/extraction.v. *) [@@@ocaml.warning ""-9-20-27-32-33-34-37-39-50-67""] (* End of prelude. ".
 
 Extraction Inline ssrbool.is_left.

--- a/proofs/lang/gen_map.v
+++ b/proofs/lang/gen_map.v
@@ -683,28 +683,12 @@ Module DMmake (K:CmpType) (E:CompuEqDec with Definition t := K.t).
 End DMmake.
 
 (* --------------------------------------------------------------------------
- ** Map of positive
+ ** Map of Z
  * -------------------------------------------------------------------------- *)
 
 From Coq Require Import ZArith.
-
-Module CmpPos.
-
-  Definition t : eqType := positive.
-
-  Definition cmp : t -> t -> comparison := Pos.compare.
-
-  Lemma cmpO : Cmp cmp.
-  Proof. apply positiveO. Qed.
-
-End CmpPos.
-
-Module Mp := Mmake CmpPos.
-
-(* --------------------------------------------------------------------------
- ** Map of Z
- * -------------------------------------------------------------------------- *)
 From mathcomp Require Import word_ssrZ.
+
 Module CmpZ.
 
   Definition t : eqType := Z.
@@ -767,9 +751,3 @@ Module Smake (T:CmpType).
   Module Ordered := MkMOrdT T.
   Include (MSetAVL.Make Ordered).
 End Smake.
-
-Module PosSet.
-  Module Sp  := Smake CmpPos.
-  Module SpP := MSetEqProperties.EqProperties Sp.
-  Module SpD := MSetDecide.WDecide Sp.
-End PosSet.

--- a/proofs/lang/global.v
+++ b/proofs/lang/global.v
@@ -8,7 +8,7 @@ Require Export xseq word utils var warray_.
 
 Variant glob_value := 
   | Gword : forall (ws:wsize), word ws -> glob_value
-  | Garr  : forall (p:positive), WArray.array p -> glob_value.
+  | Garr  : forall (len:Z), WArray.array len -> glob_value.
 
 (* ---------------------------------------------------------------------- *)
 

--- a/proofs/lang/operators.v
+++ b/proofs/lang/operators.v
@@ -119,14 +119,14 @@ Variant combine_flags :=
 #[only(eqbOK)] derive
 Variant opN :=
 | Opack of wsize & pelem (* Pack words of size pelem into one word of wsize *)
-| Oarray of positive (* Literal array of bytes *)
+| Oarray of Z (* Literal array of bytes *)
 | Ocombine_flags of combine_flags
 .
 
 #[only(eqbOK)] derive
 Variant opN_safety :=
-| Ois_arr_init of positive
-| Ois_barr_init of positive
+| Ois_arr_init of Z
+| Ois_barr_init of Z
 .
 
 HB.instance Definition _ := hasDecEq.Build op_kind op_kind_eqb_OK.

--- a/proofs/lang/psem_defs.v
+++ b/proofs/lang/psem_defs.v
@@ -123,7 +123,7 @@ Fixpoint sem_pexpr (s:estate) (e : pexpr) : exec value :=
   | Pconst z => ok (Vint z)
   | Pbool b  => ok (Vbool b)
   | Parr_init ws n =>
-    let len := Z.to_pos (arr_size ws n) in
+    let len := arr_size ws n in
     ok (Varr (WArray.empty len))
   | Pvar v => get_gvar wdb gd s.(evm) v
   | Pget al aa ws x e =>
@@ -190,7 +190,7 @@ Definition write_lval (l : lval) (v : value) (s : estate) : exec estate :=
   | Lasub aa ws len x i =>
     Let (n,t) := wdb, s.[x] in
     Let i := sem_pexpr s i >>= to_int in
-    Let t' := to_arr (Z.to_pos (arr_size ws len)) v in
+    Let t' := to_arr (arr_size ws len) v in
     Let t := @WArray.set_sub n aa ws len t i t' in
     write_var x (@to_val (carr n) t) s
   end.

--- a/proofs/lang/pseudo_operator.v
+++ b/proofs/lang/pseudo_operator.v
@@ -26,9 +26,9 @@ Canonical spill_op_eqType := @ceqT_eqType _ eqTC_spill_op.
 #[only(eqbOK)] derive
 Variant pseudo_operator :=
 | Ospill    of spill_op & seq atype
-| Ocopy     of wsize & positive
+| Ocopy     of wsize & Z
 | Odeclassify of atype
-| Odeclassify_mem of positive
+| Odeclassify_mem of Z
 | Onop
 | Omulu     of wsize   (* cpu   : [aword; aword]        -> [aword;aword] *)
 | Oaddcarry of wsize   (* cpu   : [aword; aword; abool] -> [abool;aword] *)

--- a/proofs/lang/safety_common.v
+++ b/proofs/lang/safety_common.v
@@ -9,7 +9,7 @@ Context (m: var -> option (signedness * var)).
 
 Definition safety_cond := seq eassert.
 
-Definition esubtype (ty1 ty2 : extended_type positive) :=
+Definition esubtype (ty1 ty2 : extended_type Z) :=
  match ty1, ty2 with
  | ETword None w, ETword None w' => (w ≤ w')%CMP
  | ETword (Some sg) w, ETword (Some sg') w' => (sg == sg') && (w == w')
@@ -35,7 +35,7 @@ Fixpoint aands es :=
   | e::es => Pand e (aands es)
   end.
 
-Definition to_etype sg (t:atype) : extended_type positive:=
+Definition to_etype sg (t:atype) : extended_type Z :=
   match t with
   | abool    => tbool
   | aint     => tint
@@ -45,7 +45,7 @@ Definition to_etype sg (t:atype) : extended_type positive:=
 
 Definition sign_of_var x := Option.map fst (m x).
 
-Definition etype_of_var x : extended_type positive :=
+Definition etype_of_var x : extended_type Z :=
   to_etype (sign_of_var x) (vtype x).
 
 Definition sign_of_gvar (x : gvar) :=
@@ -54,13 +54,13 @@ Definition sign_of_gvar (x : gvar) :=
 
 Definition etype_of_gvar x := to_etype (sign_of_gvar x) (vtype (gv x)).
 
-Definition sign_of_etype (ty: extended_type positive) : option signedness :=
+Definition sign_of_etype (ty: extended_type Z) : option signedness :=
   match ty with
   | ETword (Some s) _ => Some s
   | _ => None
   end.
 
-Fixpoint etype_of_expr (e:pexpr) : extended_type positive :=
+Fixpoint etype_of_expr (e:pexpr) : extended_type Z :=
   match e with
   | Pconst _ => tint
   | Pbool _ => tbool

--- a/proofs/lang/sem_op_typed.v
+++ b/proofs/lang/sem_op_typed.v
@@ -189,7 +189,7 @@ Definition sem_opN_typed (o: opN) :
       let ty := curry (A := cint) (sz %/ pe) (λ vs, ok (wpack sz pe vs)) in
       ecast l (sem_prod l _) (esym (map_nseq _ _ _)) ty
   | Oarray len =>
-      let ty := sem_prod_app (collect (Pos.to_nat len) [::]) (λ vs : seq (sem_t (cword U8)), WArray.fill len vs) in
+      let ty := sem_prod_app (collect (Z.to_nat len) [::]) (λ vs : seq (sem_t (cword U8)), WArray.fill _ vs) in
       ecast l (sem_prod l _) (esym (map_nseq _ _ _)) ty
   | Ocombine_flags cf =>
       fun b0 b1 b2 b3 => ok (sem_combine_flags cf b0 b1 b2 b3)
@@ -200,8 +200,9 @@ Lemma sem_opN_typed_ok (op: opN) :
 Proof.
   case: op => // [ ws pe | len ] /=; rewrite -> map_nseq => /=.
   + by case: ws pe => - [].
-  apply: sem_forall_prod_app (size_collect (Pos.to_nat len) [::]) => bytes /=.
-  rewrite ssrnat.addn0 /WArray.fill => hlen; rewrite hlen eqxx /=.
+  apply: sem_forall_prod_app (size_collect (Z.to_nat len) [::]) => bytes /=.
+  rewrite ssrnat.addn0 => hlen.
+  rewrite /WArray.fill hlen arr_sizeE wsize8 Z.mul_1_l eqxx /=.
   by case/is_okP: (WArray.fill_aux_ok (Nat.eq_le_incl _ _ hlen)) => ? ->.
 Qed.
 
@@ -213,10 +214,10 @@ Definition sem_opN_safety_typed (o: opN_safety) :
   sem_prod t.1 (exec (sem_t t.2)) :=
   match o with
   | Ois_arr_init alen =>
-      fun (a:WArray.array alen) (lo:Z) (len:Z) =>
+      fun (a:WArray.array _) (lo:Z) (len:Z) =>
         ok (all (WArray.is_init a) (ziota lo len))
   | Ois_barr_init alen =>
-      fun (a:WArray.array alen) (lo:Z) (len:Z) =>
+      fun (a:WArray.array _) (lo:Z) (len:Z) =>
         ok (all (WArray.is_initb a) (ziota lo len))
   end.
 

--- a/proofs/lang/slh_ops.v
+++ b/proofs/lang/slh_ops.v
@@ -20,15 +20,15 @@ Variant slh_op :=
   | SLHupdate
   | SLHmove
   | SLHprotect of wsize
-  | SLHprotect_ptr of wsize & positive
-  | SLHprotect_ptr_fail of wsize & positive.  (* Not exported to the user *)
+  | SLHprotect_ptr of wsize & Z
+  | SLHprotect_ptr_fail of wsize & Z.  (* Not exported to the user *)
 
 HB.instance Definition _ := hasDecEq.Build slh_op slh_op_eqb_OK.
 
-Definition is_protect_ptr (slho : slh_op) : option (wsize * positive) :=
-  if slho is SLHprotect_ptr ws p then Some (ws, p) else None.
+Definition is_protect_ptr (slho : slh_op) : option (wsize * Z) :=
+  if slho is SLHprotect_ptr ws n then Some (ws, n) else None.
 
-Lemma is_protect_ptrP op : is_reflect (fun '(ws, p) => SLHprotect_ptr ws p) op (is_protect_ptr op).
+Lemma is_protect_ptrP op : is_reflect (fun '(ws, n) => SLHprotect_ptr ws n) op (is_protect_ptr op).
 Proof.
   case: op; try by constructor.
   by move=> ws len; apply: (Is_reflect_some _ (_, _)).

--- a/proofs/lang/sopn.v
+++ b/proofs/lang/sopn.v
@@ -137,8 +137,8 @@ Qed.
 
 HB.instance Definition _ := hasDecEq.Build sopn sopn_eq_axiom.
 
-Definition sopn_copy (ws : wsize) (p : positive) : sopn :=
-  Opseudo_op (Ocopy ws p).
+Definition sopn_copy (ws : wsize) (len : Z) : sopn :=
+  Opseudo_op (Ocopy ws len).
 Definition sopn_nop : sopn := Opseudo_op Onop.
 Definition sopn_mulu (ws : wsize) : sopn := Opseudo_op (Omulu ws).
 Definition sopn_addcarry (ws : wsize) : sopn := Opseudo_op (Oaddcarry ws).
@@ -170,11 +170,11 @@ Proof. by case: o => // -[] // ?? [-> ->]. Qed.
 
 Local Notation E n := (ADExplicit n ACR_any).
 
-Lemma array_copy_errty ws p:
-  let sz := Z.to_pos (arr_size ws p) in
-  let tin := [:: carr sz] in
-  let semi := @WArray.copy ws p in
-  sem_forall (fun r : result error (sem_tuple [:: carr sz]) => r <> Error ErrType) tin semi.
+Lemma array_copy_errty ws n:
+  let len := arr_size ws n in
+  let tin := [:: carr len] in
+  let semi := @WArray.copy ws n in
+  sem_forall (fun r : result error (sem_tuple [:: carr len]) => r <> Error ErrType) tin semi.
 Proof.
   move=> /= t; rewrite /WArray.copy /WArray.fcopy.
   elim: ziota (WArray.empty _) => // j js hrec t1 /=.
@@ -192,11 +192,11 @@ Proof.
   rewrite {2}/WArray.set8; case: WArray.in_bound => [ | [<-]] //=; apply: hrec'.
 Qed.
 
-Lemma array_copy_safe ws p:
-  let sz := Z.to_pos (arr_size ws p) in
-  let tin := [:: carr sz] in
-  let semi := @WArray.copy ws p in
-  interp_safe_cond_ty (tin:=tin) [:: AllInit ws p 0] semi.
+Lemma array_copy_safe ws n:
+  let len := arr_size ws n in
+  let tin := [:: carr len] in
+  let semi := @WArray.copy ws n in
+  interp_safe_cond_ty (tin:=tin) [:: AllInit ws n 0] semi.
 Proof.
   move=> /= t /= h; have /= {h} := List.Forall_inv h.
   rewrite WArray.castK => /(_ _ erefl) h.
@@ -205,12 +205,12 @@ Proof.
   + by move=> /=; eauto.
   move=> j js hj hrec t1 /=.
   have [w -> /=] := h _ hj; rewrite /WArray.set.
-  have := [elaborate (writeV (CM:= WArray.array_CM (Z.to_pos (arr_size ws p))))].
+  have := [elaborate (writeV (CM:= WArray.array_CM (arr_size ws n)))].
   move => /(_ _ w t1 Unaligned (j * mk_scale AAscale ws)%Z) wP.
   assert (h1 : validw t1 Unaligned (j * mk_scale AAscale ws)%Z ws).
   + rewrite /validw /is_aligned_if andTb.
     apply ziota_ind => //= i ? hi ->; rewrite andbT; apply/WArray.in_boundP.
-    rewrite WArray.addE; change (Zpos _) with ((wsize_size ws) * p)%Z;Lia.nia.
+    by rewrite WArray.addE arr_sizeE; Lia.nia.
   move/wP: h1 => [t2 ->] /=; apply hrec.
 Qed.
 
@@ -372,7 +372,7 @@ Definition Oswap_instr ty :=
 Definition pseudo_op_get_instr_desc (o : pseudo_operator) : instruction_desc :=
   match o with
   | Ospill o tys => Ospill_instr o tys
-  | Ocopy ws p   => Ocopy_instr ws p
+  | Ocopy ws n   => Ocopy_instr ws n
   | Odeclassify t=> Odeclassify_instr t
   | Odeclassify_mem len => Odeclassify_mem_instr len
   | Onop         => Onop_instr
@@ -398,9 +398,9 @@ Definition se_move_sem (w : wmsf) : wmsf := w.
 
 Definition se_protect_sem {ws : wsize} (w : word ws) (msf : wmsf) : word ws := w.
 
-Definition se_protect_ptr_sem {p:positive} (t: WArray.array p) (msf : wmsf) : WArray.array p := t.
+Definition se_protect_ptr_sem {len:Z} (t: WArray.array len) (msf : wmsf) : WArray.array len := t.
 
-Definition se_protect_ptr_fail_sem {p:positive} (t: WArray.array p) (msf : wmsf) : exec (WArray.array p) :=
+Definition se_protect_ptr_fail_sem {len:Z} (t: WArray.array len) (msf : wmsf) : exec (WArray.array len) :=
   Let _ := assert (msf == 0%w) ErrSemUndef in
   ok t.
 
@@ -444,14 +444,14 @@ Definition SLHprotect_instr ws :=
       (@se_protect_sem ws)
       true.
 
-Lemma protect_ptr_semu p vs vs' v:
+Lemma protect_ptr_semu n vs vs' v:
   values_uincl vs vs' ->
-  @app_sopn_v [::carr p; cty_msf] [::carr p] (sem_prod_ok [:: carr p; cty_msf ] (@se_protect_ptr_sem p)) vs = ok v ->
+  @app_sopn_v [::carr n; cty_msf] [::carr n] (sem_prod_ok [:: carr n; cty_msf ] (@se_protect_ptr_sem n)) vs = ok v ->
   exists2 v' : values,
-   @app_sopn_v [::carr p; cty_msf] [::carr p] (sem_prod_ok [:: carr p; cty_msf ] (@se_protect_ptr_sem p)) vs' = ok v' &
+   @app_sopn_v [::carr n; cty_msf] [::carr n] (sem_prod_ok [:: carr n; cty_msf ] (@se_protect_ptr_sem n)) vs' = ok v' &
    values_uincl v v'.
 Proof.
-  rewrite /app_sopn_v /= => -[] {vs vs'} // v1 v2 + + /of_value_uincl_te -/(_ (carr p)) /= hu.
+  rewrite /app_sopn_v /= => -[] {vs vs'} // v1 v2 + + /of_value_uincl_te -/(_ (carr n)) /= hu.
   move=> [ | v1' [ | ]]; [ by t_xrbindP | | by t_xrbindP].
   move=> _ /List_Forall2_inv_l -[v2' [_ [-> [/of_value_uincl_te -/(_ cty_msf) /= hu' /List_Forall2_inv_l ->]]]].
   t_xrbindP => /= t a /hu [t' -> ha] w' /hu' -> <- <- /=.
@@ -459,18 +459,18 @@ Proof.
 Qed.
 
 Definition SLHprotect_ptr_str := "protect_ptr"%string.
-Definition SLHprotect_ptr_instr ws p :=
-  let tin := [:: aarr ws p; ty_msf ] in
+Definition SLHprotect_ptr_instr ws n :=
+  let tin := [:: aarr ws n; ty_msf ] in
   let ctin := map eval_atype tin in
-  let semi := @se_protect_ptr_sem (Z.to_pos (arr_size ws p)) in
+  let semi := @se_protect_ptr_sem (arr_size ws n) in
   {| str      := pp_s SLHprotect_ptr_str;
      tin      := tin;
      i_in     := [:: E 0; E 1 ]; (* this info is irrelevant *)
-     tout     := [:: aarr ws p ];
+     tout     := [:: aarr ws n ];
      i_out    := [:: E 2 ]; (* this info is irrelevant *)
      conflicts:=[::];
      semi     := sem_prod_ok ctin semi;
-     semu     := @protect_ptr_semu (Z.to_pos (arr_size ws p));
+     semu     := @protect_ptr_semu (arr_size ws n);
      i_safe   := [::];
      i_valid  := true;
      i_safe_wf    := refl_equal;
@@ -478,45 +478,45 @@ Definition SLHprotect_ptr_instr ws p :=
      i_semi_safe  := fun _ => (@sem_prod_ok_safe _ ctin semi);
   |}.
 
-Lemma protect_ptr_fail_semu p vs vs' v:
+Lemma protect_ptr_fail_semu n vs vs' v:
   values_uincl vs vs' ->
-  @app_sopn_v [::carr p; cty_msf] [::carr p] (@se_protect_ptr_fail_sem p) vs = ok v ->
+  @app_sopn_v [::carr n; cty_msf] [::carr n] (@se_protect_ptr_fail_sem n) vs = ok v ->
   exists2 v' : values,
-   @app_sopn_v [::carr p; cty_msf] [::carr p] (@se_protect_ptr_fail_sem p) vs' = ok v' &
+   @app_sopn_v [::carr n; cty_msf] [::carr n] (@se_protect_ptr_fail_sem n) vs' = ok v' &
    values_uincl v v'.
 Proof.
-  rewrite /app_sopn_v /= => -[] {vs vs'} // v1 v2 + + /of_value_uincl_te -/(_ (carr p)) /= hu.
+  rewrite /app_sopn_v /= => -[] {vs vs'} // v1 v2 + + /of_value_uincl_te -/(_ (carr n)) /= hu.
   move=> [ | v1' [ | ]]; [ by t_xrbindP | | by t_xrbindP].
   move=> _ /List_Forall2_inv_l -[v2' [_ [-> [/of_value_uincl_te -/(_ cty_msf) /= hu' /List_Forall2_inv_l ->]]]].
   rewrite /se_protect_ptr_fail_sem; t_xrbindP => /= t a /hu [t' -> ha] w' /hu' -> /eqP -> <- <- /=.
   by exists [::Varr t'] => //; constructor.
 Qed.
 
-Lemma protect_ptr_fail_errty p:
-  let tin := [:: carr p; cty_msf ] in
-  let semi := @se_protect_ptr_fail_sem p in
-  sem_forall (fun r : result error (sem_tuple [:: carr p]) => r <> Error ErrType) tin semi.
+Lemma protect_ptr_fail_errty n:
+  let tin := [:: carr n; cty_msf ] in
+  let semi := @se_protect_ptr_fail_sem n in
+  sem_forall (fun r : result error (sem_tuple [:: carr n]) => r <> Error ErrType) tin semi.
 Proof. by rewrite /= /se_protect_ptr_fail_sem => t msf; case: eqP. Qed.
 
 (* Remark the safety condition is stronger than needed but it
    is not important because the instruction is not visible at Jasmin source level.
    This instruction is only used internally.
 *)
-Lemma protect_ptr_fail_safe p:
-  let tin := [:: carr p; cty_msf ] in
-  let semi := @se_protect_ptr_fail_sem p in
+Lemma protect_ptr_fail_safe n:
+  let tin := [:: carr n; cty_msf ] in
+  let semi := @se_protect_ptr_fail_sem n in
   interp_safe_cond_ty (tin:=tin) [:: ScFalse] semi.
 Proof.
   by rewrite /interp_safe_cond_ty /= => t msf h; have := List.Forall_inv h.
 Qed.
 
 Definition SLHprotect_ptr_fail_str := "protect_ptr_fail"%string.
-Definition SLHprotect_ptr_fail_instr ws p :=
-  let len := (Z.to_pos (arr_size ws p)) in
+Definition SLHprotect_ptr_fail_instr ws n :=
+  let len := arr_size ws n in
   {| str      := pp_s SLHprotect_ptr_fail_str;
-     tin      := [:: aarr ws p; ty_msf ];
+     tin      := [:: aarr ws n; ty_msf ];
      i_in     := [:: E 0; E 1 ]; (* this info is irrelevant *)
-     tout     := [:: aarr ws p ];
+     tout     := [:: aarr ws n ];
      i_out    := [:: E 2 ]; (* this info is irrelevant *)
      conflicts:=[::];
      semi     := @se_protect_ptr_fail_sem len;
@@ -534,8 +534,8 @@ Definition slh_op_instruction_desc  (o : slh_op) : instruction_desc :=
   | SLHupdate             => SLHupdate_instr
   | SLHmove               => SLHmove_instr
   | SLHprotect ws         => SLHprotect_instr ws
-  | SLHprotect_ptr ws p      => SLHprotect_ptr_instr ws p
-  | SLHprotect_ptr_fail ws p => SLHprotect_ptr_fail_instr ws p
+  | SLHprotect_ptr ws n      => SLHprotect_ptr_instr ws n
+  | SLHprotect_ptr_fail ws n => SLHprotect_ptr_fail_instr ws n
   end.
 
 (* ---------------------------------------------------------------------- *)
@@ -573,7 +573,7 @@ Definition primP {A: Type} (f: wsize -> A) :=
 
 Definition sopn_prim_string : seq (string * prim_constructor sopn) :=
   [::
-    ("copy", primP (fun sz => Opseudo_op (Ocopy sz xH)));  (* The size is fixed later *)
+    ("copy", primP (fun sz => Opseudo_op (Ocopy sz 0)));  (* The size is fixed later *)
     ("swap", primM (Opseudo_op (Oswap abool))); (* The type is fixed later *)
     (* "NOP" is ignored on purpose *)
     ("mulu", primP (fun sz => Opseudo_op (Omulu sz)));
@@ -583,7 +583,7 @@ Definition sopn_prim_string : seq (string * prim_constructor sopn) :=
     ("update_msf" , primM (Oslh SLHupdate));
     ("mov_msf"    , primM (Oslh SLHmove));
     ("protect"    , primP (fun sz => Oslh (SLHprotect sz)));
-    ("protect_ptr", primM (Oslh (SLHprotect_ptr U8 xH))) (* The size is fixed later *)
+    ("protect_ptr", primM (Oslh (SLHprotect_ptr U8 0))) (* The size is fixed later *)
    ]%string
   ++ map (fun '(s, p) => (s, map_prim_constructor Oasm p)) prim_string.
 

--- a/proofs/lang/syscall.v
+++ b/proofs/lang/syscall.v
@@ -9,7 +9,7 @@ Require Import
 
 #[only(eqbOK)] derive
 Variant syscall_t : Type := 
-  | RandomBytes of wsize & positive.
+  | RandomBytes of wsize & Z.
 
 HB.instance Definition _ := hasDecEq.Build syscall_t syscall_t_eqb_OK.
 

--- a/proofs/lang/syscall_sem.v
+++ b/proofs/lang/syscall_sem.v
@@ -24,7 +24,7 @@ Definition exec_getrandom_u (scs : syscall_state) len vs :=
     | [:: v] => to_arr len v
     | _ => type_error
     end in
-  let sd := get_random scs (Zpos len) in
+  let sd := get_random scs len in
   Let t := WArray.fill len sd.2 in
   ok (sd.1, [::Varr t]).
 
@@ -36,8 +36,8 @@ Definition exec_syscall_u
   (vs : values) :
   exec (syscall_state_t * mem * values) :=
   match o with
-  | RandomBytes ws p =>
-      let len := Z.to_pos (arr_size ws p) in
+  | RandomBytes ws n =>
+      let len := arr_size ws n in
       Let sv := exec_getrandom_u scs len vs in
       ok (sv.1, m, sv.2)
   end.

--- a/proofs/lang/type.v
+++ b/proofs/lang/type.v
@@ -22,7 +22,7 @@ Variant ltype : Set :=
 Variant atype : Set :=
 | abool
 | aint
-| aarr of wsize & positive
+| aarr of wsize & Z
 | aword of wsize.
 
 (* Value types, i.e. types appearing in the semantics *)
@@ -30,7 +30,7 @@ Variant atype : Set :=
 Variant ctype : Set :=
 | cbool
 | cint
-| carr  of positive
+| carr  of Z
 | cword of wsize.
 
 Definition atype_of_ltype ty :=
@@ -80,7 +80,7 @@ Definition atype_cmp t t' :=
   | aword w , aword w'      => wsize_cmp w w'
   | aword _ , _             => Gt
 
-  | aarr ws n , aarr ws' n' => Lex (wsize_cmp ws ws') (Pos.compare n n')
+  | aarr ws n , aarr ws' n' => Lex (wsize_cmp ws ws') (Z.compare n n')
   | aarr _ _  , _           => Gt
   end.
 
@@ -114,35 +114,6 @@ Module CEDecAtype.
 
   Definition t : eqType := atype.
 
-  Fixpoint pos_dec (p1 p2:positive) : {p1 = p2} + {True} :=
-    match p1 as p1' return {p1' = p2} + {True} with
-    | xH =>
-      match p2 as p2' return {xH = p2'} + {True} with
-      | xH => left (erefl xH)
-      | _  => right I
-      end
-    | xO p1' =>
-      match p2 as p2' return {xO p1' = p2'} + {True} with
-      | xO p2' =>
-        match pos_dec p1' p2' with
-        | left eq =>
-          left (eq_rect p1' (fun p => xO p1' = xO p) (erefl (xO p1')) p2' eq)
-        | _ => right I
-        end
-      | _ => right I
-      end
-    | xI p1' =>
-      match p2 as p2' return {xI p1' = p2'} + {True} with
-      | xI p2' =>
-        match pos_dec p1' p2' with
-        | left eq =>
-          left (eq_rect p1' (fun p => xI p1' = xI p) (erefl (xI p1')) p2' eq)
-        | _ => right I
-        end
-      | _ => right I
-      end
-    end.
-
   Definition eq_dec (t1 t2:t) : {t1 = t2} + {True} :=
     match t1 as t return {t = t2} + {True} with
     | abool =>
@@ -160,7 +131,7 @@ Module CEDecAtype.
       | aarr ws2 n2 =>
         match wsize_eq_dec ws1 ws2 with
         | left eqw =>
-          match pos_dec n1 n2 with
+          match Z.eq_dec n1 n2 with
           | left eqn => left (f_equal2 aarr eqw eqn)
           | right _ => right I
           end
@@ -179,23 +150,12 @@ Module CEDecAtype.
       end
     end.
 
-  Lemma pos_dec_r n1 n2 tt: pos_dec n1 n2 = right tt -> n1 != n2.
-  Proof.
-    case: tt.
-    elim: n1 n2 => [n1 Hrec|n1 Hrec|] [n2|n2|] //=.
-    + case: pos_dec (Hrec n2) => //= -[] /(_ (erefl _)) /eqP ? _.
-      by apply /eqP; congruence.
-    case: pos_dec (Hrec n2) => //= -[] /(_ (erefl _)) /eqP ? _.
-    by apply /eqP; congruence.
-  Qed.
-
   Lemma eq_dec_r t1 t2 tt: eq_dec t1 t2 = right tt -> t1 != t2.
   Proof.
     case: tt;case:t1 t2=> [||ws n|w] [||ws' n'|w'] //=.
     + case: wsize_eq_dec => eqw.
-      + case: pos_dec (@pos_dec_r n n' I) => [Heq _ | [] neq ] //=.
-        move => _; apply/eqP => -[].
-        by move/eqP: (neq erefl).
+      + case: Z.eq_dec => // hneq.
+        by move=> _; apply /eqP => -[].
       by move=> _; apply/eqP => -[].
     case: wsize_eq_dec => // eqw.
     by move=> _;apply /eqP;congruence.
@@ -246,14 +206,14 @@ Definition is_not_carr t := ~~ is_carr t.
 End OtherDefs.
 
 (* -------------------------------------------------------------------- *)
-Definition arr_size (ws:wsize) (len:positive)  := 
+Definition arr_size (ws:wsize) (len:Z)  := 
    (wsize_size ws * len)%Z.
 
 Lemma arr_sizeE ws len : arr_size ws len = (wsize_size ws * len)%Z.
 Proof. done. Qed.
 
-Lemma gt0_arr_size ws len : (0 < arr_size ws len)%Z.
-Proof. done. Qed.
+Lemma gt0_arr_size ws len : (0 < len)%Z -> (0 < arr_size ws len)%Z.
+Proof. by move=> ?; rewrite arr_sizeE; apply Z.mul_pos_pos. Qed.
 
 Opaque arr_size.
 
@@ -261,7 +221,7 @@ Definition eval_atype ty :=
   match ty with
   | abool => cbool
   | aint => cint
-  | aarr ws len => carr (Z.to_pos (arr_size ws len))
+  | aarr ws len => carr (arr_size ws len)
   | aword ws => cword ws
   end.
 
@@ -427,7 +387,7 @@ Definition twint {len} (s : signedness) (ws : wsize) := ETword len (Some s) ws.
 Definition tuint {len} ws : extended_type len := twint Unsigned ws.
 Definition tsint {len} ws : extended_type len := twint Signed ws.
 
-Definition to_atype (t:extended_type positive) : atype :=
+Definition to_atype (t:extended_type Z) : atype :=
   match t with
   | ETbool      => abool
   | ETint       => aint

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -1549,6 +1549,7 @@ Proof. move=> /P_ltP ? /P_leP ?;apply /P_ltP; Lia.lia. Qed.
 
 (* TODO: when elpi.derive supports it, register Pos.eqb_spec instead *)
 #[only(eqbOK)] derive positive.
+#[only(eqbOK)] derive Z.
 
 HB.instance Definition _ := hasDecEq.Build positive positive_eqb_OK.
 

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -1591,6 +1591,21 @@ Proof.
   by rewrite (Z.odd_pow _ _ hn).
 Qed.
 
+(* Variant of [natlike_ind] with conclusion about all integers, not just non-negative ones.
+   In some places, to apply [natlike_ind], one has to first do a case analysis.
+   This case analysis is factored out in this lemma. *)
+Lemma natlike_ind_full (P : Z -> Prop) :
+  (forall x, x <= 0 -> P x) -> (forall x, 0 <= x -> P x -> P (Z.succ x)) ->
+  forall x, P x.
+Proof.
+  move=> hneg ih x.
+  case: (Z.nonpos_nonneg_cases x); move: x.
+  - apply hneg.
+  - apply natlike_ind.
+    + by apply hneg.
+    by apply ih.
+Qed.
+
 (* ** Some Extra tactics
  * -------------------------------------------------------------------- *)
 
@@ -1739,15 +1754,13 @@ Qed.
 
 Lemma in_ziota (p z i:Z) : (i \in ziota p z) = ((p <=? i) && (i <? p + z)).
 Proof.
-  case: (ZleP 0 z) => hz.
-  + move: p; pattern z; apply natlike_ind => [ p | {}z {}hz hrec p| //].
-    + by rewrite ziota0 in_nil; case: andP => // -[/ZleP ? /ZltP ?]; Lia.lia.
-    rewrite ziotaS_cons // in_cons; case: eqP => [-> | ?] /=.
-    + by rewrite Z.leb_refl /=; symmetry; apply /ZltP; Lia.lia.
-    by rewrite hrec; apply Bool.eq_iff_eq_true;split=> /andP [/ZleP ? /ZltP ?];
-      (apply /andP;split;[apply /ZleP| apply /ZltP]); Lia.lia.
-  rewrite ziota_neg;last Lia.lia.
-  rewrite in_nil;symmetry;apply /negP => /andP [/ZleP ? /ZltP ?]; Lia.lia.
+  move: p; pattern z; apply natlike_ind_full => {z} [ z hz p | z hz hrec p ].
+  + rewrite ziota_neg // in_nil; symmetry; apply /negP => /andP [/ZleP ? /ZltP ?].
+    by Lia.lia.
+  rewrite ziotaS_cons // in_cons; case: eqP => [-> | ?] /=.
+  + by rewrite Z.leb_refl /=; symmetry; apply /ZltP; Lia.lia.
+  by rewrite hrec; apply Bool.eq_iff_eq_true;split=> /andP [/ZleP ? /ZltP ?];
+    (apply /andP;split;[apply /ZleP| apply /ZltP]); Lia.lia.
 Qed.
 
 Lemma size_ziota p z: size (ziota p z) = Z.to_nat z.

--- a/proofs/lang/values.v
+++ b/proofs/lang/values.v
@@ -57,12 +57,12 @@ Lemma Varr_inj n n' t t' (e: @Varr n t = @Varr n' t') :
   exists en: n = n', eq_rect n (λ s, WArray.array s) t n' en = t'.
 Proof.
   case: e => ?; subst n'; exists erefl.
-  exact: (Eqdep_dec.inj_pair2_eq_dec _ Pos.eq_dec).
+  exact: (Eqdep_dec.inj_pair2_eq_dec _ Z.eq_dec).
 Qed.
 
 Corollary Varr_inj1 n t t' : @Varr n t = @Varr n t' -> t = t'.
 Proof.
-  by move=> /Varr_inj [en ]; rewrite (Eqdep_dec.UIP_dec Pos.eq_dec en erefl).
+  by move=> /Varr_inj [en ]; rewrite (Eqdep_dec.UIP_dec Z.eq_dec en erefl).
 Qed.
 
 Lemma Vword_inj sz sz' w w' (e: @Vword sz w = @Vword sz' w') :
@@ -801,12 +801,12 @@ Proof.
   by rewrite (vuincl_sopn hall hu h1) /= h2.
 Qed.
 
-Lemma vuincl_copy_eq ws p :
-  let sz := Z.to_pos (arr_size ws p) in
+Lemma vuincl_copy_eq ws n :
+  let len := arr_size ws n in
   forall vs vs' v,
   values_uincl vs vs' ->
-  @app_sopn_v [::carr sz] [::carr sz] (@WArray.copy ws p) vs = ok v ->
-  @app_sopn_v [::carr sz] [::carr sz] (@WArray.copy ws p) vs' = ok v.
+  @app_sopn_v [::carr len] [::carr len] (@WArray.copy ws n) vs = ok v ->
+  @app_sopn_v [::carr len] [::carr len] (@WArray.copy ws n) vs' = ok v.
 Proof.
   move=> sz _ _ v [// | v1 v2 [_ /value_uinclE hu /List_Forall2_inv_l -> |]];
     rewrite /app_sopn_v /=; t_xrbindP=> // ??.
@@ -824,12 +824,12 @@ Proof.
   by exists v => //; exact: List_Forall2_refl.
 Qed.
 
-Lemma vuincl_copy ws p :
-  let sz := Z.to_pos (arr_size ws p) in
+Lemma vuincl_copy ws n :
+  let len := arr_size ws n in
   forall vs vs' v,
   values_uincl vs vs' ->
-  @app_sopn_v [::carr sz] [::carr sz] (@WArray.copy ws p) vs = ok v ->
-  exists2 v' : values, @app_sopn_v [::carr sz] [::carr sz] (@WArray.copy ws p) vs' = ok v' & values_uincl v v'.
+  @app_sopn_v [::carr len] [::carr len] (@WArray.copy ws n) vs = ok v ->
+  exists2 v' : values, @app_sopn_v [::carr len] [::carr len] (@WArray.copy ws n) vs' = ok v' & values_uincl v v'.
 Proof.
   move=> ??? v /vuincl_copy_eq h/h{h}?.
   by exists v => //; exact: List_Forall2_refl.
@@ -912,9 +912,9 @@ Definition interp_safe_cond (vs : values) (sc : safe_cond) :=
     forall w1 w2, to_word ws (nth undef_b vs k1) = ok w1 ->
                   to_word ws (nth undef_b vs k2) = ok w2 ->
                   (wunsigned w1 + wunsigned w2 <= z)%Z
-  | AllInit ws p k =>
-    forall t, to_arr (Z.to_pos (arr_size ws p)) (nth undef_b vs k) = ok t ->
-    forall i, (0 <= i < p)%Z ->
+  | AllInit ws n k =>
+    forall t, to_arr (arr_size ws n) (nth undef_b vs k) = ok t ->
+    forall i, (0 <= i < n)%Z ->
      exists w, WArray.get Unaligned AAscale ws t i = ok w
   | X86Division sz sign =>
     forall hi lo dv,

--- a/proofs/lang/varmap.v
+++ b/proofs/lang/varmap.v
@@ -1,4 +1,5 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool seq eqtype ssralg.
+From mathcomp Require Import word_ssrZ.
 From Coq Require Import ZArith Setoid Morphisms.
 Require Export var type values.
 Import Utf8 ssrbool.
@@ -50,7 +51,7 @@ Definition truncatable wdb ty v :=
  match v, ty with
  | Vbool _, cbool => true
  | Vint _, cint   => true
- | Varr p _, carr p' => p == p'
+ | Varr len _, carr len' => len == len'
  (* TODO: change the order of the conditions to simplify proofs
   suggestion: ws' ≤ ws || sw_allowed || ~~ wdb *)
  | Vword ws w, cword ws' =>  ~~wdb || (sw_allowed || (ws' <= ws)%CMP)
@@ -65,7 +66,7 @@ Definition vm_truncate_val ty v :=
  match v, ty with
  | Vbool _, cbool => v
  | Vint _, cint   => v
- | Varr p _, carr p' => if p == p' then v else undef_addr ty
+ | Varr len _, carr len' => if len == len' then v else undef_addr ty
  | Vword ws w, cword ws' =>
    if (sw_allowed || (ws' <= ws)%CMP) then
      if (ws <= ws')%CMP then Vword w else Vword (zero_extend ws' w)

--- a/proofs/lang/warray_.v
+++ b/proofs/lang/warray_.v
@@ -500,13 +500,10 @@ Module WArray.
       else Mz.get a k.
   Proof.
     rewrite /set_sub_data.
-    have [hneg|hpos] := Z.nonpos_nonneg_cases (arr_size ws len).
+    elim /natlike_ind_full: (arr_size ws len) a => [ {}len hneg | {}len hpos ih ] data.
     + rewrite ziota_neg //=.
       by case: ifPn => //; rewrite !zify; lia.
-    elim /natlike_ind: (arr_size ws len) a;
-      last by apply hpos.
-    + move=> data; rewrite ziota0 /=; case: andP => // -[]; rewrite !zify; lia.
-    move=> sz hsz ih data; rewrite ziotaS_cat // foldr_cat Z.add_0_l /= ih.
+    rewrite ziotaS_cat // foldr_cat Z.add_0_l /= ih.
     case: ifPn; rewrite !zify => h3; case: ifPn; rewrite !zify => h4 //.
     + nia.
     + case heq: (Mz.get t) => [w|].
@@ -577,13 +574,10 @@ Module WArray.
       else None.
   Proof.
     rewrite /get_sub_data -(Mz.get0 u8 k).
-    have [hneg|hpos] := Z.nonpos_nonneg_cases (arr_size ws len).
+    elim /natlike_ind_full: (arr_size ws len) (Mz.empty u8) => [ {}len hneg | {}len hpos ih ] b.
     + rewrite ziota_neg //=.
       by case: ifPn => //; rewrite !zify; lia.
-    elim /natlike_ind: (arr_size ws len) (Mz.empty u8);
-      last by apply hpos.
-    + move => b; rewrite ziota0 /=; case: andP => //; rewrite !zify; lia.
-    move=> sz hsz ih b; rewrite ziotaS_cat // foldr_cat Z.add_0_l /= ih.
+    rewrite ziotaS_cat // foldr_cat Z.add_0_l /= ih.
     case: ifPn; rewrite !zify => h3; case: ifPn; rewrite !zify => h4 //.
     + nia.
     + case heq: (Mz.get a) => [w|].

--- a/proofs/lang/warray_.v
+++ b/proofs/lang/warray_.v
@@ -24,10 +24,10 @@ Definition mk_scale (aa:arr_access) ws :=
 
 Module WArray.
 
-  Record array (s:positive)  :=
+  Record array (s:Z) :=
     { arr_data : Mz.t u8 }.
 
-  Definition empty (s:positive) : array s :=
+  Definition empty (s:Z) : array s :=
     {| arr_data := Mz.empty _ |}.
 
   #[ local ]
@@ -61,7 +61,7 @@ Module WArray.
   Section WITH_POINTER_DATA.
   Context {pd: PointerData}.
 
-  Lemma is_align_scale (p:pointer) ws : is_align (p * mk_scale AAscale ws)%Z ws.
+  Lemma is_align_scale (i:pointer) ws : is_align (i * mk_scale AAscale ws)%Z ws.
   Proof. by rewrite is_alignE /mk_scale /= Z_mod_mult. Qed.
 
   Lemma arr_is_align i ws :
@@ -71,11 +71,11 @@ Module WArray.
   Qed.
 
   Section CM.
-    Variable (s:positive).
+    Variable (s:Z).
 
-    Definition in_bound (_:array s) p := (0 <=? p) && (p <? s).
+    Definition in_bound (_:array s) i := (0 <=? i) && (i <? s).
 
-    Lemma in_boundP m p : reflect (0 <= p < s) (in_bound m p).
+    Lemma in_boundP m i : reflect (0 <= i < s) (in_bound m i).
     Proof. by apply (iffP andP); rewrite !zify. Qed.
 
     Definition is_init (m:array s) (i:pointer) :=
@@ -99,20 +99,20 @@ Module WArray.
       Let _ := assert (in_bound m i) ErrOob in
       ok {| arr_data := Mz.set m.(arr_data) i v |}.
 
-    Lemma valid8P m p w : reflect (exists m', set8 m p w = ok m') (in_bound m p).
+    Lemma valid8P m i w : reflect (exists m', set8 m i w = ok m') (in_bound m i).
     Proof.
       by (rewrite /set8; case: in_bound => /=; constructor); [eexists; eauto | move=> []].
     Qed.
 
-    Lemma get_valid8 m p w : get8 m p = ok w -> in_bound m p.
+    Lemma get_valid8 m i w : get8 m i = ok w -> in_bound m i.
     Proof. by rewrite /get8; t_xrbindP. Qed.
 
-    Lemma valid8_set m p w m' p' : set8 m p w = ok m' -> in_bound m' p' = in_bound m p'.
+    Lemma valid8_set m i w m' i' : set8 m i w = ok m' -> in_bound m' i' = in_bound m i'.
     Proof. by rewrite /set8; t_xrbindP => _ <-. Qed.
 
-    Lemma set8P m p w p' m' :
-      set8 m p w = ok m' ->
-      get8 m' p' = if p == p' then ok w else get8 m p'.
+    Lemma set8P m i w i' m' :
+      set8 m i w = ok m' ->
+      get8 m' i' = if i == i' then ok w else get8 m i'.
     Proof.
       rewrite /get8 /set8 => /[dup] /valid8_set ->; t_xrbindP => hb <-.
       case heq: in_bound => //=; last by case: eqP => // h;move: heq; rewrite -h hb.
@@ -122,18 +122,18 @@ Module WArray.
     Global Instance array_CM : coreMem pointer (array s) :=
       CoreMem set8P valid8P get_valid8 valid8_set.
 
-    Definition in_range (p:pointer) (ws:wsize) :=
-      ((0 <=? p) && (p + wsize_size ws <=? s))%Z.
+    Definition in_range (i:pointer) (ws:wsize) :=
+      ((0 <=? i) && (i + wsize_size ws <=? s))%Z.
 
-    Lemma in_rangeP p ws:
-      reflect (0 <= p /\ p + wsize_size ws <= s)%Z (in_range p ws).
+    Lemma in_rangeP i ws:
+      reflect (0 <= i /\ i + wsize_size ws <= s)%Z (in_range i ws).
     Proof.
       rewrite /in_range; case: andP => h; constructor; move: h; rewrite !zify; nia.
     Qed.
 
-    Lemma validw_in_range m al p ws : validw m al p ws = (is_aligned_if al p ws && in_range p ws).
+    Lemma validw_in_range m al i ws : validw m al i ws = (is_aligned_if al i ws && in_range i ws).
     Proof.
-      apply (sameP (validwP m al p ws)).
+      apply (sameP (validwP m al i ws)).
       apply (iffP andP).
       + move=> [] ? /in_rangeP ?;split => // k hk.
         by rewrite -valid8_validw /valid8 /= /in_bound !zify !addE; lia.
@@ -144,68 +144,68 @@ Module WArray.
 
   End CM.
 
-  Definition get len al (aa: arr_access) ws (a: array len) (p: Z) :=
-    CoreMem.read a al (p * mk_scale aa ws)%Z ws.
+  Definition get len al (aa: arr_access) ws (a: array len) (i: Z) :=
+    CoreMem.read a al (i * mk_scale aa ws)%Z ws.
 
-  Definition set {len ws} (a: array len) al aa p (v: word ws) : exec (array len) :=
-    CoreMem.write a al (p * mk_scale aa ws)%Z v.
+  Definition set {len ws} (a: array len) al aa i (v: word ws) : exec (array len) :=
+    CoreMem.write a al (i * mk_scale aa ws)%Z v.
 
   Definition fcopy ws len (a t: WArray.array len) i j :=
     foldM (fun i t =>
              Let w := get Unaligned AAscale ws a i in set t Unaligned AAscale i w) t
       (ziota i j).
 
-  Definition copy ws p (a:array (Z.to_pos (arr_size ws p))) :=
-    fcopy ws a (WArray.empty _) 0 p.
+  Definition copy ws n (a:array (arr_size ws n)) :=
+    fcopy ws a (WArray.empty _) 0 n.
 
   Definition fill_aux len : seq u8 → exec (pointer * array len) :=
-    foldM (λ w pt,
-        Let t := set pt.2 Aligned AAscale pt.1 w in
-         ok (pt.1 + 1, t))
+    foldM (λ w it,
+        Let t := set it.2 Aligned AAscale it.1 w in
+         ok (it.1 + 1, t))
       (0%Z, empty len).
 
   Definition fill len (bytes: seq u8) : exec (array len) :=
-    Let _ := assert (size bytes == Pos.to_nat len) ErrType in
-    Let pt := fill_aux len bytes in
-    ok pt.2.
+    Let _ := assert (size bytes == Z.to_nat len) ErrType in
+    Let it := fill_aux len bytes in
+    ok it.2.
 
-  Definition get_sub_data (aa:arr_access) ws len (a:Mz.t u8) p :=
+  Definition get_sub_data (aa:arr_access) ws len (a:Mz.t u8) i :=
      let size := arr_size ws len in
-     let start := (p * mk_scale aa ws)%Z in
+     let start := (i * mk_scale aa ws)%Z in
      foldr (fun i data =>
        match Mz.get a (start + i) with
        | None => Mz.remove data i
        | Some w => Mz.set data i w
        end) (Mz.empty _) (ziota 0 size).
 
-  Definition get_sub lena (aa:arr_access) ws len (a:array lena) p  : exec (array (Z.to_pos (arr_size ws len))) :=
+  Definition get_sub lena (aa:arr_access) ws len (a:array lena) i : exec (array (arr_size ws len)) :=
      let size := arr_size ws len in
-     let start := (p * mk_scale aa ws)%Z in
+     let start := (i * mk_scale aa ws)%Z in
      if (0 <=? start) && (start + size <=? lena) then
-       ok (Build_array (Z.to_pos size) (get_sub_data aa ws len (arr_data a) p))
+       ok (Build_array size (get_sub_data aa ws len (arr_data a) i))
      else Error ErrOob.
 
-  Definition set_sub_data (aa:arr_access) ws len (a:Mz.t u8) p (b:Mz.t u8) :=
+  Definition set_sub_data (aa:arr_access) ws len (a:Mz.t u8) i (b:Mz.t u8) :=
     let size := arr_size ws len in
-    let start := (p * mk_scale aa ws)%Z in
+    let start := (i * mk_scale aa ws)%Z in
     foldr (fun i data =>
       match Mz.get b i with
       | None => Mz.remove data (start + i)
       | Some w => Mz.set data (start + i) w
       end) a (ziota 0 size).
 
-  Definition set_sub lena (aa:arr_access) ws len (a:array lena) p (b:array (Z.to_pos (arr_size ws len))) : exec (array lena) :=
+  Definition set_sub lena (aa:arr_access) ws len (a:array lena) i (b:array (arr_size ws len)) : exec (array lena) :=
     let size := arr_size ws len in
-    let start := (p * mk_scale aa ws)%Z in
+    let start := (i * mk_scale aa ws)%Z in
     if (0 <=? start) && (start + size <=? lena) then
-      ok (Build_array lena (set_sub_data aa ws len (arr_data a) p (arr_data b)))
+      ok (Build_array lena (set_sub_data aa ws len (arr_data a) i (arr_data b)))
     else Error ErrOob.
 
   Definition cast len len' (a:array len) : result error (array len') :=
     if len' == len then ok {| arr_data := a.(arr_data) |}
     else type_error.
 
-  Definition of_list {ws} (l:list (word ws)) : array (Z.to_pos (Z.of_nat (size l) * wsize_size ws)) :=
+  Definition of_list {ws} (l:list (word ws)) : array (Z.of_nat (size l) * wsize_size ws) :=
     let m := Mz.empty in
     let do8 (mz: Mz.t _ * Z) (w:u8) :=
       let '(m,z) := mz in
@@ -301,37 +301,37 @@ Module WArray.
     get Aligned aa U8 m k = read m Aligned k U8.
   Proof. by rewrite /get mk_scale_U8 Z.mul_1_r. Qed.
 
-  Lemma set_get8 len (m m':array len) al aa p ws (v: word ws) :
-    set m al aa p v = ok m' ->
+  Lemma set_get8 len (m m':array len) al aa i ws (v: word ws) :
+    set m al aa i v = ok m' ->
     forall k,
       read m' Aligned k U8 =
-        let i := (k - p * mk_scale aa ws)%Z in
-         if ((0 <=? i) && (i <? wsize_size ws))%Z then ok (LE.wread8 v i)
+        let j := (k - i * mk_scale aa ws)%Z in
+         if ((0 <=? j) && (j <? wsize_size ws))%Z then ok (LE.wread8 v j)
          else read m Aligned k U8.
   Proof. by eauto using write_read8. Qed.
 
-  Lemma setP len (m m':array len) al al' p1 p2 ws (v: word ws) :
-    set m al AAscale p1 v = ok m' ->
-    get al' AAscale ws m' p2 = if p1 == p2 then ok v else get al' AAscale ws m p2.
+  Lemma setP len (m m':array len) al al' i1 i2 ws (v: word ws) :
+    set m al AAscale i1 v = ok m' ->
+    get al' AAscale ws m' i2 = if i1 == i2 then ok v else get al' AAscale ws m i2.
   Proof.
     rewrite /set /get; case:eqP => [<- | hne hw]; last first.
     - apply: (CoreMem.writeP_neq _ hw); move=> ??; rewrite !addE /mk_scale;nia.
     move => hwrite.
     apply: writeP_eq.
-    have hal := is_align_scale p1 ws.
+    have hal := is_align_scale i1 ws.
     move: hwrite; rewrite /write (is_aligned_if_is_align al hal) (is_aligned_if_is_align al' hal).
     exact.
   Qed.
 
-  Lemma setP_eq len (m m':array len) al p1 ws (v: word ws) :
-    set m al AAscale p1 v = ok m' ->
-    get al AAscale ws m' p1 = ok v.
+  Lemma setP_eq len (m m':array len) al i1 ws (v: word ws) :
+    set m al AAscale i1 v = ok m' ->
+    get al AAscale ws m' i1 = ok v.
   Proof. by move=> /setP ->; rewrite eqxx. Qed.
 
-  Lemma setP_neq len (m m':array len) al al' p1 p2 ws (v: word ws) :
-    p1 != p2 ->
-    set m al AAscale p1 v = ok m' ->
-    get al' AAscale ws m' p2 = get al' AAscale ws m p2.
+  Lemma setP_neq len (m m':array len) al al' i1 i2 ws (v: word ws) :
+    i1 != i2 ->
+    set m al AAscale i1 v = ok m' ->
+    get al' AAscale ws m' i2 = get al' AAscale ws m i2.
   Proof. by move=> /negPf h /setP ->; rewrite h. Qed.
 
   Lemma mk_scale_bound aa ws : (1 <= mk_scale aa ws <= wsize_size ws)%Z.
@@ -357,13 +357,13 @@ Module WArray.
     by rewrite validw_in_range => /andP [] ? /in_rangeP [].
   Qed.
 
-  Lemma get_empty (n:positive) off :
+  Lemma get_empty (n:Z) off :
     read (empty n) Aligned off U8 = if (0 <=? off) && (off <? n) then Error ErrAddrUndef else Error ErrOob.
   Proof.
     by rewrite -get_read8 /memory_model.get /= /get8 /in_bound /is_init /=; case: ifP.
   Qed.
 
-  Lemma get0 (n:positive) off : (0 <= off ∧ off < n)%Z ->
+  Lemma get0 (n:Z) off : (0 <= off ∧ off < n)%Z ->
     read (empty n) Aligned off U8 = Error ErrAddrUndef.
   Proof. by rewrite get_empty => -[/ZleP -> /ZltP ->]. Qed.
 
@@ -415,24 +415,27 @@ Module WArray.
     by have [t2' [-> /hrec ]] /= := uincl_set hu hset; apply.
   Qed.
 
-  Lemma uincl_copy ws p a1 a2 a1' :
+  Lemma uincl_copy ws n a1 a2 a1' :
      uincl a1 a2 ->
-     @copy ws p a1 = ok a1' ->
-     @copy ws p a2 = ok a1'.
+     @copy ws n a1 = ok a1' ->
+     @copy ws n a2 = ok a1'.
   Proof.
     move=> hu; rewrite /copy /fcopy.
     elim: ziota (empty _) => [ | i il hrec] a //=.
     t_xrbindP => a' w /(uincl_get hu) -> /= ->; apply: hrec.
   Qed.
 
-  Lemma fill_aux_ok len bytes : size bytes ≤ Pos.to_nat len → is_ok (fill_aux len bytes).
+  Lemma fill_aux_ok len bytes : size bytes ≤ Z.to_nat len → is_ok (fill_aux len bytes).
   Proof.
     move => hsize.
+    have [hneg|hpos] := Z.nonpos_pos_cases len.
+    + have: size bytes = 0%nat by lia.
+      by move=> /size0nil ->.
     have : (0, empty len).1 + Z.of_nat (size bytes) <= len by rewrite /=; lia.
     clear hsize.
-    have : bytes = [::] ∨ in_bound (0, empty len).2 (0, empty len).1 by right.
+    have : bytes = [::] ∨ in_bound (0, empty len).2 (0, empty len).1 by right; apply /ZltP.
     rewrite /fill_aux; move: (0, empty len).
-    elim: bytes => // b bytes ih [] p t /= [ // | ] hpt.
+    elim: bytes => // b bytes ih [] i t /= [ // | ] hpt.
     rewrite {2}/set -set_write8 /= /set8 Z.mul_1_r hpt /= => hsize.
     case/in_boundP: hpt => le0p lept.
     apply: ih; last by rewrite /=; lia.
@@ -443,7 +446,7 @@ Module WArray.
 
   Definition fill_size len l a :
     fill len l = ok a ->
-    Pos.to_nat len = size l.
+    Z.to_nat len = size l.
   Proof. by rewrite /fill; t_xrbindP => /eqP. Qed.
 
   Lemma fill_get8 len l a :
@@ -454,8 +457,14 @@ Module WArray.
         else Error ErrOob.
   Proof.
     rewrite /fill /fill_aux; t_xrbindP=> /eqP hsize -[z {}a] /= hfold <- k.
+    have [hneg|hpos] := Z.nonpos_nonneg_cases len.
+    + move: hfold.
+      have: size l = 0%nat by lia.
+      move=> /size0nil -> /= [_ <-].
+      rewrite get_empty.
+      by case: andP => //; rewrite !zify; lia.
     have: forall z0 a0,
-      foldM (fun w pt => Let t := set pt.2 Aligned AAscale pt.1 w in ok (pt.1 + 1, t)) (z0, a0) l = ok (z, a) ->
+      foldM (fun w it => Let t := set it.2 Aligned AAscale it.1 w in ok (it.1 + 1, t)) (z0, a0) l = ok (z, a) ->
       read a Aligned k U8 =
         let i := k - z0 in
         if (0 <=? i) && (i <? Z.of_nat (size l)) then ok (nth 0%R l (Z.to_nat i))
@@ -463,7 +472,7 @@ Module WArray.
       last first.
     + move=> /(_ _ _ hfold) ->.
       rewrite Z.sub_0_r get_empty /=.
-      rewrite hsize positive_nat_Z.
+      rewrite hsize Z2Nat.id //.
       by case: andb.
     elim: l {hsize hfold} => [ | w l ih] z0 a0 /=.
     + move=> [_ <-].
@@ -484,15 +493,18 @@ Module WArray.
     by rewrite Z.sub_diag.
   Qed.
 
-  Lemma set_sub_data_get8 aa ws a len p t k:
-    Mz.get (@set_sub_data aa ws len a p t) k =
-      let i := (k - p * mk_scale aa ws)%Z in
-      if (0 <=? i) && (i <? arr_size ws len) then Mz.get t i
+  Lemma set_sub_data_get8 aa ws a len i t k:
+    Mz.get (@set_sub_data aa ws len a i t) k =
+      let j := (k - i * mk_scale aa ws)%Z in
+      if (0 <=? j) && (j <? arr_size ws len) then Mz.get t j
       else Mz.get a k.
   Proof.
     rewrite /set_sub_data.
+    have [hneg|hpos] := Z.nonpos_nonneg_cases (arr_size ws len).
+    + rewrite ziota_neg //=.
+      by case: ifPn => //; rewrite !zify; lia.
     elim /natlike_ind: (arr_size ws len) a;
-      last by apply: Z.lt_le_incl (gt0_arr_size _ _).
+      last by apply hpos.
     + move=> data; rewrite ziota0 /=; case: andP => // -[]; rewrite !zify; lia.
     move=> sz hsz ih data; rewrite ziotaS_cat // foldr_cat Z.add_0_l /= ih.
     case: ifPn; rewrite !zify => h3; case: ifPn; rewrite !zify => h4 //.
@@ -507,12 +519,12 @@ Module WArray.
     rewrite Mz.removeP; case eqP => [? | //]; lia.
   Qed.
 
-  Lemma set_sub_get8 aa ws lena a len p t a' :
-    @set_sub lena aa ws len a p t = ok a' ->
+  Lemma set_sub_get8 aa ws lena a len i t a' :
+    @set_sub lena aa ws len a i t = ok a' ->
     forall k,
       read a' Aligned k U8 =
-        let i := (k - p * mk_scale aa ws)%Z in
-        if (0 <=? i) && (i <? arr_size ws len) then read t Aligned i U8
+        let j := (k - i * mk_scale aa ws)%Z in
+        if (0 <=? j) && (j <? arr_size ws len) then read t Aligned j U8
         else read a Aligned k U8.
   Proof.
     rewrite /set_sub; case: andP => // -[/ZleP h1 /ZleP h2] [<-] /= k.
@@ -520,13 +532,13 @@ Module WArray.
     case: andP; rewrite !zify //= => ?; case: andP; rewrite !zify //= => ?; lia.
   Qed.
 
-  Lemma set_sub_bound aa ws lena a len p t a' :
-    @set_sub lena aa ws len a p t = ok a' ->
-    0 <= p * mk_scale aa ws /\ p * mk_scale aa ws + arr_size ws len <= lena.
+  Lemma set_sub_bound aa ws lena a len i t a' :
+    @set_sub lena aa ws len a i t = ok a' ->
+    0 <= i * mk_scale aa ws /\ i * mk_scale aa ws + arr_size ws len <= lena.
   Proof. by rewrite /set_sub; case: ifP => //; rewrite !zify. Qed.
 
   Transparent arr_size. Opaque Z.mul ziota.
-  Lemma set_sub_get lena ws len (t: array lena) i (s: array (Z.to_pos (arr_size ws len))) t' al :
+  Lemma set_sub_get lena ws len (t: array lena) i (s: array (arr_size ws len)) t' al :
     set_sub AAscale t i s = ok t' ->
     forall j,
     get al AAscale ws t' j =
@@ -535,9 +547,6 @@ Module WArray.
   Proof.
     move=> hget j.
     have ht':= set_sub_get8 hget.
-    have := set_sub_bound hget.
-    have ltws := wsize_size_pos ws; rewrite /arr_size /mk_scale => hb.
-    have [{hb} h0i hilen'] : (0 <= i /\ i + len <= lena)%Z by nia.
     rewrite /get !readE !is_aligned_if_is_align ?is_align_scale // /=.
     case: ifPn.
     + move=> /andP[]/ZleP ? /ZltP ?.
@@ -561,15 +570,18 @@ Module WArray.
   Qed.
   Transparent Z.mul ziota. Opaque arr_size.
 
-  Lemma get_sub_data_get8 aa ws a len p k:
-    Mz.get (get_sub_data aa ws len a p) k =
-      let start := (p * mk_scale aa ws)%Z in
+  Lemma get_sub_data_get8 aa ws a len i k:
+    Mz.get (get_sub_data aa ws len a i) k =
+      let start := (i * mk_scale aa ws)%Z in
       if (0 <=? k) && (k <? arr_size ws len) then Mz.get a (start + k)
       else None.
   Proof.
     rewrite /get_sub_data -(Mz.get0 u8 k).
+    have [hneg|hpos] := Z.nonpos_nonneg_cases (arr_size ws len).
+    + rewrite ziota_neg //=.
+      by case: ifPn => //; rewrite !zify; lia.
     elim /natlike_ind: (arr_size ws len) (Mz.empty u8);
-      last by apply: Z.lt_le_incl (gt0_arr_size _ _).
+      last by apply hpos.
     + move => b; rewrite ziota0 /=; case: andP => //; rewrite !zify; lia.
     move=> sz hsz ih b; rewrite ziotaS_cat // foldr_cat Z.add_0_l /= ih.
     case: ifPn; rewrite !zify => h3; case: ifPn; rewrite !zify => h4 //.
@@ -582,11 +594,11 @@ Module WArray.
     by rewrite Mz.removeP; case: eqP => //; nia.
   Qed.
 
-  Lemma get_sub_get8 aa ws lena a len p a' :
-    @get_sub lena aa ws len a p = ok a' ->
+  Lemma get_sub_get8 aa ws lena a len i a' :
+    @get_sub lena aa ws len a i = ok a' ->
     forall k,
       read a' Aligned k U8 =
-        let start := (p * mk_scale aa ws)%Z in
+        let start := (i * mk_scale aa ws)%Z in
         if (0 <=? k) && (k <? arr_size ws len) then read a Aligned (start + k) U8
         else Error ErrOob.
   Proof.
@@ -595,9 +607,9 @@ Module WArray.
     case: andP; rewrite !zify //= => ?; case: andP; rewrite !zify //= => ?; lia.
   Qed.
 
-  Lemma get_sub_bound aa ws lena a len p a' :
-    @get_sub lena aa ws len a p = ok a' ->
-    0 <= p * mk_scale aa ws /\ p * mk_scale aa ws + arr_size ws len <= lena.
+  Lemma get_sub_bound aa ws lena a len i a' :
+    @get_sub lena aa ws len a i = ok a' ->
+    0 <= i * mk_scale aa ws /\ i * mk_scale aa ws + arr_size ws len <= lena.
   Proof. by rewrite /get_sub; case: ifP => //; rewrite !zify. Qed.
 
   Lemma uincl_get_sub {len1 len2} (a1 : array len1) (a2 : array len2)
@@ -616,7 +628,7 @@ Module WArray.
   Qed.
 
   Lemma uincl_set_sub {ws len1 len2 len} (a1 a1': array len1) (a2: array len2) aa i
-        (t1 t2:array (Z.to_pos (arr_size ws len))) :
+        (t1 t2:array (arr_size ws len)) :
     uincl a1 a2 -> uincl t1 t2 ->
     set_sub aa a1 i t1 = ok a1' ->
     exists2 a2', set_sub aa a2 i t2 = ok a2' & uincl a1' a2'.

--- a/proofs/lang/wsize.v
+++ b/proofs/lang/wsize.v
@@ -200,8 +200,8 @@ Variant safe_cond :=
   | UGe of wsize & Z & nat
   (*  the sum of the nth arguments (unsigned interpretation) must be in the <= z *)
   | UaddLe of wsize & nat & nat & Z
-  (* the nth argument of is an array ws[p] where all ceil are initialized *)
-  | AllInit of wsize & positive & nat
+  (* the nth argument is an array ws[n] where all cells are initialized *)
+  | AllInit of wsize & Z & nat
   (* Unsatisfiable safe_cond *)
   | ScFalse.
 


### PR DESCRIPTION
# Motivation

Motivation is PR https://github.com/jasmin-lang/jasmin/pull/1325. I'm about to introduce variables and some arithmetic in array lengths. And the question is what to do when one of the variables has no associated value (impossible, but it's easier to manipulate a definition where this is allowed) or when the length expression evaluates to a non-positive integer.

# Description

The solution implemented here is to allow array types of non-positive lengths. Array values are also generalized to avoid requiring positive lengths. An array of non-positive size has no valid cell.

The change was easy to implement, except for the proof of stack allocation. The idea of the change in the proof is to notice that non-positive slots are never used for something meaningful, like reading a value in them, because they are empty. I thus weakened a lot of lemmas to mention only slots of positive sizes.

I did not remove the check introduced by https://github.com/jasmin-lang/jasmin/pull/1158, so in concrete syntax arrays of non-positive lengths are still not allowed.

I am not sure how this impacts the semantics of Jasmin. Also, I did not check whether this breaks the extraction to EC or the safety analysis.

# Alternative ideas

- use `N` rather than `Z` for the type of array lengths: negative lengths do not make a lot of sense, and for https://github.com/jasmin-lang/jasmin/pull/1325 just having arrays of length `0` should be enough, but at least in this PR everything happens in `Z` (nearly no coercions)
- define array values only for arrays of positive lengths: just an idea, but maybe we can allow types of arrays of non-positive lengths, but make sure these types are empty (no value exists for such a type)
- make `eval_atype` capable of failing: my initial idea, but @bgregoir suggested something closer to this PR, we feared that the change on the code base would be large