### PR TITLE
Adapt to math-comp/math-comp#1456

### DIFF
--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -159,9 +159,8 @@ Proof.
   + by have := size_slot_gt0 x; lia.
   + exists (l0 ++ rdata ++ vdata).
     rewrite heq -!catA; split => //.
-    have ? := size_slot_gt0 x.
-    rewrite -Nat2Z.inj_iff !size_cat !Nat2Z.inj_add Z2Nat.id //; last by lia.
-    by rewrite hsz1 hsz2 heqsz !Z2Nat.id //; first ((rewrite ?(addZE, subZE); ring) || ring); lia.  (* remove the last "|| ring" when requiring MC >= 2.7 *)
+    have slot_x_gt0 := size_slot_gt0 x.
+    by rewrite !size_cat hsz1 hsz2 heqsz; clear -hbase1 h1 slot_x_gt0; lia.
   move=> x1 ofs1 ws1.
   rewrite Mvar.setP.
   case: eqP => [|_].


### PR DESCRIPTION
Get rid of ring on the problematic line, and rely only on lia

~Restores the original patch proposed by Pierre Roux, now that we require at least Rocq 9.0~

(cf. https://github.com/jasmin-lang/jasmin/pull/1428)