### PR TITLE
x86: emit VMOV for zero-extend to 128-bit

### DIFF
--- a/changes/03-other/1433-vmovq.md
+++ b/changes/03-other/1433-vmovq.md
@@ -1,0 +1,3 @@
+- Zero-extension from 32/64 to 128 bits on x86 uses the AVX instructions
+  (`VMOVD`/`VMOVQ`) instead of the SSE2 instructions (`MOVD`/`MOVQ`)
+  ([PR 1433](https://github.com/jasmin-lang/jasmin/pull/1433)).

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -269,13 +269,13 @@ Definition lower_cassgn_classify ty e x : lower_cassgn_t :=
     | U32 =>
         match szo with
         | U64 => kb true szo (LowerCopn (Oasm (ExtOp Ox86MOVZX32)) [:: a])
-        | U128 => kb true szo (LowerCopn (Ox86 (MOVD szi)) [:: a])
+        | U128 => kb true szo (LowerCopn (Ox86 (VMOV szi)) [:: a])
         | U256 => kb true szo (LowerCopn (Oasm (BaseOp (Some szo, VMOV szi))) [:: a])
         | _ => LowerAssgn
         end
     | U64 =>
         match szo with
-        | U128 => kb true szo (LowerCopn (Ox86 (MOVD szi)) [:: a])
+        | U128 => kb true szo (LowerCopn (Ox86 (VMOV szi)) [:: a])
         | U256 => kb true szo (LowerCopn (Oasm (BaseOp (Some szo, VMOV szi))) [:: a])
         | _ => LowerAssgn
         end


### PR DESCRIPTION
This should help avoiding the SSE/AVX transition costs.