### PR TITLE
Warn about assumed alignment of arguments to export functions

### DIFF
--- a/changes/01-feature/1438-weaker-align-assumptions.md
+++ b/changes/01-feature/1438-weaker-align-assumptions.md
@@ -1,0 +1,6 @@
+- The compiler now warns when array arguments to export functions are assumed to
+  have some unexpected alignment. Such arrays are expected to be aligned to the
+  declared size of their elements, unless the `-only-trivial-alignment`
+  command-line flag is used, in which case they are not expected to have any
+  specific alignment.
+  ([PR 1438](https://github.com/jasmin-lang/jasmin/pull/1438)).

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -29,6 +29,7 @@ let introduce_array_copy = ref true
 let introduce_export_renaming = ref true
 let print_dependencies = ref false
 let lazy_regalloc = ref false
+let only_trivial_alignment = ref false
 
 let verbosity = ref 1
 
@@ -48,6 +49,7 @@ let set_linting_level i =
 
 let enable_all_warnings () =
   linting_level := 2;
+  only_trivial_alignment := true;
   set_all_warnings ()
 
 let do_auto_spill = ref None
@@ -223,6 +225,7 @@ let options = [
     "-wall", Arg.Unit enable_all_warnings, " Enable all warnings";
     "-nowarning", Arg.Unit (nowarning), " Do no print warnings";
     "-linting-level", Arg.Int set_linting_level, "[n] Set linting level to n (defaults to 1; disable linting when set to 0)";
+    "-only-trivial-alignment", Arg.Set only_trivial_alignment, " Warn if export functions assume some alignment for their array arguments";
     "-color", Arg.Symbol (["auto"; "always"; "never"], set_color), " Print messages with color";
     "-help-intrinsics", Arg.Set help_intrinsics, " List the set of intrinsic operators (and exit)";
     "-auto-spill", Arg.Unit set_auto_spill, " Enable naive spilling of #[spill]-annotated variables";

--- a/compiler/src/utils.ml
+++ b/compiler/src/utils.ml
@@ -390,6 +390,7 @@ type warning =
   | UnusedVar (* -wunusedvar *)
   | SCTchecker
   | Linter
+  | NonTrivialAlignment
   | Deprecated
   | Experimental
   | Always
@@ -406,6 +407,7 @@ let default_warnings =
       Experimental;
       PedanticPretyping;
       Linter;
+      NonTrivialAlignment;
     ]
 
 let all_warnings = ExtraAssignment :: UseLea :: IntroduceArrayCopy :: KeptRenaming :: default_warnings

--- a/compiler/src/utils.mli
+++ b/compiler/src/utils.mli
@@ -158,6 +158,7 @@ type warning =
   | UnusedVar
   | SCTchecker
   | Linter
+  | NonTrivialAlignment
   | Deprecated
   | Experimental
   | Always

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -274,7 +274,7 @@ let init_slots pd stack_pointers alias coloring fv =
   !slots, lalloc
 
 (* --------------------------------------------------- *)
-let all_alignment pd (ctbl: alignment) alias params lalloc : param_info option list * wsize Hv.t =
+let all_alignment ~is_export pd (ctbl: alignment) alias params lalloc : param_info option list * wsize Hv.t =
 
   let get_align c =
     try Hv.find ctbl c.Alias.in_var
@@ -291,6 +291,20 @@ let all_alignment pd (ctbl: alignment) alias params lalloc : param_info option l
         | _ | exception Not_found -> assert false in
       let pi_writable = w = Writable in
       let pi_align = get_align c in
+      (* Check that the assumed alignment for array arguments to export functions does not exceed some bound.
+         The bound is U8 (no assumption allowed) when “only_trivial_alignment” is set.
+         Otherwise, the declared size of the array cells is used as the assumed alignment bound. *)
+      if is_export then begin
+          match x.v_ty with
+          | Arr (ws, _) ->
+             let strict = !Glob_options.only_trivial_alignment in
+             let ws = if strict then U8 else ws in
+             if wsize_cmp ws pi_align.ac_strict == Lt then
+               warning NonTrivialAlignment (L.i_loc0 x.v_dloc) "argument %a is used with %a-bit alignment"
+                 (Printer.pp_var ~debug:false) x
+                 PrintCommon.pp_wsize pi_align.ac_strict
+          | _ -> assert false
+        end;
       Some { pi_ptr; pi_writable; pi_align }
     | _ -> assert false in
   let params = List.map doparam params in
@@ -415,7 +429,7 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
   in
   let sao_return = get_returned_params ~funname:fd.f_name.fn_name alias fd.f_args fd.f_ret in
 
-  let sao_params, atbl = all_alignment pd ctbl alias fd.f_args lalloc in
+  let sao_params, atbl = all_alignment ~is_export:(FInfo.is_export fd.f_cc) pd ctbl alias fd.f_args lalloc in
 
   let ra_on_stack =
     match fd.f_cc with 

--- a/compiler/tests/success/common/assertion.jazz
+++ b/compiler/tests/success/common/assertion.jazz
@@ -12,7 +12,7 @@ export fn checked(reg u32 a) -> reg u32 {
 #[safety = { ensures = is_arr_init(x, 0, 32) } ]
 export fn set_zero(reg ptr u8[4] x) -> reg ptr u8[4] {
   reg u32 zero = 0;
-  x[:u32 0] = zero;
+  x[#unaligned:u32 0] = zero;
   return x;
 }
 

--- a/compiler/tests/success/common/bug_1296.jazz
+++ b/compiler/tests/success/common/bug_1296.jazz
@@ -2,6 +2,6 @@ param int x = 2;
 param int y = 1 << x;
 
 export fn load(reg ptr u8[y] v) -> reg u32 {
-  reg u32 r = v[:u32 0];
+  reg u32 r = v[#unaligned:u32 0];
   return r;
 }

--- a/compiler/tests/success/x86-64/array_cast.jazz
+++ b/compiler/tests/success/x86-64/array_cast.jazz
@@ -1,11 +1,11 @@
 fn store(reg ptr u64[8] a) -> reg ptr u16[4*8] {
   reg u256 zero = #set0_256();
-  a[0] = 0;
-  a[:u8 0] = 0;
-  a[:u32 0] = 0;
-  a[:u64 0] = 0;
-  a[:u128 0] = zero;
-  a[:u256 0] = zero;
+  a[#unaligned 0] = 0;
+  a[#unaligned:u8 0] = 0;
+  a[#unaligned:u32 0] = 0;
+  a[#unaligned:u64 0] = 0;
+  a[#unaligned:u128 0] = zero;
+  a[#unaligned:u256 0] = zero;
 
   a.[0] = 0;
   a.[:u8 0] = 0;
@@ -25,12 +25,12 @@ fn load(reg ptr u128[4] a) -> reg u8 {
   reg u128 x128;
   reg u256 x256;
 
-  x8   = a[:u8   0];
-  x16  = a[:u16  0];
-  x32  = a[:u32  0];
-  x64  = a[:u64  0];
-  x128 = a[:u128 0];
-  x256 = a[:u256 0];
+  x8   = a[#unaligned:u8   0];
+  x16  = a[#unaligned:u16  0];
+  x32  = a[#unaligned:u32  0];
+  x64  = a[#unaligned:u64  0];
+  x128 = a[#unaligned:u128 0];
+  x256 = a[#unaligned:u256 0];
 
   x128 ^= x256;
   y64 = x128;

--- a/compiler/tests/warning/common/non-trivial-alignment.jazz
+++ b/compiler/tests/warning/common/non-trivial-alignment.jazz
@@ -1,0 +1,14 @@
+inline fn load(reg ptr u32[1] p) -> reg u32 {
+  reg u32 r = p[0];
+  return r;
+}
+
+export fn strict(reg ptr u8[4] p) -> reg u32 {
+  reg u32 r = load(p);
+  return r;
+}
+
+export fn weak(reg ptr u32[1] p) -> reg u32 {
+  reg u32 r = load(p);
+  return r;
+}

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -89,3 +89,14 @@
   warning: the variable g is already declared at "warning/common/bug_1347.jazz", line 2 (6-7)
   "warning/common/bug_1347.jazz", line 8 (20-21)
   warning: the variable C::x is already declared at "warning/common/bug_1347.jazz", line 7 (20-21)
+
+  $ ../jasminc warning/common/non-trivial-alignment.jazz
+  "warning/common/non-trivial-alignment.jazz", line 6 (31-32)
+  warning: argument p is used with 32-bit alignment
+
+  $ ../jasminc -only-trivial-alignment warning/common/non-trivial-alignment.jazz
+  "warning/common/non-trivial-alignment.jazz", line 6 (31-32)
+  warning: argument p is used with 32-bit alignment
+  "warning/common/non-trivial-alignment.jazz", line 11 (30-31)
+  warning: argument p is used with 32-bit alignment
+


### PR DESCRIPTION
The compiler infers the required alignment for function arguments. For export functions, the inferred alignment should not excess the declared type of said argument. When the inferred alignment excesses the bound, a warning is emitted.

The new command-line flag `-only-trivial-alignment` restrict the bound to `U8` (i.e., warns more often).

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed
