### PR TITLE
Simplify arch_sem syscall assumptions

### DIFF
--- a/proofs/arch/arch_sem.v
+++ b/proofs/arch/arch_sem.v
@@ -128,18 +128,21 @@ Definition preserved_registerb (r : asm_typed_reg) (m0 m1 : asmmem) :=
 (* FIXME we need to generalize this *)
 Class asm_syscall_sem := {
   eval_syscall : syscall_t -> asmmem -> exec asmmem;
-  eval_syscall_spec1 :
-    forall o s1 s2,
-      eval_syscall o s1 = ok s2 ->
-      let vargs := map (fun r => Vword (s1.(asm_reg) r)) (take (size (syscall_sig_s o).(scs_tin)) call_reg_args) in
-      let vres  := map (fun r => Vword (s2.(asm_reg) r)) (take (size (syscall_sig_s o).(scs_tout)) call_reg_ret) in
-      [/\ exec_syscall_s s1.(asm_scs) s1.(asm_mem) o vargs = ok (s2.(asm_scs), s2.(asm_mem), vres),
-          (forall r, r \in callee_saved -> preserved_register r s1 s2) &
-          s1.(asm_rip) = s2.(asm_rip)];
   eval_syscall_spec2 :
     forall o s1 vargs scs m vres,
       exec_syscall_s s1.(asm_scs) s1.(asm_mem) o vargs = ok (scs, m, vres) ->
-      exists s2, eval_syscall o s1 = ok s2;
+      exists2 s2, eval_syscall o s1 = ok s2
+                & [/\ s2.(asm_scs) = scs,
+                      s2.(asm_mem) = m &
+                      vres = [seq Vword (s2.(asm_reg) r)
+                             | r <- take (size (syscall_sig_s o).(scs_tout)) call_reg_ret]];
+  eval_syscall_preserves :
+    forall o s1 s2,
+      eval_syscall o s1 = ok s2 ->
+      [/\ forall r, r \in callee_saved -> preserved_register r s1 s2
+        , s1.(asm_rip) = s2.(asm_rip)
+        & stack_stable s1.(asm_mem) s2.(asm_mem)
+      ];
 }.
 
 Context {asm_scsem : asm_syscall_sem}.
@@ -581,8 +584,8 @@ Proof.
     by case: decode_label => // ? /eval_JMP_invariant <-.
   - by rewrite /eval_op /exec_instr_op; t_xrbindP => ? ? ? /mem_write_vals_invariant -> <-.
   - t_xrbindP => m hm <-.
-    have /= [h1 h2 h3]:= eval_syscall_spec1 hm; split => //.
-    by have [] := exec_syscallSs h1.
+    have /= [_ hrip hss] := eval_syscall_preserves hm.
+    by split.
   - by move=> [<-].
   by move=> _ [<-].
 Qed.

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -1604,19 +1604,12 @@ Proof.
   t_xrbindP=> ves hves [[scs m] vs] ho; t_xrbindP=> s hw ?; subst ls' => /=.
   rewrite ok_fd /=; split => //.
   case: (hloeq) ho => /= -> -> _ _ _ _ _ _ ho.
-  have [xs' hxs'] := (eval_syscall_spec2 ho).
+  have [xs' hxs' [hscs1 hmem1 hvres]] := eval_syscall_spec2 ho.
   rewrite hxs' /=.
   eexists; first reflexivity.
   exists (lfd_body fd) => //.
-  have [hex hpr hrip] := eval_syscall_spec1 hxs'.
-  move: hex; rewrite (exec_syscallPs_eq ho); last first.
-  - move: hves => {vs hw ho}.
-    elim: (take (size (syscall_sig_s sc).(scs_tin)) call_reg_args) ves
-        => [ | r rs ih] /= _vs.
-    + by move=> [<-].
-    t_xrbindP => v hv vs /ih ? <-; constructor => //.
-    by apply : getreg hloeq hv.
-  move=> [???]; subst scs m vs.
+  have [hpr hrip _] := eval_syscall_preserves hxs'.
+  move: hw; rewrite -hscs1 -hmem1 hvres => hw.
   split => //=; last by apply: asm_pos_incr ok_i hac heq hip.
   rewrite to_estate_of_estate.
   case: hloeq => /= hscs hmem hgetrip hdisjrip hreg hregx hxreg hflag.


### PR DESCRIPTION
# Description

The assembly parameter for the semantics of syscalls required conditions forward and backward, but we only need forward plus some well-formedness on the stack. I believe that this is strictly weaker than what we had before, but I'm not certain that it's the weakest we can go. This is the result of a discussion with @bgregoir 