### PR TITLE
riscv: emit neg instruction for #NEG intrinsic

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Benjamin Salling Hvass
 Benoît Viguier
 Clément Sartori
 Côme Le Breton
+Dominik Heinz
 Fabio Campos
 Francisca Barros
 François Dupressoir

--- a/changes/02-bugfix/1443-neg-instruction-riscv.md
+++ b/changes/02-bugfix/1443-neg-instruction-riscv.md
@@ -1,0 +1,1 @@
+- Emit neg instruction instead of not instruction when the #NEG intrinsic is used on RISCV. ([PR 1443](https://github.com/jasmin-lang/jasmin/pull/1443)).

--- a/proofs/compiler/riscv_instr_decl.v
+++ b/proofs/compiler/riscv_instr_decl.v
@@ -403,7 +403,7 @@ Definition riscv_NEG_instr : instr_desc_t :=
       id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
     |}.
 
-Definition prim_NEG := ("NEG"%string, primM NOT).
+Definition prim_NEG := ("NEG"%string, primM NEG).
 
 
 (* Loads *)


### PR DESCRIPTION
# Description

Previously, the compiler incorrectly emitted a `not` instruction instead of a `neg` instruction for the #NEG intrinsic.
The compiler should now correctly emit the `neg` instruction when the `#NEG` intrinsic is used under RISCV.
Fixes https://github.com/jasmin-lang/jasmin/issues/1442 

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [ ] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [ ] Update the documentation if needed
