### PR TITLE
CI: update nixpkgs (elpi 3.7.1 for coq-master)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ let inherit (lib) optionals; in
 
 let coqPackages =
   if coqMaster then
-    let elpi-version = "3.6.1"; in
+    let elpi-version = "3.7.1"; in
     let rocqPackages = pkgs.rocqPackages.overrideScope (self: super: {
       rocq-core = super.rocq-core.override { version = "master"; };
       rocq-elpi = super.rocq-elpi.override { version = "master"; inherit elpi-version; };

--- a/scripts/nixpkgs.nix
+++ b/scripts/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/c6f52ebd45e5925c188d1a20119978aa4ffd5ef6.tar.gz";
-  sha256 = "sha256:0gwxhs3j1nglyymbaqyqg8miz0rk84n4ijag5s4bx6yfb6vrd4lv";
+  url = "https://github.com/NixOS/nixpkgs/archive/e6682d5a3c6d6319af96b45cc5d11f88c377049f.tar.gz";
+  sha256 = "sha256:1rzfw4lw7zblva9nr2x1m0nv6az8as7nl9y96d6bjk60lnhrl4zy";
 })


### PR DESCRIPTION
The `coq-master` has been failing. This fixes it by updating `elpi` to version 3.7.1 (which is only available in recent `nixpkgs`).