### PR TITLE
Fix in varalloc: functions taking both arrays and booleans as arguments

### DIFF
--- a/changes/02-bugfix/1449-varalloc-boolean-arg.md
+++ b/changes/02-bugfix/1449-varalloc-boolean-arg.md
@@ -1,0 +1,2 @@
+- Do not crash on functions with a mix of arrays and booleans as arguments
+  ([PR 1449](https://github.com/jasmin-lang/jasmin/pull/1449)).

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -360,13 +360,13 @@ let alloc_local_stack size slots atbl =
 
 (* --------------------------------------------------- *)
 let get_returned_params ~funname (alias: Alias.alias) args =
+  let arg_slices = List.map (fun arg -> if is_ptr arg.v_kind then Some (Alias.normalize_var alias arg) else None) args in
   List.map (fun xr ->
       let x = L.unloc xr in
       if is_ptr x.v_kind then
         let c = Alias.normalize_var alias x in
-        let arg_slices = List.map (Alias.normalize_var alias) args in
-        match List.index_of c arg_slices with
-        | None ->
+        match fst (List.findi (fun _ slice -> Some c = slice) arg_slices) with
+        | exception Not_found ->
            let msg =
              if List.mem c.in_var args
              then "a strict sub-slice of a parameter"
@@ -377,7 +377,7 @@ let get_returned_params ~funname (alias: Alias.alias) args =
              (Printer.pp_var ~debug:false) x
              msg
              Alias.pp_slice c
-        | i -> i
+        | i -> Some i
       else None
     )
 

--- a/compiler/tests/success/subroutines/x86-64/array_boolarg.jazz
+++ b/compiler/tests/success/subroutines/x86-64/array_boolarg.jazz
@@ -1,0 +1,28 @@
+param int N = 8;
+
+fn zero(reg ptr u64[N] t, reg bool b) -> reg u64, reg ptr u64[N] {
+  inline int i;
+  reg u64 sum tmp;
+  for i = 0 to N {
+    t[i] = 0;
+    sum = i;
+    tmp = sum if b;
+    t[i] = tmp;
+  }
+  sum = 0;
+  for i = 0 to N {
+    sum += t[i];
+  }
+  return sum, t;
+}
+
+export
+fn main(reg u64 x) -> reg u64 {
+  reg u64 result;
+  reg bool b;
+  _, _, _, _, b = #TEST(x, x);
+
+  stack u64[N] s;
+  result, s = zero(s, b);
+  return result;
+}


### PR DESCRIPTION
The compiler used to crash on such functions.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix