### PR TITLE
CT checker: run after lowering for DOIT

### DIFF
--- a/changes/02-bugfix/1450-ct-doit-after-lowering.md
+++ b/changes/02-bugfix/1450-ct-doit-after-lowering.md
@@ -1,0 +1,3 @@
+- The constant-time checker for DOIT runs after the lowering pass; previous
+  behavior can be restored using the `--after=propagate` command line flag
+  ([PR 1450](https://github.com/jasmin-lang/jasmin/pull/1450)).

--- a/compiler/CCT/success/doit/bug_1450.jazz
+++ b/compiler/CCT/success/doit/bug_1450.jazz
@@ -1,0 +1,8 @@
+#[ct = "a × b → public"]
+export fn main(reg u32 x y) -> reg u8 {
+  reg u8 r = 0;
+  reg bool b = x <s y;
+  #declassify(b);
+  if b { r = 1; }
+  return r;
+}

--- a/compiler/entry/jasmin_ct.ml
+++ b/compiler/entry/jasmin_ct.ml
@@ -69,8 +69,8 @@ let parse_and_check arch call_conv idirs =
       nowarning ();
       add_warning Deprecated ());
     let compile =
-      if doit && compile < Compiler.PropagateInline then
-        Compiler.PropagateInline
+      if doit && compile < Compiler.LowerInstruction then
+        Compiler.LowerInstruction
       else compile
     in
     match check ~doit infer ct_list speculative compile file print with

--- a/docs/source/tools/ct.md
+++ b/docs/source/tools/ct.md
@@ -264,8 +264,8 @@ are indeed public.
 
 In order to know what assembly instructions are emitted by the compiler, the
 checker has to run after instruction selection. More specifically, using the
-`--doit` mode makes verification occur after the [“Propagate
-Inline”](../compiler/passes/propagate_inline) compilation pass (or any further
+`--doit` mode makes verification occur after the [“Instruction
+selection”](../compiler/passes/inst_select) compilation pass (or any further
 pass specified by the `--after` argument).
 
 For instance, the following program is accepted by the type-checker, but rejected in “doit” mode,


### PR DESCRIPTION
# Description

Declassification of boolean variables does not work well after the “propagate inline” pass, which can cause trouble when checking DOIT.

This PR allows running the CT-checker in DOIT mode *before* that pass (or after, at the user’s convenience).

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed