### PR TITLE
Move `spill_to_mmx` to `cparams` instead of `IDENT`

### DIFF
--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -56,9 +56,14 @@ let warn_extra_fd pd msfsize asmOp (_, fd) = List.iter (warn_extra_i pd msfsize 
 
 (* -------------------------------------------------------------------- *)
 
+let spill_to_mmx v =
+  Annot.ensure_uniq1 "spill_to_mmx" Annot.none (v.Var0.Var.vname).v_annot
+  |> Option.is_some
+
+
 let do_spill_unspill asmop ?(debug = false) cp =
   let p = Conv.cuprog_of_prog cp in
-  match Lower_spill.spill_uprog asmop Compiler.default_LoopCounter Conv.fresh_var_ident p with
+  match Lower_spill.spill_uprog asmop Compiler.default_LoopCounter Conv.fresh_var_ident spill_to_mmx p with
   | Utils0.Error msg -> Error (Conv.error_of_cerror (Printer.pp_err ~debug) msg)
   | Utils0.Ok p -> Ok (Conv.prog_of_cuprog p)
 
@@ -418,6 +423,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.warning;
       Compiler.lowering_opt = Arch.lowering_opt;
       Compiler.fresh_var_ident = Conv.fresh_var_ident;
+      Compiler.spill_to_mmx;
       Compiler.slh_info;
       Compiler.stack_zero_info = szs_of_fn;
       Compiler.dead_vars_ufd;

--- a/compiler/src/coreIdent.ml
+++ b/compiler/src/coreIdent.ml
@@ -109,11 +109,6 @@ module Cident = struct
   let id_name (x: t) : Name.t = x.v_name
   let id_kind (x: t) : v_kind = x.v_kind
 
-  let spill_to_mmx (x:t) =
-    match Annot.ensure_uniq1 "spill_to_mmx" Annot.none x.v_annot with
-    | Some () -> true
-    | None    -> false
-
 end
 
 (* ------------------------------------------------------------------------ *)

--- a/compiler/src/coreIdent.mli
+++ b/compiler/src/coreIdent.mli
@@ -113,8 +113,6 @@ module Cident : sig
   val tag : var -> Uint63.t
   val id_name : t -> Name.t
   val id_kind : t -> v_kind
-
-  val spill_to_mmx : t -> bool
 end
 
 (* -------------------------------------------------------------------- *)

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -197,6 +197,7 @@ Record compiler_params
   lowering_opt     : lowering_options;
   insert_renaming  : fun_info -> bool;
   fresh_var_ident  : v_kind -> instr_info -> int -> string -> atype -> Ident.ident;
+  spill_to_mmx     : var -> bool;
   slh_info         : _uprog → funname → seq slh_t * seq slh_t;
   stack_zero_info  : funname -> option (stack_zero_strategy * option wsize);
   dead_vars_ufd    : _ufun_decl -> instr_info -> Sv.t;
@@ -284,6 +285,7 @@ Definition compiler_first_part (to_keep: seq funname) (p: uprog) : cexec uprog :
   Let p :=
     spill_prog
       (fresh_var_ident cparams)
+      (spill_to_mmx cparams)
       p in
   let p := cparams.(print_uprog) LowerSpill p in
 

--- a/proofs/compiler/lower_spill.v
+++ b/proofs/compiler/lower_spill.v
@@ -28,6 +28,7 @@ Section ASM_OP.
 Context `{asmop : asmOp}.
 Context {LC : LoopCounter}.
 Context (fresh_var_ident: v_kind -> instr_info -> int -> string -> atype -> Ident.ident).
+Context (spill_to_mmx : var -> bool).
 
 Definition to_spill_e s e :=
   match e with
@@ -188,8 +189,8 @@ Definition init_map fi (s:Sv.t) :=
     let n := vname x in
     let k :=
       match Ident.id_kind n with
-      | Reg (_, r) => 
-          if Ident.spill_to_mmx n then Reg(Extra, r)
+      | Reg (_, r) =>
+          if spill_to_mmx x then Reg(Extra, r)
           else Stack r
       | _ => Stack Direct (* This is a dummy value, pretyping ensure this never appen *)
       end in

--- a/proofs/compiler/lower_spill_proof.v
+++ b/proofs/compiler/lower_spill_proof.v
@@ -21,8 +21,9 @@ Context
   {pT  : progT}
   {sCP : semCallParams}
   (fresh_var_ident : v_kind -> instr_info -> int -> string -> atype -> Ident.ident)
+  (spill_to_mmx : var -> bool)
   (p p' : prog) (ev : extra_val_t)
-  (spill_prog_ok : spill_prog fresh_var_ident p = ok p').
+  (spill_prog_ok : spill_prog fresh_var_ident spill_to_mmx p = ok p').
 
 Notation gd := (p_globs p).
 
@@ -325,7 +326,7 @@ Proof.
 Qed.
 
 Lemma init_map_ty fi toS x sx :
-  let: (m, _) := init_map fresh_var_ident fi toS in
+  let: (m, _) := init_map fresh_var_ident spill_to_mmx fi toS in
   Mvar.get m x = Some sx -> vtype x = vtype sx.
 Proof.
   have : Mvar.get (Mvar.empty var) x = Some sx -> vtype x = vtype sx by done.
@@ -391,7 +392,7 @@ Proof.
 Qed.
 
 Lemma lower_get_spillP fi toS X m count :
-  init_map fresh_var_ident fi toS = (m, count) ->
+  init_map fresh_var_ident spill_to_mmx fi toS = (m, count) ->
   let get_spill := lower_spill.get_spill m in
   (check_map m X).1 ->
   ∀ (ii : instr_info) (x sx : var), get_spill ii x = ok sx → vtype x = vtype sx ∧ ¬ Sv.In sx X.
@@ -408,7 +409,7 @@ Lemma lower_get_spill_ii m :
 Proof. by rewrite /lower_spill.get_spill => ii x sx hx ii'; case: Mvar.get hx. Qed.
 
 Lemma lower_get_spill_inj fi toS X m count :
-  init_map fresh_var_ident fi toS = (m, count) ->
+  init_map fresh_var_ident spill_to_mmx fi toS = (m, count) ->
   let get_spill := lower_spill.get_spill m in
   (check_map m X).1 ->
   ∀ (ii ii' : instr_info) (x x' sx : var), get_spill ii x = ok sx → get_spill ii' x' = ok sx → x = x'.
@@ -629,7 +630,7 @@ Local Lemma Hproc : sem_Ind_proc p ev Pc Pfun.
 Proof.
   move=> scs1 m1 scs2 m2 fn f vargs vargs' s0 s1 s2 vres vres' hfun htra hinit hw hsc hc hres hfull ??.
   rewrite /Pfun; subst scs2 m2.
-  have spillok : map_cfprog_name (spill_fd fresh_var_ident) (p_funcs p) = ok (p_funcs p').
+  have spillok : map_cfprog_name (spill_fd fresh_var_ident spill_to_mmx) (p_funcs p) = ok (p_funcs p').
   + by move: spill_prog_ok; rewrite /spill_prog; t_xrbindP => ? ? <-.
   have [f' hf'1 hf'2] := get_map_cfprog_name_gen spillok hfun.
   case: f hfun htra hinit hw hsc hc hres hfull hf'1 hf'2 =>
@@ -723,7 +724,7 @@ Lemma it_lower_spill_fdP fn :
   wiequiv_f p p' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
 Proof.
   apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
-  have spillok : map_cfprog_name (spill_fd fresh_var_ident) (p_funcs p) = ok (p_funcs p').
+  have spillok : map_cfprog_name (spill_fd fresh_var_ident spill_to_mmx) (p_funcs p) = ok (p_funcs p').
   + by move: spill_prog_ok; rewrite /spill_prog; t_xrbindP => ? ? <-.
   have [fd' hfd'1 hfd'2] := get_map_cfprog_name_gen spillok hget.
   exists fd' => // {hget hfd'2}.

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -52,8 +52,6 @@ Extract Constant ident.Cident.tag     => "CoreIdent.Cident.tag".
 Extract Constant ident.Cident.id_name => "CoreIdent.Cident.id_name".
 Extract Constant ident.Cident.id_kind => "CoreIdent.Cident.id_kind".
 
-Extract Constant ident.Cident.spill_to_mmx => "CoreIdent.Cident.spill_to_mmx".
-
 Set Extraction Output Directory "lang/ocaml".
 
 Extraction Blacklist String List Nat Uint63 Utils Var Array.

--- a/proofs/lang/ident.v
+++ b/proofs/lang/ident.v
@@ -12,8 +12,6 @@ Module Type CORE_IDENT.
   Parameter id_name : t -> string.
   Parameter id_kind : t -> wsize.v_kind.
 
-  Parameter spill_to_mmx : t -> bool.
-
 End CORE_IDENT.
 
 (* An implementation of CORE_IDENT.
@@ -29,7 +27,6 @@ Module Cident : CORE_IDENT.
   Definition id_name (_: t) : string := "".
   Definition id_kind (_: t) := wsize.Const.
 
-  Definition spill_to_mmx (x : t) := false.
 End Cident.
 
 Module Tident <: TAGGED with Definition t := Cident.t
@@ -55,5 +52,4 @@ Module Ident <: IDENT.
 
   Module Mid := Tident.Mt.
 
-  Definition spill_to_mmx : ident -> bool := Cident.spill_to_mmx.
 End Ident.


### PR DESCRIPTION
# Description

This PR moves the `spill_to_mmx` projection of `IDENT` to a compiler parameter in `cparams`. I think we want to keep `IDENT` as small as possible because of the extraction trick.