### PR TITLE
Better error message for invalid load/store alignment in asmgen

### DIFF
--- a/compiler/tests/fail/x86-64/invalid_load_align.jazz
+++ b/compiler/tests/fail/x86-64/invalid_load_align.jazz
@@ -1,0 +1,4 @@
+export fn load_vmovdqa(reg u64 p) -> reg u128 {
+  reg u128 v = #VMOVDQA_128([:u128 p]);
+  return v;
+}

--- a/compiler/tests/fail/x86-64/invalid_store_align.jazz
+++ b/compiler/tests/fail/x86-64/invalid_store_align.jazz
@@ -1,0 +1,3 @@
+export fn store_vmovdqa(reg u64 p, reg u128 v) {
+  [:u128 p] = #VMOVDQA_128(v);
+}

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1469,6 +1469,20 @@ fail/x86-64/bug_1366.jazz:
 
 "fail/x86-64/bug_1366.jazz", line 2 (2-21): invalid number of lvalues, 1 provided instead of 2
 
+fail/x86-64/invalid_load_align.jazz:
+
+"fail/x86-64/invalid_load_align.jazz", line 2 (2-39):
+compilation error in function load_vmovdqa:
+asmgen: invalid rexpr for oprd [:u128 RDI]
+        invalid Load alignment constraint
+
+fail/x86-64/invalid_store_align.jazz:
+
+"fail/x86-64/invalid_store_align.jazz", line 2 (2-30):
+compilation error in function store_vmovdqa:
+asmgen: invalid rexpr for oprd [:u128 RDI]
+        invalid Store alignment constraint
+
 fail/x86-64/mmx_conflicts.jazz:
 
 compilation error:
@@ -1568,4 +1582,4 @@ Statistics:
 	Pretyping:  51
 	Parsing:     4
 	Typing:      1
-	Compile:   193
+	Compile:   195

--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -256,14 +256,13 @@ Definition assemble_word_load (is_input: bool) rip ii al (sz: wsize) (e: rexpr) 
   | Rexpr (Fvar x) =>
     xreg_of_var ii x
   | Load al' sz' e' =>
+    let op := (if is_input then "Load" else "Store")%string in
     Let _ := assert (sz == sz')
-                    (E.werror ii e "invalid Load size") in
-    let msg :=
-      ("invalid "
-      ++ (if is_input then "Load" else "Store")
-      ++ " alignment constraint")%string
+                    (E.werror ii e ("invalid " ++ op ++ " size")) in
+    Let _ := assert
+               (aligned_le al al')
+               (E.werror ii e ("invalid " ++ op ++ " alignment constraint"))
     in
-    Let _ := assert (aligned_le al al') (E.werror ii e msg) in
     Let w := addr_of_fexpr rip ii Uptr e' in
     ok (Addr w)
   | _ => Error (E.werror ii e "invalid rexpr for word")
@@ -281,7 +280,16 @@ Definition assemble_word (is_input: bool) (k:addr_kind) rip ii (sz:wsize) (e: re
 Definition arg_of_rexpr (is_input: bool) k rip ii (ty: ltype) (e: rexpr) :=
   match ty with
   | lbool =>
-      Let e := if e is Rexpr f then ok f else Error (E.werror ii e "not able to assemble a load expression of type bool") in
+      Let e :=
+        if e is Rexpr f then ok f
+        else
+          let msg :=
+            ("not able to assemble a "
+            ++ (if is_input then "load" else "store")
+            ++ " expression of type bool")%string
+          in
+          Error (E.werror ii e msg)
+      in
       Let c := assemble_cond ii e in ok (Condt c)
   | lword sz => assemble_word is_input k rip ii sz e
   end.

--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -243,7 +243,7 @@ Definition xreg_of_var ii (x: var_i) : cexec asm_arg :=
   else if to_regx x is Some r then ok (Regx r)
   else Error (E.verror false "Not a (x)register" ii x).
 
-Definition assemble_word_load rip ii al (sz: wsize) (e: rexpr) :=
+Definition assemble_word_load (is_input: bool) rip ii al (sz: wsize) (e: rexpr) :=
   match e with
   | Rexpr (Fapp1 (Oword_of_int sz') (Fconst z)) =>
     let w := wrepr sz' z in
@@ -258,28 +258,32 @@ Definition assemble_word_load rip ii al (sz: wsize) (e: rexpr) :=
   | Load al' sz' e' =>
     Let _ := assert (sz == sz')
                     (E.werror ii e "invalid Load size") in
-    Let _ := assert (aligned_le al al')
-                    (E.werror ii e "invalid Load alignment constraint") in
+    let msg :=
+      ("invalid "
+      ++ (if is_input then "Load" else "Store")
+      ++ " alignment constraint")%string
+    in
+    Let _ := assert (aligned_le al al') (E.werror ii e msg) in
     Let w := addr_of_fexpr rip ii Uptr e' in
     ok (Addr w)
   | _ => Error (E.werror ii e "invalid rexpr for word")
   end.
 
-Definition assemble_word (k:addr_kind) rip ii (sz:wsize) (e: rexpr) :=
+Definition assemble_word (is_input: bool) (k:addr_kind) rip ii (sz:wsize) (e: rexpr) :=
   match k with
-  | AK_mem al => assemble_word_load rip ii al sz e
+  | AK_mem al => assemble_word_load is_input rip ii al sz e
   | AK_compute =>
     Let f := if e is Rexpr f then ok f else Error (E.werror ii e "invalid rexpr for LEA") in
     Let w := addr_of_fexpr rip ii sz f in
     ok (Addr w)
   end.
 
-Definition arg_of_rexpr k rip ii (ty: ltype) (e: rexpr) :=
+Definition arg_of_rexpr (is_input: bool) k rip ii (ty: ltype) (e: rexpr) :=
   match ty with
   | lbool =>
       Let e := if e is Rexpr f then ok f else Error (E.werror ii e "not able to assemble a load expression of type bool") in
       Let c := assemble_cond ii e in ok (Condt c)
-  | lword sz => assemble_word k rip ii sz e
+  | lword sz => assemble_word is_input k rip ii sz e
   end.
 
 Definition rexpr_of_lexpr (lv: lexpr) : rexpr :=
@@ -306,7 +310,7 @@ Definition is_implicit (i: implicit_arg) (e: rexpr) : bool :=
   end.
 *)
 
-Definition compile_arg rip ii (ade: (arg_desc * ltype) * rexpr) (m: nmap asm_arg) : cexec (nmap asm_arg) :=
+Definition compile_arg (is_input: bool) rip ii (ade: (arg_desc * ltype) * rexpr) (m: nmap asm_arg) : cexec (nmap asm_arg) :=
   let ad := ade.1 in
   let e := ade.2 in
   match ad.1 with
@@ -316,7 +320,7 @@ Definition compile_arg rip ii (ade: (arg_desc * ltype) * rexpr) (m: nmap asm_arg
              (E.internal_error ii "(compile_arg) bad implicit register") in
     ok m
   | ADExplicit k n o =>
-    Let a := arg_of_rexpr k rip ii ad.2 e in
+    Let a := arg_of_rexpr is_input k rip ii ad.2 e in
     Let _ :=
       assert (check_oreg o a)
              (E.internal_error ii "(compile_arg) bad forced register") in
@@ -328,8 +332,14 @@ Definition compile_arg rip ii (ade: (arg_desc * ltype) * rexpr) (m: nmap asm_arg
     end
   end.
 
-Definition compile_args rip ii adts (es: rexprs) (m: nmap asm_arg) :=
-  foldM (compile_arg rip ii) m (zip adts es).
+Definition compile_args (is_input: bool) rip ii adts (es: rexprs) (m: nmap asm_arg) :=
+  foldM (compile_arg is_input rip ii) m (zip adts es).
+
+Definition compile_in_args rip ii adts es m :=
+  compile_args true rip ii adts es m.
+
+Definition compile_out_args rip ii adts lx m :=
+  compile_args false rip ii adts [seq rexpr_of_lexpr l | l <- lx] m.
 
 Definition compat_imm ty a' a :=
   (a == a') || match ty, a, a' with
@@ -343,7 +353,7 @@ Definition check_sopn_arg rip ii (loargs : seq asm_arg) (x : rexpr) (adt : arg_d
   | ADExplicit k n o =>
     match onth loargs n with
     | Some a =>
-      if arg_of_rexpr k rip ii adt.2 x is Ok a' then compat_imm adt.2 a a' && check_oreg o a
+      if arg_of_rexpr true k rip ii adt.2 x is Ok a' then compat_imm adt.2 a a' && check_oreg o a
       else false
     | None => false
     end
@@ -356,7 +366,7 @@ Definition check_sopn_dest rip ii (loargs : seq asm_arg) (x : rexpr) (adt : arg_
     match onth loargs n with
     | Some a =>
       if k is AK_mem al then
-      if arg_of_rexpr (AK_mem al) rip ii adt.2 x is Ok a' then (a == a') && check_oreg o a
+      if arg_of_rexpr false (AK_mem al) rip ii adt.2 x is Ok a' then (a == a') && check_oreg o a
       else false
       else false
     | None => false
@@ -365,9 +375,8 @@ Definition check_sopn_dest rip ii (loargs : seq asm_arg) (x : rexpr) (adt : arg_
 
 Definition assemble_asm_op_aux rip ii op (outx : lexprs) (inx : rexprs) :=
   let id := instr_desc op in
-  Let m := compile_args rip ii (zip id.(id_in) id.(id_tin)) inx (nempty _) in
-  let eoutx := map rexpr_of_lexpr outx in
-  Let m := compile_args rip ii (zip id.(id_out) id.(id_tout)) eoutx m in
+  Let m := compile_in_args rip ii (zip id.(id_in) id.(id_tin)) inx (nempty _) in
+  Let m := compile_out_args rip ii (zip id.(id_out) id.(id_tout)) outx m in
   match oseq.omap (nget m) (iota 0 id.(id_nargs)) with
   | None => Error (E.internal_error ii "compile_arg : assert false nget")
   | Some asm_args => ok asm_args
@@ -543,7 +552,7 @@ Definition assemble_declassify rip ii d es :=
       | Some lty => ok lty
       | None => Error (E.internal_error ii "declassify array")
       end in
-    Let a := arg_of_rexpr (AK_mem Unaligned) rip ii lty e in
+    Let a := arg_of_rexpr true (AK_mem Unaligned) rip ii lty e in
     ok (Declassify_val lty a)
 
   | Odeclassify_mem len, [:: Rexpr e] =>
@@ -580,7 +589,7 @@ Definition assemble_i (rip : var) (i : linstr) : cexec (seq asm_i) :=
 
   | Ligoto e =>
       Let _ := assert (is_not_app1 e) (E.werror ii e "Ligoto/JMPI") in
-      Let arg := assemble_word (AK_mem Aligned) rip ii Uptr e in
+      Let arg := assemble_word true (AK_mem Aligned) rip ii Uptr e in
       ok [:: mk (JMPI arg) ]
 
   | LstoreLabel x lbl =>

--- a/proofs/arch/asm_gen_proof.v
+++ b/proofs/arch/asm_gen_proof.v
@@ -300,9 +300,9 @@ Variant check_sopn_argI rip ii args e : arg_desc -> ltype -> Prop :=
        is_implicit i e
     -> check_sopn_argI (ADImplicit i) ty
 
-| CSA_Explicit k n o a a' ty :
+| CSA_Explicit is_input k n o a a' ty :
        onth args n = Some a
-    -> arg_of_rexpr agparams k rip ii ty e = ok a'
+    -> arg_of_rexpr agparams is_input k rip ii ty e = ok a'
     -> compat_imm ty a a'
     -> check_oreg o a
     -> check_sopn_argI (ADExplicit k n o) ty.
@@ -314,7 +314,7 @@ Proof.
 case: sp => -[i|k n o] ty; first by apply: CSA_Implicit.
 rewrite /check_sopn_arg /=; case Enth: onth => [a|] //.
 case E: arg_of_rexpr => [a'|] // /andP[??].
-by apply: (CSA_Explicit (a := a) (a' := a')).
+by apply: (CSA_Explicit (is_input := true) (a := a) (a' := a')).
 Qed.
 
 Lemma var_of_flagP rip m s f v ty vt:
@@ -391,7 +391,7 @@ Proof.
   + move=> i {}ty /is_implicitP[] vi -> vt /=.
     case: i => /= [f | r]; first by apply: var_of_flagP eqm.
     by apply: var_of_regP eqm.
-  move=> k n o a a' [ | ws] //= ->.
+  move=> is_input k n o a a' [ | ws] //= ->.
   + case: e; first by [].
     t_xrbindP => e _ <- c hac <-.
     rewrite /compat_imm orbF => /eqP <- -> /= b hb.
@@ -1278,10 +1278,10 @@ Qed.
 (* -------------------------------------------------------------------- *)
 (* Assembling machine words. *)
 
-Lemma eval_assemble_word ii al sz e a s xs v :
+Lemma eval_assemble_word is_input ii al sz e a s xs v :
   lom_eqv rip s xs
   -> is_not_app1 e
-  -> assemble_word_load agparams rip ii al sz e = ok a
+  -> assemble_word_load agparams is_input rip ii al sz e = ok a
   -> sem_rexpr s.(emem) s.(evm) e = ok v
   -> exists2 v',
        eval_asm_arg (AK_mem al) xs a (lword sz) = ok v'


### PR DESCRIPTION
# Description

Asmgen uses the same function to compile inputs and outputs, but the error messages are written from the input perspective, which caused me a big headache when debugging. The last commit applies this change to some other errors, but I believe they are unreachable, so I don't know if we should merge those.

# Checklist

- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix