### PR TITLE
Move spill_to_mmx to Prog

### DIFF
--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -55,11 +55,7 @@ let rec warn_extra_i pd msfsize asmOp i =
 let warn_extra_fd pd msfsize asmOp (_, fd) = List.iter (warn_extra_i pd msfsize asmOp) fd.f_body
 
 (* -------------------------------------------------------------------- *)
-
-let spill_to_mmx v =
-  Annot.ensure_uniq1 "spill_to_mmx" Annot.none (v.Var0.Var.vname).v_annot
-  |> Option.is_some
-
+let spill_to_mmx x = spill_to_mmx x.Var0.Var.vname
 
 let do_spill_unspill asmop ?(debug = false) cp =
   let p = Conv.cuprog_of_prog cp in

--- a/compiler/src/prog.ml
+++ b/compiler/src/prog.ml
@@ -83,6 +83,10 @@ let is_regx x =
   | Reg (Extra, _) -> true
   | _ -> false
 
+let spill_to_mmx v =
+  Annot.ensure_uniq1 "spill_to_mmx" Annot.none v.v_annot
+  |> Option.is_some
+
 (* ------------------------------------------------------------------------ *)
 
 type 'len glval =

--- a/compiler/src/prog.mli
+++ b/compiler/src/prog.mli
@@ -47,6 +47,7 @@ val is_stk_ptr_kind : v_kind -> bool
 
 val is_reg_direct_kind : v_kind -> bool
 
+val spill_to_mmx : var -> bool
 
 (* ------------------------------------------------------------------------ *)
 


### PR DESCRIPTION
and make it more general (applies to OCaml `var` instead of Coq `var`).

This makes it easier to reuse this function in other (OCaml) parts of the compiler.