### PR TITLE
CI: do not download an extra copy of nixpkgs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,6 @@ stages:
 image: nixos/nix:2.24.15
 
 variables:
-  NIX_PATH: nixpkgs=channel:nixpkgs-unstable
-
   EXTRA_SUBSTITUTERS: https://jasmin.cachix.org
   EXTRA_PUBLIC_KEYS: jasmin.cachix.org-1:aA5r1ovq4HYKUa+8QHVvIP7K6Fi9L75b0SaN/sooWSY=
   NIXOS_PUBLIC_KEY: cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
@@ -77,7 +75,7 @@ coq-master:
   rules:
     - if: $CI_COMMIT_BRANCH !~ /^release-/
   variables:
-    EXTRA_NIX_ARGUMENTS: --arg pinned-nixpkgs false --arg coqDeps true --arg coqMaster true
+    EXTRA_NIX_ARGUMENTS: --arg coqDeps true --arg coqMaster true
   extends: .common
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C proofs'


### PR DESCRIPTION
This might save some bandwidth.