### PR TITLE
Update the x86 DOIT instruction list

### DIFF
--- a/changes/01-feature/1458-doit-update.md
+++ b/changes/01-feature/1458-doit-update.md
@@ -1,5 +1,5 @@
 - More instructions are considered “DOIT” on `x86_64`: byte swap (`BSWAP`),
-  sign-extend (`CDQ`, `CQO`), rotations (`ROL`, `RORX`, `ROR`), shifts (`SHLD`,
+  sign-extend (`CQO`), rotations (`ROL`, `RORX`, `ROR`), shifts (`SHLD`,
   `SHRD`)
   ([PR 1458](https://github.com/jasmin-lang/jasmin/pull/1458);
   fixes [#1422](https://github.com/jasmin-lang/jasmin/issues/1422)).

--- a/changes/01-feature/1458-doit-update.md
+++ b/changes/01-feature/1458-doit-update.md
@@ -1,0 +1,5 @@
+- More instructions are considered “DOIT” on `x86_64`: byte swap (`BSWAP`),
+  sign-extend (`CDQ`, `CQO`), rotations (`ROL`, `RORX`, `ROR`), shifts (`SHLD`,
+  `SHRD`)
+  ([PR 1458](https://github.com/jasmin-lang/jasmin/pull/1458);
+  fixes [#1422](https://github.com/jasmin-lang/jasmin/issues/1422)).

--- a/compiler/CCT/fail/doit/x86_64/cqo.jazz
+++ b/compiler/CCT/fail/doit/x86_64/cqo.jazz
@@ -1,0 +1,6 @@
+/* CDQ/CWD are not explicitly listed as DOIT */
+#[ct = "secret → secret"]
+export fn sign_extend(reg u32 a) -> reg u32 {
+    reg u32 d = #CQO_32(a);
+    return d;
+}

--- a/compiler/CCT/fail/doit/x86_64/lzcnt.jazz
+++ b/compiler/CCT/fail/doit/x86_64/lzcnt.jazz
@@ -1,0 +1,7 @@
+#[ct="secret → secret"]
+export
+fn lzcnt (reg u64 x) -> reg u64 {
+   ?{}, x = #LZCNT(x);
+   return x;
+}
+

--- a/compiler/CCT/fail/doit/x86_64/rol.jazz
+++ b/compiler/CCT/fail/doit/x86_64/rol.jazz
@@ -1,7 +1,7 @@
-// This is CT in the ordinary sense, but not DOIT as ROL is not DOIT.
+// This is CT in the ordinary sense, but not DOIT as RCL is not DOIT.
 #[ct="secret -> secret"]
 export fn rol(reg u32 x) -> reg u32 {
-  x <<r = 5;
-  x = x;
+  reg bool cf = #STC();
+  ?{}, x = #RCL_32(x, 5, cf);
   return x;
 }

--- a/compiler/CCT/success/doit/cqo.jazz
+++ b/compiler/CCT/success/doit/cqo.jazz
@@ -1,0 +1,5 @@
+#[ct = "secret → secret"]
+export fn sign_extend(reg u64 a) -> reg u64 {
+    reg u64 d = #CQO_64(a);
+    return d;
+}

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -74,7 +74,8 @@ module X86_core = struct
     | CLFLUSH -> false (* Not DOIT *)
     | CMOVcc _ -> true
     | CMP _ -> true
-    | CQO _ -> true
+    | CQO U64 -> true
+    | CQO _ -> false (* Not DOIT *)
     | DEC _ -> true
     | DIV _ -> false (* Not DOIT *)
     | IDIV _ -> false (* Not DOIT *)

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -66,7 +66,7 @@ module X86_core = struct
     | BLENDV (VE8, _) -> true
     | BLENDV _ -> false (* Not DOIT *)
     | BSR _ -> false (* Not DOIT *)
-    | BSWAP _ -> false (* Not DOIT *)
+    | BSWAP _ -> true
     | BT _ -> true
     | BTR _ -> true
     | BTS _ -> true
@@ -74,7 +74,7 @@ module X86_core = struct
     | CLFLUSH -> false (* Not DOIT *)
     | CMOVcc _ -> true
     | CMP _ -> true
-    | CQO _ -> false (* Not DOIT *)
+    | CQO _ -> true
     | DEC _ -> true
     | DIV _ -> false (* Not DOIT *)
     | IDIV _ -> false (* Not DOIT *)
@@ -113,9 +113,9 @@ module X86_core = struct
     | RCR _ -> false (* Not DOIT *)
     | RDTSC _ -> false (* Not DOIT *)
     | RDTSCP _ -> false (* Not DOIT *)
-    | ROL _ -> false (* Not DOIT *)
-    | RORX _ -> false (* Not DOIT *)
-    | ROR _ -> false (* Not DOIT *)
+    | ROL _ -> true
+    | RORX _ -> true
+    | ROR _ -> true
     | SAL _ -> false (* Not DOIT *)
     | SAR _ -> true
     | SARX _ -> false (* Not DOIT *)
@@ -126,10 +126,10 @@ module X86_core = struct
     | SHA256MSG2 -> true
     | SHA256RNDS2 -> true
     | SHL _ -> true
-    | SHLD _ -> false (* Not DOIT *)
+    | SHLD _ -> true
     | SHLX _ -> true
     | SHR _ -> true
-    | SHRD _ -> false (* Not DOIT *)
+    | SHRD _ -> true
     | SHRX _ -> true
     | STC -> false (* Not DOIT *)
     | SUB _ -> true

--- a/docs/source/tools/ct.md
+++ b/docs/source/tools/ct.md
@@ -268,16 +268,16 @@ checker has to run after instruction selection. More specifically, using the
 selection”](../compiler/passes/inst_select) compilation pass (or any further
 pass specified by the `--after` argument).
 
-For instance, the following program is accepted by the type-checker, but rejected in “doit” mode,
-as the rotation instructions (on x86_64) are not listed as DOIT.
+For instance, the following program is accepted by the type-checker, but
+rejected in “doit” mode, as the “Count the Number of Leading Zero Bits”
+instructions (on `x86_64`) are not listed as DOIT.
 
 ~~~
 #[ct="secret → secret"]
 export
-fn rotate(reg u32 x) -> reg u32 {
-  x = x;
-  x >>r= 1;
-  return x;
+fn lzcnt (reg u64 x) -> reg u64 {
+   ?{}, x = #LZCNT(x);
+   return x;
 }
 ~~~
 


### PR DESCRIPTION
# Description

Update the list of DOIT instructions for x86 according to #1422 and change the insecure example from the documentation (as rotations are now DOIT).

Fixes #1422.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed

