### PR TITLE
Safety checker: share some common code

### DIFF
--- a/compiler/safetylib/safetyMain.ml
+++ b/compiler/safetylib/safetyMain.ml
@@ -1,5 +1,6 @@
 open Jasmin
 open Prog
+open Utils
 
 module Make (Arch : SafetyArch.SafetyArch) : sig
   val analyze :
@@ -10,10 +11,10 @@ module Make (Arch : SafetyArch.SafetyArch) : sig
     (unit, Arch.extended_op) prog ->
     bool
 end = struct
-
   let analyze ?fmt ~safety_param source_f_decl f_decl p =
     let module PW = struct
       type extended_op = Arch.extended_op
+
       let main_source = source_f_decl
       let main = f_decl
       let prog = p
@@ -22,3 +23,44 @@ end = struct
     AbsInt.analyze ?fmt ~safety_param ()
 end
 
+module type ArchWithAnalyze = sig
+  module A : Arch_full.Arch
+
+  val analyze :
+    ?fmt:Format.formatter ->
+    safety_param:string option ->
+    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) func ->
+    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) func ->
+    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) prog ->
+    bool
+end
+
+let get_arch_with_analyze arch call_conv : (module ArchWithAnalyze) =
+  match arch with
+  | X86_64 ->
+      (module struct
+        module C =
+          (val CoreArchFactory.core_arch_x86 ~use_lea:!Glob_options.lea
+                 ~use_set0:!Glob_options.set0 call_conv)
+
+        module A = Arch_full.Arch_from_Core_arch (C)
+        module Safety = Make (X86_safety.X86_safety (A))
+
+        let analyze = Safety.analyze
+      end)
+  | ARM_M4 ->
+      (module struct
+        module C = CoreArchFactory.Core_arch_ARM
+        module A = Arch_full.Arch_from_Core_arch (C)
+        module Safety = Make (Arm_safety.Arm_safety (A))
+
+        let analyze = Safety.analyze
+      end)
+  | RISCV ->
+      (module struct
+        module C = CoreArchFactory.Core_arch_RISCV
+        module A = Arch_full.Arch_from_Core_arch (C)
+        module Safety = Make (Riscv_safety.Riscv_safety (A))
+
+        let analyze = Safety.analyze
+      end)

--- a/compiler/safetylib/safetyMain.mli
+++ b/compiler/safetylib/safetyMain.mli
@@ -1,0 +1,16 @@
+open Jasmin
+
+module type ArchWithAnalyze = sig
+  module A : Arch_full.Arch
+
+  val analyze :
+    ?fmt:Format.formatter ->
+    safety_param:string option ->
+    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) Prog.func ->
+    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) Prog.func ->
+    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) Prog.prog ->
+    bool
+end
+
+val get_arch_with_analyze :
+  Utils.architecture -> Glob_options.call_conv -> (module ArchWithAnalyze)

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -55,55 +55,19 @@ let check_safety_p pd msf_size asmOp analyze s (p : (_, 'asm) Prog.prog) source_
           let source_f_decl = List.find (fun source_f_decl ->
               f_decl.f_name.fn_name = source_f_decl.f_name.fn_name
             ) (snd source_p) in
-          analyze ~safety_param:!Glob_options.safety_param source_f_decl f_decl p && res
+          analyze ?fmt:None ~safety_param:!Glob_options.safety_param source_f_decl f_decl p && res
         else res)
       true
       (List.rev (snd p)) in
   if not is_safe then exit(2)
 
 (* -------------------------------------------------------------------- *)
-module type ArchWithAnalyze = sig
-  module A : Arch_full.Arch
-  val analyze :
-    safety_param:string option ->
-    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) func ->
-    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) func ->
-    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) prog ->
-    bool
-end
-
-
 let main () =
 
   try
     let infile = parse() in
 
-    let (module P : ArchWithAnalyze) =
-      match !target_arch with
-      | X86_64 ->
-         (module struct
-            module C = (val CoreArchFactory.core_arch_x86 ~use_lea:!lea ~use_set0:!set0 !call_conv)
-            module A = Arch_full.Arch_from_Core_arch (C)
-            module Safety = SafetyMain.Make (Jasmin_checksafety.X86_safety.X86_safety (A))
-            let analyze = Safety.analyze ?fmt:None
-          end)
-      | ARM_M4 ->
-         (module struct
-            module C = CoreArchFactory.Core_arch_ARM
-            module A = Arch_full.Arch_from_Core_arch (C)
-            open Jasmin_checksafety
-            module Safety = SafetyMain.Make (Jasmin_checksafety.Arm_safety.Arm_safety (A))
-            let analyze = Safety.analyze ?fmt:None
-          end)
-      | RISCV ->
-         (module struct
-            module C = CoreArchFactory.Core_arch_RISCV
-            module A = Arch_full.Arch_from_Core_arch (C)
-            open Jasmin_checksafety
-            module Safety = SafetyMain.Make (Jasmin_checksafety.Riscv_safety.Riscv_safety (A))
-            let analyze = Safety.analyze ?fmt:None
-          end)
-    in
+    let (module P) = SafetyMain.get_arch_with_analyze !target_arch !call_conv in
     let module Arch = P.A in
 
     if !safety_makeconfigdoc <> None

--- a/compiler/tests/safety/run.ml
+++ b/compiler/tests/safety/run.ml
@@ -25,19 +25,6 @@ let config path =
       ("fail/x86-64/popcnt.jazz", "off_by_one>;");
     ]
 
-(* taken from main_compiler.ml *)
-module type ArchWithAnalyze = sig
-  module A : Arch_full.Arch
-
-  val analyze :
-    ?fmt:Format.formatter ->
-    safety_param:string option ->
-    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) func ->
-    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) func ->
-    (unit, (A.reg, A.regx, A.xreg, A.rflag, A.cond, A.asm_op, A.extra_op) Arch_extra.extended_op) prog ->
-    bool
-end
-
 let load_file arch_info pointer_data msf_size asmOp name =
   try
     let open Pretyping in
@@ -51,32 +38,7 @@ let load_file arch_info pointer_data msf_size asmOp name =
     assert false
 
 let load_and_analyze ~fmt ~safety_param expect path arch =
-  let (module P : ArchWithAnalyze) =
-    match arch with
-    | X86_64 ->
-       (module struct
-          module C = (val CoreArchFactory.core_arch_x86 ~use_lea:!Glob_options.lea ~use_set0:!Glob_options.set0 Linux)
-          module A = Arch_full.Arch_from_Core_arch (C)
-          module Safety = SafetyMain.Make (Jasmin_checksafety.X86_safety.X86_safety (A))
-          let analyze = Safety.analyze
-        end)
-    | ARM_M4 ->
-       (module struct
-          module C = CoreArchFactory.Core_arch_ARM
-          module A = Arch_full.Arch_from_Core_arch (C)
-          open Jasmin_checksafety
-          module Safety = SafetyMain.Make (Jasmin_checksafety.Arm_safety.Arm_safety (A))
-          let analyze = Safety.analyze
-        end)
-    | RISCV ->
-       (module struct
-          module C = CoreArchFactory.Core_arch_RISCV
-          module A = Arch_full.Arch_from_Core_arch (C)
-          open Jasmin_checksafety
-          module Safety = SafetyMain.Make (Jasmin_checksafety.Riscv_safety.Riscv_safety (A))
-          let analyze = Safety.analyze
-        end)
-  in
+  let (module P) = SafetyMain.get_arch_with_analyze arch Linux in
   let module Arch = P.A in
   Format.fprintf fmt "File %s (on arch %s):@." path (architecture_to_string arch);
   let ((_, fds) as p) = load_file Arch.arch_info Arch.pointer_data Arch.msf_size Arch.asmOp path in


### PR DESCRIPTION
The module type ArchWithAnalyze and its three instances are now defined in the SafetyMain module.
