### PR TITLE
Accept Lnone as destination for #randombytes

### DIFF
--- a/changes/02-bugfix/1464-randombytes-lnone.md
+++ b/changes/02-bugfix/1464-randombytes-lnone.md
@@ -1,0 +1,4 @@
+- The `randombytes` primitive accepts a hole (`_`) as destination
+  ([PR 1464](https://github.com/jasmin-lang/jasmin/pull/1464);
+  fixes [#1462](https://github.com/jasmin-lang/jasmin/issues/1462)).
+

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -2074,10 +2074,17 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((pannot,pi) : S.pinstr) : 'asm 
         match xs with
         | [x] ->
           let loc, x, oty = tt_lvalue arch_info.pd env_lhs x in
-          let ty =
+          let x, ty =
             match oty with
-            | None -> rs_tyerror ~loc (string_error "_ lvalue not accepted here")
-            | Some ty -> ty in
+            | Some ty -> x, ty
+            | None ->
+               (* No destination: create a variable to hold the returned pointer, using the type of the argument *)
+               match tt_exprs arch_info.pd env_lhs args with
+               | (_, ty) :: _ ->
+                  (fun _ -> Lvar (L.mk_loc loc P.(GV.mk "bytes" (Reg (Normal, Pointer Constant)) (gty_of_gety ty) loc []))),
+                  ty
+               | [] -> x, P.(ETarr (U8, PE (Pconst Z.zero))) (* this will fail a few lines below in tt_exprs_cast *)
+          in
           loc, x ty, ty
         | _ ->
           rs_tyerror ~loc:(L.loc pi)

--- a/compiler/tests/success/syscall/x86-64/bug_1462.jazz
+++ b/compiler/tests/success/syscall/x86-64/bug_1462.jazz
@@ -1,0 +1,5 @@
+export fn main() {
+  stack u8[1] s;
+  _ = #randombytes(s);
+}
+


### PR DESCRIPTION
# Description

Although it is arguably OK to reject programs that simply discard the result of a call to `#randombytes`, claiming that this is a “typing error” is wrong.

Fixes #1462

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
