### PR TITLE
 memory_model: more efficient is_align (for non-negative values)

### DIFF
--- a/proofs/compiler/arm_stack_zeroization_proof.v
+++ b/proofs/compiler/arm_stack_zeroization_proof.v
@@ -264,7 +264,7 @@ Proof.
   have hn: (0 < wsize_size ws <= n)%Z.
   + split=> //.
     have := hsr.(sr_aligned).
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m ?].
     have ? := wsize_size_pos ws.
     have: (0 < m)%Z; nia.
@@ -366,7 +366,7 @@ Proof.
   move=> hsubset hsr hlt.
   have [k hn]: (exists k, n = Z.of_nat k * wsize_size ws)%Z.
   + have := hsr.(sr_aligned).
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m ?].
     exists (Z.to_nat m).
     rewrite Z2Nat.id //.
@@ -521,7 +521,7 @@ Local Opaque wsize_size Z.of_nat.
       rewrite Z2Nat.id; last by lia.
       rewrite Z.mul_sub_distr_r.
       rewrite Z.mul_comm -(proj2 (Z.div_exact _ _ _)) //.
-      by move: halign; rewrite /is_align WArray.p_to_zE => /eqP.
+      by move: halign; rewrite is_alignE WArray.p_to_zE => /eqP.
     rewrite addnS.
     apply: store_zero_eval_instr => //=.
     + by rewrite /get_var hsr.(sr_vzero).
@@ -578,7 +578,7 @@ Proof.
     exists k, (stk_max = Z.of_nat k * wsize_size ws)%Z
            /\ k <= Z.to_nat (stk_max / wsize_size ws).
   + have := halign.
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m h].
     exists (Z.to_nat m).
     split.

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -1844,7 +1844,7 @@ Section PROOF.
     is_align sz ws ->
     align_top top ws sz = align_word ws top.
   Proof.
-    move=> hpos hb hal.
+    rewrite is_alignE => hpos hb hal.
     rewrite /align_top /top_stack_after_alloc.
     apply wunsigned_inj.
     rewrite wunsigned_add; last first.

--- a/proofs/compiler/riscv_stack_zeroization_proof.v
+++ b/proofs/compiler/riscv_stack_zeroization_proof.v
@@ -254,7 +254,7 @@ Proof.
   have hn: (0 < wsize_size ws <= n)%Z.
   + split=> //.
     have := hsr.(sr_aligned).
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m ?].
     have ? := wsize_size_pos ws.
     have: (0 < m)%Z; nia.
@@ -361,7 +361,7 @@ Proof.
   move=> hsubset hsr hlt.
   have [k hn]: (exists k, n = Z.of_nat k * wsize_size ws)%Z.
   + have := hsr.(sr_aligned).
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m ?].
     exists (Z.to_nat m).
     rewrite Z2Nat.id //.
@@ -521,7 +521,7 @@ Local Opaque wsize_size Z.of_nat.
       rewrite Z2Nat.id; last by lia.
       rewrite Z.mul_sub_distr_r.
       rewrite Z.mul_comm -(proj2 (Z.div_exact _ _ _)) //.
-      by move: halign; rewrite /is_align WArray.p_to_zE => /eqP.
+      by move: halign; rewrite is_alignE WArray.p_to_zE => /eqP.
     rewrite addnS.
     apply: store_zero_eval_instr => //=.
     + by rewrite /get_var hsr.(sr_vzero).
@@ -578,7 +578,7 @@ Proof.
     exists k, (stk_max = Z.of_nat k * wsize_size ws)%Z
            /\ k <= Z.to_nat (stk_max / wsize_size ws).
   + have := halign.
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m h].
     exists (Z.to_nat m).
     split.

--- a/proofs/compiler/stack_alloc_proof_1.v
+++ b/proofs/compiler/stack_alloc_proof_1.v
@@ -1268,7 +1268,7 @@ Section EXPR.
     + apply (is_align_m halign).
       rewrite -hwf.(wfr_align).
       by apply (slot_align hwf.(wfr_slot)).
-    rewrite /is_align !p_to_zE.
+    rewrite !is_alignE !p_to_zE.
     have [cs ok_cs _] := hwf.(wfsr_zone).
     have := wunsigned_sub_region_addr hwf ok_cs.
     rewrite ok_w => -[_ [<-] ->].

--- a/proofs/compiler/stack_alloc_proof_2.v
+++ b/proofs/compiler/stack_alloc_proof_2.v
@@ -939,7 +939,7 @@ Proof.
     apply is_align_add.
     + apply: is_align_m rip_align.
       by apply wsize_ge_U256.
-    rewrite WArray.arr_is_align.
+    rewrite WArray.arr_is_align is_alignE.
     by apply /eqP; apply (init_map_align heq).
   + rewrite /Addr /Align !(pick_slot_locals hin).
     move /in_Slots_slots : hin.
@@ -948,7 +948,7 @@ Proof.
     apply is_align_add.
     + apply: is_align_m rsp_align.
       by apply (init_stack_layout_stack_align heq).
-    rewrite WArray.arr_is_align.
+    rewrite WArray.arr_is_align is_alignE.
     by apply /eqP; apply (init_stack_layout_align heq).
   rewrite /Addr /Align !(pick_slot_params hin).
   by apply wf_Slots_params.
@@ -1169,7 +1169,7 @@ Proof.
       + by apply in_Slots; right; left.
       + by rewrite /Writable (pick_slot_locals hin).
       + by rewrite /Align (pick_slot_locals hin) /Align_locals /Align_slots heq.
-      + by rewrite WArray.arr_is_align; apply /eqP.
+      + by rewrite WArray.arr_is_align is_alignE; apply /eqP.
       + by rewrite /Addr (pick_slot_locals hin) /Addr_locals /Offset_slots heq.
       + by apply SvD.F.add_1.
       move=> w sw ofsw wsw' zw wf.

--- a/proofs/compiler/x86_stack_zeroization_proof.v
+++ b/proofs/compiler/x86_stack_zeroization_proof.v
@@ -147,7 +147,7 @@ Proof.
   have hn: (0 < wsize_size ws <= n)%Z.
   + split=> //.
     have := hsr.(sr_aligned).
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m ?].
     have ? := wsize_size_pos ws.
     have: (0 < m)%Z; nia.
@@ -252,7 +252,7 @@ Proof.
   move=> hsr hlt.
   have [k hn]: (exists k, n = Z.of_nat k * wsize_size ws)%Z.
   + have := hsr.(sr_aligned).
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m ?].
     exists (Z.to_nat m).
     rewrite Z2Nat.id //.
@@ -431,7 +431,7 @@ Proof.
   have hn: (0 < wsize_size ws <= n)%Z.
   + split=> //.
     have := hsr.(sr_aligned).
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m ?].
     have ? := wsize_size_pos ws.
     have: (0 < m)%Z; nia.
@@ -534,7 +534,7 @@ Proof.
   move=> hsr hlt.
   have [k hn]: (exists k, n = Z.of_nat k * wsize_size ws)%Z.
   + have := hsr.(sr_aligned).
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m ?].
     exists (Z.to_nat m).
     rewrite Z2Nat.id //.
@@ -782,7 +782,7 @@ Local Opaque wsize_size Z.of_nat.
       rewrite Z2Nat.id; last by lia.
       rewrite Z.mul_sub_distr_r.
       rewrite Z.mul_comm -(proj2 (Z.div_exact _ _ _)) //.
-      by move: halign; rewrite /is_align WArray.p_to_zE => /eqP.
+      by move: halign; rewrite is_alignE WArray.p_to_zE => /eqP.
     rewrite /eval_instr /=.
     rewrite wrepr0.
     have -> /=: exec_sopn (Ox86 (MOV ws)) [:: @Vword ws 0] = ok [:: @Vword ws 0].
@@ -843,7 +843,7 @@ Proof.
     exists k, (stk_max = Z.of_nat k * wsize_size ws)%Z
            /\ k <= Z.to_nat (stk_max / wsize_size ws).
   + have := halign.
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m h].
     exists (Z.to_nat m).
     split.
@@ -1019,7 +1019,7 @@ Local Opaque wsize_size Z.of_nat.
       rewrite Z2Nat.id; last by lia.
       rewrite Z.mul_sub_distr_r.
       rewrite Z.mul_comm -(proj2 (Z.div_exact _ _ _)) //.
-      by move: halign; rewrite /is_align WArray.p_to_zE => /eqP.
+      by move: halign; rewrite is_alignE WArray.p_to_zE => /eqP.
     rewrite /eval_instr /=.
     rewrite [get_var _ _ vlri]/get_var hsr.(srul_vlr) /=.
     rewrite /exec_sopn /= (@truncate_word_u ws) /= /sopn_sem /sopn_sem_ /= /semi_to_atype computational_eq_refl /x86_VMOVDQ.
@@ -1077,7 +1077,7 @@ Proof.
     exists k, (stk_max = Z.of_nat k * wsize_size ws)%Z
            /\ k <= Z.to_nat (stk_max / wsize_size ws).
   + have := halign.
-    rewrite /is_align WArray.p_to_zE.
+    rewrite is_alignE WArray.p_to_zE.
     move=> /eqP /Z.mod_divide [//|m h].
     exists (Z.to_nat m).
     split.

--- a/proofs/lang/memory_example.v
+++ b/proofs/lang/memory_example.v
@@ -721,7 +721,7 @@ Module MemoryI : MemoryT.
     set x := (X in is_align X).
     have -> : x = align_word ws_stk (stk_root m - wrepr _ fs - (wrepr _ sz + wrepr _ sz')).
     + by rewrite /x; ssring.
-    rewrite /is_align p_to_zE; apply align_word_aligned.
+    rewrite is_alignE p_to_zE; apply align_word_aligned.
   Qed.
 
   Lemma ass_root m ws_stk sz ioff sz' m' :

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -91,12 +91,43 @@ Class pointer_op (pointer: eqType) : Type := PointerOp {
 
 Context {Pointer: pointer_op pointer}.
 
+Fixpoint pos_is_aligned_to (p: positive) (n: nat) {struct n} : bool :=
+  if n is n.+1 then
+    (if p is p~0 then
+      pos_is_aligned_to p n
+    else false)%positive
+  else true.
+
+Lemma pos_is_aligned_toE p n :
+  pos_is_aligned_to p n = (mod_pow2 p n == 0)%N.
+Proof.
+  elim: n p => // n ih [] // p /=.
+  - by case: (_ p n).
+  rewrite ih.
+  by case: (_ p n).
+Qed.
+
+Definition is_aligned_to (z: Z) (n: nat) : bool :=
+  match z with
+  | Z0 => true
+  | Zpos p => pos_is_aligned_to p n
+  | Zneg _ => z mod 2 ^ Z.of_nat n == 0
+  end.
+
 Definition is_align (p: pointer) (sz: wsize) : bool :=
-  (p_to_z p mod wsize_size sz == 0)%Z.
+  is_aligned_to (p_to_z p) (wsize_log2 sz).
 
 Lemma is_alignE p sz :
   is_align p sz = (p_to_z p mod wsize_size sz == 0)%Z.
-Proof. by []. Qed.
+Proof.
+  rewrite /is_align; case: (p_to_z p) => // {} p;
+  rewrite /is_aligned_to wsize_size_is_pow2;
+    last done.
+  rewrite pos_is_aligned_toE.
+  suff : (p mod 2 ^ Z.of_nat (wsize_log2 sz)) = Z.of_N (mod_pow2 p (wsize_log2 sz)).
+  - case: eqP; case: eqP; lia.
+  by rewrite mod_pow2E N2Z.inj_mod /= shift_nat_correct Zpower_nat_Z Z.mul_1_r.
+Qed.
 
 Global Opaque is_align.
 

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -91,11 +91,17 @@ Class pointer_op (pointer: eqType) : Type := PointerOp {
 
 Context {Pointer: pointer_op pointer}.
 
-Definition is_align (p:pointer) (sz:wsize) :=
+Definition is_align (p: pointer) (sz: wsize) : bool :=
   (p_to_z p mod wsize_size sz == 0)%Z.
 
+Lemma is_alignE p sz :
+  is_align p sz = (p_to_z p mod wsize_size sz == 0)%Z.
+Proof. by []. Qed.
+
+Global Opaque is_align.
+
 Lemma is_align8 p : is_align p U8.
-Proof. by rewrite /is_align Zmod_1_r. Qed.
+Proof. by rewrite is_alignE Zmod_1_r. Qed.
 
 Class coreMem (core_mem: Type) := CoreMem {
   get : core_mem -> pointer -> exec u8;
@@ -649,7 +655,7 @@ Proof.
 Qed.
 
 Lemma is_align_modE ptr sz : (wunsigned ptr mod wsize_size sz == 0)%Z = is_align ptr sz.
-Proof. by rewrite /is_align p_to_zE (rwP eqP). Qed.
+Proof. by rewrite is_alignE p_to_zE (rwP eqP). Qed.
 
 Lemma is_align_mod ptr sz : reflect (wunsigned ptr mod wsize_size sz = 0)%Z (is_align ptr sz).
 Proof. rewrite -is_align_modE; apply eqP. Qed.
@@ -672,6 +678,7 @@ Lemma is_align_m sz sz' (ptr: pointer) :
   is_align ptr sz →
   is_align ptr sz'.
 Proof.
+  rewrite !is_alignE.
   have wsnz s : wsize_size s ≠ 0.
   - by have := wsize_size_pos s.
   move => /wsize_size_le le /eqP /Z.mod_divide - /(_ (wsnz _)) /(Z.divide_trans _ _ _ le) {}le.
@@ -682,13 +689,13 @@ Lemma is_align_mul sz j : is_align (wrepr Uptr (wsize_size sz * j)) sz.
 Proof.
   have hn := wsize_size_pos sz.
   have hnz : wsize_size sz ≠ 0%Z by lia.
-  by rewrite /is_align p_to_zE wunsigned_repr mod_wbase_wsize_size Z.mul_comm Z_mod_mult.
+  by rewrite is_alignE p_to_zE wunsigned_repr mod_wbase_wsize_size Z.mul_comm Z_mod_mult.
 Qed.
 
 Lemma is_align_no_overflow ptr sz :
   is_align ptr sz → no_overflow ptr (wsize_size sz).
 Proof.
-  rewrite /no_overflow /is_align p_to_zE => /eqP ha; apply/ZleP.
+  rewrite /no_overflow is_alignE p_to_zE => /eqP ha; apply/ZleP.
   have hn := wsize_size_pos sz.
   have hnz : wsize_size sz ≠ 0%Z by lia.
   move: (wunsigned ptr) (wunsigned_range ptr) ha => {}ptr.
@@ -700,7 +707,7 @@ Qed.
 Notation do_align := align_word (only parsing).
 
 Lemma do_align_is_align sz p : is_align (do_align sz p) sz.
-Proof. apply align_word_aligned. Qed.
+Proof. rewrite is_alignE; apply align_word_aligned. Qed.
 
 Lemma is_align_array ptr sz j :
   is_align ptr sz → is_align (wrepr _ (wsize_size sz * j) + ptr)%R sz.
@@ -899,7 +906,7 @@ Lemma top_stack_after_aligned_alloc p ws sz :
   is_align p ws ->
   top_stack_after_alloc p ws sz = (p + wrepr Uptr (- round_ws ws sz))%R.
 Proof.
-  rewrite /is_align p_to_zE => /eqP hal.
+  rewrite is_alignE p_to_zE => /eqP hal.
   rewrite round_wsE.
   rewrite /top_stack_after_alloc.
   apply wunsigned_inj.

--- a/proofs/lang/warray_.v
+++ b/proofs/lang/warray_.v
@@ -62,12 +62,12 @@ Module WArray.
   Context {pd: PointerData}.
 
   Lemma is_align_scale (p:pointer) ws : is_align (p * mk_scale AAscale ws)%Z ws.
-  Proof. by rewrite /is_align /mk_scale /= Z_mod_mult. Qed.
+  Proof. by rewrite is_alignE /mk_scale /= Z_mod_mult. Qed.
 
   Lemma arr_is_align i ws :
     is_align (wrepr Uptr i) ws = is_align i ws.
   Proof.
-    by rewrite /is_align [in RHS]p_to_zE memory_model.p_to_zE wunsigned_repr mod_wbase_wsize_size.
+    by rewrite !is_alignE [in RHS]p_to_zE memory_model.p_to_zE wunsigned_repr mod_wbase_wsize_size.
   Qed.
 
   Section CM.


### PR DESCRIPTION
Current implementation does a full division, when we only need to look at a few least significant bits.