### PR TITLE
CI: move verbose output to a file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,6 +173,10 @@ check:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run './compiler/jasminc -version'
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'cd compiler && dune runtest'
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -j$NIX_BUILD_CORES -C compiler check-ci $EXTRA_MAKE_ARGUMENTS'
+  artifacts:
+    when: always
+    paths:
+    - compiler/report.log
 
 check-proofs:
   stage: test
@@ -249,7 +253,7 @@ test-extract-to-ec:
     matrix:
       - EASYCRYPT_REF: [release, dev]
   variables:
-    EXTRA_NIX_ARGUMENTS: --arg ocamlDeps true --arg testDeps true --argstr ecRef $EASYCRYPT_REF
+    EXTRA_NIX_ARGUMENTS: --arg testDeps true --argstr ecRef $EASYCRYPT_REF
     WHY3_CONF: $CI_PROJECT_DIR/why3.conf
     ECARGS: -why3 $WHY3_CONF
     JSJOBS: $(NIX_BUILD_CORES)
@@ -259,7 +263,7 @@ test-extract-to-ec:
   - ocaml
   script:
   - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'easycrypt why3config -why3 $WHY3_CONF'
-  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -C compiler CHECKCATS="x86-64-extraction arm-m4-extraction risc-v-extraction" check'
+  - nix-shell --arg inCI true $EXTRA_NIX_ARGUMENTS --run 'make -C compiler CHECKCATS="x86-64-extraction arm-m4-extraction risc-v-extraction" check-ci'
   artifacts:
     when: always
     paths:

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -45,11 +45,10 @@ CIL:
 	cp ../proofs/lang/ocaml/*.ml  src/CIL/
 	cp ../proofs/lang/ocaml/*.mli src/CIL/
 
-check: all
-	$(CHECK) --report=report.log $(CHECKCATS)
+check: all check-ci
 
 check-ci:
-	$(CHECK) --report=- $(CHECKCATS)
+	$(CHECK) --report=report.log $(CHECKCATS)
 
 check-ec:
 	$(MAKE) -C examples/gimli/proofs


### PR DESCRIPTION
And do not recompile the compiler in the test-extract-to-ec jobs

The motivation is to remove some dependencies of the `extract-to-ec` jobs: OCaml, apron, etc.