### PR TITLE
Checksafety: new CLI / command-line tool

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,7 @@ ocaml:
     - compiler/jasmin2tex
     - compiler/jasmin2ec
     - compiler/jasminc
+    - compiler/jasmin-checksafety
     - compiler/jasmin-ct
 
 eclib:

--- a/changes/01-feature/1470-jasmin-checksafety.md
+++ b/changes/01-feature/1470-jasmin-checksafety.md
@@ -1,0 +1,4 @@
+- A new command line interface to the safety checker is available through the
+  `jasmin-checksafety` program; the legacy command-line interface (`jasminc`)
+  is deprecated
+  ([PR 1470](https://github.com/jasmin-lang/jasmin/pull/1470)).

--- a/compiler/.gitignore
+++ b/compiler/.gitignore
@@ -10,3 +10,4 @@ report.log
 /jasmin2tex
 /jasmin-ct
 /jasmin2ec
+/jasmin-checksafety

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -35,7 +35,7 @@ OBELISK ?= obelisk
 .PHONY: clean install uninstall dist
 
 all:
-	$(RM) jasminc jasmin2tex jasmin-ct jasmin2ec
+	$(RM) jasminc jasmin2tex jasmin-ct jasmin2ec jasmin-checksafety
 	dune build @check @install
 	for p in _build/install/default/bin/*; do ln -sf $$p $$(basename $$p); done
 
@@ -59,7 +59,7 @@ check-all: check
 
 clean:
 	dune clean
-	$(RM) jasminc jasmin2tex jasmin-ct jasmin2ec
+	$(RM) jasminc jasmin2tex jasmin-ct jasmin2ec jasmin-checksafety
 
 install:
 	dune install $(DUNE_OPTS)

--- a/compiler/default.nix
+++ b/compiler/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/bin
-    for p in jasminc jasmin2tex jasmin-ct
+    for p in jasminc jasmin2tex jasmin-ct jasmin-checksafety
     do
       cp -L _build/install/default/bin/$p $out/bin/$p
     done

--- a/compiler/dune
+++ b/compiler/dune
@@ -33,4 +33,11 @@
  (modules jasmin2ec)
  (modes byte exe)
  (libraries commonCLI))
+
+(executable
+ (public_name jasmin-checksafety)
+ (name jasmin_checksafety)
+ (modules jasmin_checksafety)
+ (modes byte exe)
+ (libraries commonCLI jasmin_checksafety))
 )

--- a/compiler/entry/jasmin_checksafety.ml
+++ b/compiler/entry/jasmin_checksafety.ml
@@ -1,0 +1,113 @@
+open Jasmin
+open Utils
+open Prog
+open Jasmin_checksafety
+open CommonCLI
+open Cmdliner
+
+(* -------------------------------------------------------------------- *)
+let checksafety arch call_conv idirs slice safety_param no_check_alignment
+    config file =
+  Option.may SafetyConfig.load_config config;
+  let () = if no_check_alignment then Glob_options.trust_aligned := true in
+  let module P = (val SafetyMain.get_arch_with_analyze arch call_conv) in
+  let module Arch = P.A in
+  let after_pass = SafetyConfig.sc_comp_pass () in
+  let prog =
+    parse_and_compile (module Arch) ~wi2i:false after_pass file idirs
+  in
+  let () =
+    if SafetyConfig.sc_print_program () then
+      let s1, s2 = Glob_options.print_strings after_pass in
+      Format.eprintf "@[<v>At compilation pass: %s@;%s@;@;%a@;@]@." s1 s2
+        (Printer.pp_prog ~debug:true Arch.pointer_data Arch.msf_size Arch.asmOp)
+        prog
+  in
+  let () = SafetyConfig.pp_current_config_diff () in
+  let fds = prog |> snd |> List.filter (fun fd -> FInfo.is_export fd.f_cc) in
+  let fds =
+    if slice <> [] then
+      fds |> List.filter (fun fd -> List.mem fd.f_name.fn_name slice)
+    else fds
+  in
+  let is_safe =
+    List.fold_left
+      (fun res f_decl ->
+        let () =
+          Format.eprintf "@[<v>Analyzing function %s@]@." f_decl.f_name.fn_name
+        in
+
+        P.analyze ~safety_param f_decl prog && res)
+      true fds
+  in
+  exit (if is_safe then 0 else 2)
+
+(* -------------------------------------------------------------------- *)
+let docdir =
+  let doc = "Make the safety checker configuration docs in $(i, DIR)" in
+  Arg.(
+    value & opt (some dir) None & info ~doc ~docv:"DIR" [ "make-config-doc" ])
+
+let file =
+  let doc = "The Jasmin source file to verify." in
+  Arg.(value & pos 0 (some non_dir_file) None & info [] ~docv:"JAZZ" ~doc)
+
+let slice =
+  let doc =
+    "Only check the given function (and its dependencies). This argument may \
+     be repeated to check many functions. If not given, all export functions \
+     will be checked."
+  in
+  Arg.(value & opt_all string [] & info [ "slice"; "only"; "on" ] ~doc)
+
+let param =
+  let doc =
+    " Parameter for automatic safety verification:\n\
+    \    format: \"f_1>param_1|f_2>param_2|...\" where each param_i is of the \
+     form:\n\
+    \    pt_1,...,pt_n;len_1,...,len_k\n\
+    \    pt_1,...,pt_n: input pointers of f_i\n\
+    \    len_1,...,len_k: input lengths of f_i"
+  in
+  Arg.(value & opt (some string) None & info [ "param" ] ~doc ~docv:"PARAM")
+
+let config =
+  let doc = "Use $(i,JSON) as configuration file" in
+  Arg.(
+    value & opt (some non_dir_file) None & info [ "config" ] ~docv:"JSON" ~doc)
+
+let no_check_alignment =
+  let doc = "Do not report alignment issue as safety violations" in
+  Arg.(value & flag & info [ "no-check-alignment" ] ~doc)
+
+let parse docdir arch call_conv idirs slice param no_check_alignment config file
+    =
+  match (docdir, file) with
+  | None, None -> `Error (true, "Nothing to do…")
+  | Some _, Some _ -> `Error (true, "Too many arguments")
+  | Some dir, None -> `Ok (SafetyConfig.mk_config_doc dir)
+  | None, Some file ->
+      `Ok
+        (checksafety arch call_conv idirs slice param no_check_alignment config
+           file)
+
+(* -------------------------------------------------------------------- *)
+let () =
+  let doc = "Check safety of Jasmin programs" in
+  let man =
+    [
+      `S Manpage.s_environment;
+      Manpage.s_environment_intro;
+      `I ("OCAMLRUNPARAM", "This is an OCaml program");
+      `I ("JASMINPATH", "To resolve $(i,require) directives");
+    ]
+  in
+  let info =
+    Cmd.info "jasmin-checksafety" ~version:Glob_options.version_string ~doc ~man
+  in
+  Cmd.v info
+    Term.(
+      ret
+        (const parse $ docdir $ arch $ call_conv $ idirs $ slice $ param
+       $ no_check_alignment $ config $ file))
+  |> Cmd.eval |> exit

--- a/compiler/src/CLI_errors.ml
+++ b/compiler/src/CLI_errors.ml
@@ -62,4 +62,13 @@ let check_options () =
     then warning Experimental Location.i_dummy
       "support of the RISC-V architecture is experimental";
 
+  if
+    !check_safety || !trust_aligned || !safety_param <> None
+    || !safety_config <> None
+    || !safety_makeconfigdoc <> None
+  then
+    warning Deprecated Location.i_dummy
+      "the legacy (jasminc) interface to the safety checker is deprecated; use \
+       jasmin-checksafety instead";
+
   chk_out_file outfile

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -202,17 +202,17 @@ let options = [
     "-set0"     , Arg.Set set0          , " Use [xor x x] to set x to 0 (default is not)";
     "-noset0"   , Arg.Clear set0        , " Do not use set0 option";
     "-slice"    , Arg.String set_slice  , "[f] Keep function [f] and everything it needs";
-    "-checksafety", Arg.Unit set_checksafety, " Automatically check for safety";
+    "-checksafety", Arg.Unit set_checksafety, " Automatically check for safety (deprecated)";
     "-safetyparam", Arg.String set_safetyparam,
     " Parameter for automatic safety verification:\n    \
      format: \"f_1>param_1|f_2>param_2|...\" \
      where each param_i is of the form:\n    \
      pt_1,...,pt_n;len_1,...,len_k\n    \
      pt_1,...,pt_n: input pointers of f_i\n    \
-     len_1,...,len_k: input lengths of f_i";
-     "-safetyconfig", Arg.String set_safetyconfig, "[filename] Use filename (JSON) as configuration file for the safety checker";
-    "-safetymakeconfigdoc", Arg.String set_safety_makeconfigdoc, "[dir] Make the safety checker configuration docs in [dir]";
-    "-nocheckalignment", Arg.Set trust_aligned, " Do not report alignment issue as safety violations";
+     len_1,...,len_k: input lengths of f_i\n    (deprecated)";
+     "-safetyconfig", Arg.String set_safetyconfig, "[filename] Use filename (JSON) as configuration file for the safety checker (deprecated)";
+    "-safetymakeconfigdoc", Arg.String set_safety_makeconfigdoc, "[dir] Make the safety checker configuration docs in [dir] (deprecated)";
+    "-nocheckalignment", Arg.Set trust_aligned, " Do not report alignment issue as safety violations (deprecated)";
     "-wlea", Arg.Unit (add_warning UseLea), " Print warning when lea is used";
     "-wea", Arg.Unit (add_warning ExtraAssignment), " Print warning when extra assignment is introduced";
     "-winsertarraycopy", Arg.Unit (add_warning IntroduceArrayCopy), " Print warning when array copy is introduced";

--- a/docs/source/tools/ct.md
+++ b/docs/source/tools/ct.md
@@ -452,7 +452,7 @@ fn gimli(reg ptr u32[12] state) -> reg ptr u32[12] {
 This program is safe, as long as the `state` argument points to a valid memory region of at least 48 bytes, aligned for 32-bit accesses.
 This is automatically proved by the safety checker, called as follows:
 
-    jasminc -checksafety gimli.jazz
+    jasmin-checksafety gimli.jazz
 
 The EasyCrypt model for constant-time verification can be obtained by calling `jasmin2ec` as follows:
 

--- a/docs/source/tools/safety_checker.md
+++ b/docs/source/tools/safety_checker.md
@@ -2,7 +2,7 @@
 
 The Jasmin compiler comes with a static analyser that attempts to automatically prove the safety of the program to be compiled.
 
-To use it, just call the compiler with the `-checksafety` flag on the command line:
+To use it, just call the command-line tool `jasmin-checksafety`:
 it will check the safety of the *export* functions rather than compiling them.
 
 Safety is formally defined as “to have a well defined semantics”, according to the Coq specification that is given in the `proofs/lang/psem.v` file:
@@ -21,11 +21,11 @@ Therefore, the safety checker outputs a *safety precondition*: a property of the
 (initial memory and arguments) that, when satisfied, ensures that the execution is safe.
 
 As an example, we give below the final results we obtained when
-analysing `compiler/examples/loop_add.jazz` and `compiler/examples/memcmp.jazz`, and explain how to interpret them.
+analysing `loop_add.jazz` and `compiler/examples/x86-64/memcmp.jazz`, and explain how to interpret them.
 
 
 ## Example: `loop_add.jazz`
-Assuming we are in the `compiler/` directory, running `./jasminc -checksafety examples/loop_add.jazz` should yield:
+Assuming we are in the `compiler/` directory, running `./jasmin-checksafety examples/loop_add.jazz` should yield:
 
 ```
 Default checker parameters.
@@ -54,9 +54,9 @@ The `memcmp` export function has the signature:
 ```
 export fn memcmp(reg u64 p, reg u64 q, reg u64 n) -> reg u64
 ```
-Essentially, it takes two pointers `p` and `q` of length `n`, and compare them.  To help the analyser, we can declare which inputs are pointers and which inputs are lengths, which is done through the `safetyparam` option as follows:
+Essentially, it takes two pointers `p` and `q` of length `n`, and compare them.  To help the analyser, we can declare which inputs are pointers and which inputs are lengths, which is done through the `--param` option as follows:
 ```
-./jasminc -checksafety examples/memcmp.jazz -safetyparam "memcmp>p,q;n"
+./jasmin-checksafety examples/x86-64/memcmp.jazz --param "memcmp>p,q;n"
 ```
 (pointers and lengths are comma `,` separated lists of input variables).
 
@@ -75,8 +75,6 @@ Memory ranges:
 {inv_n ≤ 18446744073709551615, 8·inv_n ≥ mem_q, 8·inv_n ≥ mem_p, mem_q ≥ 0, mem_p ≥ 0}
 mem_p ∊ [0; 147573952589676412920]
 mem_q ∊ [0; 147573952589676412920]
-
-* Alignment: p 64; q 64; 
 ```
 Here, because the allocated memory regions pointed by `p` and `q` are of size depending on the initial value of `n`, we must check the `Rel` entry. This entry gives the allocated memory region safety pre-condition through a conjunctions of linear inequalities. 
 


### PR DESCRIPTION
# Description

This creates a new command-line tool for safety checking. The legacy interface through `jasminc` is deprecated and will be removed in a follow-up PR.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [ ] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed
<!-- if this is your first contribution - [ ] Add your name to `AUTHORS` -->
