### PR TITLE
Add overlay

### DIFF
--- a/changes/01-feature/1475-overlay.md
+++ b/changes/01-feature/1475-overlay.md
@@ -1,0 +1,8 @@
+- Add `overlay` annotation allowing to force the compiler to share different stack arrays, possibly of different size.
+  ``` #[overlay = t] stack u32[2] t1;
+      #[overlay = t] stack u64[3] t2;
+      #[overlay = u] stack u16[5] u1;
+      #[overlay = u] stack u16[3] u2;
+  ```
+  In this case, `t1` and `t2` (resp. `u1` and `u2`) will be allocated to the same stack region.
+  ([PR 1475](https://github.com/jasmin-lang/jasmin/pull/1475)).

--- a/compiler/src/alias.ml
+++ b/compiler/src/alias.ml
@@ -130,19 +130,19 @@ let compare_gvar params x gx y gy =
     let sx = size_of x.v_ty in
     let sy = size_of y.v_ty in
     match gx, gy with
-    | E.Sglob, E.Sglob -> 
+    | E.Sglob, E.Sglob ->
       hierror_no_loc "cannot merge two globals (%a and %a)" pp_var x pp_var y
-    | E.Sglob, E.Slocal -> 
+    | E.Sglob, E.Slocal ->
       if (Sv.mem y params) then hierror_no_loc "cannot merge a global and a param (%a and %a)" pp_var x pp_var y;
       check_size "global" y sy x sx;
       1
-    | E.Slocal, E.Sglob -> 
+    | E.Slocal, E.Sglob ->
       if (Sv.mem x params) then hierror_no_loc "cannot merge a param and a global (%a and %a)" pp_var x pp_var y;
       check_size "global" x sx y sy;
       -1
     | E.Slocal, E.Slocal ->
       match Sv.mem x params, Sv.mem y params with
-      | true, true -> 
+      | true, true ->
         hierror_no_loc "cannot merge two params (%a and %a)" pp_var x pp_var y;
       | true, false -> check_size "param" y sy x sx; 1
       | false, true -> check_size "param" x sx y sy; -1
@@ -234,11 +234,11 @@ let link_array_return params a xs es cc =
         )
         a xs cc
 
-let opn_cc o = 
+let opn_cc o =
   match o with
   | Sopn.Oslh (SLHprotect_ptr_fail _) -> Some [Some 0]
   | Sopn.Opseudo_op(Pseudo_operator.Oswap _) -> Some [Some 1; Some 0]
-  | _ -> None 
+  | _ -> None
 
 let rec analyze_instr_r params cc a =
   function
@@ -246,10 +246,10 @@ let rec analyze_instr_r params cc a =
   | Ccall (xs, fn, es) -> link_array_return params a xs es (cc fn)
   | Csyscall (xs, o, es) -> link_array_return params a xs es (syscall_cc o)
   | Cassgn (x, _, ty, e) -> if is_ty_arr ty then assign_arr params a x e else a
-  | Copn (xs, _, o, es) -> 
+  | Copn (xs, _, o, es) ->
     (* A special case for operators that can return array *)
-    begin match opn_cc o with 
-    | None -> a 
+    begin match opn_cc o with
+    | None -> a
     | Some l -> link_array_return params a xs es l
     end
   | Cassert _ -> a

--- a/compiler/src/alias.ml
+++ b/compiler/src/alias.ml
@@ -8,16 +8,23 @@ let hierror = hierror ~kind:"compilation error" ~sub_kind:"stack allocation"
    by catching the exception and reemiting it with more information. *)
 let hierror_no_loc ?funname = hierror ~loc:Lnone ?funname
 
+type range = int * int
 type sub_slice_kind =
-  | Exact
+  | Exact of range
     (* the range is exact *)
   | Sub of Wsize.wsize
     (* the precise offset is not known, we remember that it is a subpart
        and its alignment *)
 
-type slice = { in_var : var ; scope : E.v_scope ; range : int * int; kind : sub_slice_kind }
+type slice = { in_var : var ; scope : E.v_scope ; kind : sub_slice_kind }
 
 type alias = slice Mv.t
+
+(* --------------------------------------------------- *)
+let is_exact s =
+  match s with
+  | Exact _ -> true
+  | Sub _ -> false
 
 (* --------------------------------------------------- *)
 let pp_var fmt x = pp_var ~debug:!Glob_options.debug fmt x
@@ -30,10 +37,9 @@ let pp_range fmt (lo, hi) =
 
 let pp_slice fmt s =
   match s.kind with
-  | Exact ->
-    Format.fprintf fmt "%a%a[%a[" pp_scope s.scope pp_var s.in_var pp_range s.range
-  | Sub ws ->
-   Format.fprintf fmt "%a%a ⊆ [%a[ (aligned on %a)" pp_scope s.scope pp_var s.in_var pp_range s.range PrintCommon.pp_wsize ws
+  | Exact r ->
+    Format.fprintf fmt "%a%a[%a[" pp_scope s.scope pp_var s.in_var pp_range r
+  | Sub ws -> Format.fprintf fmt "⊆  %a%a (aligned on %a)" pp_scope s.scope pp_var s.in_var PrintCommon.pp_wsize ws
 
 let pp_binding fmt x s =
   Format.fprintf fmt "%a ↦ %a;@ " pp_var x pp_slice s
@@ -56,18 +62,18 @@ let align_of_offset lo =
 
 let wsize_min = Utils0.cmp_min wsize_cmp
 
-let range_in_slice (lo, hi) kind s =
+(* the sub slice of [s] described by [kind] *)
+let range_in_slice kind s =
   match kind, s.kind with
-  | Exact, Exact ->
-      let (u, v) = s.range in
+  | Exact (lo, hi), Exact (u, v) ->
       if u + hi <= v
-      then { s with range = u + lo, u + hi }
+      then { s with kind = Exact (u + lo, u + hi) }
       else
         hierror_no_loc "cannot access the subarray [%a[ of %a, the access overflows, your program is probably unsafe"
           pp_range (lo, hi) pp_slice s
-  | Sub ws, Exact ->
-      { s with kind = Sub (wsize_min ws (align_of_offset (fst s.range))) }
-  | Exact, Sub ws ->
+  | Sub ws, Exact (u, _v) ->
+      { s with kind = Sub (wsize_min ws (align_of_offset u)) }
+  | Exact(lo, _hi), Sub ws ->
       { s with kind = Sub (wsize_min ws (align_of_offset lo)) }
   | Sub ws1, Sub ws2 ->
       { s with kind = Sub (wsize_min ws1 ws2) }
@@ -77,7 +83,7 @@ let range_of_var x =
 
 let slice_of_var ?(scope=E.Slocal) in_var =
   let range = range_of_var in_var in
-  { in_var ; scope ; range; kind = Exact }
+  { in_var ; scope ; kind = Exact range }
 
 let rec normalize_var a x =
   match Mv.find x a with
@@ -86,7 +92,7 @@ let rec normalize_var a x =
 and normalize_slice a s =
   if s.scope = E.Sglob then s
   else
-    range_in_slice s.range s.kind (normalize_var a s.in_var)
+    range_in_slice s.kind (normalize_var a s.in_var)
 
 let normalize_gvar a { gv ; gs } =
   let x = L.unloc gv in
@@ -118,10 +124,10 @@ let incl a1 a2 =
 
 (* Partial order on variables, by scope and size *)
 let compare_gvar params x gx y gy =
-  let check_size kind x1 s1 x2 s2 =
+  let check_size kind1 kind2 x1 s1 x2 s2 =
     if not (s1 <= s2) then
-      hierror_no_loc "cannot merge a %s and a local that is larger (%a of size %i, and %a of size %i)"
-        kind pp_var x2 s2 pp_var x1 s1
+      hierror_no_loc "cannot merge a %s and a %s that is larger (%a of size %i, and %a of size %i)"
+        kind1 kind2 pp_var x2 s2 pp_var x1 s1
   in
 
   if V.equal x y
@@ -134,47 +140,76 @@ let compare_gvar params x gx y gy =
       hierror_no_loc "cannot merge two globals (%a and %a)" pp_var x pp_var y
     | E.Sglob, E.Slocal ->
       if (Sv.mem y params) then hierror_no_loc "cannot merge a global and a param (%a and %a)" pp_var x pp_var y;
-      check_size "global" y sy x sx;
+      check_size "global" "local" y sy x sx;
       1
     | E.Slocal, E.Sglob ->
       if (Sv.mem x params) then hierror_no_loc "cannot merge a param and a global (%a and %a)" pp_var x pp_var y;
-      check_size "global" x sx y sy;
+      check_size "global" "local" x sx y sy;
       -1
     | E.Slocal, E.Slocal ->
       match Sv.mem x params, Sv.mem y params with
       | true, true ->
         hierror_no_loc "cannot merge two params (%a and %a)" pp_var x pp_var y;
-      | true, false -> check_size "param" y sy x sx; 1
-      | false, true -> check_size "param" x sx y sy; -1
+      | true, false -> check_size "param" "local" y sy x sx; 1
+      | false, true -> check_size "param" "local" x sx y sy; -1
       | false, false ->
-        let c = Stdlib.Int.compare sx sy in
-        if c = 0 then
-          match is_ptr x.v_kind, is_ptr y.v_kind with
-          | true, false -> -1
-          | false, true -> 1
-          | _, _ -> V.compare x y
-        else c
+         match is_ptr x.v_kind, is_ptr y.v_kind with
+         | true, false -> check_size "local" "pointer" x sx y sy; -1
+         | false, true -> check_size "local" "pointer" y sy x sx; 1
+         | _, _ ->
+           let c = Stdlib.Int.compare sx sy in
+           if c = 0 then V.compare x y
+           else c
+
+
+let mk_sub sz1 sz2 ws =
+  if sz1 = sz2 then Exact(0,sz2)
+  else Sub ws
 
 (* Precondition: s1 and s2 are normal forms (aka roots) in a *)
+(* We want to unify the slice of s1 and the slice of s2,
+   Assume that [size_of s1.in_var <= size_of s2.in_var]
+   We need to express the position of the slice
+    [{in_var = s1.in_var; kind : Exact (0, size_of s1.in_var)}]
+    in term of [s2.in_var], in such way that s1 and s2 overlap,
+    i.e. correspond to the same memory part.
+  s1.in_var   =               [......   | s1 | ...]
+  s2.in_var   =   [...........|...| s2 | ... | ......]
+*)
+
 (* x1[e1:n1] = x2[e2:n2] *)
 let merge_slices params a s1 s2 =
   let c = compare_gvar params s1.in_var s1.scope s2.in_var s2.scope in
   if c = 0 then
     (* in particular, s1.in_var and s2.in_var are the same variable *)
-    if s1 = s2 || s1.kind <> Exact || s2.kind <> Exact then
+    if s1 <> s2 && is_exact s1.kind && is_exact s2.kind then
+      hierror_no_loc "cannot merge distinct slices of the same array: %a and %a" pp_slice s1 pp_slice s2
+    else
       (* when s1.kind or s2.kind is Sub _, we cannot be precise, we prefer not to fail, and we don't update a *)
       a
-    else
-      hierror_no_loc "cannot merge distinct slices of the same array: %a and %a" pp_slice s1 pp_slice s2
   else
     let s1, s2 = if c < 0 then s1, s2 else s2, s1 in
-    let x = s1.in_var in
-    let y = s2.in_var in
-    let lo = fst s2.range - fst s1.range in
-    let hi = lo + size_of x.v_ty in
-    if lo < 0 || size_of y.v_ty < hi
-    then hierror_no_loc "merging slices %a and %a may introduce invalid accesses; consider declaring variable %a smaller" pp_slice s1 pp_slice s2 pp_var x;
-    Mv.add x { s2 with range = lo, hi; kind = s1.kind } a
+    let sz1 = size_of s1.in_var.v_ty in
+    let sz2 = size_of s2.in_var.v_ty in
+    (* s1 is expressed as a subpart of s2 *)
+    let kind =
+      match s1.kind, s2.kind with
+      | Exact(lo1, _hi1), Exact(lo2, _hi2) ->
+        let lo = lo2 - lo1 in
+        let hi = lo + size_of s1.in_var.v_ty in
+        if lo < 0 || sz2 < hi
+        then hierror_no_loc "merging slices %a and %a may introduce invalid accesses; consider declaring variable %a smaller" pp_slice s1 pp_slice s2 pp_var s1.in_var;
+        Exact(lo, hi)
+      | Exact(lo1,_hi1), Sub ws2 ->
+        let ws = wsize_min ws2 (align_of_offset lo1) in
+        mk_sub sz1 sz2 ws
+      | Sub ws1, Exact(lo2, _hi2) ->
+        let ws = wsize_min ws1 (align_of_offset lo2) in
+        mk_sub sz1 sz2 ws
+      | Sub ws1, Sub ws2 ->
+        mk_sub sz1 sz2 (wsize_min ws1 ws2)
+    in
+    Mv.add s1.in_var { s2 with kind } a
 
 (* Precondition: both maps are normalized *)
 let merge params a1 a2 =
@@ -184,23 +219,22 @@ let merge params a1 a2 =
       merge_slices params a s1 s2
     ) a1 a2
 
-let range_of_asub aa ws len _gv i =
+let range_of_asub aa ws len i =
   match get_ofs aa ws i with
   | None ->
-      let range = (0, arr_size ws len) in
-      let kind =
+      let ws =
         begin match aa with
-        | AAscale -> Sub ws
-        | AAdirect -> Sub U8
+        | AAscale -> ws
+        | AAdirect -> U8
         end
       in
-      range, kind
-  | Some start -> (start, start + arr_size ws len), Exact
+      Sub ws
+  | Some start -> Exact (start, start + arr_size ws len)
 
 let normalize_asub a aa ws len x i =
   let s = normalize_gvar a x in
-  let range, kind = range_of_asub aa ws len x.gv i in
-  range_in_slice range kind s
+  let kind = range_of_asub aa ws len i in
+  range_in_slice kind s
 
 let slice_of_pexpr a =
   function

--- a/compiler/src/alias.ml
+++ b/compiler/src/alias.ml
@@ -308,9 +308,44 @@ and analyze_instr params cc a { i_loc ; i_desc } =
 and analyze_stmt params cc a s =
   List.fold_left (analyze_instr params cc) a s
 
+let is_stack_direct k = k = Stack Direct
+
+let has_overlay annot =
+  Annot.ensure_uniq1
+    "overlay"
+    (Annot.on_attribute ~on_id:(fun _ _ s -> s) ~on_string:(fun _ _ s -> s)
+       (fun loc id -> Annot. error ~loc "attribute for “%s” should be a string" id))
+    annot
+
+let merge_overlay params fd =
+  let vars = vars_c fd.f_body in
+  let process x m =
+    if is_stack_direct x.v_kind then
+      match has_overlay x.v_annot with
+      | Some s -> Ms.modify_def Sv.empty s (Sv.add x) m
+      | None -> m
+    else m in
+  let m = Sv.fold process vars Ms.empty in
+  let a =
+    Ms.fold (fun s sv a ->
+      match Sv.pop sv with
+      | exception Not_found -> a
+      | (x, sv) ->
+          if Sv.is_empty sv then
+            warning Always (Location.i_loc0 x.v_dloc)
+              "“overlay = %s” is applied only to one variable (“%a”), this will have no effect. Is it a typo?"
+              s pp_var x;
+          Sv.fold (fun y a ->
+              let s1 = normalize_var a x in
+              let s2 = normalize_var a y in
+              merge_slices params a s1 s2) sv a) m Mv.empty in
+   a
+
 let analyze_fd cc fd =
   let params = Sv.of_list fd.f_args in
-  try analyze_stmt params cc Mv.empty fd.f_body |> normalize_map
+  try
+    let a = merge_overlay params fd in
+    analyze_stmt params cc a fd.f_body |> normalize_map
   with (HiError e) -> raise (HiError { e with err_funname = Some fd.f_name.fn_name })
 
 (* --------------------------------------------------- *)

--- a/compiler/src/alias.mli
+++ b/compiler/src/alias.mli
@@ -1,13 +1,13 @@
 open Prog
 
+type range = int * int
 type sub_slice_kind =
-  | Exact
+  | Exact of range
     (* the range is exact *)
   | Sub of Wsize.wsize
-    (* the precise offset is not known, we remember that it is a subpart
-       and its alignment *)
+    (* the precise offset is not known, we remember its alignment *)
 
-type slice = { in_var : var ; scope : E.v_scope ; range : int * int; kind : sub_slice_kind }
+type slice = { in_var : var ; scope : E.v_scope ; kind : sub_slice_kind }
 
 type alias = slice Mv.t
 

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -152,15 +152,15 @@ let classes_alignment (onfun : funname -> param_info option list) (gtbl: alignme
         set al c.in_var c.scope ws;
         if al == Aligned then
          match c.kind with
-         | Exact ->
-             if (fst c.range + i) land (size_of_ws ws - 1) <> 0 then
-            hierror ~loc:(Lone (L.loc x.gv)) "bad range alignment for %a[%d]: %a was allocated in slot %a, which conflicts with the required alignment (%s)"
-              (Printer.pp_var ~debug:false) x' i
-              (Printer.pp_var ~debug:false) x' Alias.pp_slice c (string_of_ws ws)
+         | Exact range ->
+            if (fst range + i) land (size_of_ws ws - 1) <> 0 then
+              hierror ~loc:(Lone (L.loc x.gv)) "bad range alignment for %a[%d]: %a was allocated in slot %a, which conflicts with the required alignment (%s)"
+                (Printer.pp_var ~debug:false) x' i
+                (Printer.pp_var ~debug:false) x' Alias.pp_slice c (string_of_ws ws)
          | Sub ws' ->
-             if not (wsize_le ws ws') then
-               hierror ~loc:(Lone (L.loc x.gv)) "bad alignment for var %a: %a (expected: %a)"
-                 (Printer.pp_var ~debug:false) x' PrintCommon.pp_wsize ws' PrintCommon.pp_wsize ws
+           if not (wsize_le ws ws') then
+             hierror ~loc:(Lone (L.loc x.gv)) "@[the access to array %a (aligned on %a) could not be proved to be aligned on %a;@ if you know what you are doing or want to perform an unaligned access,@ you can use “#unaligned”@]"
+               (Printer.pp_var ~debug:false) x' PrintCommon.pp_wsize ws' PrintCommon.pp_wsize ws
       end
     else set al x' E.Sglob ws in
 
@@ -239,15 +239,20 @@ let init_slots pd stack_pointers alias coloring fv =
     | Stack Direct ->
       if is_ty_arr v.v_ty then
         let c = Alias.normalize_var alias v in
+        let range =
+          match c.kind with
+          | Exact range -> range
+          | Sub _ ->
+              hierror ~loc:(Lone v.v_dloc) "cannot allocate in the stack the variable “%a” to “%a” with non constant start index"
+                    (Printer.pp_var ~debug:false) v
+                    (Printer.pp_var ~debug:false) c.in_var in
         if c.scope = E.Sglob then
-          (* TODO: do we need to check that we are exact and fail otherwise? *)
-          add_local v (Direct (c.in_var, r2i c.range, E.Sglob))
+          add_local v (Direct (c.in_var, r2i range, E.Sglob))
         else
           begin
             let slot = get_slot coloring c.in_var in
             add_slot slot;
-            (* TODO: do we need to check that we are exact and fail otherwise? *)
-            add_local v (Direct (slot, r2i c.range, E.Slocal))
+            add_local v (Direct (slot, r2i range, E.Slocal))
           end
       else begin match v.v_ty with
            | Bty (U ws) ->

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -5,7 +5,7 @@ open Prog
 
 module G = IntervalGraphColoring
 
-let hierror = hierror ~kind:"compilation error" ~sub_kind:"variable allocation"
+let hierror = hierror ~kind:"compilation error" ~sub_kind:"stack allocation"
 
 type liverange = G.graph Mint.t
 

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -23,30 +23,30 @@ type param_info = {
   pi_align    : alignment_constraint;
 }
 
-type ptr_kind = 
+type ptr_kind =
   | Direct   of var * Interval.interval * E.v_scope
-  | StackPtr of var 
-  | RegPtr   of var  
+  | StackPtr of var
+  | RegPtr   of var
 
 type stk_alloc_oracle_t =
   { sao_calls  : Sf.t
   ; sao_params : param_info option list (* Allocation of pointer params *)
   ; sao_return : int option list        (* Where to find the param input region *)
-  ; sao_slots  : (var * wsize * int) list 
+  ; sao_slots  : (var * wsize * int) list
   ; sao_align : wsize
   ; sao_size  : int               (* Not normalized with respect to sao_local_align *)
   ; sao_alloc : ptr_kind Hv.t
   ; sao_modify_rsp : bool
   }
 
-type glob_alloc_oracle_t = 
-  { gao_data : Word0.word list 
-  ; gao_slots  : (var * wsize * int) list 
+type glob_alloc_oracle_t =
+  { gao_data : Word0.word list
+  ; gao_slots  : (var * wsize * int) list
   ; gao_align : wsize
   ; gao_size  : int               (* Not normalized with respect to sao_local_align *)
   }
 
- 
+
 (* --------------------------------------------------- *)
 let incr_liverange r x d : liverange =
   let s = size_of x.v_ty in
@@ -169,8 +169,8 @@ let classes_alignment (onfun : funname -> param_info option list) (gtbl: alignme
     | Pget (al, _, ws, x, e) -> add_ggvar al x ws 0; add_e e
     | Psub (_,_,_,_,e) | Pload (_, _, e) | Papp1 (_, e) -> add_e e
     | Papp2 (_, e1,e2) -> add_e e1; add_e e2
-    | PappN (_, es) -> add_es es 
-    | Pif (_,e1,e2,e3) -> add_e e1; add_e e2; add_e e3 
+    | PappN (_, es) -> add_es es
+    | Pif (_,e1,e2,e3) -> add_e e1; add_e e2; add_e e3
   and add_es es = List.iter add_e es in
 
   let add_lv = function
@@ -179,15 +179,15 @@ let classes_alignment (onfun : funname -> param_info option list) (gtbl: alignme
     | Laset(al, _, ws,x,e) -> add_ggvar al (gkvar x) ws 0; add_e e in
 
   let add_lvs = List.iter add_lv in
-  
-  let add_p opi e = 
+
+  let add_p opi e =
     match opi, e with
     | None, _ -> add_e e
     | Some pi, Pvar x ->
        add_ggvar Aligned x pi.pi_align.ac_strict 0;
        add_ggvar Unaligned x pi.pi_align.ac_heuristic 0
     | Some pi, Psub(aa,ws,_, x, e) ->
-      let i = 
+      let i =
         match get_ofs aa ws e with
         | None ->
           (* this error is probably always caught before by the similar code in alias.ml *)
@@ -224,7 +224,7 @@ let get_slot ?var coloring x =
 
 let get_stack_pointer stack_pointers x =
   try Hv.find stack_pointers x
-  with Not_found -> assert false 
+  with Not_found -> assert false
 
 let init_slots pd stack_pointers alias coloring fv =
   let slots = ref Sv.empty in
@@ -267,7 +267,7 @@ let init_slots pd stack_pointers alias coloring fv =
       add_local v (StackPtr slot)
     | Reg (k, Pointer _) ->
       let p = V.mk v.v_name (Reg(k, Direct)) (tu pd) v.v_dloc v.v_annot in
-      add_local v (RegPtr p) 
+      add_local v (RegPtr p)
     | _ -> () in
 
   Sv.iter dovar fv;
@@ -285,7 +285,7 @@ let all_alignment pd (ctbl: alignment) alias params lalloc : param_info option l
     | Reg (_, Pointer w) ->
       let c = Alias.normalize_var alias x in
       assert (V.equal x c.in_var && c.scope = E.Slocal);
-      let pi_ptr = 
+      let pi_ptr =
         match Hv.find lalloc x with
         | RegPtr p -> p
         | _ | exception Not_found -> assert false in
@@ -296,13 +296,13 @@ let all_alignment pd (ctbl: alignment) alias params lalloc : param_info option l
   let params = List.map doparam params in
 
   let atbl = Hv.create 1007 in
-  let set slot ws = 
+  let set slot ws =
     Hv.modify_def U8 slot (fun ws' -> if wsize_lt ws' ws then ws else ws') atbl in
   let doalloc x pk =
     match pk with
     | Direct (_, _, E.Sglob) | RegPtr _ -> ()
     | Direct (slot, _, E.Slocal) ->
-      let ws = 
+      let ws =
         match x.v_ty with
         | Arr _ -> (get_align (Alias.normalize_var alias x)).ac_heuristic
         | Bty (U ws) -> ws
@@ -321,35 +321,35 @@ let round_ws ws sz =
   else (sz/d + 1) * d
 
 let alloc_local_stack size slots atbl =
-  let do1 x = 
-    let ws = 
+  let do1 x =
+    let ws =
       try Hv.find atbl x
-      with Not_found -> 
+      with Not_found ->
         match x.v_ty with
         | Arr _ -> U8
-        | Bty (U ws) -> ws 
+        | Bty (U ws) -> ws
         | _ -> assert false
     in
     (x, ws) in
 
   let slots = List.map do1 slots in
 
-  (* Sort by alignment, bigger first *) 
-  let cmp (_,ws1) (_,ws2) = 
+  (* Sort by alignment, bigger first *)
+  let cmp (_,ws1) (_,ws2) =
     match Wsize.wsize_cmp ws1 ws2 with
     | Lt -> 1
     | Eq -> 0
     | Gt -> -1 in
   let slots = List.sort cmp slots in
 
-  let stk_align = 
+  let stk_align =
     match slots with
     | [] -> U8
     | (_,ws) :: _ -> ws in
 
   let size = ref size in
-  
-  let init_slot (x,ws) = 
+
+  let init_slot (x,ws) =
     let pos = round_ws ws !size in
     let n = size_of x.v_ty in
     size := pos + n;
@@ -389,8 +389,8 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
     Alias.analyze_fd get_cc fd in
   let classes = Alias.classes alias in
 
-  let ptr_args = 
-    List.fold_left (fun s x -> if is_reg_ptr_kind x.v_kind then Sv.add x s else s) 
+  let ptr_args =
+    List.fold_left (fun s x -> if is_reg_ptr_kind x.v_kind then Sv.add x s else s)
       Sv.empty fd.f_args in
   (* True if z is a pointer aliasing only other pointers *)
   let ptr_classes z =
@@ -418,18 +418,18 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
   let sao_params, atbl = all_alignment pd ctbl alias fd.f_args lalloc in
 
   let ra_on_stack =
-    match fd.f_cc with 
-    | Internal -> assert false 
+    match fd.f_cc with
+    | Internal -> assert false
     | Export ->
-        if fd.f_annot.retaddr_kind = Some OnReg then 
+        if fd.f_annot.retaddr_kind = Some OnReg then
              Utils.warning Always (L.i_loc fd.f_loc [])
               "for function %s, return address by reg not allowed for export function, annotation is ignored"
               fd.f_name.fn_name;
         false (* For export function ra is not counted in the frame *)
     | Subroutine ->
-      match callstyle with 
+      match callstyle with
       | Arch_full.StackDirect ->
-        if fd.f_annot.retaddr_kind = Some OnReg then 
+        if fd.f_annot.retaddr_kind = Some OnReg then
           Utils.warning Always (L.i_loc fd.f_loc [])
             "for function %s, return address by reg not allowed for that architecture, annotation is ignored"
             fd.f_name.fn_name;
@@ -440,9 +440,9 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
         let dfl = oreg <> None && has_call_or_syscall fd.f_body in
         match fd.f_annot.retaddr_kind with
         | None -> dfl
-        | Some k -> 
-            if k = OnReg && dfl then 
-              Utils.warning Always (L.i_loc fd.f_loc []) 
+        | Some k ->
+            if k = OnReg && dfl then
+              Utils.warning Always (L.i_loc fd.f_loc [])
                 "for function %s, return address by reg not possible, annotation is ignored" fd.f_name.fn_name;
             dfl || k = OnStack in
 
@@ -467,7 +467,7 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
     sao_slots;
     sao_align;
     sao_size;
-    sao_alloc; 
+    sao_alloc;
     sao_modify_rsp;
   } in
   sao
@@ -475,19 +475,19 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
 let alloc_mem (gtbl: wsize Hv.t) globs =
   let gao_align, gao_slots, gao_size = alloc_local_stack 0 (List.map fst globs) gtbl in
   let t = Array.make gao_size (Word0.wrepr U8 (Conv.cz_of_int 0)) in
-  let get x = 
+  let get x =
     try List.assoc x globs with Not_found -> assert false in
 
-  let doslot (v, _, ofs) = 
+  let doslot (v, _, ofs) =
     match get v with
     | Global.Gword(ws, w) ->
       let w = Memory_model.LE.encode ws w in
-      List.iteri (fun i w -> t.(ofs + i) <- w) w 
+      List.iteri (fun i w -> t.(ofs + i) <- w) w
 
     | Global.Garr(p, gt) ->
       let ip = Conv.int_of_pos p in
       for i = 0 to ip - 1 do
-        let w = 
+        let w =
           match Warray_.WArray.get p Aligned Warray_.AAdirect U8 gt (Conv.cz_of_int i) with
           | Ok w -> w
           | _    -> assert false in
@@ -502,26 +502,23 @@ let alloc_stack_prog callstyle pd (globs, fds) =
   let ftbl = Hf.create 107 in
   let get_info fn = Hf.find ftbl fn in
   let set_info fn sao = Hf.add ftbl fn sao in
-  let doit fd = 
+  let doit fd =
     let sao = alloc_stack_fd callstyle pd get_info gtbl fd in
     set_info fd.f_name sao in
   List.iter doit (List.rev fds);
   let gao =  alloc_mem (Hv.map (fun _ x -> x.ac_heuristic) gtbl) globs in
-  gao, ftbl 
+  gao, ftbl
 
 let extend_sao sao extra =
   let tbl = Hv.create 11 in
-  let doit x = 
+  let doit x =
     match x.v_ty with
-    | Bty (U ws) -> Hv.add tbl x ws 
+    | Bty (U ws) -> Hv.add tbl x ws
     | _          -> assert false in
   List.iter doit extra;
-    
+
   let align, slots, size = alloc_local_stack sao.sao_size extra tbl in
   let align = if wsize_lt align sao.sao_align then sao.sao_align else align in
   let slots = List.map (fun (x,_,pos) -> (x,pos)) slots in
   size - sao.sao_size, align, slots
-
-
-  
 

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -410,8 +410,7 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
 
   let getfun fn = (get_info fn).sao_params in
   let ctbl, sao_calls =
-    try classes_alignment getfun gtbl alias fd.f_body
-    with HiError e -> raise (HiError { e with err_funname = Some fd.f_name.fn_name })
+    classes_alignment getfun gtbl alias fd.f_body
   in
   let sao_return = get_returned_params ~funname:fd.f_name.fn_name alias fd.f_args fd.f_ret in
 
@@ -503,8 +502,10 @@ let alloc_stack_prog callstyle pd (globs, fds) =
   let get_info fn = Hf.find ftbl fn in
   let set_info fn sao = Hf.add ftbl fn sao in
   let doit fd =
-    let sao = alloc_stack_fd callstyle pd get_info gtbl fd in
-    set_info fd.f_name sao in
+    try
+      let sao = alloc_stack_fd callstyle pd get_info gtbl fd in
+      set_info fd.f_name sao
+    with HiError e -> raise (HiError { e with err_funname = Some fd.f_name.fn_name }) in
   List.iter doit (List.rev fds);
   let gao =  alloc_mem (Hv.map (fun _ x -> x.ac_heuristic) gtbl) globs in
   gao, ftbl

--- a/compiler/tests/fail/common/overlay_live.jazz
+++ b/compiler/tests/fail/common/overlay_live.jazz
@@ -1,0 +1,13 @@
+export fn overlay_live () -> reg u32 {
+  #[overlay = o1] stack u32[2] t1;
+  #[overlay = o1] stack u32[1] t2;
+  t1[0] = 0;
+  t1[1] = 0;
+  t2[0] = 0;
+  reg u32 x y;
+  x = t2[0];
+  // Remark it would be nice if the the example work with `y = t1[1];`
+  y = t1[0];
+  x = x + y;
+  return x;
+}

--- a/compiler/tests/fail/stack_allocation/x86-64/bad_alignment.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/bad_alignment.jazz
@@ -1,9 +1,9 @@
 export fn f (reg u64 i) -> reg u32 {
   reg u32 res;
   stack u64[2] a;
-  stack u32[10] b;
+  reg ptr u32[3] b;
   a[i]=0;
   b[1:2] = a[:u32 i:2];
-  res = b[1];
+  res = b[:u64 1];
   return res;
 }

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -538,6 +538,24 @@ fail/common/not-unrollable-for-loop.jazz:
 compilation error in function main:
 loop unrolling: for loops remain
 
+fail/common/overlay_live.jazz:
+
+"fail/common/overlay_live.jazz", line 10 (6-8):
+compilation error in function overlay_live:
+stack allocation: the region associated to variable t1 is partial
+
+fail/common/overlay_live.jazz:
+
+"fail/common/overlay_live.jazz", line 10 (6-8):
+compilation error in function overlay_live:
+stack allocation: the region associated to variable t1 is partial
+
+fail/common/overlay_live.jazz:
+
+"fail/common/overlay_live.jazz", line 10 (6-8):
+compilation error in function overlay_live:
+stack allocation: the region associated to variable t1 is partial
+
 fail/common/storage_signature_mismatch.jazz:
 
 "fail/common/storage_signature_mismatch.jazz", line 1 (0) to line 4 (1): In function “sum”, return statement variable “r” has storage type “reg”, which differs from declared return storage type “stack”
@@ -1575,4 +1593,4 @@ Statistics:
 	Pretyping:  48
 	Parsing:     4
 	Typing:      1
-	Compile:   194
+	Compile:   197

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1043,9 +1043,11 @@ stack allocation: do not know how to compile this array access into a memory acc
 
 fail/stack_allocation/x86-64/bad_alignment.jazz:
 
-"fail/stack_allocation/x86-64/bad_alignment.jazz", line 5 (2-3):
+"fail/stack_allocation/x86-64/bad_alignment.jazz", line 7 (8-9):
 compilation error in function f:
-stack allocation: bad alignment for var a: 32 (expected: 64)
+stack allocation: the access to array b (aligned on 32) could not be proved to be aligned on 64;
+                  if you know what you are doing or want to perform an unaligned access,
+                  you can use “#unaligned”
 
 fail/stack_allocation/x86-64/bad_range_alignment.jazz:
 
@@ -1283,7 +1285,7 @@ fail/stack_allocation/x86-64/unaligned_sub_offset.jazz:
 
 "fail/stack_allocation/x86-64/unaligned_sub_offset.jazz", line 9 (8-9):
 compilation error in function main:
-stack allocation: the access to array r could not be proved to be aligned;
+stack allocation: the access to array r (aligned on 32) could not be proved to be aligned on 64;
                   if you know what you are doing or want to perform an unaligned access,
                   you can use “#unaligned”
 
@@ -1291,7 +1293,7 @@ fail/stack_allocation/x86-64/unaligned_sub_offset_unscaled.jazz:
 
 "fail/stack_allocation/x86-64/unaligned_sub_offset_unscaled.jazz", line 8 (8-9):
 compilation error in function main:
-stack allocation: the access to array r could not be proved to be aligned;
+stack allocation: the access to array r (aligned on 8) could not be proved to be aligned on 64;
                   if you know what you are doing or want to perform an unaligned access,
                   you can use “#unaligned”
 
@@ -1330,14 +1332,7 @@ fail/subarrays/x86-64/unscaled_access.jazz:
 
 "fail/subarrays/x86-64/unscaled_access.jazz", line 14 (2-4):
 compilation error in function main:
-stack allocation: the assignment to array s2 cannot be turned into a nop
-source
-  { region = { slot = s; align = u32; writable = true };
-    zone = [0:40][1 * (uint) i:20] }
-and destination
-  { region = { slot = s; align = u32; writable = true };
-    zone = [0:20] }
-regions are not equal
+stack allocation: cannot allocate in the stack the variable “s2” to “s” with non constant start index
 
 fail/subarrays/x86-64/write_and_read_fails.jazz:
 

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1003,19 +1003,19 @@ fail/stack_allocation/arm-m4/bug_1384.jazz:
 
 "fail/stack_allocation/arm-m4/bug_1384.jazz", line 3 (14-15):
 compilation error:
-variable allocation: cannot allocate in the stack the variable “x_spill” of type int
+stack allocation: cannot allocate in the stack the variable “x_spill” of type int
 
 fail/stack_allocation/arm-m4/bug_1384a.jazz:
 
 "fail/stack_allocation/arm-m4/bug_1384a.jazz", line 2 (12-17):
 compilation error:
-variable allocation: cannot allocate in the stack the variable “x” of type int
+stack allocation: cannot allocate in the stack the variable “x” of type int
 
 fail/stack_allocation/arm-m4/bug_1384b.jazz:
 
 "fail/stack_allocation/arm-m4/bug_1384b.jazz", line 3 (13-21):
 compilation error:
-variable allocation: cannot allocate in the stack the variable “b” of type bool
+stack allocation: cannot allocate in the stack the variable “b” of type bool
 
 fail/stack_allocation/arm-m4/cannot_compute_address.jazz:
 
@@ -1045,13 +1045,13 @@ fail/stack_allocation/x86-64/bad_alignment.jazz:
 
 "fail/stack_allocation/x86-64/bad_alignment.jazz", line 5 (2-3):
 compilation error in function f:
-variable allocation: bad alignment for var a: 32 (expected: 64)
+stack allocation: bad alignment for var a: 32 (expected: 64)
 
 fail/stack_allocation/x86-64/bad_range_alignment.jazz:
 
 "fail/stack_allocation/x86-64/bad_range_alignment.jazz", line 5 (2-3):
 compilation error in function f:
-variable allocation: bad range alignment for a[0]: a was allocated in slot b[4; 20[, which conflicts with the required alignment (u64)
+stack allocation: bad range alignment for a[0]: a was allocated in slot b[4; 20[, which conflicts with the required alignment (u64)
 
 fail/stack_allocation/x86-64/bug_54.jazz:
 
@@ -1069,7 +1069,7 @@ fail/stack_allocation/x86-64/local_stack_to_pointer.jazz:
 
 "fail/stack_allocation/x86-64/local_stack_to_pointer.jazz", line 1 (0) to line 6 (1):
 compilation error in function f:
-variable allocation: cannot put a reg ptr argument into the local stack
+stack allocation: cannot put a reg ptr argument into the local stack
 
 fail/stack_allocation/x86-64/merge_global_param.jazz:
 
@@ -1202,7 +1202,7 @@ fail/stack_allocation/x86-64/pointer_to_local_stack.jazz:
 
 "fail/stack_allocation/x86-64/pointer_to_local_stack.jazz", line 1 (0) to line 8 (1):
 compilation error in function bad:
-variable allocation: cannot put a reg ptr argument into the local stack
+stack allocation: cannot put a reg ptr argument into the local stack
 
 fail/stack_allocation/x86-64/protect_ptr_arg.jazz:
 
@@ -1259,19 +1259,19 @@ fail/stack_allocation/x86-64/return_ptr_global.jazz:
 
 "fail/stack_allocation/x86-64/return_ptr_global.jazz", line 5 (9-10):
 compilation error in function main:
-variable allocation: returned variable p points to a region that should not escape the local scope: #g:g[0; 4[
+stack allocation: returned variable p points to a region that should not escape the local scope: #g:g[0; 4[
 
 fail/stack_allocation/x86-64/return_ptr_local.jazz:
 
 "fail/stack_allocation/x86-64/return_ptr_local.jazz", line 5 (9-10):
 compilation error in function main:
-variable allocation: returned variable r points to a region that should not escape the local scope: s[0; 4[
+stack allocation: returned variable r points to a region that should not escape the local scope: s[0; 4[
 
 fail/stack_allocation/x86-64/return_subslice.jazz:
 
 "fail/stack_allocation/x86-64/return_subslice.jazz", line 3 (9-10):
 compilation error in function sub:
-variable allocation: returned variable r points to a strict sub-slice of a parameter: p[0; 1[
+stack allocation: returned variable r points to a strict sub-slice of a parameter: p[0; 1[
 
 fail/stack_allocation/x86-64/stack_ptr_in_expr.jazz:
 

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1002,19 +1002,19 @@ speculative execution lowering: Not able to prove that ! __zf__
 fail/stack_allocation/arm-m4/bug_1384.jazz:
 
 "fail/stack_allocation/arm-m4/bug_1384.jazz", line 3 (14-15):
-compilation error:
+compilation error in function spilled_int:
 stack allocation: cannot allocate in the stack the variable “x_spill” of type int
 
 fail/stack_allocation/arm-m4/bug_1384a.jazz:
 
 "fail/stack_allocation/arm-m4/bug_1384a.jazz", line 2 (12-17):
-compilation error:
+compilation error in function stack_int:
 stack allocation: cannot allocate in the stack the variable “x” of type int
 
 fail/stack_allocation/arm-m4/bug_1384b.jazz:
 
 "fail/stack_allocation/arm-m4/bug_1384b.jazz", line 3 (13-21):
-compilation error:
+compilation error in function stack_bool:
 stack allocation: cannot allocate in the stack the variable “b” of type bool
 
 fail/stack_allocation/arm-m4/cannot_compute_address.jazz:

--- a/compiler/tests/success/common/overlay.jazz
+++ b/compiler/tests/success/common/overlay.jazz
@@ -1,0 +1,14 @@
+/* The stacksize of 20 ensure that s and s2 overlay else a size of 24 is needed */
+#[stacksize = 20]
+export fn overlay () -> reg u32 {
+  #[overlay = myoverlay] stack u32[1] s;
+  #[overlay = myoverlay] stack u32[5] s2;
+  reg u32 i z;
+  z = 0;
+  s[0] = z;
+  i = s[0];
+  s2[0] = z; s2[4] = z;
+  z = s2[0];
+  i += z;
+  return i;
+}

--- a/compiler/tests/success/common/overlay_fun.jazz
+++ b/compiler/tests/success/common/overlay_fun.jazz
@@ -1,0 +1,22 @@
+/* overlay should also work with inlining */
+
+inline fn overlay_f () -> reg u32 {
+  #[overlay = myoverlay] stack u32[1] s;
+  reg u32 i;
+  reg u32 z = 0;
+  s[0] = z;
+  i = s[0];
+  return i;
+}
+
+#[stacksize = 20]
+export fn overlay () -> reg u32 {
+  #[overlay = myoverlay] stack u32[5] s2;
+  reg u32 i;
+  i = overlay_f();
+  reg u32 z = 0;
+  s2[0] = z; s2[4] = z;
+  z = s2[0];
+  i += z;
+  return i;
+}

--- a/compiler/tests/success/common/overlay_fun_propagate.jazz
+++ b/compiler/tests/success/common/overlay_fun_propagate.jazz
@@ -1,0 +1,20 @@
+inline fn overlay_f () -> stack u32[1] {
+  stack u32[1] s;
+  reg u32 z = 0;
+  s[0] = z;
+  return s;
+}
+
+#[stacksize = 20]
+export fn overlay () -> reg u32 {
+  #[overlay = myoverlay] stack u32[5] s2;
+  #[overlay = myoverlay] stack u32[1] s;
+  reg u32 i z;
+  z = 0;
+  s = overlay_f();
+  i = s[0];
+  s2[0] = z; s2[4] = z;
+  z = s2[0];
+  i += z;
+  return i;
+}

--- a/docs/source/language/semantics/arrays.md
+++ b/docs/source/language/semantics/arrays.md
@@ -41,7 +41,7 @@ Consider for instance the following snippet:
 
     stack u64[4] a;
     a[3] = 1;
-    
+
 The second line accesses the 64 bits in memory at offset 3 × 8 after the beginning of the array `a`.
 Indeed, according to the declared type of the array, each element is 8 bytes wide, therefore the fourth elements starts at offset 24.
 If the index is statically known, scaling is computed at compile-time.
@@ -49,7 +49,7 @@ If the index is statically known, scaling is computed at compile-time.
 The Jasmin language allows to disable the implicit scaling through the following syntax for direct access (i.e., not scaled):
 
     a.[24] = 1;
-    
+
 Notice the dot before the opening square bracket.
 
 This feature is specially useful when the instruction set does not provide the addressing mode with appropriate scaling.
@@ -104,3 +104,105 @@ sp = r;   // the address is copied in the stack, the register can be used for ot
 r = sp;   // the address is put back into a register
 ...       // r can be used again
 ```
+
+## Sharing Stack Space
+
+The Jasmin compiler automatically tries to reduce stack usage by sharing stack arrays of the same size when they do not overlap in their lifetimes.
+
+For example:
+
+```
+#[stacksize = 20]
+export fn test() -> reg u32 {
+  stack u32[5] t1;
+  stack u32[5] t2;
+  inline int i;
+
+  for i = 0 to 5 {
+    t1[i] = i;
+  }
+
+  reg u32 s = 0;
+
+  for i = 0 to 5 {
+    s += t1[i];
+  }
+
+  for i = 0 to 5 {
+    t2[i] = i;
+  }
+
+  for i = 0 to 5 {
+    s += t2[i];
+  }
+
+  return s;
+}
+```
+
+Here, the arrays `t1` and `t2` are not live at the same time, so they can share the same stack location (i.e., they are merged).
+
+The annotation `#[stacksize = 20]` ensures that the stack size of the function `test` does not exceed 20 bytes (`5 × 4` bytes). If the arrays were not merged, 40 bytes of stack space would be required.
+
+### Overlay
+
+The compiler only shares memory regions of the same size. To share memory regions of different sizes (similarly to using a `union` type in C), you can use the `overlay` annotation on stack variables:
+
+```
+#[stacksize = 20]
+export fn overlay() -> reg u32 {
+  #[overlay = myoverlay] stack u32[1] s;
+  #[overlay = myoverlay] stack u32[5] s2;
+
+  reg u32 i;
+
+  s[0] = 0;
+  i = s[0];
+
+  s2[0] = 0;
+  s2[4] = 0;
+
+  i += s2[0];
+
+  return i;
+}
+```
+
+In this example, all stack variables that share the same `overlay` identifier (here, `myoverlay`) are allocated in the same stack region.
+
+The stack space required for this function is 20 bytes (`5 × 4`). Without the overlay, 24 bytes would be required.
+
+Naturally, you can define and use multiple overlays if needed.
+
+The `overlay` annotation is compatible with function inlining, as shown below:
+
+```
+inline fn overlay_f() -> reg u32 {
+  #[overlay = myoverlay] stack u32[1] s;
+
+  reg u32 i;
+
+  s[0] = 0;
+  i = s[0];
+
+  return i;
+}
+
+#[stacksize = 20]
+export fn overlay() -> reg u32 {
+  #[overlay = myoverlay] stack u32[5] s2;
+
+  reg u32 i;
+
+  i = overlay_f();
+
+  s2[0] = 0;
+  s2[4] = 0;
+
+  i += s2[0];
+
+  return i;
+}
+```
+
+In this example, the stack variable `s` from the inlined function `overlay_f` and the stack variable `s2` from `overlay` share the same overlay region and therefore the same stack allocation.


### PR DESCRIPTION
# Description
The first commits fix some error in the code of alias.
The seconds add the overlay annotation allowing the user to force the compiler to merge stack arrays (possibly of different size).

This is done in collaboration with Jean-Christophe Léchenet.
Fixes # (issue) <!-- if applicable -->

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed
<!-- if this is your first contribution - [ ] Add your name to `AUTHORS` -->
