### PR TITLE
Checksafety: handle #copy of array slices

### DIFF
--- a/changes/03-other/1477-checksafety-copy-slice.md
+++ b/changes/03-other/1477-checksafety-copy-slice.md
@@ -1,0 +1,2 @@
+- The safety checker now handles `#copy` applied to array slices
+  ([PR 1477](https://github.com/jasmin-lang/jasmin/pull/1477)).

--- a/compiler/safetylib/safetyInterpreter.ml
+++ b/compiler/safetylib/safetyInterpreter.ml
@@ -423,10 +423,17 @@ let safe_opn pd asmOp safe opn es =
          let n = Papp2 (Omod (Unsigned, Op_int), n, Pconst (Z.of_int 32)) in
          [ InRange(Pconst (Conv.z_of_cz lo), Pconst (Conv.z_of_cz hi), n) ]
       | Wsize.AllInit(ws, p, i) ->
-        let e = List.nth es (Conv.int_of_nat i) in
-        let y = match e with Pvar y -> y | _ -> assert false in
-        List.flatten
-          (List.init (Conv.int_of_pos p) (fun i -> init_get y Warray_.AAscale ws (Pconst (Z.of_int i)) 1))
+         let array, aa, offset =
+           match List.nth es (Conv.int_of_nat i) with
+           | Pvar y -> y, Warray_.AAscale, icnst
+           | Psub (Warray_.AAdirect, _ws, _len, y, ofs) ->
+              y, Warray_.AAdirect, (fun i -> Papp2 (Oadd Op_int, ofs, icnst (size_of_ws ws * i)))
+           | Psub (Warray_.AAscale, ws', _len, y, ofs) ->
+              y, Warray_.AAdirect, (fun i -> Papp2 (Oadd Op_int, Papp2 (Omul Op_int, ofs, icnst (size_of_ws ws')), icnst (size_of_ws ws * i)))
+           | _ -> assert false
+         in
+           List.flatten
+             (List.init (Conv.int_of_pos p) (fun i -> init_get array aa ws (offset i) 1))
       | NotZero (sz, n) ->
         [ notZero(sz, List.nth es (Conv.int_of_nat n)) ]
 

--- a/compiler/tests/safety/success/common/copy-slice.jazz
+++ b/compiler/tests/safety/success/common/copy-slice.jazz
@@ -1,0 +1,14 @@
+export fn main(reg u32 x) -> reg u32 {
+  stack u8[16] s;
+  stack u32[1] z;
+  z[0] = x;
+  inline int i;
+  for i = 0 to 4 {
+    s[:u32 i : 1] = #copy_32(z[0:1]);
+  }
+  x = s[:u32 2];
+  s[:u32 1] = x;
+  z = #copy_32(s.[:u16 4 : 2]);
+  x = z[0];
+  return x;
+}


### PR DESCRIPTION
# Description

Currently, the safety checker crashes with an assertion failure.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
