### PR TITLE
Array #copy does not assume alignment

### DIFF
--- a/changes/03-other/1478-copy-unaligned.md
+++ b/changes/03-other/1478-copy-unaligned.md
@@ -1,0 +1,3 @@
+- The `#copy` operator uses “unaligned” accesses, i.e., no longer assumes that
+  its source and destination have any known alignment
+  ([PR 1478](https://github.com/jasmin-lang/jasmin/pull/1478)).

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -309,7 +309,7 @@ fail/array_expansion/x86-64/default_scale_2.jazz:
 
 "fail/array_expansion/x86-64/default_scale_2.jazz", line 10 (8-9):
 compilation error in function main:
-array expansion: cannot expand variable r (alignement must be enforced)
+array expansion: cannot expand variable r (the default scale must be used)
 
 fail/array_expansion/x86-64/default_scale_lv.jazz:
 
@@ -321,7 +321,7 @@ fail/array_expansion/x86-64/default_scale_lv_2.jazz:
 
 "fail/array_expansion/x86-64/default_scale_lv_2.jazz", line 10 (2-3):
 compilation error in function main:
-array expansion: cannot expand variable r (alignement must be enforced)
+array expansion: cannot expand variable r (the default scale must be used)
 
 fail/array_expansion/x86-64/default_scale_param.jazz:
 
@@ -1563,12 +1563,6 @@ fail/x86-64/swap_type_mismatch.jazz:
 
 "fail/x86-64/swap_type_mismatch.jazz", line 2 (18-19): the expression has type u64 instead of u8[8]
 
-fail/x86-64/unaligned_slice_copy.jazz:
-
-"fail/x86-64/unaligned_slice_copy.jazz", line 6 (3-24):
-compilation error in function main:
-variable allocation: bad range alignment for src[0]: src was allocated in slot s[3; 7[, which conflicts with the required alignment (u32)
-
 fail/x86-64/zxspill.jazz:
 
 "fail/x86-64/zxspill.jazz", line 5 (2-14):
@@ -1582,4 +1576,4 @@ Statistics:
 	Pretyping:  51
 	Parsing:     4
 	Typing:      1
-	Compile:   195
+	Compile:   194

--- a/compiler/tests/success/x86-64/unaligned_slice_copy.jazz
+++ b/compiler/tests/success/x86-64/unaligned_slice_copy.jazz
@@ -1,4 +1,4 @@
-// Cannot copy by chunks of 4 bytes starting at offset 3 bytes
+// Ensure we can copy by chunks of 4 bytes starting at offset 3 bytes
 export fn main() -> reg u32 {
    stack u8[8] s;
    s[:u64 0] = 0;

--- a/proofs/compiler/array_copy.v
+++ b/proofs/compiler/array_copy.v
@@ -45,15 +45,15 @@ Context (fi : fun_info).
 *)
 
 Definition direct_copy ws x y i :=
-  [:: Cassgn (Laset Aligned AAscale ws x i) AT_none (aword ws) (Pget Aligned AAscale ws y i) ].
+  [:: Cassgn (Laset Unaligned AAscale ws x i) AT_none (aword ws) (Pget Unaligned AAscale ws y i) ].
 
 Definition tmp_var ws :=
   {| vtype := aword ws; vname := fresh_temporary fi ws |}.
 
 Definition indirect_copy ws x y i :=
   let tmp := {| v_var := tmp_var ws ; v_info := v_info x |} in
-  [:: Cassgn (Lvar tmp) AT_none (aword ws) (Pget Aligned AAscale ws y i);
-   Cassgn (Laset Aligned AAscale ws x i) AT_none (aword ws) (Pvar (mk_lvar tmp)) ].
+  [:: Cassgn (Lvar tmp) AT_none (aword ws) (Pget Unaligned AAscale ws y i);
+   Cassgn (Laset Unaligned AAscale ws x i) AT_none (aword ws) (Pvar (mk_lvar tmp)) ].
 
 Definition needs_temporary x y : bool :=
   is_var_in_memory x && is_var_in_memory y.

--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -198,6 +198,7 @@ Opaque esem.
         case: (hu) => _ h /h hw8; rewrite (write_read8 hset) /=.
         rewrite WArray.subE; case: andP => //; rewrite !zify => hb.
         have [ _ /(_ _ hb) ] := read_read8 hget.
+        rewrite (read8_alignment Aligned).
         case: hu => _ hu /hu <-.
         by rewrite -hw8 WArray.addE /mk_scale; f_equal; ring.
       rewrite Vm.setP_neq; last by apply /eqP.

--- a/proofs/compiler/array_expansion.v
+++ b/proofs/compiler/array_expansion.v
@@ -124,7 +124,6 @@ Fixpoint expand_e (m : t) (e : pexpr) : cexec pexpr :=
       match Mvar.get m.(sarrs) x, is_const e1 with
       | Some ai, Some i =>
         Let _ := assert (ai.(ai_ty) == ws) (reg_error x "(the default scale must be used)") in
-        Let _ := assert (al == Aligned) (reg_error x "(alignement must be enforced)") in
         Let _ := assert (aa == AAscale) (reg_error x "(the default scale must be used)") in
         Let _ := assert [&& 0 <=? i & i <? ai.(ai_len)]%Z (reg_error x "(index out of bounds)") in
         let v := znth (v_var x) ai.(ai_elems) i in
@@ -182,7 +181,6 @@ Definition expand_lv (m : t) (x : lval)  :=
       match Mvar.get m.(sarrs) x, is_const e with
       | Some ai, Some i =>
         Let _ := assert (ai.(ai_ty) == ws) (reg_error x "(the default scale must be used)") in
-        Let _ := assert (al == Aligned) (reg_error x "(alignement must be enforced)") in
         Let _ := assert (aa == AAscale) (reg_error x "(the default scale must be used)") in
         Let _ := assert [&& 0 <=? i & i <? ai.(ai_len)]%Z (reg_error x "(index out of bounds)") in
         let v := znth (v_var x) ai.(ai_elems) i in

--- a/proofs/compiler/array_expansion_proof.v
+++ b/proofs/compiler/array_expansion_proof.v
@@ -26,7 +26,7 @@ Definition wf_t (m : t) :=
 
 Definition eval_array ws v i :=
   if v is Varr _ t
-  then ok (rdflt undef_w (rmap (@Vword _) (WArray.get Aligned AAscale ws t i)))
+  then ok (rdflt undef_w (rmap (@Vword _) (WArray.get Unaligned AAscale ws t i)))
   else type_error.
 
 Definition eq_alloc_vm {wsw : WithSubWord} (m : t) vm1 vm2 :=
@@ -112,7 +112,7 @@ Qed.
 
 Lemma expand_vP n a ws l :
   mapM (eval_array ws (@Varr n a)) l =
-    ok (map (fun i => rdflt undef_w (rmap (@Vword _) (WArray.get Aligned AAscale ws a i)))  l).
+    ok (map (fun i => rdflt undef_w (rmap (@Vword _) (WArray.get Unaligned AAscale ws a i)))  l).
 Proof. by elim: l => // *; simpl map; rewrite -mapM_cons. Qed.
 
 
@@ -199,10 +199,12 @@ Proof.
       apply: on_arr_gvarP => n t hty ->.
       by t_xrbindP=> i vi /he -> /= -> /= w -> <-.
     case hgetx : Mvar.get => [ax|//]; case: is_constP => // i.
-    t_xrbindP=> /eqP <- /eqP -> /eqP -> hbound <- v; have hai := valid hgetx.
+    t_xrbindP=> /eqP <- /eqP -> hbound <- v; have hai := valid hgetx.
     apply: on_arr_gvarP => n t /eqP hty.
     rewrite /get_gvar hlv{hlv} => /get_varP [ hx1 _ _] /=.
-    t_xrbindP=> ? hw <-.
+    t_xrbindP => z /(@aligned_le_read _ _ _ _ _ _ _ _ Unaligned) /=.
+    rewrite /aligned_le eqxx => /(_ erefl).
+    rewrite -/(WArray.get Unaligned AAscale _ t _) => hw <-.
     case: h=> _ _ -[_] /(_ _ _ _ hgetx (wf_mem (v_var (gv x)) hai hbound)).
     by rewrite -hx1 /= (wf_index _ hai hbound) /get_gvar /get_var hw /= => -[<-] /=; rewrite orbT.
   + move=> aa sz len x e hrec e2 he e1 /hrec hrec1 <- /=.
@@ -267,7 +269,7 @@ Proof.
       t_xrbindP => i vi /(expand_eP h he) -> /= -> /= ? -> /= t' -> hw.
       by apply (eq_alloc_write_var h hin hw).
     case hai: Mvar.get => [ai | //].
-    case: is_constP => // i ; t_xrbindP => /eqP <- /eqP -> /eqP -> hbound <- v s1'.
+    case: is_constP => // i ; t_xrbindP => /eqP <- /eqP -> hbound <- v s1'.
     apply on_arr_varP => n t hty hget /=.
     t_xrbindP => w hvw t' ht' /[dup] hw1 /write_varP [? _ htrv]; subst s1'.
     have vai := valid hai; have hin := wf_mem (v_var x) vai hbound.
@@ -394,12 +396,12 @@ Lemma wf_write_get s (x:var_i) ai (a : WArray.array (Z.to_pos (arr_size (ai_ty a
   (0 <= i)%Z -> (i + len <= ai_len ai)%Z -> (0 <= len)%Z ->
   exists2 vm,
     write_lvals false gd s [seq Lvar {| v_var := znth (v_var x) (ai_elems ai) x0; v_info := v_info x |} | x0 <- ziota i len]
-      [seq rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Aligned AAscale (ai_ty ai) a i)) | i <- ziota i len] = ok (with_vm s vm) &
+      [seq rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Unaligned AAscale (ai_ty ai) a i)) | i <- ziota i len] = ok (with_vm s vm) &
     forall y,
       vm.[y] =
         let j := zindex y (ai_elems ai) in
         if j \in ziota i len then
-           rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Aligned AAscale (ai_ty ai) a j))
+           rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Unaligned AAscale (ai_ty ai) a j))
         else (evm s).[y].
 Proof.
   move => hva h0i hilen h0l.
@@ -414,7 +416,7 @@ Proof.
   + by apply/andP; split; [apply/ZleP|apply/ZltP]; lia.
   have hin := wf_mem (v_var x) hva hk1.
   rewrite (xi_ty hva hin).
-  have -> /= : (truncatable false (cword (ai_ty ai)) (rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Aligned AAscale (ai_ty ai) a k)))).
+  have -> /= : (truncatable false (cword (ai_ty ai)) (rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Unaligned AAscale (ai_ty ai) a k)))).
   + by case: WArray.get => //=.
   set s1 := with_vm _ _.
   case: (hrec s1 huni) => vm -> hvm; exists vm => // y; rewrite in_cons.
@@ -484,8 +486,8 @@ Proof.
   have [vm2 ] := wf_write_get s2 ra hva h0i hilen' (Zle_0_pos _).
   rewrite {1 2}(ziota_shift i len') -!map_comp /comp.
   have -> :
-   [seq rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Aligned AAscale (ai_ty ai) ra (i + x0))) | x0 <- ziota 0 len'] =
-   [seq rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Aligned AAscale (ai_ty ai) sa i0)) | i0 <- ziota 0 len'].
+   [seq rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Unaligned AAscale (ai_ty ai) ra (i + x0))) | x0 <- ziota 0 len'] =
+   [seq rdflt undef_w (rmap (Vword (s:=ai_ty ai)) (WArray.get Unaligned AAscale (ai_ty ai) sa i0)) | i0 <- ziota 0 len'].
   + apply eq_in_map => j; rewrite in_ziota => /andP [] /ZleP ? /ZltP ?.
     rewrite (WArray.set_sub_get _ hra).
     have -> : (i <=? i + j)%Z && (i + j <? i + len')%Z; last by do 3!f_equal; ring.
@@ -633,7 +635,7 @@ Proof.
   have h : ((0 <= Z0 < wsize_size (ai_ty ai)))%Z.
   + by move=> /=; have := wsize_size_pos (ai_ty ai); lia.
   have [_ /(_ Z0 h)] := read_read8 heq.
-  by rewrite WArray.get0 //= WArray.addE; have := wsize_size_pos (ai_ty ai); lia.
+  by rewrite (read8_alignment Aligned) WArray.get0 //= WArray.addE; have := wsize_size_pos (ai_ty ai); lia.
 Qed.
 
 Lemma mapM2_dc_truncate_id tys vs vs':

--- a/proofs/lang/sopn.v
+++ b/proofs/lang/sopn.v
@@ -206,9 +206,9 @@ Proof.
   move=> j js hj hrec t1 /=.
   have [w -> /=] := h _ hj; rewrite /WArray.set.
   have := [elaborate (writeV (CM:= WArray.array_CM (Z.to_pos (arr_size ws p))))].
-  move => /(_ _ w t1 Aligned (j * mk_scale AAscale ws)%Z) wP.
-  assert (h1 : validw t1 Aligned (j * mk_scale AAscale ws)%Z ws).
-  + rewrite /validw /is_aligned_if WArray.is_align_scale andTb.
+  move => /(_ _ w t1 Unaligned (j * mk_scale AAscale ws)%Z) wP.
+  assert (h1 : validw t1 Unaligned (j * mk_scale AAscale ws)%Z ws).
+  + rewrite /validw /is_aligned_if andTb.
     apply ziota_ind => //= i ? hi ->; rewrite andbT; apply/WArray.in_boundP.
     rewrite WArray.addE; change (Zpos _) with ((wsize_size ws) * p)%Z;Lia.nia.
   move/wP: h1 => [t2 ->] /=; apply hrec.

--- a/proofs/lang/values.v
+++ b/proofs/lang/values.v
@@ -908,7 +908,7 @@ Definition interp_safe_cond (vs : values) (sc : safe_cond) :=
   | AllInit ws p k =>
     forall t, to_arr (Z.to_pos (arr_size ws p)) (nth undef_b vs k) = ok t ->
     forall i, (0 <= i < p)%Z ->
-     exists w, WArray.get Aligned AAscale ws t i = ok w
+     exists w, WArray.get Unaligned AAscale ws t i = ok w
   | X86Division sz sign =>
     forall hi lo dv,
       mapM (to_word sz) (take 3 vs) = ok [:: hi; lo; dv] ->

--- a/proofs/lang/warray_.v
+++ b/proofs/lang/warray_.v
@@ -152,7 +152,7 @@ Module WArray.
 
   Definition fcopy ws len (a t: WArray.array len) i j :=
     foldM (fun i t =>
-             Let w := get Aligned AAscale ws a i in set t Aligned AAscale i w) t
+             Let w := get Unaligned AAscale ws a i in set t Unaligned AAscale i w) t
       (ziota i j).
 
   Definition copy ws p (a:array (Z.to_pos (arr_size ws p))) :=


### PR DESCRIPTION
# Description

Currently, the `#copy` operator assumes that its source and destination are aligned and its translation emits “aligned” memory accesses. This imposes some constraints on the arrays that are involved in `#copy` operation but programmers have no control over it and these constraints are often spurious (emitted code would be the same without the alignment assumption).

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
