### PR TITLE
Catch annotation errors

### DIFF
--- a/compiler/src/annot.ml
+++ b/compiler/src/annot.ml
@@ -40,8 +40,8 @@ let filter_string_list dfl l arg =
   let error loc nid =
     assert (l <> []);
     let pp fmt l =
-      Format.fprintf fmt "(@[%a@])"
-        (pp_list " |@ " (fun fmt (s, _) -> Format.pp_print_string fmt s))
+      Format.fprintf fmt "one of %a"
+        (pp_list ", " (fun fmt (s, _) -> Format.fprintf fmt "“%s”" s))
         l
     in
     error_attribute loc nid pp l Format.pp_print_string dfl

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -87,6 +87,7 @@ let main () =
     let env, pprog, _ast =
       try Compile.parse_file Arch.arch_info ~idirs:!Glob_options.idirs infile
       with
+      | Annot.AnnotationError (loc, code) -> hierror ~loc:(Lone loc) ~kind:"annotation error" "%t" code
       | Pretyping.TyError (loc, code) -> hierror ~loc:(Lone loc) ~kind:"typing error" "%a" Pretyping.pp_tyerror code
       | Syntax.ParseError (loc, msg) ->
           let msg =

--- a/compiler/tests/fail/annotation/x86-64/returnaddress.jazz
+++ b/compiler/tests/fail/annotation/x86-64/returnaddress.jazz
@@ -1,0 +1,4 @@
+// wrong annotation, we check that an error is reported
+
+#[returnaddress]
+export fn f () {}

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -4,6 +4,10 @@ fail/annotation/x86-64/calldepth.jazz:
 compilation error in function f:
 stack allocation: the maximum call depth is 1 (expected: 2)
 
+fail/annotation/x86-64/returnaddress.jazz:
+
+"fail/annotation/x86-64/returnaddress.jazz", line 3 (2-15): attribute for “returnaddress” should be one of “stack”, “reg”
+
 fail/annotation/x86-64/stackalign.jazz:
 
 "fail/annotation/x86-64/stackalign.jazz", line 4 (0) to line 14 (1):
@@ -1572,7 +1576,7 @@ Allowed args are:
   [[reg]; [reg; mem (glob allowed)]]
 
 Statistics:
-	Annots:      0
+	Annots:      1
 	Pretyping:  51
 	Parsing:     4
 	Typing:      1

--- a/compiler/tests/negative.ml
+++ b/compiler/tests/negative.ml
@@ -88,7 +88,7 @@ let check_file_on_arch path errors arch =
        | Utils0.Ok _asm -> raise Did_not_fail
      with
     | Annot.AnnotationError (loc, code) ->
-        printf "%a: %t" Location.pp_loc loc code;
+        printf "%a: %t\n\n" Location.pp_loc loc code;
         counters.annot <- counters.annot + 1
     | Pretyping.TyError (loc, code) ->
         printf "%a: %a\n\n" Location.pp_loc loc Pretyping.pp_tyerror code;

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -505,8 +505,8 @@ Definition pop_to_save
     Let last := foldM (λ a base,
                        Let: (ofs, ws) := check_to_save_slot a in
                        Let _ := assert (base <=? ofs)%Z (E.my_error (pp_hov [::pp_s "to-save: overlap"; pp_e (Pconst base); pp_e (Pconst ofs)])) in
-                       Let _ := assert (ws ≤ al)%CMP (E.error "to-save: bad frame alignement") in
-                       Let _ := assert (is_align (wrepr Uptr ofs) ws) (E.error "to-save: bad slot alignement") in
+                       Let _ := assert (ws ≤ al)%CMP (E.error "to-save: bad frame alignment") in
+                       Let _ := assert (is_align (wrepr Uptr ofs) ws) (E.error "to-save: bad slot alignment") in
                        Let _ := assert (lip_check_ws liparams ws) (E.error "to-save: bad wsize") in
                        ok (ofs + wsize_size ws)%Z
                       ) lo m in

--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -784,7 +784,7 @@ Class memory (mem: Type) (CM: coreMem pointer mem) : Type :=
       stack_root : mem -> pointer
     ; stack_limit : mem -> pointer
     ; frames : mem -> seq pointer
-    ; alloc_stack : mem -> wsize -> Z -> Z -> Z -> exec mem (* alignement, size, extra initial size, extra-size *)
+    ; alloc_stack : mem -> wsize -> Z -> Z -> Z -> exec mem (* alignment, size, extra initial size, extra-size *)
     ; free_stack : mem -> mem
     ; init : seq (pointer * Z) → pointer → exec mem
 


### PR DESCRIPTION
# Description

Annotation errors were not caught in `main_compiler.ml`. I also added a test case, even though I realized later that for such test cases, we do not call `jasminc` but Jasmin as a library (and thus it does not exercise the change I did). It's good to have anyway.

Does it need a changelog entry?

The first commit is unrelated.

# Checklist

- [ ] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
