### PR TITLE
Do not assume non-trivial alignment of array arguments to export functions

### DIFF
--- a/changes/01-feature/1482-enforce-export-unaligned.md
+++ b/changes/01-feature/1482-enforce-export-unaligned.md
@@ -1,0 +1,4 @@
+- The compiler no longer assumes non-trivial alignment of array arguments to
+  export functions; alignment requirements can be expressed through the
+  `required_alignment` annotation
+  ([PR 1482](https://github.com/jasmin-lang/jasmin/pull/1482)).

--- a/compiler/src/functionAnnotations.ml
+++ b/compiler/src/functionAnnotations.ml
@@ -86,3 +86,32 @@ let process_f_annot loc funname f_cc annot =
     stack_zero_strategy;
     f_user_annot          = annot;
   }
+
+let get_required_alignment fd =
+  let key = "required_alignment" in
+  let args = List.fold_left (fun s x -> Ss.add x.v_name s) Ss.empty fd.f_args in
+  let default =
+    if FInfo.is_export fd.f_cc then
+      Ss.fold (fun a -> Ms.add a Wsize.U8) args Ms.empty
+    else Ms.empty
+  in
+  match Annotations.get key fd.f_annot.f_user_annot with
+  | None | Some None -> default
+  | Some (Some { L.pl_desc = Astruct ra }) ->
+      List.fold_left
+        (fun m (x, k) ->
+          let iloc = L.i_loc0 (L.loc x) in
+          let a = L.unloc x in
+          if not (Ss.mem a args) then
+            warning Always iloc "ignored unknown argument %s in “%s” annotation"
+              a key;
+          match k with
+          | Some { L.pl_desc = Annotations.Aws ws } -> Ms.add a ws m
+          | _ ->
+              warning Always iloc
+                "invalid constraint for argument %s (word-size expected)" a;
+              m)
+        default ra
+  | Some (Some { L.pl_loc = loc }) ->
+      warning Always (L.i_loc0 loc) "ignored ill-formed %s annotation" key;
+      default

--- a/compiler/src/functionAnnotations.mli
+++ b/compiler/src/functionAnnotations.mli
@@ -9,3 +9,8 @@ val process_f_annot :
   Syntax.pannotations ->
   FInfo.f_annot
 (** Extracts a few well-known attributes from the annotation of a function. *)
+
+val get_required_alignment : _ Prog.gfunc -> Wsize.wsize Utils.Ms.t
+(** Extracts the required alignment for each function argument. Reads the
+    function annotations first then defaults to U8 for export functions (no
+    requirement for non-export functions). *)

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -121,7 +121,7 @@ let memory_analysis pp_sr pp_err ~debug up =
       Stack_alloc.({
         pp_ptr = Conv.cvar_of_var pi.pi_ptr;
         pp_writable = pi.pi_writable;
-        pp_align    = pi.pi_align.ac_strict;
+        pp_align    = pi.pi_align.ac_strict.get_ws;
       }) in
     let conv_sub (i:Interval.t) = 
       Stack_alloc.{ cs_ofs = Conv.cz_of_int i.min;

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -9,13 +9,18 @@ let hierror = hierror ~kind:"compilation error" ~sub_kind:"stack allocation"
 
 type liverange = G.graph Mint.t
 
+type wsize_constraint = { get_ws : wsize ; trace : Utils.Siloc.t }
+(** An alignment constraint (a wsize) together with the set of locations that require this alignment *)
+
 (* --------------------------------------------------- *)
 (** Invariant: heuristic is always higher than the strict constraint *)
 type alignment_constraint =
-  { ac_strict: wsize
+  { ac_strict: wsize_constraint
   ; ac_heuristic: wsize }
 
-let no_alignment_constraint = { ac_strict = U8; ac_heuristic = U8 }
+let no_alignment_constraint =
+  { ac_strict = { get_ws = U8; trace = Siloc.empty }
+  ; ac_heuristic = U8 }
 
 type param_info = {
   pi_ptr      : var;
@@ -128,10 +133,16 @@ let check_class f_name f_loc ptr_classes args x s =
     hierror ~loc:(Lone f_loc) ~funname:f_name "cannot put a reg ptr argument into the local stack"
 
 (* --------------------------------------------------- *)
-let max_align al ws ac =
+let max_align ~loc al ws ac =
   let max_align ws' = if wsize_lt ws' ws then ws else ws' in
+  let max_constraint c =
+    match wsize_cmp c.get_ws ws with
+    | Datatypes.Lt -> { get_ws = ws ; trace = loc }
+    | Datatypes.Eq -> { c with trace = Siloc.union loc c.trace }
+    | Datatypes.Gt -> c
+  in
   match al with
-  | Aligned -> { ac_strict = max_align ac.ac_strict; ac_heuristic = max_align ac.ac_heuristic }
+  | Aligned -> { ac_strict = max_constraint ac.ac_strict; ac_heuristic = max_align ac.ac_heuristic }
   | Unaligned -> { ac with ac_heuristic = max_align ac.ac_heuristic }
 
 type alignment = alignment_constraint Hv.t
@@ -140,16 +151,16 @@ let classes_alignment (onfun : funname -> param_info option list) (gtbl: alignme
   let ltbl = Hv.create 117 in
   let calls = ref Sf.empty in
 
-  let set al x scope ws =
+  let set ~loc al x scope ws =
     let tbl = if scope = E.Sglob then gtbl else ltbl in
-    Hv.modify_def no_alignment_constraint x (max_align al ws) tbl in
+    Hv.modify_def no_alignment_constraint x (max_align ~loc al ws) tbl in
 
-  let add_ggvar al x ws i =
+  let add_ggvar ~loc al x ws i =
     let x' = L.unloc x.gv in
     if is_gkvar x then
       begin
         let c = Alias.normalize_var alias x' in
-        set al c.in_var c.scope ws;
+        set ~loc al c.in_var c.scope ws;
         if al == Aligned then
          match c.kind with
          | Exact range ->
@@ -162,30 +173,30 @@ let classes_alignment (onfun : funname -> param_info option list) (gtbl: alignme
              hierror ~loc:(Lone (L.loc x.gv)) "@[the access to array %a (aligned on %a) could not be proved to be aligned on %a;@ if you know what you are doing or want to perform an unaligned access,@ you can use “#unaligned”@]"
                (Printer.pp_var ~debug:false) x' PrintCommon.pp_wsize ws' PrintCommon.pp_wsize ws
       end
-    else set al x' E.Sglob ws in
+    else set ~loc al x' E.Sglob ws in
 
-  let rec add_e = function
+  let rec add_e ~loc = function
     | Pconst _ | Pbool _ | Parr_init _  | Pvar _ -> ()
-    | Pget (al, _, ws, x, e) -> add_ggvar al x ws 0; add_e e
-    | Psub (_,_,_,_,e) | Pload (_, _, e) | Papp1 (_, e) -> add_e e
-    | Papp2 (_, e1,e2) -> add_e e1; add_e e2
-    | PappN (_, es) -> add_es es
-    | Pif (_,e1,e2,e3) -> add_e e1; add_e e2; add_e e3
-  and add_es es = List.iter add_e es in
+    | Pget (al, _, ws, x, e) -> add_ggvar ~loc:(Siloc.singleton loc) al x ws 0; add_e ~loc e
+    | Psub (_,_,_,_,e) | Pload (_, _, e) | Papp1 (_, e) -> add_e ~loc e
+    | Papp2 (_, e1,e2) -> add_es ~loc [e1;  e2]
+    | PappN (_, es) -> add_es ~loc es
+    | Pif (_,e1,e2,e3) -> add_es ~loc [ e1; e2; e3 ]
+  and add_es ~loc es = List.iter (add_e ~loc) es in
 
-  let add_lv = function
+  let add_lv ~loc = function
     | Lnone _ | Lvar _ -> ()
-    | Lmem (_, _, _, e) | Lasub (_,_,_,_,e) -> add_e e
-    | Laset(al, _, ws,x,e) -> add_ggvar al (gkvar x) ws 0; add_e e in
+    | Lmem (_, _, _, e) | Lasub (_,_,_,_,e) -> add_e ~loc e
+    | Laset(al, _, ws,x,e) -> add_ggvar ~loc:(Siloc.singleton loc) al (gkvar x) ws 0; add_e ~loc e in
 
-  let add_lvs = List.iter add_lv in
+  let add_lvs ~loc = List.iter (add_lv ~loc) in
 
-  let add_p opi e =
+  let add_p ~loc opi e =
     match opi, e with
-    | None, _ -> add_e e
+    | None, _ -> add_e ~loc e
     | Some pi, Pvar x ->
-       add_ggvar Aligned x pi.pi_align.ac_strict 0;
-       add_ggvar Unaligned x pi.pi_align.ac_heuristic 0
+       add_ggvar ~loc:(Siloc.add loc pi.pi_align.ac_strict.trace) Aligned x pi.pi_align.ac_strict.get_ws 0;
+       add_ggvar ~loc:(Siloc.singleton loc) Unaligned x pi.pi_align.ac_heuristic 0
     | Some pi, Psub(aa,ws,_, x, e) ->
       let i =
         match get_ofs aa ws e with
@@ -193,22 +204,23 @@ let classes_alignment (onfun : funname -> param_info option list) (gtbl: alignme
           (* this error is probably always caught before by the similar code in alias.ml *)
           hierror ~loc:(Lone (L.loc x.gv)) "Cannot compile sub-array %a that has a non-constant start index" (Printer.pp_var ~debug:true) (L.unloc x.gv)
         | Some i -> i in
-      add_ggvar Aligned x pi.pi_align.ac_strict i;
-      add_ggvar Unaligned x pi.pi_align.ac_heuristic i
+      add_ggvar ~loc:(Siloc.add loc pi.pi_align.ac_strict.trace) Aligned x pi.pi_align.ac_strict.get_ws i;
+      add_ggvar ~loc:(Siloc.singleton loc) Unaligned x pi.pi_align.ac_heuristic i
     | _, _ -> assert false in
 
   iter_instr (fun i ->
+    let loc = i.i_loc in
     try match i.i_desc with
-    | Cassgn(x,_,_,e) -> add_lv x; add_e e
-    | Copn(xs,_,_,es) | Csyscall(xs,_,es) -> add_lvs xs; add_es es
+    | Cassgn(x,_,_,e) -> add_lv ~loc x; add_e ~loc e
+    | Copn(xs,_,_,es) | Csyscall(xs,_,es) -> add_lvs ~loc xs; add_es ~loc es
     | Cassert _ -> assert false (* used after remove_assert *)
-    | Cif(e, _, _) | Cwhile (_, _, e, _, _) -> add_e e
+    | Cif(e, _, _) | Cwhile (_, _, e, _, _) -> add_e ~loc e
     | Cfor _ -> assert false
     | Ccall(xs, fn, es) ->
-      add_lvs xs;
+      add_lvs ~loc xs;
       calls := Sf.add fn !calls;
-      List.iter2 add_p (onfun fn) es
-    with HiError e -> raise (HiError (add_iloc e i.i_loc))
+      List.iter2 (add_p ~loc) (onfun fn) es
+    with HiError e -> raise (HiError (add_iloc e loc))
     ) c;
 
   ltbl, !calls

--- a/compiler/src/varalloc.ml
+++ b/compiler/src/varalloc.ml
@@ -291,7 +291,7 @@ let init_slots pd stack_pointers alias coloring fv =
   !slots, lalloc
 
 (* --------------------------------------------------- *)
-let all_alignment pd (ctbl: alignment) alias params lalloc : param_info option list * wsize Hv.t =
+let all_alignment ~funname ~contract pd (ctbl: alignment) alias params lalloc : param_info option list * wsize Hv.t =
 
   let get_align c =
     try Hv.find ctbl c.Alias.in_var
@@ -308,6 +308,18 @@ let all_alignment pd (ctbl: alignment) alias params lalloc : param_info option l
         | _ | exception Not_found -> assert false in
       let pi_writable = w = Writable in
       let pi_align = get_align c in
+      let pi_align =
+        (* Check the contract for array arguments and propagate to callers *)
+        match Ms.find x.v_name contract with
+        | exception Not_found -> pi_align
+        | ws ->
+          if wsize_cmp ws pi_align.ac_strict.get_ws == Lt then
+            hierror ~funname ~loc:(Lone x.v_dloc) "argument %a is used with %a-bit alignment at:\n%a"
+              (Printer.pp_var ~debug:false) x
+              PrintCommon.pp_wsize pi_align.ac_strict.get_ws
+              (pp_list "@ " L.pp_iloc) (Siloc.elements pi_align.ac_strict.trace);
+          max_align ~loc:Siloc.empty Aligned ws pi_align
+      in
       Some { pi_ptr; pi_writable; pi_align }
     | _ -> assert false in
   let params = List.map doparam params in
@@ -431,7 +443,8 @@ let alloc_stack_fd callstyle pd get_info gtbl fd =
   in
   let sao_return = get_returned_params ~funname:fd.f_name.fn_name alias fd.f_args fd.f_ret in
 
-  let sao_params, atbl = all_alignment pd ctbl alias fd.f_args lalloc in
+  let contract = FunctionAnnotations.get_required_alignment fd in
+  let sao_params, atbl = all_alignment ~funname:fd.f_name.fn_name ~contract pd ctbl alias fd.f_args lalloc in
 
   let ra_on_stack =
     match fd.f_cc with

--- a/compiler/src/varalloc.mli
+++ b/compiler/src/varalloc.mli
@@ -1,8 +1,10 @@
 open Wsize
 open Prog
 
+type wsize_constraint = { get_ws : wsize ; trace : Utils.Siloc.t }
+
 type alignment_constraint =
-  { ac_strict: wsize
+  { ac_strict: wsize_constraint
   ; ac_heuristic: wsize }
 
 type param_info = {

--- a/compiler/tests/fail/common/alignment.jazz
+++ b/compiler/tests/fail/common/alignment.jazz
@@ -1,0 +1,4 @@
+export fn assumes_alignment(reg ptr u8[4] a) -> reg u32 {
+  reg u32 r = a[#aligned:u32 0];
+  return r;
+}

--- a/compiler/tests/fail/common/alignment_internal.jazz
+++ b/compiler/tests/fail/common/alignment_internal.jazz
@@ -1,0 +1,12 @@
+/* This function needs no specific alignment but requires it. */
+#[required_alignment = { p = u32 }]
+fn inner(reg ptr u32[1] p) -> reg u32 {
+  reg u32 x = p[#unaligned 0];
+  return x;
+}
+
+export fn main(reg ptr u8[4] a) -> reg u32 {
+  /* Caller must comply with the contract of the callee; here, it does not */
+  reg u32 r = inner(a);
+  return r;
+}

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -484,6 +484,48 @@ fail/asmgen/x86-64/uninit_flag.jazz:
 compilation error:
 register allocation: variables { unitialized } remain unallocated
 
+fail/common/alignment.jazz:
+
+"fail/common/alignment.jazz", line 1 (42-43):
+compilation error in function assumes_alignment:
+stack allocation: argument a is used with 32-bit alignment at:
+"fail/common/alignment.jazz", line 2 (2-32)
+
+fail/common/alignment.jazz:
+
+"fail/common/alignment.jazz", line 1 (42-43):
+compilation error in function assumes_alignment:
+stack allocation: argument a is used with 32-bit alignment at:
+"fail/common/alignment.jazz", line 2 (2-32)
+
+fail/common/alignment.jazz:
+
+"fail/common/alignment.jazz", line 1 (42-43):
+compilation error in function assumes_alignment:
+stack allocation: argument a is used with 32-bit alignment at:
+"fail/common/alignment.jazz", line 2 (2-32)
+
+fail/common/alignment_internal.jazz:
+
+"fail/common/alignment_internal.jazz", line 8 (29-30):
+compilation error in function main:
+stack allocation: argument a is used with 32-bit alignment at:
+"fail/common/alignment_internal.jazz", line 10 (2-23)
+
+fail/common/alignment_internal.jazz:
+
+"fail/common/alignment_internal.jazz", line 8 (29-30):
+compilation error in function main:
+stack allocation: argument a is used with 32-bit alignment at:
+"fail/common/alignment_internal.jazz", line 10 (2-23)
+
+fail/common/alignment_internal.jazz:
+
+"fail/common/alignment_internal.jazz", line 8 (29-30):
+compilation error in function main:
+stack allocation: argument a is used with 32-bit alignment at:
+"fail/common/alignment_internal.jazz", line 10 (2-23)
+
 fail/common/bug_1214.jazz:
 
 "fail/common/bug_1214.jazz", line 13 (6-7):
@@ -1605,4 +1647,4 @@ Statistics:
 	Pretyping:  47
 	Parsing:     4
 	Typing:      5
-	Compile:   197
+	Compile:   203

--- a/compiler/tests/success/common/required_alignment.jazz
+++ b/compiler/tests/success/common/required_alignment.jazz
@@ -1,0 +1,28 @@
+/* This function uses its first argument a with 32-bit alignment and its second
+ * argument b without any specific alignment.
+    The annotation checks that the actual accesses do not excess the claimed
+    bounds (dst is used with alignment at most u32 and src with alignment at
+    most u128) and asks the caller to ensure the constraints (dst should have
+    alignment at least u32 and src at least u128). */
+#[required_alignment = { dst = u32, src = u128 }]
+fn copy(reg ptr u8[4] dst src) -> reg ptr u8[4] {
+  reg u32 x = src[#unaligned:u32 0];
+  dst[#aligned:u32 0] = x;
+  return dst;
+}
+
+/* In order to comply with the alignment requirement for the src parameter of
+ * function copy, the compiler will lay out the stack in such a way that the 
+   data array is aligned to 128 bits; the following annotation asserts that
+   this is indeed the case. */
+#[stackalign = u128]
+export
+fn main(reg ptr u8[4] p) -> reg u32 {
+  stack u32[3] data;
+  reg ptr u32[1] in = data[0:1], out = data[2:1];
+  reg u32 v = p[#unaligned:u32 0];
+  in[#unaligned 0] = v;
+  out = copy(out, in);
+  v = out[#unaligned 0];
+  return v;
+}

--- a/compiler/tests/success/common/stack_alignment.jazz
+++ b/compiler/tests/success/common/stack_alignment.jazz
@@ -1,0 +1,16 @@
+/* This function has no real alignement constraints but requires it through its annotation */
+#[required_alignment = { p = u256 }]
+fn load_aligned(reg ptr u8[4] p) -> reg u32 {
+  reg u32 r = p[#unaligned:u32 0];
+  return r;
+}
+
+#[stackalign = u256]
+export
+fn main() -> reg u32 {
+  reg u32 v = 42;
+  stack u32[1] s;
+  s[0] = v;
+  v = load_aligned(s);
+  return v;
+}

--- a/compiler/tests/success/subarrays/x86-64/align.jazz
+++ b/compiler/tests/success/subarrays/x86-64/align.jazz
@@ -4,13 +4,14 @@ fn double (reg ptr u32[N] a) -> reg ptr u32[N] {
   inline int i;
   reg u32 tmp;
   for i = 0 to N {
-    tmp = a[i];
+    tmp = a[#aligned i];
     tmp *= 2;
-    a[i] = tmp;
+    a[#aligned i] = tmp;
   }
   return a;
 }
 
+#[required_alignment = { a = u32 }]
 export fn main (reg ptr u32[4*N] a) -> reg ptr u32[4*N] {
   reg u64 i = 0;
   while (i < 4*N) {

--- a/compiler/tests/success/x86-64/vmovdqa.jazz
+++ b/compiler/tests/success/x86-64/vmovdqa.jazz
@@ -1,0 +1,9 @@
+#[required_alignment = { src = u256 }]
+export
+fn copy_256AU(reg ptr u256[4] dst src, reg u64 offset) -> reg ptr u256[4] {
+  offset &= 3;
+  offset <<= 5;
+  reg u256 t = #VMOVDQA_256(src.[#aligned offset]);
+  dst[0] = t;
+  return dst;
+}

--- a/compiler/tests/warning/x86-64/alignment.jazz
+++ b/compiler/tests/warning/x86-64/alignment.jazz
@@ -1,0 +1,20 @@
+#[required_alignment = { hello = u32 }]
+export fn no_argument() {}
+
+#[required_alignment = u32 ]
+export fn unstructured_alignment(reg ptr u32[1] arg) -> reg u32 {
+  reg u32 v = arg[0];
+  return v;
+}
+
+#[required_alignment = { arg }]
+export fn empty_alignment(reg ptr u32[1] arg) -> reg u32 {
+  reg u32 v = arg[0];
+  return v;
+}
+
+#[required_alignment = { arg = { size = u32 } }]
+export fn invalid_alignment(reg ptr u32[1] arg) -> reg u32 {
+  reg u32 v = arg[0];
+  return v;
+}

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -89,3 +89,13 @@
   warning: the variable g is already declared at "warning/common/bug_1347.jazz", line 2 (6-7)
   "warning/common/bug_1347.jazz", line 8 (20-21)
   warning: the variable C::x is already declared at "warning/common/bug_1347.jazz", line 7 (20-21)
+
+  $ ../jasminc warning/x86-64/alignment.jazz
+  "warning/x86-64/alignment.jazz", line 1 (25-30)
+  warning: ignored unknown argument hello in “required_alignment” annotation
+  "warning/x86-64/alignment.jazz", line 4 (23-26)
+  warning: ignored ill-formed required_alignment annotation
+  "warning/x86-64/alignment.jazz", line 10 (25-28)
+  warning: invalid constraint for argument arg (word-size expected)
+  "warning/x86-64/alignment.jazz", line 16 (25-28)
+  warning: invalid constraint for argument arg (word-size expected)

--- a/docs/source/language/syntax/expressions.md
+++ b/docs/source/language/syntax/expressions.md
@@ -215,3 +215,54 @@ frames in such a way that the resulting pointers are aligned. On the other hand,
 `#aligned` accesses must be applied to aligned pointer and thus the compiler may
 turn them into instructions that require this alignment (e.g., `vmovdqa` on
 x86_64).
+
+When some array accesses assume that some `export` functions receive **aligned**
+pointers as argument, these requirements **must** be documented. Otherwise the
+[stack allocation pass](../../compiler/passes/stack_alloc) will produce an
+error. To describe alignment requirements, function declarations can be
+decorated with a `required_alignment` annotation whose value is a map whose keys
+are *names* of function parameters and values are word-sizes. Parameters of the
+function that are not bound in this map have no requirement. For instance, the
+program below reads from its `src` parameter assuming it is aligned to 32 bytes.
+Alignment makes no sense for the numerical `offset` parameter and is irrelevant
+for the `dst` parameter; therefore none of them is listed in the annotation.
+
+~~~
+#[required_alignment = { src = u256 }]
+export
+fn copy_256AU(reg ptr u256[4] dst src, reg u64 offset) -> reg ptr u256[4] {
+  offset &= 3;
+  offset <<= 5;
+  reg u256 t = #VMOVDQA_256(src.[#aligned offset]);
+  dst[#unaligned 0] = t;
+  return dst;
+}
+~~~
+
+When used on local functions, this annotation acts as an assertion about the
+upper bound on the expected alignment and as a lower bound that the compiler
+should enforce. In the following example, the annotation claims that indeed, no
+access inside the function needs a more specific alignment than what is written
+and asks the compiler to enforce that the arrays that are given as argument are
+at least as aligned as what is written.
+
+~~~
+#[required_alignment = { dst = u32, src = u128 }]
+fn copy(reg ptr u8[4] dst src) -> reg ptr u8[4] {
+  reg u32 x = src[#unaligned:u32 0];
+  dst[#aligned:u32 0] = x;
+  return dst;
+}
+
+#[stackalign = u128]
+export
+fn main(reg ptr u8[4] p) -> reg u32 {
+  stack u32[3] data;
+  reg ptr u32[1] in = data[0:1], out = data[2:1];
+  reg u32 v = p[#unaligned:u32 0];
+  in[#unaligned 0] = v;
+  out = copy(out, in);
+  v = out[#unaligned 0];
+  return v;
+}
+~~~


### PR DESCRIPTION
# Description

Array arguments to export functions are turned into memory addresses after compilation. They usually cannot be assumed to have any specific alignment. Such assumptions can be expressed explicitly through a `required_alignment` annotation.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed

# TODO

- [x] Discuss libjade changes
- [x] Write documentation