### PR TITLE
Make `#unaligned` the default

### DIFF
--- a/changes/02-bugfix/1485-sarx-no-alignment.md
+++ b/changes/02-bugfix/1485-sarx-no-alignment.md
@@ -1,0 +1,3 @@
+- The BMI2 instructions that “shift without affecting flags”
+  (`SARX`/`SHLX`/`SHRX`) have no requirement about memory alignment
+  ([PR 1485](https://github.com/jasmin-lang/jasmin/pull/1485)).

--- a/changes/03-other/1485-default-unaligned.md
+++ b/changes/03-other/1485-default-unaligned.md
@@ -1,0 +1,4 @@
+- Array accesses are by default considered as “unaligned”, i.e., without any
+  requirement on the alignment of the underlying pointer; this usually relaxes
+  the assumptions made about arguments to export functions
+  ([PR 1485](https://github.com/jasmin-lang/jasmin/pull/1485)).

--- a/compiler/safetylib/safetyInterpreter.ml
+++ b/compiler/safetylib/safetyInterpreter.ml
@@ -140,7 +140,7 @@ let pp_arr_slice fmt slice =
   let pp_expr = Printer.pp_expr ~debug:false in
   let ws = non_default_wsize slice.as_arr slice.as_wsize in
   if Stdlib.Int.equal slice.as_len 1 then
-    pp_arr_access pp_var pp_expr fmt Memory_model.Aligned slice.as_access ws
+    pp_arr_access pp_var pp_expr fmt Memory_model.Unaligned slice.as_access ws
       slice.as_arr slice.as_offset
   else
     pp_arr_slice pp_var pp_expr pp_len fmt slice.as_access ws slice.as_arr

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1182,10 +1182,10 @@ let is_combine_flags id =
   List.mem_assoc (L.unloc id) combine_flags
 
 (* -------------------------------------------------------------------- *)
-let tt_al aa =
+let tt_al =
   let open Memory_model in
   function
-  | None -> (match aa with Warray_.AAdirect -> Unaligned | AAscale -> Aligned)
+  | None
   | Some `Unaligned -> Unaligned
   | Some `Aligned -> Aligned
 
@@ -1287,7 +1287,7 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
     let i = cast_int (L.loc pi) (Some `Unsigned) i ity in
     begin match olen with
     | None ->
-       let al = tt_al aa al in
+       let al = tt_al al in
        P.Pget (al, aa, ws, x, i), ty
     | Some plen ->
        ignore_align ~loc:(L.loc pe) al;
@@ -1419,7 +1419,7 @@ and tt_mem_access pd ?(mode=`AllVar) (env : 'asm Env.env)
   let loc = L.loc e in
   let e = tt_expr_cast ~mode pd env e (P.etw pd) in
   let ct = tt_mem_wsize pd ct in
-  let al = tt_al AAdirect al in
+  let al = tt_al al in
   (ct, loc, e, al)
 
 (* -------------------------------------------------------------------- *)
@@ -1517,7 +1517,7 @@ let tt_lvalue pd (env : 'asm Env.env) { L.pl_desc = pl; L.pl_loc = loc; } =
     let i = cast_int (L.loc pi) (Some `Unsigned) i ity in
     begin match olen with
     | None ->
-      let al = tt_al aa al in
+      let al = tt_al al in
       loc, (fun _ -> P.Laset (al, aa, ws, L.mk_loc xlc x, i)), Some ty
     | Some plen ->
       ignore_align ~loc al;

--- a/compiler/src/printCommon.ml
+++ b/compiler/src/printCommon.ml
@@ -23,12 +23,6 @@ let pp_aligned fmt =
      Format.fprintf fmt "#aligned "
   | Unaligned -> ()
 
-let pp_unaligned fmt =
-  function
-  | Memory_model.Aligned -> ()
-  | Unaligned ->
-     Format.fprintf fmt "#unaligned "
-
 (* -------------------------------------------------------------------- *)
 
 let string_of_signess s = if s = Unsigned then "u" else "s"
@@ -214,7 +208,7 @@ let pp_arr_access pp_gvar pp_expr fmt al aa ws x e =
   fprintf fmt "%a%s[%a%a%a]"
     pp_gvar x
     (if aa = Warray_.AAdirect then "." else "")
-    pp_unaligned al
+    pp_aligned al
     pp_access_size ws
     pp_expr (peel_implicit_cast_to_uint e)
 

--- a/compiler/tests/fail/stack_allocation/x86-64/bad_alignment.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/bad_alignment.jazz
@@ -4,6 +4,6 @@ export fn f (reg u64 i) -> reg u32 {
   reg ptr u32[3] b;
   a[i]=0;
   b[1:2] = a[:u32 i:2];
-  res = b[:u64 1];
+  res = b[#aligned:u64 1];
   return res;
 }

--- a/compiler/tests/fail/stack_allocation/x86-64/bad_range_alignment.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/bad_range_alignment.jazz
@@ -2,7 +2,7 @@ export fn f () -> reg u32 {
   reg u32 res;
   stack u64[2] a;
   stack u32[10] b;
-  a[0]=0;
+  a[#aligned 0]=0;
   b[1:2] = a[:u32 0:2];
   res = b[1];
   return res;

--- a/compiler/tests/fail/stack_allocation/x86-64/unaligned_sub_offset.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/unaligned_sub_offset.jazz
@@ -6,7 +6,7 @@ export fn main (reg u64 i) -> reg u64 {
   s[i] = 0;
   s[i+1] = 0;
   r = s[i:2]; // scaled access: r is known to be aligned on U32
-  res = r[:u64 0]; // but not to be aligned on U64 -> error
+  res = r[#aligned:u64 0]; // but not to be aligned on U64 -> error
 
   return res;
 }

--- a/compiler/tests/fail/stack_allocation/x86-64/unaligned_sub_offset_unscaled.jazz
+++ b/compiler/tests/fail/stack_allocation/x86-64/unaligned_sub_offset_unscaled.jazz
@@ -5,7 +5,7 @@ export fn main (reg u64 i) -> reg u64 {
 
   s[i] = 0;
   r = s.[i:2]; // unscaled access: r is known to be aligned on U8
-  res = r[0]; // but not to be aligned on U64 -> error
+  res = r[#aligned 0]; // but not to be aligned on U64 -> error
 
   return res;
 }

--- a/docs/source/language/syntax/expressions.md
+++ b/docs/source/language/syntax/expressions.md
@@ -190,8 +190,7 @@ Memory and array accesses may have alignment annotations, either `#aligned` or
 memory address) underlying the access is aligned, i.e., a multiple of the size
 (in bytes) of the accessed data.
 
-When no annotation is given it defaults to `#aligned` for scaled array accesses
-and `#unaligned` otherwise (unscaled array access, memory access).
+When no annotation is given it defaults to `#unaligned`.
 
 They are used in two ways by the compiler:
 

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -466,7 +466,7 @@ Notation mk_instr_division sg name semi check prc valid pp_asm semi_errty semi_s
   mk_instr (pp_sz name sz) (w3_ty sz) (b5w2_ty sz) [:: R RDX; R RAX; Eu 0]  (implicit_flags ++ [:: R RAX; R RDX]) (reg_msb_flag sz) (semi sz) (check sz) 1 [::X86Division sz sg] (valid sz) (pp_asm sz) refl_equal (semi_errty sz) (semi_safe sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_w2_w_120 name semi check prc valid pp_asm := ((fun sz =>
-  mk_instr_safe (pp_sz name sz) (w2_ty sz sz) (w_ty sz) [:: Ea 1 ; Eu 2] [:: Ea 0] MSB_CLEAR (semi sz) (check sz) 3 (valid sz) (pp_asm sz)), (name%string,prc))  (only parsing).
+  mk_instr_safe (pp_sz name sz) (w2_ty sz sz) (w_ty sz) [:: Eu 1 ; Eu 2] [:: Eu 0] MSB_CLEAR (semi sz) (check sz) 3 (valid sz) (pp_asm sz)), (name%string,prc))  (only parsing).
 
 Notation mk_instr_ww8_w_120 name semi check prc valid pp_asm := ((fun sz =>
   mk_instr_safe (pp_sz name sz) (ww8_ty sz) (w_ty sz) [:: Eu 1 ; Ea 2] [:: Ea 0] (reg_msb_flag sz) (semi sz) (check sz) 3 (valid sz) (pp_asm sz)), (name%string,prc))  (only parsing).


### PR DESCRIPTION
Is the `#aligned` annotation of any use?