### PR TITLE
Remove some checks in pre-typing

### DIFF
--- a/changes/02-bugfix/1486-less-pretyping.md
+++ b/changes/02-bugfix/1486-less-pretyping.md
@@ -1,0 +1,3 @@
+- Pre-typing reject less programs
+  ([PR 1486](https://github.com/jasmin-lang/jasmin/pull/1486);
+  fixes [#1479](https://github.com/jasmin-lang/jasmin/issues/1479)).

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1363,8 +1363,7 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
       if nargs <> nexp then
         rs_tyerror ~loc:(L.loc pe) (InvalidArgCount(nargs, nexp));
       let tt_expr pe =
-        let e, ety = tt_expr ~mode pd env pe in
-        check_ty_eq ~loc:(L.loc pe) ~from:ety ~to_:P.etbool;
+        let e, _ety = tt_expr ~mode pd env pe in
         e in
       let args = List.map tt_expr args in
       P.PappN (Ocombine_flags c, args), P.etbool

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1402,11 +1402,10 @@ let rec tt_expr pd ?(mode=`AllVar) (env : 'asm Env.env) pe =
      P.PappN (Oarray len, es), P.(ETarr (U8, PE (Pconst (Conv.z_of_pos len))))
 
   | S.PEIf (pe1, pe2, pe3) ->
-    let e1, ty1 = tt_expr ~mode pd env pe1 in
+    let e1, _ty1 = tt_expr ~mode pd env pe1 in
     let e2, ty2 = tt_expr ~mode pd env pe2 in
     let e3, ty3 = tt_expr ~mode pd env pe3 in
 
-    check_ty_eq ~loc:(L.loc pe1) ~from:ty1 ~to_:P.etbool;
     let ty = max_ty ty2 ty3 |> oget ~exn:(tyerror ~loc:(L.loc pe3) (TypeMismatch (ty3, ty2))) in
     P.Pif(P.gty_of_gety ty, e1, e2, e3), ty
 

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -2243,8 +2243,7 @@ let rec tt_instr arch_info (env : 'asm Env.env) ((pannot,pi) : S.pinstr) : 'asm 
   | PIFor ({ pl_loc = lx } as x, (d, i1, i2), s) ->
       let i1   = tt_expr_int arch_info.pd env i1 in
       let i2   = tt_expr_int arch_info.pd env i2 in
-      let vx, xty = tt_var `AllVar env x in
-      check_ty_eq ~loc:lx ~from:xty ~to_:P.etint;
+      let vx, _xty = tt_var `AllVar env x in
       let s    = tt_block arch_info env s in
       let d    = match d with `Down -> E.DownTo | `Up -> E.UpTo in
       env, [mk_i (P.Cfor (L.mk_loc lx vx, (d, i1, i2), s))]

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -692,11 +692,6 @@ let check_sig_lvs loc sig_ lvs =
   if nlvs <> nsig_ then
     rs_tyerror ~loc:(loc ()) (InvalidLvalCount(nlvs, nsig_));
 
-  List.iter2
-    (fun ty (loc, _, lty) -> lty
-      |> Option.may (fun lty -> check_ty_eq ~loc ~from:lty ~to_:ty))
-     sig_ lvs;
-
   List.map2 (fun ty (_,flv,_) -> flv ty) sig_ lvs
 
 

--- a/compiler/tests/fail/typing/x86-64/conditional_not_bool.jazz
+++ b/compiler/tests/fail/typing/x86-64/conditional_not_bool.jazz
@@ -1,0 +1,5 @@
+export fn main () -> reg u64 {
+  reg u64 x = 0;
+  x = x ? x : x;
+  return x;
+}

--- a/compiler/tests/fail/typing/x86-64/flags_not_bool.jazz
+++ b/compiler/tests/fail/typing/x86-64/flags_not_bool.jazz
@@ -1,0 +1,5 @@
+export fn main(reg u64 x) {
+  reg bool o c s p z;
+  o, c, s, p, z = #CMP(x, x);
+  p = _EQ(o, c, x, z);
+}

--- a/compiler/tests/fail/typing/x86-64/for_not_int.jazz
+++ b/compiler/tests/fail/typing/x86-64/for_not_int.jazz
@@ -1,0 +1,5 @@
+export fn main(reg ui32 a b) -> reg ui32 {
+  for a = 0 to b {
+  }
+  return a;
+}

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -986,7 +986,7 @@ speculative constant type checker: instruction assigns msf, which is required to
 
 fail/slh/x86-64/invalid_type.jazz:
 
-"fail/slh/x86-64/invalid_type.jazz", line 2 (4-5): the expression has type u32 instead of u64
+"fail/slh/x86-64/invalid_type.jazz", line 2 (17-18): can not implicitly cast u32 into u64
 
 fail/slh/x86-64/mov_msf.jazz:
 
@@ -1425,7 +1425,7 @@ fail/typing/x86-64/init_global.jazz:
 
 fail/typing/x86-64/lval_mismatch.jazz:
 
-"fail/typing/x86-64/lval_mismatch.jazz", line 4 (7-8): the expression has type bool instead of u64
+"fail/typing/x86-64/lval_mismatch.jazz", line 4 (2-26): the left value b has type bool while u64 is expected
 
 fail/typing/x86-64/lval_param.jazz:
 
@@ -1602,7 +1602,7 @@ Allowed args are:
 
 Statistics:
 	Annots:      4
-	Pretyping:  48
+	Pretyping:  47
 	Parsing:     4
-	Typing:      4
+	Typing:      5
 	Compile:   197

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1395,6 +1395,10 @@ fail/typing/x86-64/export_stack_res.jazz:
 "fail/typing/x86-64/export_stack_res.jazz", line 5 (9-10):
 typing error: x has kind stack, only reg or reg ptr are allowed in result of non inlined function
 
+fail/typing/x86-64/flags_not_bool.jazz:
+
+"fail/typing/x86-64/flags_not_bool.jazz", line 4 (2-22): the expression x has type u64 while bool is expected
+
 fail/typing/x86-64/for_not_int.jazz:
 
 "fail/typing/x86-64/for_not_int.jazz", line 2 (2) to line 3 (3): the expression a has type u32 while int is expected
@@ -1600,5 +1604,5 @@ Statistics:
 	Annots:      4
 	Pretyping:  48
 	Parsing:     4
-	Typing:      3
+	Typing:      4
 	Compile:   197

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1395,6 +1395,10 @@ fail/typing/x86-64/export_stack_res.jazz:
 "fail/typing/x86-64/export_stack_res.jazz", line 5 (9-10):
 typing error: x has kind stack, only reg or reg ptr are allowed in result of non inlined function
 
+fail/typing/x86-64/for_not_int.jazz:
+
+"fail/typing/x86-64/for_not_int.jazz", line 2 (2) to line 3 (3): the expression a has type u32 while int is expected
+
 fail/typing/x86-64/global_in_global_def.jazz:
 
 "fail/typing/x86-64/global_in_global_def.jazz", line 2 (10-19): the expression has type u8 instead of u16
@@ -1596,5 +1600,5 @@ Statistics:
 	Annots:      4
 	Pretyping:  48
 	Parsing:     4
-	Typing:      2
+	Typing:      3
 	Compile:   197

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1371,6 +1371,10 @@ fail/typing/x86-64/bug_69.jazz:
 
 "fail/typing/x86-64/bug_69.jazz", line 5 (3-28): primitive operator AND_64 returns an output of size 64; it cannot be zero-extended to size 32
 
+fail/typing/x86-64/conditional_not_bool.jazz:
+
+"fail/typing/x86-64/conditional_not_bool.jazz", line 3 (2-16): the expression x has type u64 while bool is expected
+
 fail/typing/x86-64/conditional_op_mismatch.jazz:
 
 "fail/typing/x86-64/conditional_op_mismatch.jazz", line 4 (14-15): the expression has type u64 instead of bool
@@ -1592,5 +1596,5 @@ Statistics:
 	Annots:      4
 	Pretyping:  48
 	Parsing:     4
-	Typing:      1
+	Typing:      2
 	Compile:   197

--- a/compiler/tests/success/typing/x86-64/bug_1479.jazz
+++ b/compiler/tests/success/typing/x86-64/bug_1479.jazz
@@ -1,0 +1,6 @@
+export fn main () -> reg u32 {
+  reg u32 x;
+  reg u64 y = 1;
+  ?{}, x = #ADD_64(y, y);
+  return x;
+}


### PR DESCRIPTION
# Description

The role of pre-typing is not to do type-checking. This removes some checks from type-checking that are either already done in the type-checker or not motivated at all.

Fixes #1479.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
