### PR TITLE
Linter: check that no “inline” variable depend on a non-inline

### DIFF
--- a/changes/01-feature/1487-taint-analysis.md
+++ b/changes/01-feature/1487-taint-analysis.md
@@ -1,0 +1,2 @@
+- Linter now warns about inline variables whose value depends on non-inline ones
+  ([PR 1487](https://github.com/jasmin-lang/jasmin/pull/1487)).

--- a/compiler/linter/Analysis/TaintAnalysis.ml
+++ b/compiler/linter/Analysis/TaintAnalysis.ml
@@ -1,0 +1,244 @@
+open Jasmin.Syscall_t
+open Jasmin.Utils
+open Jasmin.Prog
+open Annotation
+
+type dependencies = Sv.t Mv.t
+(** Maps each variable to the set of variables it depends on. *)
+
+type writeset = { get_writeset : Sv.t } [@@unboxed]
+(** The set of variables that are written by a statement. *)
+
+type signatures = (var list * var list) Mf.t
+(** Maps each function name to its signature (parameters and returned
+    variables). *)
+
+let empty_writeset = { get_writeset = Sv.empty }
+
+let merge_writesets w1 w2 =
+  { get_writeset = Sv.union w1.get_writeset w2.get_writeset }
+
+let get_dependencies (deps : dependencies) (x : var) : Sv.t =
+  Mv.find_default Sv.empty x deps
+
+let kill_dependencies (deps : dependencies) (x : var) : dependencies =
+  Mv.remove x deps
+
+let set_dependencies (deps : dependencies) (x : var) (d : Sv.t) : dependencies =
+  if Sv.is_empty d then kill_dependencies deps x else Mv.add x d deps
+
+let join_dependencies (deps : dependencies) (x : var) (d : Sv.t) : dependencies
+    =
+  Mv.modify_def Sv.empty x (Sv.union d) deps
+
+let merge_dependencies d d' : dependencies =
+  Mv.merge
+    (fun _x o1 o2 ->
+      match (o1, o2) with
+      | Some s1, Some s2 -> Some (Sv.union s1 s2)
+      | None, o | o, _ -> o)
+    d d'
+
+let is_included d d' : bool =
+  Mv.for_all (fun x s -> Sv.subset s (get_dependencies d' x)) d
+
+let write_dependencies (d : Sv.t) deps (x : lval) : dependencies =
+  match x with
+  | Lnone _ | Lmem _ -> deps
+  | Lvar x -> set_dependencies deps (L.unloc x) d
+  | Laset (_, _, _, x, e) | Lasub (_, _, _, x, e) ->
+      let d' = vars_e e in
+      join_dependencies deps (L.unloc x) (Sv.union d d')
+
+let written_lvs w xs =
+  { get_writeset = List.fold_left written_lv w.get_writeset xs }
+
+let after_join deps d w : dependencies =
+  Sv.fold (fun x deps -> join_dependencies deps x d) w.get_writeset deps
+
+let analyse_call_args deps args es =
+  List.fold_left2 (fun d x e -> set_dependencies d x (vars_e e)) deps args es
+
+let analyse_stmt (context : signatures) dom stmt =
+  let rec analyse_stmt dom stmt = List.fold_left_map analyse_instr dom stmt
+  and analyse_instr ((_w, deps) as dom) instr =
+    let dom, i_desc = analyse_instr_r dom instr.i_desc in
+    (dom, { instr with i_desc; i_info = Annotation deps })
+  and analyse_instr_r (w, deps) ir =
+    match ir with
+    | Cassgn (x, tg, ty, e) ->
+        let d = vars_e e in
+        ( ( { get_writeset = written_lv w.get_writeset x },
+            write_dependencies d deps x ),
+          Cassgn (x, tg, ty, e) )
+    | Copn (xs, tg, op, es) ->
+        let d = vars_es es in
+        ( (written_lvs w xs, List.fold_left (write_dependencies d) deps xs),
+          Copn (xs, tg, op, es) )
+    | Ccall (xs, fn, es) ->
+        let args, rets = Mf.find fn context in
+        let w =
+          {
+            get_writeset =
+              (let w =
+                 List.fold_left (fun s x -> Sv.add x s) w.get_writeset args
+               in
+               List.fold_left (fun s x -> Sv.add x s) w rets);
+          }
+        in
+        let deps = analyse_call_args deps args es in
+        let deps =
+          List.fold_left2
+            (fun d lv x -> write_dependencies (Sv.singleton x) d lv)
+            deps xs rets
+        in
+        ((written_lvs w xs, deps), Ccall (xs, fn, es))
+    | Csyscall ([ x ], RandomBytes len, es) ->
+        (* The result of #randombytes does not depend on its argument. *)
+        ( ( { get_writeset = written_lv w.get_writeset x },
+            write_dependencies Sv.empty deps x ),
+          Csyscall ([ x ], RandomBytes len, es) )
+    | Csyscall _ -> assert false
+    | Cassert (msg, e) -> ((w, deps), Cassert (msg, e))
+    | Cif (e, th, el) ->
+        let (wth, dth), th = analyse_stmt (empty_writeset, deps) th in
+        let (wel, del), el = analyse_stmt (empty_writeset, deps) el in
+        let w' = merge_writesets wth wel in
+        let d' = merge_dependencies dth del in
+        ((merge_writesets w w', after_join d' (vars_e e) w'), Cif (e, th, el))
+    | Cfor (i, (d, lo, hi), c) ->
+        let range_vars = vars_es [ lo; hi ] in
+        let reset_i deps = set_dependencies deps (L.unloc i) range_vars in
+        let rec loop d =
+          let d' = reset_i d in
+          let (w', d'), c = analyse_stmt (empty_writeset, d') c in
+          if is_included d' d then ((w', d), c)
+          else loop (merge_dependencies d d')
+        in
+        let (w', deps'), c = loop deps in
+        ( (merge_writesets w w', after_join deps' (Sv.singleton (L.unloc i)) w'),
+          Cfor (i, (d, lo, hi), c) )
+    | Cwhile (aa, c1, e, (ei, _), c2) ->
+        let (w, deps), _ = analyse_stmt (w, deps) c1 in
+        let rec loop d =
+          let wd, c2 = analyse_stmt (empty_writeset, d) c2 in
+          let (w', d'), c1 = analyse_stmt wd c1 in
+          let d' = after_join d' (vars_e e) w' in
+          if is_included d' d then (w', d, c1, c2)
+          else loop (merge_dependencies d d')
+        in
+        let w', deps', c1, c2 = loop deps in
+        ( (merge_writesets w w', deps'),
+          Cwhile (aa, c1, e, (ei, Annotation deps'), c2) )
+  in
+  analyse_stmt dom stmt
+
+let argument_dependencies args =
+  List.fold_left (fun deps x -> Mv.add x (Sv.singleton x) deps) Mv.empty args
+
+let analyse_function (context : signatures) (f : ('info, 'asm) func) :
+    (dependencies annotation, 'asm) func =
+  let deps = argument_dependencies f.f_args in
+  let (_w, deps), f_body =
+    analyse_stmt context (empty_writeset, deps) f.f_body
+  in
+  { f with f_body; f_info = Annotation deps }
+
+(* ----------------------------------------------------------- *)
+
+(** Adds to a set of variables the variables that are read when writing an
+    L-value *)
+let uses_lv s = function
+  | Lnone _ | Lvar _ -> s
+  | Lmem (_, _, _, e) -> rvars_e Sv.add s e
+  | Laset (_, _, _, x, e) | Lasub (_, _, _, x, e) ->
+      rvars_e Sv.add (Sv.add (L.unloc x) s) e
+
+let uses (i : ('info, 'asm) instr_r) : Sv.t =
+  match i with
+  | Cassgn (x, _, _, e) -> uses_lv (vars_e e) x
+  | Copn (xs, _, _, es) | Csyscall (xs, _, es) ->
+      List.fold_left uses_lv (vars_es es) xs
+  | Cassert (_, a) -> vars_a a
+  | Cif (e, _, _) | Cwhile (_, _, e, _, _) -> vars_e e
+  | Cfor _ | Ccall _ -> assert false
+
+let error ~kind x y loc =
+  let pp_var = Jasmin.Printer.pp_var ~debug:false in
+  let pp_vars fmt = Format.fprintf fmt "{ %a }" (pp_list "; " pp_var) in
+  let pp_varset fmt y =
+    match Sv.elements y with
+    | [ y ] ->
+        Format.fprintf fmt " “%a (declared at %a)”" pp_var y L.pp_loc y.v_dloc
+    | [] -> assert false
+    | ys -> Format.fprintf fmt "s %a" pp_vars ys
+  in
+  let open CompileError in
+  {
+    location = loc;
+    level = 1;
+    code = "IR-E001";
+    to_text =
+      (fun fmt ->
+        Format.fprintf fmt "%s “%a” depends on (non-inline) variable%a" kind
+          pp_var x pp_varset y);
+  }
+
+let check_func (context : signatures) fd : CompileError.t list =
+  let errors = ref [] in
+  let check_set ~kind ~loc x d =
+    let ys =
+      Sv.filter
+        (fun y ->
+          match y.v_kind with
+          | Stack _ | Reg _ -> true
+          | Const | Inline | Global -> false)
+        d
+    in
+    if not (Sv.is_empty ys) then errors := error ~kind x ys loc :: !errors
+  in
+
+  let check ?(kind = "Inline variable") ~loc a s =
+    let a = Annotation.unwrap a in
+    Sv.iter
+      (fun x ->
+        if x.v_kind = Inline then
+          match Mv.find x a with
+          | exception Not_found -> ()
+          | d -> check_set ~kind ~loc x d)
+      s
+  in
+  let check_instr i =
+    match i.i_desc with
+    | Ccall (xs, fn, es) ->
+        check ~loc:i.i_loc.base_loc i.i_info
+          (List.fold_left uses_lv (vars_es es) xs);
+        let args, _rets = Mf.find fn context in
+        let deps = Annotation.unwrap i.i_info in
+        let deps = analyse_call_args deps args es in
+        check ~kind:"Inline parameter" ~loc:i.i_loc.base_loc (Annotation deps)
+          (Sv.of_list args)
+    | Cfor (x, (_, lo, hi), _) ->
+        let loc = i.i_loc.base_loc in
+        let deps = vars_es [ lo; hi ] in
+        check_set ~kind:"For loop counter" ~loc (L.unloc x) deps;
+        check ~loc i.i_info deps
+    | ir -> check ~loc:i.i_loc.base_loc i.i_info (uses ir)
+  in
+
+  iter_instr check_instr fd.f_body;
+  check ~loc:fd.f_loc fd.f_info (Sv.of_list @@ List.map L.unloc fd.f_ret);
+  !errors
+
+let check_prog (_gds, fds) : CompileError.t list =
+  (* Collect function signatures *)
+  let context =
+    List.fold_left
+      (fun a fd -> Mf.add fd.f_name (fd.f_args, List.map L.unloc fd.f_ret) a)
+      Mf.empty fds
+  in
+  fds
+  |> List.map (analyse_function context)
+  |> List.fold_left
+       (fun acc fd -> List.rev_append (check_func context fd) acc)
+       []

--- a/compiler/linter/Analysis/TaintAnalysis.ml
+++ b/compiler/linter/Analysis/TaintAnalysis.ml
@@ -61,9 +61,9 @@ let analyse_call_args deps args es =
 
 let analyse_stmt (context : signatures) dom stmt =
   let rec analyse_stmt dom stmt = List.fold_left_map analyse_instr dom stmt
-  and analyse_instr ((_w, deps) as dom) instr =
+  and analyse_instr dom instr =
     let dom, i_desc = analyse_instr_r dom instr.i_desc in
-    (dom, { instr with i_desc; i_info = Annotation deps })
+    (dom, { instr with i_desc; i_info = Annotation dom })
   and analyse_instr_r (w, deps) ir =
     match ir with
     | Cassgn (x, tg, ty, e) ->
@@ -129,7 +129,7 @@ let analyse_stmt (context : signatures) dom stmt =
         in
         let w', deps', c1, c2 = loop deps in
         ( (merge_writesets w w', deps'),
-          Cwhile (aa, c1, e, (ei, Annotation deps'), c2) )
+          Cwhile (aa, c1, e, (ei, Annotation (empty_writeset, deps')), c2) )
   in
   analyse_stmt dom stmt
 
@@ -137,31 +137,12 @@ let argument_dependencies args =
   List.fold_left (fun deps x -> Mv.add x (Sv.singleton x) deps) Mv.empty args
 
 let analyse_function (context : signatures) (f : ('info, 'asm) func) :
-    (dependencies annotation, 'asm) func =
+    ((writeset * dependencies) annotation, 'asm) func =
   let deps = argument_dependencies f.f_args in
-  let (_w, deps), f_body =
-    analyse_stmt context (empty_writeset, deps) f.f_body
-  in
-  { f with f_body; f_info = Annotation deps }
+  let annot, f_body = analyse_stmt context (empty_writeset, deps) f.f_body in
+  { f with f_body; f_info = Annotation annot }
 
 (* ----------------------------------------------------------- *)
-
-(** Adds to a set of variables the variables that are read when writing an
-    L-value *)
-let uses_lv s = function
-  | Lnone _ | Lvar _ -> s
-  | Lmem (_, _, _, e) -> rvars_e Sv.add s e
-  | Laset (_, _, _, x, e) | Lasub (_, _, _, x, e) ->
-      rvars_e Sv.add (Sv.add (L.unloc x) s) e
-
-let uses (i : ('info, 'asm) instr_r) : Sv.t =
-  match i with
-  | Cassgn (x, _, _, e) -> uses_lv (vars_e e) x
-  | Copn (xs, _, _, es) | Csyscall (xs, _, es) ->
-      List.fold_left uses_lv (vars_es es) xs
-  | Cassert (_, a) -> vars_a a
-  | Cif (e, _, _) | Cwhile (_, _, e, _, _) -> vars_e e
-  | Cfor _ | Ccall _ -> assert false
 
 let error ~kind x y loc =
   let pp_var = Jasmin.Printer.pp_var ~debug:false in
@@ -184,7 +165,8 @@ let error ~kind x y loc =
           pp_var x pp_varset y);
   }
 
-let check_func (context : signatures) fd : CompileError.t list =
+let check_func (context : signatures) (liveness : Sv.t Miloc.t) fd :
+    CompileError.t list =
   let errors = ref [] in
   let check_set ~kind ~loc x d =
     let ys =
@@ -198,38 +180,52 @@ let check_func (context : signatures) fd : CompileError.t list =
     if not (Sv.is_empty ys) then errors := error ~kind x ys loc :: !errors
   in
 
-  let check ?(kind = "Inline variable") ~loc a s =
-    let a = Annotation.unwrap a in
+  let check ?(kind = "Inline variable") ~loc deps s =
     Sv.iter
       (fun x ->
         if x.v_kind = Inline then
-          match Mv.find x a with
+          match Mv.find x deps with
           | exception Not_found -> ()
           | d -> check_set ~kind ~loc x d)
       s
   in
   let check_instr i =
+    let ws, deps = Annotation.unwrap i.i_info in
+    let written =
+      match i.i_desc with
+      | Cassgn _ | Copn _ | Csyscall _ | Cassert _ | Ccall _ ->
+          Jasmin.Prog.assigns i.i_desc
+      | Cif _ | Cfor _ | Cwhile _ -> ws.get_writeset
+    in
+    let live = Miloc.find_default Sv.empty i.i_loc liveness in
+    let tocheck = Sv.inter written live in
+    check ~loc:i.i_loc.base_loc deps tocheck;
     match i.i_desc with
-    | Ccall (xs, fn, es) ->
-        check ~loc:i.i_loc.base_loc i.i_info
-          (List.fold_left uses_lv (vars_es es) xs);
+    | Ccall (_xs, fn, _es) ->
         let args, _rets = Mf.find fn context in
-        let deps = Annotation.unwrap i.i_info in
-        let deps = analyse_call_args deps args es in
-        check ~kind:"Inline parameter" ~loc:i.i_loc.base_loc (Annotation deps)
+        check ~kind:"Inline parameter" ~loc:i.i_loc.base_loc deps
           (Sv.of_list args)
     | Cfor (x, (_, lo, hi), _) ->
         let loc = i.i_loc.base_loc in
-        let deps = vars_es [ lo; hi ] in
-        check_set ~kind:"For loop counter" ~loc (L.unloc x) deps;
-        check ~loc i.i_info deps
-    | ir -> check ~loc:i.i_loc.base_loc i.i_info (uses ir)
+        let s = vars_es [ lo; hi ] in
+        check_set ~kind:"For loop counter" ~loc (L.unloc x) s;
+        check ~loc deps s
+    | _ -> ()
   in
 
   iter_instr check_instr fd.f_body;
-  check ~loc:fd.f_loc fd.f_info (Sv.of_list @@ List.map L.unloc fd.f_ret);
   !errors
 
+(* ----------------------------------------------------------- *)
+let extract_liveness (fd : ('info, 'asm) func) : Sv.t Miloc.t =
+  let fd = Jasmin.Liveness.live_fd false fd in
+  let table = ref Miloc.empty in
+  iter_instr
+    (fun { i_loc; i_info = _, data; _ } -> table := Miloc.add i_loc data !table)
+    fd.f_body;
+  !table
+
+(* ----------------------------------------------------------- *)
 let check_prog (_gds, fds) : CompileError.t list =
   (* Collect function signatures *)
   let context =
@@ -240,5 +236,6 @@ let check_prog (_gds, fds) : CompileError.t list =
   fds
   |> List.map (analyse_function context)
   |> List.fold_left
-       (fun acc fd -> List.rev_append (check_func context fd) acc)
+       (fun acc fd ->
+         List.rev_append (check_func context (extract_liveness fd) fd) acc)
        []

--- a/compiler/linter/Analysis/TaintAnalysis.mli
+++ b/compiler/linter/Analysis/TaintAnalysis.mli
@@ -1,0 +1,20 @@
+(** Dependency analysis and check that no inline variable depends, when used, of
+    a non-inline one.
+
+    This is a variation on a standard information-flow tracking system in which
+    it is OK to assign Low (inline) variables in High contexts as long as the
+    Low variable is not used outside of said context.
+
+    Dependencies are not transitively closed; for instance, if X depends on Y
+    and Y depends on Z, the dependency of X on Z might be overlooked. This is
+    meant to reduce the amount of reported warnings and produce more focused
+    diagnostic messages.
+
+    Current limitation: flows through memory are ignored, therefore loading a
+    value from memory into an inline variable will not cause any warning to be
+    issued. *)
+
+val check_prog : ('info, 'asm) Jasmin.Prog.prog -> CompileError.t list
+(** Detects whenever an inline variable, whose value is expected to be known at
+    compile-time, depends on some non-inline variable and is used. Such
+    situation usually leads to the failure of the compilation. *)

--- a/compiler/src/main_compiler.ml
+++ b/compiler/src/main_compiler.ml
@@ -130,8 +130,9 @@ let main () =
       let vi_errors = VariableInitialisation.check_prog ([], funcs) in
       let funcs = List.map LivenessAnalyser.analyse_function funcs in
       let dv_errors = DeadVariables.check_prog ([], funcs) in
+      let ir_errors = TaintAnalysis.check_prog ([], funcs) in
       let open CompileError in
-      vi_errors @ dv_errors
+      vi_errors @ dv_errors @ ir_errors
       |> List.filter (fun e -> e.level <= !Glob_options.linting_level)
       |> List.iter (fun error ->
           warning Linter (Location.i_loc0 error.location) "%t" error.to_text

--- a/compiler/tests/fail/unroll/x86-64/run-time-bound.jazz
+++ b/compiler/tests/fail/unroll/x86-64/run-time-bound.jazz
@@ -1,0 +1,9 @@
+/* The number of iterations is not known until run time: loop unrolling fails. */
+export fn count(reg ui32 up) -> reg u8 {
+  reg u8 r = 0;
+  inline int i;
+  for i = 0 to up {
+    r += 1;
+  }
+  return r;
+}

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -1536,6 +1536,12 @@ internal compilation error:
   unrolling: loop iterator too small
 Please report at https://github.com/jasmin-lang/jasmin/issues
 
+fail/unroll/x86-64/run-time-bound.jazz:
+
+"fail/unroll/x86-64/run-time-bound.jazz", line 5 (2) to line 7 (3):
+compilation error in function count:
+loop unrolling: for loops remain
+
 fail/x86-64/bug_1366.jazz:
 
 "fail/x86-64/bug_1366.jazz", line 2 (2-21): invalid number of lvalues, 1 provided instead of 2
@@ -1647,4 +1653,4 @@ Statistics:
 	Pretyping:  47
 	Parsing:     4
 	Typing:      5
-	Compile:   203
+	Compile:   204

--- a/compiler/tests/success/common/inline.jazz
+++ b/compiler/tests/success/common/inline.jazz
@@ -1,0 +1,15 @@
+inline fn inc(reg u32 x, inline u32 g) -> reg u32, inline u32 {
+  x += 1;
+  g += 1;
+  return x, g;
+}
+
+export fn main(reg u32 a) -> reg u32 {
+  inline u32 i = 0;
+  reg u32 b = 12 + i;
+  while (a < b) {
+    a, i = inc(a, 0);
+    a += i;
+  }
+  return a;
+}

--- a/compiler/tests/warning/common/inline.jazz
+++ b/compiler/tests/warning/common/inline.jazz
@@ -1,0 +1,44 @@
+inline fn id(inline u32 x) -> inline u32 { return x; }
+inline fn zero() -> reg u32 { reg u32 z = 0; return z; }
+
+fn funcall(reg u32 a) -> reg u32 {
+  a = id(a);
+  inline u32 b = zero();
+  inline u32 c = id(b);
+  return a;
+}
+
+fn after_if(reg u32 a) -> reg u32 {
+  reg u32 b = 0;
+  inline u32 t;
+  reg u32 c = a;
+  if c <s 0 { t = 1; }
+  b += t;
+  return b;
+}
+
+fn for_guard(reg u32 p) {
+  inline int i;
+  for i = 0 to p {}
+}
+
+fn ok(reg u32 x) -> reg u32 {
+  inline int i;
+  if x <s 0 { i = 0; x = i; }
+  for i = 0 to 4 {
+    if x < i {
+      i = 0;
+      x = i;
+    }
+  }
+  return x;
+}
+
+fn indirect(reg u32 a) -> reg u32 {
+  inline u32 z = 0;
+  if a <s 0 {
+    z = id(1);
+  }
+  a += z;
+  return a;
+}

--- a/compiler/tests/warning/common/inline.jazz
+++ b/compiler/tests/warning/common/inline.jazz
@@ -42,3 +42,34 @@ fn indirect(reg u32 a) -> reg u32 {
   a += z;
   return a;
 }
+
+inline fn ret(reg bool b) -> inline u32 {
+  inline u32 v = 0;
+  if b { v = 1; }
+  return v;
+}
+
+fn late(reg u32 x) -> reg u32 {
+  inline int i = 0;
+  if x == 0 {
+    i = 1; // does i depends on x ? not yet
+    x = i; // this is fine
+  }
+  // here i depends on x
+  x += i; // this is bad
+  return x;
+}
+
+// In this program, we get two warnings about b depending on a
+// 1. on the assignment in the then branch
+// 2. on the if statement
+fn twice(reg u32 a) -> reg u32 {
+  inline u32 b = 0;
+  if a == 0 {
+    b = a;
+    a = b;
+  }
+  a += b;
+  a += b;
+  return a;
+}

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -103,12 +103,19 @@
   $ ../jasminc warning/common/inline.jazz
   "warning/common/inline.jazz", line 5 (2-12)
   warning: Inline parameter “x” depends on (non-inline) variable “a (declared at "warning/common/inline.jazz", line 4 (19-20))”
-  "warning/common/inline.jazz", line 7 (2-23)
+  "warning/common/inline.jazz", line 6 (2-24)
   warning: Inline variable “b” depends on (non-inline) variable “z (declared at "warning/common/inline.jazz", line 2 (38-39))”
-  "warning/common/inline.jazz", line 16 (2-9)
+  "warning/common/inline.jazz", line 15 (2-22)
   warning: Inline variable “t” depends on (non-inline) variable “c (declared at "warning/common/inline.jazz", line 14 (10-11))”
   "warning/common/inline.jazz", line 22 (2-19)
   warning: For loop counter “i” depends on (non-inline) variable “p (declared at "warning/common/inline.jazz", line 20 (21-22))”
-  "warning/common/inline.jazz", line 42 (2-9)
+  "warning/common/inline.jazz", line 39 (2) to line 41 (3)
   warning: Inline variable “z” depends on (non-inline) variable “a (declared at "warning/common/inline.jazz", line 37 (20-21))”
-
+  "warning/common/inline.jazz", line 48 (2-17)
+  warning: Inline variable “v” depends on (non-inline) variable “b (declared at "warning/common/inline.jazz", line 46 (23-24))”
+  "warning/common/inline.jazz", line 54 (2) to line 57 (3)
+  warning: Inline variable “i” depends on (non-inline) variable “x (declared at "warning/common/inline.jazz", line 52 (16-17))”
+  "warning/common/inline.jazz", line 68 (2) to line 71 (3)
+  warning: Inline variable “b” depends on (non-inline) variable “a (declared at "warning/common/inline.jazz", line 66 (17-18))”
+  "warning/common/inline.jazz", line 69 (4-10)
+  warning: Inline variable “b” depends on (non-inline) variable “a (declared at "warning/common/inline.jazz", line 66 (17-18))”

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -99,3 +99,16 @@
   warning: invalid constraint for argument arg (word-size expected)
   "warning/x86-64/alignment.jazz", line 16 (25-28)
   warning: invalid constraint for argument arg (word-size expected)
+
+  $ ../jasminc warning/common/inline.jazz
+  "warning/common/inline.jazz", line 5 (2-12)
+  warning: Inline parameter “x” depends on (non-inline) variable “a (declared at "warning/common/inline.jazz", line 4 (19-20))”
+  "warning/common/inline.jazz", line 7 (2-23)
+  warning: Inline variable “b” depends on (non-inline) variable “z (declared at "warning/common/inline.jazz", line 2 (38-39))”
+  "warning/common/inline.jazz", line 16 (2-9)
+  warning: Inline variable “t” depends on (non-inline) variable “c (declared at "warning/common/inline.jazz", line 14 (10-11))”
+  "warning/common/inline.jazz", line 22 (2-19)
+  warning: For loop counter “i” depends on (non-inline) variable “p (declared at "warning/common/inline.jazz", line 20 (21-22))”
+  "warning/common/inline.jazz", line 42 (2-9)
+  warning: Inline variable “z” depends on (non-inline) variable “a (declared at "warning/common/inline.jazz", line 37 (20-21))”
+

--- a/docs/source/tools/linter.md
+++ b/docs/source/tools/linter.md
@@ -23,6 +23,7 @@ reported.
 1. Level 1 reports:
   - Variables used without initialization
   - Instructions assigning dead variables only
+  - Inline variables whose values depend on non-inline ones
 2. Level 2 also reports:
   - Dead variables assigned within an instruction that has other effects
 
@@ -106,7 +107,7 @@ no warning.
 ~~~
 fn dead_no_warn(reg u64 x) {
   reg u64 msf = #init_msf();
-  #keep x += 1;
+  #[keep] x += 1;
 }
 ~~~
 
@@ -121,5 +122,24 @@ fn only_one_live_result(reg u64 x) -> reg u64 {
   reg u64 z = 0;
   x, z = #swap(z, x); // z is assigned but never used afterwards
   return x;
+}
+~~~
+
+## Flows from non-inline variables to inline variables
+
+This check warns about inline variables whose values depend on the values of
+non-inline variables. This situation usually leads to compilation failure. For
+instance in the following program, the number of iteration of a `for` loop
+depends on a run-time value (the argument `up`); therefore the loop cannot be
+unrolled and the program cannot be compiled.
+
+~~~
+export fn count(reg ui32 up) -> reg u8 {
+  reg u8 r = 0;
+  inline int i;
+  for i = 0 to up {
+    r += 1;
+  }
+  return r;
 }
 ~~~


### PR DESCRIPTION
# Description

New linting analysis & check that inline variables do not depend too much on non-inline data.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed
