### PR TITLE
CI: fix typo in mldsa test script

### DIFF
--- a/scripts/test-mldsa.sh
+++ b/scripts/test-mldsa.sh
@@ -30,7 +30,7 @@ do
         make $PARAM $J
         echo CHECK CT
         make $PARAM $J check-ct
-        if [ "$i" == "x86-64 ref" ]
+        if [ "$i" = "x86-64 ref" ]
         then
             echo CHECK SCT
             make $PARAM $J check-sct


### PR DESCRIPTION
Prior to this PR `dash` reports:

> ./scripts/test-mldsa.sh: 33: [: arm-m4 lowram: unexpected operator

then succeeds…