### PR TITLE
"Remove unused returns" also updates annotations

### DIFF
--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -134,7 +134,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
        and type asm_op = asm_op
        and type extra_op = extra_op) visit_prog_after_pass prog cprog =
   let module RA = Regalloc.Regalloc (Arch) in
-  let module StackAlloc = StackAlloc.StackAlloc (Arch) in
+  let module SA = StackAlloc.StackAlloc (Arch) in
   let fdef_of_cufdef fn cfd = Conv.fdef_of_cufdef (fn, cfd) in
   let cufdef_of_fdef fd = snd (Conv.cufdef_of_fdef fd) in
 
@@ -161,7 +161,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
   in
 
   let memory_analysis up : Compiler.stack_alloc_oracles =
-    StackAlloc.memory_analysis
+    SA.memory_analysis
       pp_sr
       (Printer.pp_err ~debug:!debug)
       ~debug:!debug up
@@ -425,6 +425,7 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       Compiler.dead_vars_ufd;
       Compiler.dead_vars_sfd;
       Compiler.pp_sr;
+      Compiler.apply_ret_annot = StackAlloc.apply_ret_annot;
     }
   in
 

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -3,10 +3,9 @@ open Wsize
 open Prog
 open Regalloc
 
-let apply_ret_annot f (fi : FInfo.t) : FInfo.t =
+let apply_ret_annot tokeep (fi : FInfo.t) : FInfo.t =
   let (loc, annot, cc, ri) = fi in
-  let __ = let rec f _ = Obj.repr f in Obj.repr f in (* we reuse the kind of hack used by Rocq extraction *)
-  let ri = { ri with ret_annot = Obj.magic (f __ (Obj.magic ri.ret_annot)) } in
+  let ri = { ri with ret_annot = Dead_code.keep_only ri.ret_annot tokeep } in
   (loc, annot, cc, ri)
 
 let pp_var = Printer.pp_var ~debug:true

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -3,6 +3,12 @@ open Wsize
 open Prog
 open Regalloc
 
+let apply_ret_annot f (fi : FInfo.t) : FInfo.t =
+  let (loc, annot, cc, ri) = fi in
+  let __ = let rec f _ = Obj.repr f in Obj.repr f in (* we reuse the kind of hack used by Rocq extraction *)
+  let ri = { ri with ret_annot = Obj.magic (f __ (Obj.magic ri.ret_annot)) } in
+  (loc, annot, cc, ri)
+
 let pp_var = Printer.pp_var ~debug:true
 
 let pp_var_ty fmt x =
@@ -235,7 +241,7 @@ let memory_analysis pp_sr pp_err ~debug up =
   let deadcode (extra, fd) =
     let (fn, cfd) = Conv.cufdef_of_fdef fd in
     let fd = 
-      match Dead_code.dead_code_fd Arch.asmOp Compiler.default_LoopCounter Arch.aparams.ap_is_move_op false tokeep fn cfd with
+      match Dead_code.dead_code_fd Arch.asmOp Compiler.default_LoopCounter Arch.aparams.ap_is_move_op apply_ret_annot false tokeep fn cfd with
       | Utils0.Ok cfd -> Conv.fdef_of_cufdef (fn, cfd)
       | Utils0.Error _ -> assert false in 
     (extra,fd) in

--- a/compiler/src/stackAlloc.mli
+++ b/compiler/src/stackAlloc.mli
@@ -1,3 +1,7 @@
+val apply_ret_annot : (Obj.t -> Obj.t list -> Obj.t list) -> FInfo.t -> FInfo.t
+  (** Apply a function (operating on lists) on the [ret_annot] part of [FInfo.t].
+      The signature is inherited from Rocq, hence the ugly [Obj.t]. *)
+
 module StackAlloc (Arch: Arch_full.Arch) : sig
 
   val memory_analysis :

--- a/compiler/src/stackAlloc.mli
+++ b/compiler/src/stackAlloc.mli
@@ -1,6 +1,5 @@
-val apply_ret_annot : (Obj.t -> Obj.t list -> Obj.t list) -> FInfo.t -> FInfo.t
-  (** Apply a function (operating on lists) on the [ret_annot] part of [FInfo.t].
-      The signature is inherited from Rocq, hence the ugly [Obj.t]. *)
+val apply_ret_annot : bool list -> FInfo.t -> FInfo.t
+  (** Selects a subset of the [ret_annot] part of [FInfo.t]. *)
 
 module StackAlloc (Arch: Arch_full.Arch) : sig
 

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -209,6 +209,7 @@ Record compiler_params
   dead_vars_sfd    : _sfun_decl -> instr_info -> Sv.t;
     (* Same as dead_vars_ufd, but for _sfun_decl instead of _ufun_decl. *)
   pp_sr            : sub_region -> pp_error;
+  apply_ret_annot  : (forall A, seq A -> seq A) -> fun_info -> fun_info;
 }.
 
 Context
@@ -353,7 +354,7 @@ Definition compiler_third_part (returned_params: funname -> option (seq (option 
     | None => rminfo fn
     end
   in
-  Let pr := dead_code_prog_tokeep (ap_is_move_op aparams) false rminfo ps in
+  Let pr := dead_code_prog_tokeep (ap_is_move_op aparams) cparams.(apply_ret_annot) false rminfo ps in
   let pr := cparams.(print_sprog) RemoveReturn pr in
 
   let pa := {| p_funcs := cparams.(regalloc) pr.(p_funcs) ; p_globs := pr.(p_globs) ; p_extra := pr.(p_extra) |} in

--- a/proofs/compiler/compiler.v
+++ b/proofs/compiler/compiler.v
@@ -209,7 +209,7 @@ Record compiler_params
   dead_vars_sfd    : _sfun_decl -> instr_info -> Sv.t;
     (* Same as dead_vars_ufd, but for _sfun_decl instead of _ufun_decl. *)
   pp_sr            : sub_region -> pp_error;
-  apply_ret_annot  : (forall A, seq A -> seq A) -> fun_info -> fun_info;
+  apply_ret_annot  : seq bool -> fun_info -> fun_info;
 }.
 
 Context

--- a/proofs/compiler/dead_code.v
+++ b/proofs/compiler/dead_code.v
@@ -82,9 +82,9 @@ Fixpoint keep_only {T:Type} (l:seq T) (tokeep : seq bool) {struct tokeep}:=
 
 Section ONFUN.
 
-(* Apply a function (operating on lists) on the [ret_annot] part of the [fun_info].
+(* Selects a subset of the [ret_annot] part of the [fun_info].
    [fun_info] is opaque on the Rocq side, so this function is implemented in OCaml. *)
-Context (apply_ret_annot : (forall A, seq A -> seq A) -> fun_info -> fun_info).
+Context (apply_ret_annot : seq bool -> fun_info -> fun_info).
 
 Context (do_nop: bool) (onfun: funname -> option (seq bool)).
 
@@ -178,7 +178,7 @@ Context {pT: progT}.
 Definition dead_code_fd {eft} fn (fd: _fundef eft) : cexec (_fundef eft) :=
   let res := fn_keep_only fn fd.(f_res) in
   let tyo := fn_keep_only fn fd.(f_tyout) in
-  let fi := apply_ret_annot (fun A => @fn_keep_only A fn) fd.(f_info) in
+  let fi := if onfun fn is Some select then apply_ret_annot select fd.(f_info) else fd.(f_info) in
   let s := read_es (map Plvar res) in
   Let c := dead_code_c dead_code_i fd.(f_body) s in
   ok {| f_info := fi;

--- a/proofs/compiler/dead_code.v
+++ b/proofs/compiler/dead_code.v
@@ -82,6 +82,10 @@ Fixpoint keep_only {T:Type} (l:seq T) (tokeep : seq bool) {struct tokeep}:=
 
 Section ONFUN.
 
+(* Apply a function (operating on lists) on the [ret_annot] part of the [fun_info].
+   [fun_info] is opaque on the Rocq side, so this function is implemented in OCaml. *)
+Context (apply_ret_annot : (forall A, seq A -> seq A) -> fun_info -> fun_info).
+
 Context (do_nop: bool) (onfun: funname -> option (seq bool)).
 
 Definition fn_keep_only {T:Type} (fn:funname) (l:seq T) := 
@@ -174,9 +178,10 @@ Context {pT: progT}.
 Definition dead_code_fd {eft} fn (fd: _fundef eft) : cexec (_fundef eft) :=
   let res := fn_keep_only fn fd.(f_res) in
   let tyo := fn_keep_only fn fd.(f_tyout) in
+  let fi := apply_ret_annot (fun A => @fn_keep_only A fn) fd.(f_info) in
   let s := read_es (map Plvar res) in
   Let c := dead_code_c dead_code_i fd.(f_body) s in
-  ok {| f_info := f_info fd;
+  ok {| f_info := fi;
         f_contract := f_contract fd;
         f_tyin := f_tyin fd;
         f_params := f_params fd;
@@ -195,6 +200,6 @@ End Section.
 End ONFUN.
 
 Definition dead_code_prog {pT:progT} (p:prog) do_nop :=
-  @dead_code_prog_tokeep do_nop (fun _ => None) pT p.
+  @dead_code_prog_tokeep (fun _ fi => fi) do_nop (fun _ => None) pT p.
 
 End ASM_OP.

--- a/proofs/compiler/dead_code_proof.v
+++ b/proofs/compiler/dead_code_proof.v
@@ -31,7 +31,7 @@ Context
 
 Section PROOF.
 
-  Context (apply_ret_annot : (forall A, seq A -> seq A) -> fun_info -> fun_info).
+  Context (apply_ret_annot : seq bool -> fun_info -> fun_info).
 
   Variables (do_nop : bool) (onfun : funname -> option (seq bool)) (p p' : prog) (ev:extra_val_t).
   Notation gd := (p_globs p).
@@ -532,7 +532,7 @@ Section PROOF.
     have [vres2 {}Hfull' Hvl'] := mapM2_dc_truncate_val Hfull' Hvl.
     eexists vres2; split=> //=.
     apply EcallRun with  {|
-           f_info := apply_ret_annot (fun A => @fn_keep_only onfun A fn) fi;
+           f_info := if onfun fn is Some select then apply_ret_annot select fi else fi;
            f_contract := fc;
            f_tyin := ft;
            f_params := fp;

--- a/proofs/compiler/dead_code_proof.v
+++ b/proofs/compiler/dead_code_proof.v
@@ -31,10 +31,12 @@ Context
 
 Section PROOF.
 
+  Context (apply_ret_annot : (forall A, seq A -> seq A) -> fun_info -> fun_info).
+
   Variables (do_nop : bool) (onfun : funname -> option (seq bool)) (p p' : prog) (ev:extra_val_t).
   Notation gd := (p_globs p).
 
-  Hypothesis dead_code_ok : dead_code_prog_tokeep is_move_op do_nop onfun p = ok p'.
+  Hypothesis dead_code_ok : dead_code_prog_tokeep is_move_op apply_ret_annot do_nop onfun p = ok p'.
 
   Lemma eq_globs : gd = p_globs p'.
   Proof. by move: dead_code_ok; rewrite /dead_code_prog_tokeep; t_xrbindP => ? _ <-. Qed.
@@ -494,7 +496,7 @@ Section PROOF.
   Local Lemma Hproc : sem_Ind_proc p ev Pc Pfun.
   Proof.
     move=> scs1 m1 scs2 m2 fn f vargs vargs' s0 s1 s2 vres vres' Hfun htra Hi Hw Hsem Hc Hres Hfull Hscs Hfi.
-    have dcok : map_cfprog_name (dead_code_fd is_move_op do_nop onfun) (p_funcs p) = ok (p_funcs p').
+    have dcok : map_cfprog_name (dead_code_fd is_move_op apply_ret_annot do_nop onfun) (p_funcs p) = ok (p_funcs p').
     + by move: dead_code_ok; rewrite /dead_code_prog_tokeep; t_xrbindP => ? ? <-.
     have [f' Hf'1 Hf'2] := get_map_cfprog_name_gen dcok Hfun.
     case: f Hf'1 Hfun htra Hi Hw Hsem Hc Hres Hfull Hscs Hfi => fi fc ft fp /= c f_tyout res fb
@@ -530,7 +532,7 @@ Section PROOF.
     have [vres2 {}Hfull' Hvl'] := mapM2_dc_truncate_val Hfull' Hvl.
     eexists vres2; split=> //=.
     apply EcallRun with  {|
-           f_info := fi;
+           f_info := apply_ret_annot (fun A => @fn_keep_only onfun A fn) fi;
            f_contract := fc;
            f_tyin := ft;
            f_params := fp;
@@ -606,7 +608,7 @@ Section PROOF.
     wiequiv_f p p' ev ev (rpreF (eS:= dc_spec)) fn fn (rpostF (eS:=dc_spec)).
   Proof.
     apply wequiv_fun_ind => {}fn _ fs ft [<- hfsu] fd hget.
-    have dcok : map_cfprog_name (dead_code_fd is_move_op do_nop onfun) (p_funcs p) = ok (p_funcs p').
+    have dcok : map_cfprog_name (dead_code_fd is_move_op apply_ret_annot do_nop onfun) (p_funcs p) = ok (p_funcs p').
     + by move: dead_code_ok; rewrite /dead_code_prog_tokeep; t_xrbindP => ? ? <-.
     have [fd' hfd' hget'] := get_map_cfprog_name_gen dcok hget.
     exists fd' => // {hget}.
@@ -729,16 +731,16 @@ End Section.
 
 Section SEM.
 
-Lemma dead_code_tokeep_callPu (p p': uprog) do_nop onfun fn ev scs mem scs' mem' va va' vr:
-  dead_code_prog_tokeep is_move_op do_nop onfun p = ok p' ->
+Lemma dead_code_tokeep_callPu (p p': uprog) apply_ret_annot do_nop onfun fn ev scs mem scs' mem' va va' vr:
+  dead_code_prog_tokeep is_move_op apply_ret_annot do_nop onfun p = ok p' ->
   values_uincl va va' ->
   sem_call p ev scs mem fn va scs' mem' vr ->
   exists vr',
     sem_call p' ev scs mem fn va scs' mem' vr' /\ values_uincl (fn_keep_only onfun fn vr) vr'.
 Proof. by move=> hd hall;apply: (dead_code_callP hd); apply List_Forall2_refl. Qed.
 
-Lemma dead_code_tokeep_callPs (p p': sprog) do_nop onfun fn wrip scs mem scs' mem' va va' vr:
-  dead_code_prog_tokeep is_move_op do_nop onfun p = ok p' ->
+Lemma dead_code_tokeep_callPs (p p': sprog) apply_ret_annot do_nop onfun fn wrip scs mem scs' mem' va va' vr:
+  dead_code_prog_tokeep is_move_op apply_ret_annot do_nop onfun p = ok p' ->
   values_uincl va va' ->
   sem_call p wrip scs mem fn va scs' mem' vr ->
   exists vr',
@@ -766,8 +768,8 @@ End SEM.
 Section IT.
 Context {E E0: Type -> Type} {wE : with_Error E E0} {rE : EventRels E0}.
 
-Lemma it_dead_code_tokeep_callPu (p p': uprog) do_nop onfun fn ev:
-  dead_code_prog_tokeep is_move_op do_nop onfun p = ok p' ->
+Lemma it_dead_code_tokeep_callPu (p p': uprog) apply_ret_annot do_nop onfun fn ev:
+  dead_code_prog_tokeep is_move_op apply_ret_annot do_nop onfun p = ok p' ->
   wiequiv_f p p' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=dc_spec onfun)).
 Proof.
   move=> hd; apply wkequiv_io_weaken with
@@ -776,8 +778,8 @@ Proof.
   apply (it_dead_code_callP ev hd).
 Qed.
 
-Lemma it_dead_code_tokeep_callPs (p p': sprog) do_nop onfun fn wrip:
-  dead_code_prog_tokeep is_move_op do_nop onfun p = ok p' ->
+Lemma it_dead_code_tokeep_callPs (p p': sprog) apply_ret_annot do_nop onfun fn wrip:
+  dead_code_prog_tokeep is_move_op apply_ret_annot do_nop onfun p = ok p' ->
   wiequiv_f p p' wrip wrip (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=dc_spec onfun)).
 Proof.
   move=> hd; apply wkequiv_io_weaken with
@@ -796,24 +798,24 @@ Lemma it_dead_code_callPs (p p': sprog) do_nop fn wrip:
   wiequiv_f p p' wrip wrip (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=uincl_spec)).
 Proof. apply it_dead_code_tokeep_callPs. Qed.
 
-Lemma dead_code_prog_tokeep_meta (p p': sprog) do_nop onfun :
-  dead_code_prog_tokeep is_move_op do_nop onfun p = ok p' →
+Lemma dead_code_prog_tokeep_meta (p p': sprog) apply_ret_annot do_nop onfun :
+  dead_code_prog_tokeep is_move_op apply_ret_annot do_nop onfun p = ok p' →
   p_globs p' = p_globs p ∧ p_extra p' = p_extra p.
 Proof.
   by rewrite /dead_code_prog_tokeep; t_xrbindP => _ _ <- /=.
 Qed.
 
-Lemma dead_code_prog_tokeep_get_fundef (p p': sprog) do_nop onfun fn f :
-  dead_code_prog_tokeep is_move_op do_nop onfun p = ok p' →
+Lemma dead_code_prog_tokeep_get_fundef (p p': sprog) apply_ret_annot do_nop onfun fn f :
+  dead_code_prog_tokeep is_move_op apply_ret_annot do_nop onfun p = ok p' →
   get_fundef (p_funcs p) fn = Some f →
-  exists2 f', dead_code_fd is_move_op do_nop onfun fn f = ok f' & get_fundef (p_funcs p') fn = Some f'.
+  exists2 f', dead_code_fd is_move_op apply_ret_annot do_nop onfun fn f = ok f' & get_fundef (p_funcs p') fn = Some f'.
 Proof.
   apply: rbindP => fds ok_fds [<-{p'}].
   exact: get_map_cfprog_name_gen ok_fds.
 Qed.
 
-Lemma dead_code_fd_meta do_nop onfun fn (fd fd': sfundef) :
-  dead_code_fd is_move_op do_nop onfun fn fd = ok fd' →
+Lemma dead_code_fd_meta apply_ret_annot do_nop onfun fn (fd fd': sfundef) :
+  dead_code_fd is_move_op apply_ret_annot do_nop onfun fn fd = ok fd' →
   [/\
    fd'.(f_tyin) = fd.(f_tyin),
    fd'.(f_params) = fd.(f_params) &


### PR DESCRIPTION
The pass used to update the list of returned values (and the list of output types), but never touched the associated list of annotations, while they should be kept in sync.

This made the compiler crash when trying to print the program just after the pass (after https://github.com/jasmin-lang/jasmin/pull/1474, before the annotations were incorrectly not printed).