### PR TITLE
Compatibility with Rocq 9.2 (and master)

### DIFF
--- a/opam
+++ b/opam
@@ -33,7 +33,8 @@ depends: [
   "yojson" {>= "1.6.0"}
   "angstrom" {>= "0.14.0"}
   "ocamlfind" { build }
-  "coq" {>= "9.0" & < "9.2~"}
+  "coq-core" {>= "9.0" & < "9.3~"}
+  "coq-stdlib"
   "coq-elpi" {>= "2.5.1"}
   "coq-mathcomp-ssreflect" {>= "2.3" & < "2.6~"}
   "coq-mathcomp-algebra"

--- a/proofs/3rdparty/xseq.v
+++ b/proofs/3rdparty/xseq.v
@@ -67,7 +67,7 @@ case: eqP=> [->|/eqP ne_xt] t_notin_s; last first.
 + by rewrite in_cons eqE /= (negbTE ne_xt).
 rewrite inE eqE /= eqxx /=; case: eqP => [->|ne_wu] _ /=.
 + by constructor.
-suff ->: (t, w) \in s = false by constructor; case=> /esym.
+suff ->: ((t, w) \in s) = false by constructor; case=> /esym.
 by apply/negbTE; apply/contra: t_notin_s => /(map_f fst).
 Qed.
 

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -15,6 +15,9 @@
 -arg "-w -deprecated-dirpath-Coq"
 # can be solved only with Stdlib >= 9.1
 -arg "-w -deprecated-reference-since-9.1"
+# the next 2 lines can be handled when requiring Rocq >= 9.2
+-arg "-w -notation-for-abbreviation"
+-arg "-w -implicit-create-rewrite-hint-db"
 # to be handled when requiring Rocq >= 9.3
 -arg "-w -rewrite-rw"
 

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -13,8 +13,10 @@
 -arg "-w -deprecated-since-mathcomp-2.5.0"
 -arg "-w -deprecated-from-Coq"
 -arg "-w -deprecated-dirpath-Coq"
-# can be solved only with Stdlib >= 9.1
+# the next 2 lines can be solved only with Stdlib >= 9.1
+# this is twice the same warning, its name changed...
 -arg "-w -deprecated-reference-since-9.1"
+-arg "-w -deprecated-reference-since-Stdlib-9.1"
 # the next 2 lines can be handled when requiring Rocq >= 9.2
 -arg "-w -notation-for-abbreviation"
 -arg "-w -implicit-create-rewrite-hint-db"

--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -416,6 +416,7 @@ Defined.
 
 Definition add_arguments {A} {lt0 lt1} (f: sem_lprod lt0 (sem_lprod lt1 A))
   : sem_lprod (lt0 ++ lt1) A.
+Proof.
   rewrite sem_lprod_cat.
   by apply: f.
 Defined.

--- a/proofs/compiler/array_expansion_proof.v
+++ b/proofs/compiler/array_expansion_proof.v
@@ -385,7 +385,7 @@ Proof.
   rewrite -Z2Nat.inj_pos (wf_take_drop (v_var (gv g)) vai) //. 2,3: by nia.
   rewrite -map_comp; apply eq_in_map => j; rewrite in_ziota /comp /= => /andP [] /ZleP ? /ZltP ?.
   have hbound : (0 <=? i + j)%Z && (i + j <? ai_len a)%Z.
-  + by apply /andP; split; [apply/ZleP|apply/ZltP] => //; nia.
+  + by apply /andP; split; [apply/ZleP|apply/ZltP]; nia.
   case: h => _ _ -[_ /(_ _ _ _ hga){hga}hgai].
   move/hgai: (wf_mem (v_var (gv g)) vai hbound); rewrite -hgx /= => -[<-].
   by rewrite (wf_index _ vai hbound) (WArray.get_sub_get _ hst).

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -258,14 +258,14 @@ case h2: (is_wconst sz e2) => [ n2 | ] //.
   have! := (is_wconstP wdb gd s h2).
   have! := (is_wconstP wdb gd s h1).
   by t_xrbindP => *; clarify; rewrite wrepr_unsigned;eauto.
-+ case: eqP => hn1; [| case: eqP => hn2] => s v /=; rewrite /sem_sop2 /sem_sop1 /=;
++ case: eqP => hn1; [| case: eqP => hn2]; move => s v /=; rewrite /sem_sop2 /sem_sop1 /=;
   have! := (is_wconstP wdb gd s h1);
   t_xrbindP => ? k1 k2 ? k3 ? k4 ? k5 ? k6 ?; clarify.
   - by rewrite wrepr0 mul_wordE GRing.mul0r;eauto.
   - case: (to_wordI k6) => {k6} sz' [w] [? /truncate_word_uincl]; subst.
     by rewrite k4 mul_wordE GRing.mul1r; eauto.
   by rewrite k4 /= k6 /= wrepr_unsigned truncate_word_u /=;eexists;split;eauto => /=.
-case: eqP => hn1; [| case: eqP => hn2] => s v /=; rewrite /sem_sop2 /sem_sop1 /=;
+case: eqP => hn1; [| case: eqP => hn2]; move => s v /=; rewrite /sem_sop2 /sem_sop1 /=;
 have! := (is_wconstP wdb gd s h2);
 t_xrbindP => ? k1 k2 ? k3 ? k4 ? k5 ? k6 ?; clarify.
 - by rewrite wrepr0 mul_wordE GRing.mulr0;eauto.

--- a/proofs/compiler/hoare_valid.v
+++ b/proofs/compiler/hoare_valid.v
@@ -72,7 +72,8 @@ Proof.
   apply khoare_ioP => fs hPf. have [/(_ _ _ hPf) herr {}hf] := hf.
   apply khoare_read with (fun fd => get_fundef (p_funcs p) fn = Some fd).
   + rewrite /kget_fundef => ??.
-    case: get_fundef hf => /= [fd | ] h; [apply lutt_Ret | apply lutt_Vis] => //.
+    case: get_fundef hf => /= [fd | ] h; first by apply lutt_Ret.
+    apply lutt_Vis => //.
     by rewrite preInv_Throw; apply herr.
   move=> fd hfd; move: hf; rewrite hfd => -[Pre Post [P] [Q] [hinit hbody hQerr hfin]].
   apply khoare_read with PredT.
@@ -82,7 +83,8 @@ Proof.
   move => _ _.
   apply khoare_read with (P fs).
   + move=> _ ->; have := hinit _ hPf.
-    case: initialize_funcall => [s | e] h; [apply lutt_Ret | apply lutt_Vis] => //.
+    case: initialize_funcall => [s | e] h; first by apply lutt_Ret.
+    apply lutt_Vis => //.
     by rewrite preInv_Throw; apply herr.
   move => s1 hs1.
   eapply khoare_read.

--- a/proofs/compiler/it_linearization_proof.v
+++ b/proofs/compiler/it_linearization_proof.v
@@ -4646,7 +4646,7 @@ Qed.
           have := read_spilled var_tmp stack_saved_rsp.
           rewrite mem_cat mem_head orbT => -[] // _ [[<-] _] [v].
           by rewrite htmp /= truncate_word_u hr3 => -[<-] [->].
-        have vrsp_to_save : vrsp \in [seq i.1 | i <- sf_to_save (f_extra fd)] = false.
+        have vrsp_to_save : (vrsp \in [seq i.1 | i <- sf_to_save (f_extra fd)]) = false.
         + by apply/negbTE/sv_of_listP/Sv_memP.
         move=> body ra lret sp callee_saved. rewrite /is_linear_of /sp_alloc_ra ok_fd' /= => -[ _ [<-] <-].
         rewrite /is_ra_of /value_of_ra /is_sp_for_call /is_callee_saved_of ok_fd => -[_ [<-] <-].

--- a/proofs/compiler/it_tunneling_proof.v
+++ b/proofs/compiler/it_tunneling_proof.v
@@ -108,7 +108,7 @@ Lemma labels_of_body_cat c1 c2 :
 Proof. by rewrite /labels_of_body pmap_cat. Qed.
 
 Lemma labels_of_body_cons l c i :
-  l \in labels_of_body (i :: c) =
+  (l \in labels_of_body (i :: c)) =
    match li_i i with
    | Llabel _ lbl => l == lbl
    | _ => false
@@ -116,7 +116,7 @@ Lemma labels_of_body_cons l c i :
 Proof. by rewrite /labels_of_body /=; case: li_i. Qed.
 
 Lemma labels_of_body_rcons l c i :
-  l \in labels_of_body (rcons c i) =
+  (l \in labels_of_body (rcons c i)) =
    (l \in labels_of_body c) ||
    match li_i i with
    | Llabel _ lbl => l == lbl

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -468,14 +468,14 @@ Fixpoint check_bool (e:fexpr) :=
     | Cif b c1 c2 =>
       Let _ := assert (if c2 is [::] then check_bool (to_fexpr b) else true)
         (E.ii_error ii "ill typed condition in linear") in
-      check_fexpr ii b >> check_c check_i c1 >> check_c check_i c2
+      check_fexpr ii b >> (check_c check_i c1 >> check_c check_i c2)
     | Cfor _ _ _ =>
       Error (E.ii_error ii "for found in linear")
     | Cwhile _ c e _ c' =>
       match is_bool e with
       | Some false => check_c check_i c
       | Some true => check_c check_i c >> check_c check_i c'
-      | None => check_fexpr ii e >> check_c check_i c >> check_c check_i c'
+      | None => check_fexpr ii e >> (check_c check_i c >> check_c check_i c')
       end
     | Ccall xs fn es =>
       Let _ := assert (fn != this) (E.ii_error ii "call to self") in

--- a/proofs/compiler/linearization_proof.v
+++ b/proofs/compiler/linearization_proof.v
@@ -4297,7 +4297,7 @@ Qed.
           have := read_spilled var_tmp stack_saved_rsp.
           rewrite mem_cat mem_head orbT => -[] // _ [[<-] _] [v].
           by rewrite htmp /= truncate_word_u hr3 => -[<-] [->].
-        have vrsp_to_save : vrsp \in [seq i.1 | i <- sf_to_save (f_extra fd)] = false.
+        have vrsp_to_save : (vrsp \in [seq i.1 | i <- sf_to_save (f_extra fd)]) = false.
         + by apply/negbTE/sv_of_listP/Sv_memP.
         exists m4 vm5' => //.
         + have heq1 : (lset_estate (setpc ls (size P)) (escs s1) m3 vm2') = ls2.

--- a/proofs/compiler/load_constants_in_cond_proof.v
+++ b/proofs/compiler/load_constants_in_cond_proof.v
@@ -354,6 +354,7 @@ Proof.
 Qed.
 
 Lemma eq_extra : p_extra p = p_extra p'.
+Proof.
   move : Hp; rewrite /load_constants_prog.
   by t_xrbindP => y Hmap <-.
 Qed.

--- a/proofs/compiler/load_constants_in_cond_proof.v
+++ b/proofs/compiler/load_constants_in_cond_proof.v
@@ -464,7 +464,7 @@ Proof.
       have [ |vm' [???]] := process_conditionP hcond he _ heq.
       + by SvD.fsetdec.
       by eexists; split;eauto.
-    by move=> []; [apply hc1 | apply hc2] => //; SvD.fsetdec.
+    by move=> []; [apply hc1 | apply hc2]; move => //; clear -hsub; SvD.fsetdec.
   + move=> x dir lo hi c hc ii c_; t_xrbindP => c' hc' <-; rewrite !read_writeE => hsub.
     apply wequiv_for_rel_eq with checker_st_eq_on X X => //.
     + by split => //; rewrite /read_es /= !read_eE; SvD.fsetdec.

--- a/proofs/compiler/makeReferenceArguments_proof.v
+++ b/proofs/compiler/makeReferenceArguments_proof.v
@@ -144,6 +144,7 @@ Context
   Qed.
 
   Lemma eq_extra : p_extra p = p_extra p'.
+  Proof.
     move : Hp.
     rewrite /makereference_prog.
     by t_xrbindP => y Hmap <-.

--- a/proofs/compiler/slh_lowering_proof.v
+++ b/proofs/compiler/slh_lowering_proof.v
@@ -1342,6 +1342,7 @@ Let Pc c : Prop :=
     wequiv_rec p p' ev ev slh_spec (st_eq env) c c' (st_eq env').
 
 Lemma it_lower_opn xs tg op es : Pi_r (Copn xs tg op es).
+Proof.
 move=> ii env env' i' ii' /=; case: is_OslhP => [slho|?] /=; last first.
 - move=> [<-] [<- <-]; apply wequiv_opn_eq.
   + rewrite hp_globs; move=> s _ vs [<- _] ->; by exists vs.
@@ -1386,6 +1387,7 @@ case: b; [exact: hc1 hchk1 hc1' | exact: hc2 hchk2 hc2'].
 Qed.
 
 Lemma lower_it_for i dir lo hi c : Pc c -> Pi_r (Cfor i (dir, lo, hi) c).
+Proof.
 move=> hc ii env env' /=; t_xrbindP=> _ _ /check_forP [env0 [hchk hle hle0]] _
   c' hc' <- <- <-.
 apply

--- a/proofs/compiler/stack_alloc.v
+++ b/proofs/compiler/stack_alloc.v
@@ -731,7 +731,7 @@ Record table := {
 (* We need to combine [result] and [option], so let's use a new kind of "let" *)
 #[global] Notation "'Let%opt' x ':=' ox 'in' body" :=
   (if ox is Some x then body else ok None)
-  (x strict pattern, at level 25).
+  (x strict pattern, at level 25, right associativity).
 
 Section CLONE.
 

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -369,9 +369,9 @@ End PRIM_RANGE.
 
 (* -------------------------------------------------------------------- *)
 
-Notation "'tpl' A" := (sem_ltuple A) (at level 200, only parsing).
+Notation tpl A := (sem_ltuple A) (only parsing).
 
-Notation "'ex_tpl' A" := (exec (sem_ltuple A)) (at level 200, only parsing).
+Notation ex_tpl A := (exec (sem_ltuple A)) (only parsing).
 
 Definition implicit_flags      := map F [::OF; CF; SF; PF; ZF].
 Definition implicit_flags_noCF := map F [::OF; SF; PF; ZF].

--- a/proofs/compiler/x86_lowering.v
+++ b/proofs/compiler/x86_lowering.v
@@ -169,7 +169,7 @@ Definition is_lea sz x e :=
   let%opt _ :=
     oassert [&& (U16 ≤ sz)%CMP, (sz ≤ U64)%CMP & ~~ is_lval_in_memory x ]
   in
-  let%opt MkLea d b sc o := mk_lea sz e in
+  let%opt (MkLea d b sc o) := mk_lea sz e in
   let check o := if o is Some x then ~~ is_var_in_memory x.(v_var) else true in
   (* FIXME: check that d is not to big *)
   let%opt _ := oassert [&& check_scale sc, check b & check o ] in

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -241,18 +241,19 @@ Section PROOF.
         , eq_exc_fresh s s'
         & sem_pexpr true gd s' e = ok (Vbool b)
       ].
-    + move=> wdiff bof bcf bsf bzf hws hseme0 hseme1 hw0 hw1.
-      have [s' [hwrite heq hof hcf hsf hzf]] :=
-        write_lflags s bof bcf bsf (PF_of_word wdiff) bzf.
-      rewrite /= /get_gvar /=.
-      eexists; split; cycle 1.
-      - eassumption.
-      - by t_simpl_rewrites.
-      rewrite
-         /sem_sopn /= hseme0 hseme1 /=
-         /exec_sopn /= hw0 hw1 /=
-         /sopn_sem /sopn_sem_ /= /x86_CMP /size_8_64 hws /=.
-      by rewrite /semi_to_atype /= computational_eq_refl /= sub_wordE.
+  Proof.
+    move=> wdiff bof bcf bsf bzf hws hseme0 hseme1 hw0 hw1.
+    have [s' [hwrite heq hof hcf hsf hzf]] :=
+      write_lflags s bof bcf bsf (PF_of_word wdiff) bzf.
+    rewrite /= /get_gvar /=.
+    eexists; split; cycle 1.
+    - eassumption.
+    - by t_simpl_rewrites.
+    rewrite
+       /sem_sopn /= hseme0 hseme1 /=
+       /exec_sopn /= hw0 hw1 /=
+       /sopn_sem /sopn_sem_ /= /x86_CMP /size_8_64 hws /=.
+    by rewrite /semi_to_atype /= computational_eq_refl /= sub_wordE.
   Qed.
 
   Lemma lower_condition_corr ii i e e' s1 cond :

--- a/proofs/compiler/x86_lowering_proof.v
+++ b/proofs/compiler/x86_lowering_proof.v
@@ -353,7 +353,7 @@ Section PROOF.
     apply: negbTE; rewrite negb_or; apply/andP.
     rewrite Z.gtb_ltb -!Z.leb_antisym -!(rwP lezP).
     apply: zquot_bound => //; try exact: wsigned_range.
-    case /Bool.andb_false_elim: hn1 => /eqP h; [ left | right ] => //.
+    case /Bool.andb_false_elim: hn1 => /eqP h; [ by left | right ].
     by rewrite -(@wsignedN1 sz) => /(can_inj (@word.sreprK _)).
   Qed.
 

--- a/proofs/lang/hoare_logic.v
+++ b/proofs/lang/hoare_logic.v
@@ -787,7 +787,8 @@ Proof.
   apply khoare_ioP => fs hPf; have [herr {}hf] := hf _ hPf.
   apply khoare_read with (fun fd => get_fundef (p_funcs p) fn = Some fd).
   + rewrite /kget_fundef => ??.
-    case: get_fundef hf => /= [fd | ] h; [apply lutt_Ret | apply lutt_Vis] => //.
+    case: get_fundef hf => /= [fd | ] h; first by apply lutt_Ret.
+    apply lutt_Vis => //.
     by rewrite preInv_Throw; apply herr.
   move=> fd hfd; move: hf; rewrite hfd => -[Pre Post [P] [Q] [hinit hbody hQerr hfin]].
   apply khoare_read with PredT.
@@ -797,7 +798,8 @@ Proof.
   move => _ _.
   apply khoare_read with P.
   + move=> _ ->; have := hinit _ hPf.
-    case: initialize_funcall => [s | e] h; [apply lutt_Ret | apply lutt_Vis] => //.
+    case: initialize_funcall => [s | e] h; first by apply lutt_Ret.
+    apply lutt_Vis => //.
     by rewrite preInv_Throw; apply herr.
     move => s1 hs1.
   eapply khoare_read.

--- a/proofs/lang/psem_defs.v
+++ b/proofs/lang/psem_defs.v
@@ -87,10 +87,10 @@ Definition on_arr_var A (v:exec value) (f:forall n, WArray.array n -> exec A) :=
   end.
 
 Notation "'Let' ( n , t ) ':=' wdb ',' s '.[' v ']' 'in' body" :=
-  (@on_arr_var _ (get_var wdb s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, s at level 0).
+  (@on_arr_var _ (get_var wdb s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, s at level 0, right associativity).
 
 Notation "'Let' ( n , t ) ':=' wdb ',' gd ',' s '.[' v ']' 'in' body" :=
-  (@on_arr_var _ (get_gvar wdb gd s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, gd at level 0, s at level 0).
+  (@on_arr_var _ (get_gvar wdb gd s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, gd at level 0, s at level 0, right associativity).
 
 Section ESTATE_UTILS.
 
@@ -260,8 +260,8 @@ End WSW.
 Definition syscall_sem__ := @syscall_sem.exec_syscall_u.
 
 Notation "'Let' ( n , t ) ':=' wdb ',' s '.[' v ']' 'in' body" :=
-  (@on_arr_var _ (get_var wdb s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, s at level 0).
+  (@on_arr_var _ (get_var wdb s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, s at level 0, right associativity).
 
 Notation "'Let' ( n , t ) ':=' wdb ',' gd ',' s '.[' v ']' 'in' body" :=
-  (@on_arr_var _ (get_gvar wdb gd s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, gd at level 0, s at level 0).
+  (@on_arr_var _ (get_gvar wdb gd s.(evm) v) (fun n (t:WArray.array n) => body)) (at level 25, gd at level 0, s at level 0, right associativity).
 

--- a/proofs/lang/psem_facts.v
+++ b/proofs/lang/psem_facts.v
@@ -201,7 +201,9 @@ Proof.
   move => s1 scs m s2 o xs es ves vs hes h.
   have [ho1 ho2]:= exec_syscallS h.
   move=> /[dup] /write_lvals_validw ho3 /write_lvals_stack_stable ?.
-  split; [rewrite ho1 | move=> ???; rewrite ho2] => //; exact: ho3.
+  split; first by rewrite ho1.
+  move=> ???; rewrite ho2 //.
+  exact: ho3.
 Qed.
 
 Lemma mem_equiv_if_true : sem_Ind_if_true P ev Pc Pi_r.

--- a/proofs/lang/relational_logic.v
+++ b/proofs/lang/relational_logic.v
@@ -1494,7 +1494,7 @@ Proof.
   + by apply: ucheck_eP hes.
   move=> b; apply wequiv_weaken with  (R de) (R d') => //.
   + by apply: check_esP_rel hes.
-  by case: b; [apply: wequiv_weaken hc1 | apply: wequiv_weaken hc2] => //; apply st_rel_weaken.
+  by case: b; [apply: wequiv_weaken hc1 | apply: wequiv_weaken hc2].
 Qed.
 
 Lemma wequiv_for_rel_uincl_R d0 d dhi di ii i dir lo hi c ii' i' lo' hi' c':
@@ -1653,7 +1653,7 @@ Proof.
   + by apply: echeck_eP hes.
   move=> b; apply wequiv_weaken with  (R de) (R d') => //.
   + by apply: check_esP_rel hes.
-  by case: b; [apply: wequiv_weaken hc1 | apply: wequiv_weaken hc2] => //; apply st_rel_weaken.
+  by case: b; [apply: wequiv_weaken hc1 | apply: wequiv_weaken hc2].
 Qed.
 
 Lemma wequiv_for_rel_eq_R d0 d dhi di ii i dir lo hi c ii' i' lo' hi' c':

--- a/proofs/lang/utils.v
+++ b/proofs/lang/utils.v
@@ -182,8 +182,8 @@ Delimit Scope result_scope with result.
 Open Scope result_scope.
 
 Notation "m >>= f" := (rbind f m) (at level 58, left associativity) : result_scope.
-Notation "'Let' x ':=' m 'in' body" := (m >>= (fun x => body)) (x name, at level 25) : result_scope.
-Notation "'Let:' x ':=' m 'in' body" := (m >>= (fun x => body)) (x strict pattern, at level 25) : result_scope.
+Notation "'Let' x ':=' m 'in' body" := (m >>= (fun x => body)) (x name, at level 25, right associativity) : result_scope.
+Notation "'Let:' x ':=' m 'in' body" := (m >>= (fun x => body)) (x strict pattern, at level 25, right associativity) : result_scope.
 Notation "m >> n" := (rbind (λ _, n) m) (at level 30, right associativity, n at next level) : result_scope.
 
 Lemma bindA eT aT bT cT (f : aT -> result eT bT) (g: bT -> result eT cT) m:
@@ -1621,7 +1621,7 @@ Proof.
 Qed.
 
 Lemma lt_nm_n n m :
-  n + m < n = false.
+  (n + m < n) = false.
 Proof.
   rewrite -{2}(addn0 n).
   rewrite ltn_add2l.
@@ -2025,11 +2025,11 @@ End Option.
 
 Notation "'let%opt' x ':=' ox 'in' body" :=
   (if ox is Some x then body else None)
-  (x strict pattern, at level 25).
+  (x strict pattern, at level 25, right associativity).
 
 Notation "'let%opt '_' ':=' ox 'in' body" :=
   (if ox is Some tt then body else None)
-  (at level 25).
+  (at level 25, right associativity).
 
 Lemma obindP aT bT oa (f : aT -> option bT) a (P : Type) :
   (forall z, oa = Some z -> f z = Some a -> P) ->

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -96,7 +96,8 @@ Definition wsize_log2 sz : nat :=
   | U256 => 5
   end.
 
-Lemma wsize8 : wsize_size U8 = 1%Z. done. Qed.
+Lemma wsize8 : wsize_size U8 = 1%Z.
+Proof. done. Qed.
 
 Definition wbase (s: wsize) : Z :=
   modulus (wsize_size_minus_1 s).+1.
@@ -1040,6 +1041,7 @@ Proof. exact: sreprK. Qed.
 Lemma truncate_word_le s s' (w: word s') :
   (s ≤ s')%CMP →
   truncate_word s w = ok (zero_extend s w).
+Proof.
   case: truncate_wordP' => //.
   - by move => ?; subst; rewrite zero_extend_u.
   by rewrite -cmp_nle_lt => /negbTE ->.


### PR DESCRIPTION
Fix warning -level-tolerance, mute others.

Depends on coq-core rather than coq in opam.

Note that there is currently no mathcomp release compatible with Rocq 9.2, so we are still not compatible with Rocq 9.2 because of that.