### PR TITLE
add annotations to type declaration

### DIFF
--- a/changes/01-feature/1496-annotations-type-alias.md
+++ b/changes/01-feature/1496-annotations-type-alias.md
@@ -1,0 +1,4 @@
+- Annotations can be added to type definitions.
+  These annotations are automatically inherited by variables when they
+  are declared ([PR 1496](https://github.com/jasmin-lang/jasmin/pull/1496)).
+

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -354,8 +354,8 @@ let pp_global fmt { pgd_type ; pgd_name ; pgd_val } =
 let pp_path fmt s =
   F.fprintf fmt "%S " (L.unloc s)
 
-let pp_typealias fmt id ty =
-  F.fprintf fmt "%a %a = %a;" kw "type" dname (L.unloc id) pp_type ty
+let pp_typealias fmt id annot ty =
+  F.fprintf fmt "%a %a %a = %a;" pp_annotations annot kw "type" dname (L.unloc id) pp_type ty
 
 let rec pp_pitem fmt pi =
   match L.unloc pi with
@@ -377,7 +377,7 @@ let rec pp_pitem fmt pi =
      List.iter (pp_pitem fmt) pis;
      F.fprintf fmt eol;
      closebrace fmt ()
-  | PTypeAlias (id,ty) -> pp_typealias fmt id ty (**)
+  | PTypeAlias (id,annot, ty) -> pp_typealias fmt id annot ty (**)
 
 let pp_info fmt =
   F.fprintf fmt "@[<v>@[%% The produced LATEX snippet is meant to be included in a@]@ ";

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -529,8 +529,8 @@ top:
 | x=pglobal  { Syntax.PGlobal x }
 | x=pexec    { Syntax.Pexec   x }
 | x=prequire { Syntax.Prequire x}
-| TYPE name = ident EQ ty = ptype SEMICOLON
-    { Syntax.PTypeAlias (name, ty)}
+| a=annotations TYPE name = ident EQ ty = ptype SEMICOLON
+    { Syntax.PTypeAlias (name, a, ty)}
 | NAMESPACE name = ident LBRACE pfs = loc(top)* RBRACE
     { Syntax.PNamespace (name, pfs) }
 (* -------------------------------------------------------------------- *)

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -1460,9 +1460,10 @@ let mk_var x sto xety xlc annot =
 
 let tt_vardecl dfl_writable pd (env : 'asm Env.env) ((annot, (sto, xty)), x) =
   let { L.pl_desc = x; L.pl_loc = xlc; } = x in
-  let regkind = tt_reg_kind annot in
-  let (sto, (aty, xety)) = (tt_sto regkind (dfl_writable x) sto, tt_type_annot pd env xty) in
+  let (aty, xety) = tt_type_annot pd env xty in
   let annot = aty @ annot in
+  let regkind = tt_reg_kind annot in
+  let sto = tt_sto regkind (dfl_writable x) sto in
   let x = mk_var x sto xety xlc annot in
   if P.is_ptr sto && not (P.is_ty_arr x.v_ty) then
     rs_tyerror ~loc:xlc PtrOnlyForArray;

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -279,8 +279,8 @@ module Env : sig
   end
 
   module TypeAlias : sig
-    val push : 'asm env -> A.pident -> P.epty -> 'asm env
-    val get : 'asm env -> A.pident -> P.epty L.located
+    val push : 'asm env -> A.pident -> A.annotations -> P.epty -> 'asm env
+    val get : 'asm env -> A.pident -> A.annotations * P.epty L.located
   end
 
   module Funs : sig
@@ -303,7 +303,7 @@ end  = struct
     }
 
   type 'asm global_bindings = {
-      gb_types : (A.symbol, P.epty L.located) Map.t;
+      gb_types : (A.symbol, A.annotations * P.epty L.located) Map.t;
       gb_vars : (A.symbol, P.pvar * P.epty * E.v_scope) Map.t;
       gb_funs : (A.symbol, (unit, 'asm) P.pfunc * fun_sig) Map.t;
     }
@@ -368,7 +368,7 @@ end  = struct
   let err_duplicate_fun name (v, _) (fd, _) =
     rs_tyerror ~loc:v.P.f_loc (DuplicateFun(name, fd.P.f_loc))
 
-  let err_duplicate_type name t1 t2 =
+  let err_duplicate_type name (_, t1) (_, t2) =
     rs_tyerror ~loc:(L.loc t2) (DuplicateAlias (name,t1,t2))
 
   let merge_bindings (ns, src) dst =
@@ -515,13 +515,13 @@ end  = struct
 
   module TypeAlias = struct
 
-    let push (env: 'asm env) (id: A.pident) (ty: P.epty) : 'asm env =
+    let push (env: 'asm env) (id: A.pident) (annot: A.annotations) (ty: P.epty) : 'asm env =
       match find (fun x -> x.gb_types) (L.unloc id) env with
-      | Some alias ->
-         rs_tyerror  ~loc:(L.loc id)  (DuplicateAlias (L.unloc id, (L.mk_loc (L.loc id) ty) ,alias) )
+      | Some (_, alias) ->
+         rs_tyerror  ~loc:(L.loc id)  (DuplicateAlias (L.unloc id, (L.mk_loc (L.loc id) ty) , alias) )
       | None ->
           let ty = L.mk_loc (L.loc id) ty in
-          let doit v = {v with gb_types = Map.add (L.unloc id) ty v.gb_types }
+          let doit v = {v with gb_types = Map.add (L.unloc id) (annot, ty) v.gb_types }
           in let binds =
           match env.e_bindings with
           | ([],gb) -> [],doit gb
@@ -529,7 +529,7 @@ end  = struct
           in
           {env with e_bindings = binds}
 
-    let get (env: 'asm env) (id: A.pident) : P.epty L.located =
+    let get (env: 'asm env) (id: A.pident) : A.annotations * P.epty L.located =
       let typea = find (fun b -> b.gb_types) (L.unloc id) env in
       match typea with
       | None ->
@@ -1416,24 +1416,28 @@ and tt_mem_access pd ?(mode=`AllVar) (env : 'asm Env.env)
   (ct, loc, e, al)
 
 (* -------------------------------------------------------------------- *)
-and tt_type pd (env : 'asm Env.env) (pty : S.ptype) : P.epty =
+and tt_type_annot pd (env : 'asm Env.env) (pty : S.ptype) : A.annotations * P.epty =
   match L.unloc pty with
-  | S.TBool     -> P.etbool
-  | S.TInt      -> P.etint
-  | S.TWord  ws -> tt_swsize ws
+  | S.TBool     -> [], P.etbool
+  | S.TInt      -> [], P.etint
+  | S.TWord  ws -> [], tt_swsize ws
   | S.TArray (ws, e) ->
      let loc, id, ety =
        match ws with
        | TypeWsize ws -> L.loc pty, None, tt_swsize ws
        | TypeSizeAlias id ->
-          let ty = Env.TypeAlias.get env id in
+          let _, ty = Env.TypeAlias.get env id in
           L.loc id, Some (L.mk_loc (L.loc ty) (L.unloc id)), L.unloc ty in
      let ws =
        match ety with
        | P.ETword(None, ws) -> ws (* wint array are not allowed this is require by wint_int *)
        | ty -> rs_tyerror ~loc (InvalidTypeAlias (id,ty))
-     in P.ETarr (ws, P.PE (fst (tt_expr ~mode:`OnlyParam pd env e)))
-  | S.TAlias id -> L.unloc (Env.TypeAlias.get env id)
+     in [], P.ETarr (ws, P.PE (fst (tt_expr ~mode:`OnlyParam pd env e)))
+  | S.TAlias id ->
+      let a, ty = Env.TypeAlias.get env id in
+      a, L.unloc ty
+
+let tt_type pd env pty : P.epty = snd (tt_type_annot pd env pty)
 
 (* -------------------------------------------------------------------- *)
 let tt_exprs pd (env : 'asm Env.env) es = List.map (tt_expr ~mode:`AllVar pd env) es
@@ -1457,7 +1461,8 @@ let mk_var x sto xety xlc annot =
 let tt_vardecl dfl_writable pd (env : 'asm Env.env) ((annot, (sto, xty)), x) =
   let { L.pl_desc = x; L.pl_loc = xlc; } = x in
   let regkind = tt_reg_kind annot in
-  let (sto, xety) = (tt_sto regkind (dfl_writable x) sto, tt_type pd env xty) in
+  let (sto, (aty, xety)) = (tt_sto regkind (dfl_writable x) sto, tt_type_annot pd env xty) in
+  let annot = aty @ annot in
   let x = mk_var x sto xety xlc annot in
   if P.is_ptr sto && not (P.is_ty_arr x.v_ty) then
     rs_tyerror ~loc:xlc PtrOnlyForArray;
@@ -2602,9 +2607,9 @@ let tt_global pd (env : 'asm Env.env) _loc (gd: S.pglobal) : 'asm Env.env =
   Env.Vars.push_global env (x,ty,d)
 
 
-let tt_typealias arch_info env id ty =
+let tt_typealias arch_info env id annot ty =
   let alias = tt_type arch_info.pd env ty in
-  Env.TypeAlias.push env id alias
+  Env.TypeAlias.push env id annot alias
 
 (* -------------------------------------------------------------------- *)
 let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
@@ -2624,7 +2629,9 @@ let rec tt_item arch_info (env : 'asm Env.env) pt : 'asm Env.env =
      let env = List.fold_left (tt_item arch_info) env items in
      let env = Env.exit_namespace env in
      env
-  | S.PTypeAlias (id,ty) -> tt_typealias arch_info env id ty
+  | S.PTypeAlias (id, pannot, ty) ->
+      let annot = pannot_to_annotations pannot in
+      tt_typealias arch_info env id annot ty
 
 and tt_file_loc arch_info from env fname =
   fst (tt_file arch_info env from (Some (L.loc fname)) (L.unloc fname))

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -474,7 +474,7 @@ type pitem =
   | Pexec of pexec
   | Prequire of (pident option * prequire list)
   | PNamespace of pident * pitem L.located list
-  | PTypeAlias of pident * ptype
+  | PTypeAlias of pident * pannotations * ptype
 
 (* -------------------------------------------------------------------- *)
 type pprogram = pitem L.located list

--- a/compiler/tests/success/x86-64/typealias_amd64.jazz
+++ b/compiler/tests/success/x86-64/typealias_amd64.jazz
@@ -22,3 +22,18 @@ export fn memncopy
 
     return (target,source);
 }
+
+#[mmx] type u32x2 = u64;
+
+fn inc(reg u32x2 a) -> reg u32x2 {
+  global u32x2 one = (2u32)[ 1, 1 ];
+  a = #PADD_2u32(a, one);
+  return a;
+}
+
+export fn test_inc(reg u64 i) -> reg u64 {
+  reg u32x2 v = i;
+  v = inc(v);
+  i = v;
+  return i;
+}

--- a/docs/source/language/syntax/structure.md
+++ b/docs/source/language/syntax/structure.md
@@ -108,25 +108,38 @@ Storage type is thus not a type, and should not be aliased.
 ### Adding annotations to type aliases
 
 Annotations can be attached to type aliases:
-
 ```
-#[mmx]
-type m64 = u64;
+#[mmx] type u32x2 = u64;
 ```
-
-These annotations are automatically inherited by variables declared using the alias. For example:
-
+These annotations are automatically inherited by variables declared using the alias.
+For example:
 ```
-fn mmx_id(reg m64 x) -> reg m64 {
-    return x;
+fn inc(reg u32x2 a) -> reg u32x2 {
+  global u32x2 one = (2u32)[ 1, 1 ];
+  a = #PADD_2u32(a, one);
+  return a;
+}
+
+export fn test_inc(reg u64 i) -> reg u64 {
+  reg u32x2 v = i;
+  v = inc(v);
+  i = v;
+  return i;
 }
 ```
-
 is equivalent to:
-
 ```
-fn mmx_id(#[mmx] reg u64 x) -> reg u64 {
-    return x;
+fn inc(#[mmx]reg u64 a) -> reg u64 {
+  global u64 one = (2u32)[ 1, 1 ];
+  a = #PADD_2u32(a, one);
+  return a;
+}
+
+export fn test_inc(reg u64 i) -> reg u64 {
+  #[mmx] reg u64 v = i;
+  v = inc(v);
+  i = v;
+  return i;
 }
 ```
 

--- a/docs/source/language/syntax/structure.md
+++ b/docs/source/language/syntax/structure.md
@@ -79,7 +79,7 @@ name, and the value. For instance:
 
 ## Types Aliases
 
-Jasmin compiler latest development version (still unreleased) introduced a
+Jasmin compiler latest development version introduced a
 new syntax feature for type definition. A type alias can be defined at top
 level of a program or a namespace. The aim of this feature is to improve
 genericity of Jasmin code. The types aliases are resolved like params,
@@ -104,6 +104,31 @@ type x = reg u64;
 We can consider that the storage type (`reg`, `stack`, `inline` ...) is
 similar to the declaration keyword `let` in other languages (for instance Rust).
 Storage type is thus not a type, and should not be aliased.
+
+### Adding annotations to type aliases
+
+Annotations can be attached to type aliases:
+
+```
+#[mmx]
+type m64 = u64;
+```
+
+These annotations are automatically inherited by variables declared using the alias. For example:
+
+```
+fn mmx_id(reg m64 x) -> reg m64 {
+    return x;
+}
+```
+
+is equivalent to:
+
+```
+fn mmx_id(#[mmx] reg u64 x) -> reg u64 {
+    return x;
+}
+```
 
 ## Global variables
 


### PR DESCRIPTION
# Description
Allows to add annotations to type declaration (alias). 
Those annotations are automatically back ported to variables at declaration
```
#[my_annot]type my_u64 = u64
fn foo (reg my_u64 x) 
```
is equivalent to
```
fn foo (#[my_annot]reg u64 x)
````

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed

