### PR TITLE
The safety checker accepts empty for loops

### DIFF
--- a/changes/02-bugfix/1498-safety-empty-for-loops.md
+++ b/changes/02-bugfix/1498-safety-empty-for-loops.md
@@ -1,0 +1,3 @@
+- The safety checker no longer crashes on empty for loops, where the
+  start bound is greater than the end bound
+  ([PR 1498](https://github.com/jasmin-lang/jasmin/pull/1498)).

--- a/compiler/safetylib/safetyInterpreter.ml
+++ b/compiler/safetylib/safetyInterpreter.ml
@@ -1756,10 +1756,10 @@ end = struct
         (match AbsExpr.aeval_cst_int state.abs e1,
               AbsExpr.aeval_cst_int state.abs e2 with
         | Some z1, Some z2 ->
-          if z1 = z2 then state else
+          if z2 <= z1 then state else
             let init_i, final_i, op = match d with
-              | UpTo -> assert (z1 < z2); (z1, z2 - 1, fun x -> x + 1)
-              | DownTo -> assert (z1 < z2); (z2, z1 + 1, fun x -> x - 1) in
+              | UpTo -> (z1, z2 - 1, fun x -> x + 1)
+              | DownTo -> (z2, z1 + 1, fun x -> x - 1) in
 
             let rec mk_range i f op =
               if i = f then [i] else i :: mk_range (op i) f op in

--- a/compiler/tests/safety/success/x86-64/empty_for.jazz
+++ b/compiler/tests/safety/success/x86-64/empty_for.jazz
@@ -1,0 +1,11 @@
+export fn main () -> reg u64 {
+  inline int i;
+  reg u64 res = 0;
+  for i = 3 to 0 {
+    res += i;
+  }
+  for i = 0 downto 3 {
+    res += i;
+  }
+  return res;
+}


### PR DESCRIPTION
where the start bound is greater than the end bound

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix