### PR TITLE
Checksafety: do not crash on strings

### DIFF
--- a/changes/02-bugfix/1500-safety-string-nocrash.md
+++ b/changes/02-bugfix/1500-safety-string-nocrash.md
@@ -1,0 +1,3 @@
+- The safety checker no longer crashes on string literals
+  ([PR 1500](https://github.com/jasmin-lang/jasmin/pull/1500),
+  fixes [#1497](https://github.com/jasmin-lang/jasmin/issues/1497)).

--- a/compiler/safetylib/safetyAbsExpr.ml
+++ b/compiler/safetylib/safetyAbsExpr.ml
@@ -1216,6 +1216,14 @@ module AbsExpr (Arch : SafetyArch.SafetyArch) (AbsDom : AbsNumBoolType) = struct
     (* If any offset is unknown, we need to forget the array content. *)
     | _, _ -> array_contents lhs.ms_v |> AbsDom.forget_list abs
 
+  let init_slice abs lhs es =
+    match lhs.ms_offset with
+    | None -> array_contents lhs.ms_v |> AbsDom.forget_list abs
+    | Some loff ->
+       List.fold_lefti (fun abs i e ->
+           AbsDom.is_init abs (AarraySlice (lhs.ms_v, U8, i))
+         ) abs es
+
   let omvar_is_offset = function
     | MLvar (_, MvarOffset _) -> true
     | _ -> false
@@ -1257,16 +1265,18 @@ module AbsExpr (Arch : SafetyArch.SafetyArch) (AbsDom : AbsNumBoolType) = struct
 
       | Arr _, MLvar  _
       | Arr _, MLasub _ ->
-        let rhs = match e with
-          | Pvar x -> msub_of_arr (L.unloc x.gv) x.gs
-          | Psub _ -> msub_of_sub_expr abs e
-          | _ -> assert false in
         let lhs = match out_mvar with
           | MLvar  (_, Mlocal (Aarray v)) -> msub_of_arr v Expr.Slocal
           | MLasub (_, msub) -> msub
           | _ -> assert false
         in
-        assign_slice abs lhs rhs
+        begin match e with
+        | Pvar x -> assign_slice abs lhs (msub_of_arr (L.unloc x.gv) x.gs)
+        | Psub _ -> assign_slice abs lhs (msub_of_sub_expr abs e)
+        | PappN (Oarray _len, es) ->
+           init_slice abs lhs es
+        | _ -> assert false
+        end
 
       | _ -> assert false
 

--- a/compiler/tests/safety/success/common/bug_1497.jazz
+++ b/compiler/tests/safety/success/common/bug_1497.jazz
@@ -1,0 +1,7 @@
+param int N = 1;
+
+inline fn f(inline u8[N] a) -> inline u8 { inline u8 r = a[0]; return r; }
+
+export fn test() {
+  _  = f("a");
+}


### PR DESCRIPTION
# Description

Minimal support for literal arrays: cells are known to be initialized, nothing is known about their contents.

Fixes #1497.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
