### PR TITLE
ARM: add instructions SXTB and SXTH

### DIFF
--- a/changes/01-feature/1501-sxtb-sxth.md
+++ b/changes/01-feature/1501-sxtb-sxth.md
@@ -1,0 +1,5 @@
+- Add instructions `SXTB`, and `SXTH` to arm-m4;
+  ([PR #1501](https://github.com/jasmin-lang/jasmin/pull/1501);
+  fixes [#805](https://github.com/jasmin-lang/jasmin/issues/805)).
+
+

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -78,6 +78,8 @@ module Arm_core = struct
     | ARM_op(STR, _) -> true
     | ARM_op(STRB, _) -> true
     | ARM_op(STRH, _) -> true
+    | ARM_op(SXTB, _) -> true
+    | ARM_op(SXTH, _) -> true
     | ARM_op(SUB, _) -> true
     | ARM_op(TST, _) -> true
     | ARM_op(UBFX, _) -> true

--- a/compiler/src/pp_arm_m4.ml
+++ b/compiler/src/pp_arm_m4.ml
@@ -172,7 +172,7 @@ end = struct
     | MUL | MLA | MLS | SDIV | UDIV | UMULL | UMAAL | UMLAL | SMULL | SMLAL
     | SMMUL | SMMULR | SMUL_hw _ | SMLA_hw _ | SMULW_hw _ | BFC | BFI | ASR
     | LSL | LSR | ROR | REV | REV16 | REVSH | ADR | MOVT | UBFX | UXTB | UXTH
-    | SBFX | CLZ | LDR | LDRB | LDRH | LDRSB | LDRSH | STR | STRB | STRH
+    | SBFX | SXTB | SXTH | CLZ | LDR | LDRB | LDRH | LDRSB | LDRSH | STR | STRB | STRH
       -> ""
 end
 

--- a/compiler/tests/success/arm-m4/intrinsic_uxtb.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_uxtb.jazz
@@ -47,3 +47,53 @@ fn uxtb(reg u32 arg0) -> reg u32 {
     res = x;
     return res;
 }
+
+export
+fn sxtb(reg u32 arg0) -> reg u32 {
+    reg u32 x;
+    reg bool nf, zf, vf, cf;
+
+    x = #SXTB(arg0, 0);
+    x = #SXTB(x, 8);
+    x = #SXTB(x, 16);
+    x = #SXTB(x, 24);
+
+    // Conditionals.
+    nf, zf, cf, vf = #CMP(x, 0);
+
+    // EQ
+    x = #SXTBcc(arg0, 8, zf, x);
+    // NE
+    x = #SXTBcc(arg0, 8, !zf, x);
+    // CS
+    x = #SXTBcc(arg0, 8, cf, x);
+    // CC
+    x = #SXTBcc(arg0, 8, !cf, x);
+    // MI
+    x = #SXTBcc(arg0, 8, nf, x);
+    // PL
+    x = #SXTBcc(arg0, 8, !nf, x);
+    // VS
+    x = #SXTBcc(arg0, 8, vf, x);
+    // VC
+    x = #SXTBcc(arg0, 8, !vf, x);
+    // HI
+    x = #SXTBcc(arg0, 8, cf && !zf, x);
+    // LS
+    x = #SXTBcc(arg0, 8, !cf || zf, x);
+    // GE
+    x = #SXTBcc(arg0, 8, nf == vf, x);
+    // LT
+    x = #SXTBcc(arg0, 8, nf != vf, x);
+    // GT
+    x = #SXTBcc(arg0, 8, !zf && nf == vf, x);
+    // LE
+    x = #SXTBcc(arg0, 8, zf || nf != vf, x);
+
+    // Combinations.
+    x = #SXTBcc(arg0, 8, !!!!zf, x);
+
+    reg u32 res;
+    res = x;
+    return res;
+}

--- a/compiler/tests/success/arm-m4/intrinsic_uxth.jazz
+++ b/compiler/tests/success/arm-m4/intrinsic_uxth.jazz
@@ -47,3 +47,53 @@ fn uxth(reg u32 arg0) -> reg u32 {
     res = x;
     return res;
 }
+
+export
+fn sxth(reg u32 arg0) -> reg u32 {
+    reg u32 x;
+    reg bool nf, zf, vf, cf;
+
+    x = #SXTH(arg0, 0);
+    x = #SXTH(x, 8);
+    x = #SXTH(x, 16);
+    x = #SXTH(x, 24);
+
+    // Conditionals.
+    nf, zf, cf, vf = #CMP(x, 0);
+
+    // EQ
+    x = #SXTHcc(arg0, 8, zf, x);
+    // NE
+    x = #SXTHcc(arg0, 8, !zf, x);
+    // CS
+    x = #SXTHcc(arg0, 8, cf, x);
+    // CC
+    x = #SXTHcc(arg0, 8, !cf, x);
+    // MI
+    x = #SXTHcc(arg0, 8, nf, x);
+    // PL
+    x = #SXTHcc(arg0, 8, !nf, x);
+    // VS
+    x = #SXTHcc(arg0, 8, vf, x);
+    // VC
+    x = #SXTHcc(arg0, 8, !vf, x);
+    // HI
+    x = #SXTHcc(arg0, 8, cf && !zf, x);
+    // LS
+    x = #SXTHcc(arg0, 8, !cf || zf, x);
+    // GE
+    x = #SXTHcc(arg0, 8, nf == vf, x);
+    // LT
+    x = #SXTHcc(arg0, 8, nf != vf, x);
+    // GT
+    x = #SXTHcc(arg0, 8, !zf && nf == vf, x);
+    // LE
+    x = #SXTHcc(arg0, 8, zf || nf != vf, x);
+
+    // Combinations.
+    x = #SXTHcc(arg0, 8, !!!!zf, x);
+
+    reg u32 res;
+    res = x;
+    return res;
+}

--- a/eclib/JModel_m4.ec
+++ b/eclib/JModel_m4.ec
@@ -347,3 +347,11 @@ op UXTBcc x n g o = if g then UXTB x n else o.
 op UXTH (x: W32.t) (n: W8.t) : W32.t =
   andw (ror x (to_uint n)) (W32.of_int 65535).
 op UXTHcc x n g o = if g then UXTH x n else o.
+
+op SXTB (x: W32.t) (n: W8.t) : W32.t =
+  W32.of_int (W8.to_sint (W8.of_int (W32.to_uint (ror x (to_uint n))))).
+op SXTBcc x n g o = if g then SXTB x n else o.
+
+op SXTH (x: W32.t) (n: W8.t) : W32.t =
+  W32.of_int (W16.to_sint (W16.of_int (W32.to_uint (ror x (to_uint n))))).
+op SXTHcc x n g o = if g then SXTH x n else o.

--- a/proofs/compiler/arm_instr_decl.v
+++ b/proofs/compiler/arm_instr_decl.v
@@ -130,6 +130,8 @@ Variant arm_mnemonic : Type :=
 | UXTB                           (* Extract a byte and zero extend *)
 | UXTH                           (* Extract a halfword and zero extend *)
 | SBFX                           (* Extract a sub-word and sign extend *)
+| SXTB                           (* Extract a byte and sign extend *)
+| SXTH                           (* Extract a halfword and sign extend *)
 | CLZ                            (* Count leading zeros. *)
 
 (* Comparison *)
@@ -162,7 +164,7 @@ Definition arm_mnemonics : seq arm_mnemonic :=
     ; SMULW_hw HWB; SMULW_hw HWT
     ; AND; BFC; BFI; BIC; EOR; MVN; ORR
     ; ASR; LSL; LSR; ROR; REV; REV16; REVSH
-    ; ADR; MOV; MOVT; UBFX; UXTB; UXTH; SBFX; CLZ
+    ; ADR; MOV; MOVT; UBFX; UXTB; UXTH; SBFX; SXTB; SXTH; CLZ
     ; CMP; TST; CMN
     ; LDR; LDRB; LDRH; LDRSB; LDRSH
     ; STR; STRB; STRH
@@ -197,7 +199,7 @@ Definition condition_mnemonics : seq arm_mnemonic :=
   [:: CMP; TST ].
 
 Definition always_has_shift_mnemonics : seq (arm_mnemonic * shift_kind) :=
-  [:: (UXTB, SROR); (UXTH, SROR) ].
+  [:: (UXTB, SROR); (UXTH, SROR); (SXTB, SROR); (SXTH, SROR) ].
 
 Definition wsize_uload_mn : seq (wsize * arm_mnemonic) :=
   [:: (U8, LDRB); (U16, LDRH); (U32, LDR) ].
@@ -281,6 +283,8 @@ Definition string_of_arm_mnemonic (mn : arm_mnemonic) : string :=
   | UXTB => "UXTB"
   | UXTH => "UXTH"
   | SBFX => "SBFX"
+  | SXTB => "SXTB"
+  | SXTH => "SXTH"
   | CLZ => "CLZ"
   | CMP => "CMP"
   | TST => "TST"
@@ -2078,6 +2082,60 @@ Definition arm_SBFX_instr : instr_desc_t :=
     id_semi_safe := fun _ => @bit_field_extract_semi_safe sh;
   |}.
 
+Definition sign_extend_bits_semi
+  (len: wsize) (wn: wreg) (wroram: u8) : wreg :=
+  sign_extend reg_size (zero_extend len (wror wn (wunsigned wroram))).
+
+Definition arm_SXTB_instr : instr_desc_t :=
+  let mn := SXTB in
+  let tin := [:: lreg; lword U8 ] in
+  let semi := sign_extend_bits_semi U8 in
+  {|
+    id_msb_flag := MSB_MERGE;
+    id_tin := tin;
+    id_in := [:: Ea 1; Ea 2 ];
+    id_tout := [:: lreg ];
+    id_out := [:: Ea 0 ];
+    (* [wroram \in [:: 0; 8; 16; 24 ]] is enforced by args_kinds *)
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 3;
+    id_args_kinds := ak_reg_reg_imm8_0_8_16_24;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := pp_s (string_of_arm_mnemonic mn);
+    id_safe := [::];
+    id_pp_asm := pp_arm_op mn opts;
+    id_valid := true;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+Definition arm_SXTH_instr : instr_desc_t :=
+  let mn := SXTH in
+  let tin := [:: lreg; lword U8 ] in
+  let semi := sign_extend_bits_semi U16 in
+  {|
+    id_msb_flag := MSB_MERGE;
+    id_tin := tin;
+    id_in := [:: Ea 1; Ea 2 ];
+    id_tout := [:: lreg ];
+    id_out := [:: Ea 0 ];
+    (* [wroram \in [:: 0; 8; 16; 24 ]] is enforced by args_kinds *)
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 3;
+    id_args_kinds := ak_reg_reg_imm8_0_8_16_24;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := pp_s (string_of_arm_mnemonic mn);
+    id_safe := [::];
+    id_pp_asm := pp_arm_op mn opts;
+    id_valid := true;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
 Definition arm_CMP_semi (wn wm : ty_r) : ty_nzcv :=
   let wmnot := wnot wm in
   nzcv_of_aluop
@@ -2318,6 +2376,8 @@ Definition mn_desc (mn : arm_mnemonic) : instr_desc_t :=
   | UXTB => arm_UXTB_instr
   | UXTH => arm_UXTH_instr
   | SBFX => arm_SBFX_instr
+  | SXTB => arm_SXTB_instr
+  | SXTH => arm_SXTH_instr
   | CLZ => arm_CLZ_instr
   | CMP => arm_CMP_instr
   | TST => arm_TST_instr


### PR DESCRIPTION
# Description

Adds two sign-extension instructions of the ARMv7-M architecture.

Fixes #805

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
