### PR TITLE
Heuristic register-allocation oracle

### DIFF
--- a/changes/01-feature/1505-callee-saved.md
+++ b/changes/01-feature/1505-callee-saved.md
@@ -1,0 +1,4 @@
+- Experimental heuristics for computing how many callee-saved registers are
+  needed by each export function can be selected through the `-callee-saved`
+  command-line option
+  ([PR 1505](https://github.com/jasmin-lang/jasmin/pull/1505)).

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -190,20 +190,25 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       ra
     in
 
-    let subst, _killed, fds = RA.alloc_prog return_addresses fds in
-    let subst_sf_return_address : Expr.stk_fun_extra -> Expr.stk_fun_extra =
-      let subst x = x |> Conv.var_of_cvar |> subst |> Conv.cvar_of_var in
-      let osubst = Option.map subst in
+    let subst, killed, fds = RA.alloc_prog return_addresses fds in
+    let subst_sf_return_address fd : Expr.stk_fun_extra -> Expr.stk_fun_extra =
+      let csubst x = x |> Conv.var_of_cvar |> subst |> Conv.cvar_of_var in
+      let osubst = Option.map csubst in
       fun fe ->
-      { fe with
-        Expr.sf_return_address =
-          match fe.Expr.sf_return_address with
-          | RAnone -> RAnone;
-          | RAreg (ret, tmp) -> RAreg (subst ret, osubst tmp)
-          | RAstack (c, r, n, t) -> RAstack (osubst c, osubst r, n, osubst t)
-      }
+      match fe.Expr.sf_return_address with
+      | RAreg (ret, tmp) -> { fe with Expr.sf_return_address = RAreg (csubst ret, osubst tmp) }
+      | RAstack (c, r, n, t) -> { fe with Expr.sf_return_address = RAstack (osubst c, osubst r, n, osubst t) }
+      | RAnone ->
+         let ro = RA.get_reg_oracle (fun _ -> true) subst killed fd in
+         { fe with
+           Expr.sf_save_stack =
+             (match fe.Expr.sf_save_stack with
+             | (SavedStackNone | SavedStackStk _) as s -> s
+             | SavedStackReg _ -> SavedStackReg (Conv.cvar_of_var (Option.get ro.ro_rsp)))
+         ; Expr.sf_to_save = List.map2 (fun x (_, ofs) -> (Conv.cvar_of_var x, ofs)) ro.ro_to_save fe.Expr.sf_to_save
+         }
     in
-    let fds = List.map (fun (e, fd) -> subst_sf_return_address e, fd) fds in
+    let fds = List.map (fun (e, fd) -> subst_sf_return_address fd e, fd) fds in
     let fds = List.map Conv.csfdef_of_fdef fds in
     fds
   in

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -132,7 +132,13 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
        and type rflag = rflag
        and type cond = cond
        and type asm_op = asm_op
-       and type extra_op = extra_op) visit_prog_after_pass prog cprog =
+       and type extra_op = extra_op)
+    visit_prog_after_pass
+    ?(callee_saved_strategy = !Glob_options.callee_saved_strategy)
+    prog cprog =
+  if callee_saved_strategy <> CSS_Tight then
+    warning Experimental L.i_dummy
+      "heuristics for callee-saved registers are experimental";
   let module RA = Regalloc.Regalloc (Arch) in
   let module SA = StackAlloc.StackAlloc (Arch) in
   let fdef_of_cufdef fn cfd = Conv.fdef_of_cufdef (fn, cfd) in
@@ -164,7 +170,9 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
     SA.memory_analysis
       pp_sr
       (Printer.pp_err ~debug:!debug)
-      ~debug:!debug up
+      ~debug:!debug
+      callee_saved_strategy
+      up
   in
 
   let global_regalloc fds =
@@ -190,6 +198,25 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
       ra
     in
 
+    let callee_saved_error fd n =
+      hierror ~loc:(Lone fd.f_loc) ~funname:fd.f_name.fn_name ~kind:"programming error"
+        "Not enough slots for saving callee-saved registers; annotate the function with “callee_saved = %d”"
+        (n + 1)
+    in
+
+    let fixup_to_save fd names slots =
+      let rec fixup_to_save n s =
+        match n, s with
+        | [], [] -> []
+        | x :: n, (_, ofs) :: s -> (Conv.cvar_of_var x, ofs) :: fixup_to_save n s
+        | [], _ ->
+           warning CalleeSavedNotTight (L.i_loc0 fd.f_loc) "unused slots: %a"
+             (pp_list ", " (fun fmt (_, ofs) -> Format.fprintf fmt "%a" Z.pp_print (Conv.z_of_cz ofs))) slots;
+           []
+        | _, [] -> callee_saved_error fd (List.length names)
+      in fixup_to_save names slots
+    in
+
     let subst, killed, fds = RA.alloc_prog return_addresses fds in
     let subst_sf_return_address fd : Expr.stk_fun_extra -> Expr.stk_fun_extra =
       let csubst x = x |> Conv.var_of_cvar |> subst |> Conv.cvar_of_var in
@@ -204,8 +231,11 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
            Expr.sf_save_stack =
              (match fe.Expr.sf_save_stack with
              | (SavedStackNone | SavedStackStk _) as s -> s
-             | SavedStackReg _ -> SavedStackReg (Conv.cvar_of_var (Option.get ro.ro_rsp)))
-         ; Expr.sf_to_save = List.map2 (fun x (_, ofs) -> (Conv.cvar_of_var x, ofs)) ro.ro_to_save fe.Expr.sf_to_save
+             | SavedStackReg _ ->
+                match ro.ro_rsp with
+                | Some r -> SavedStackReg (Conv.cvar_of_var r)
+                | None -> callee_saved_error fd 0)
+         ; Expr.sf_to_save = fixup_to_save fd ro.ro_to_save fe.Expr.sf_to_save
          }
     in
     let fds = List.map (fun (e, fd) -> subst_sf_return_address fd e, fd) fds in

--- a/compiler/src/compile.mli
+++ b/compiler/src/compile.mli
@@ -82,6 +82,7 @@ val compile :
     Sopn.asm_op_t )
   prog ->
   unit) ->
+  ?callee_saved_strategy:Utils.callee_saved_strategy ->
   _ prog ->
   ('reg, 'regx, 'xreg, 'rflag, 'cond, 'asm_op, 'extra_op) Arch_extra.extended_op
   Expr._uprog ->

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -65,6 +65,14 @@ let set_stack_zero_strategy s =
 let stack_zero_size = ref None
 let set_stack_zero_size s = stack_zero_size := Some (Annot.ws_of_string s)
 
+let callee_saved_strategy_options =
+  [ "tight", CSS_Tight; "pessimistic", CSS_Pessimistic; "optimistic", CSS_Optimistic ]
+
+let callee_saved_strategy = ref CSS_Tight
+
+let set_callee_saved_strategy s =
+  callee_saved_strategy := List.assoc s callee_saved_strategy_options
+
 let target_arch = ref X86_64
 
 let set_target_arch a =
@@ -222,6 +230,9 @@ let options = [
     "-print-stack-alloc", Arg.Set print_stack_alloc, " Print the results of the stack allocation OCaml oracle";
     "-print-export-info-json", Arg.Set print_export_info_json, " Print information about exported functions in json";
     "-lazy-regalloc", Arg.Set lazy_regalloc, " Allocate variables to registers in program order";
+    "-callee-saved",
+      Arg.Symbol (List.map fst callee_saved_strategy_options, set_callee_saved_strategy),
+      " Configure how callee-saved registers are spilled in export functions";
     "-pall"    , Arg.Unit set_all_print, " Print program after each compilation steps";
     "-print-dependencies", Arg.Set print_dependencies, " Print dependencies and exit";
     "-intel", Arg.Unit (set_syntax `Intel), " Use intel syntax (default is AT&T)"; 

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -106,7 +106,7 @@ module StackAlloc (Arch: Arch_full.Arch) = struct
 
 module Regalloc = Regalloc (Arch)
 
-let memory_analysis pp_sr pp_err ~debug up =
+let memory_analysis pp_sr pp_err ~debug callee_saved_strategy up =
   if debug then Format.eprintf "START memory analysis@.";
   let p = Conv.prog_of_cuprog up in
   let gao, sao = Varalloc.alloc_stack_prog Arch.callstyle Arch.reg_size p in
@@ -316,7 +316,12 @@ let memory_analysis pp_sr pp_err ~debug up =
   List.iter fix_subroutine_csao (List.rev fds);
 
   let return_addresses = Regalloc.create_return_addresses get_internal_size fds in
-  let subst, killed, _ = Regalloc.alloc_prog return_addresses fds in
+  let ra_data =
+    if callee_saved_strategy = CSS_Tight then
+      let subst, killed, _ = Regalloc.alloc_prog return_addresses fds in
+      Some (subst, killed)
+    else None
+  in
 
   let fix_csao (_, fd) =
     let fn = fd.f_name in
@@ -338,14 +343,27 @@ let memory_analysis pp_sr pp_err ~debug up =
     | Internal -> assert false
     | Export ->
 
-    let ro = Regalloc.get_reg_oracle has_stack subst killed fd in
-    let num_callee_save = List.length ro.ro_to_save in
-    let no_room_for_rsp = ro.ro_rsp = None in
+    let num_callee_saved, no_room_for_rsp =
+      let key = "callee_saved" in
+      match Annotations.get key fd.f_annot.f_user_annot with
+      | Some (Some { pl_desc = Aint n }) -> max 0 (Z.to_int n - 1), not (Z.equal Z.zero n)
+      | a ->
+      if Option.is_some a then
+        warning Always (L.i_loc0 fd.f_loc) "ignored ill-formed %s annotation" key;
+      match callee_saved_strategy with
+      | CSS_Tight ->
+         let subst, killed = Option.get ra_data in
+         let ro = Regalloc.get_reg_oracle has_stack subst killed fd in
+         List.length ro.ro_to_save, ro.ro_rsp = None
+      | CSS_Optimistic -> 0, has_stack fd
+      | CSS_Pessimistic -> Stdlib.Int.max_int, true
+    in
+
     let sao = Hf.find sao fn in
     let csao = get_sao fn in 
 
     let to_save =
-      List.take num_callee_save
+      List.take num_callee_saved
       (List.remove Arch.callee_save_vars Arch.rsp_var) in
     let has_stack = has_stack fd || to_save <> [] in
 

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -316,7 +316,7 @@ let memory_analysis pp_sr pp_err ~debug up =
   List.iter fix_subroutine_csao (List.rev fds);
 
   let return_addresses = Regalloc.create_return_addresses get_internal_size fds in
-  let subst, killed, fds = Regalloc.alloc_prog return_addresses fds in
+  let subst, killed, _ = Regalloc.alloc_prog return_addresses fds in
 
   let fix_csao (_, fd) =
     let fn = fd.f_name in
@@ -339,17 +339,21 @@ let memory_analysis pp_sr pp_err ~debug up =
     | Export ->
 
     let ro = Regalloc.get_reg_oracle has_stack subst killed fd in
+    let num_callee_save = List.length ro.ro_to_save in
+    let no_room_for_rsp = ro.ro_rsp = None in
     let sao = Hf.find sao fn in
     let csao = get_sao fn in 
 
-    let to_save = ro.ro_to_save in 
+    let to_save =
+      List.take num_callee_save
+      (List.remove Arch.callee_save_vars Arch.rsp_var) in
     let has_stack = has_stack fd || to_save <> [] in
 
     let rsp = V.clone Arch.rsp_var in
     let extra =
       (* FIXME: how to make this more generic? *)
       let extra = List.rev to_save in
-      if has_stack && ro.ro_rsp = None then extra @ [rsp]
+      if has_stack && no_room_for_rsp then extra @ [rsp]
       else extra in
       
     let extra_size, align, extrapos = Varalloc.extend_sao sao extra in
@@ -423,9 +427,9 @@ let memory_analysis pp_sr pp_err ~debug up =
     let max_call_depth = Z.succ max_call_depth in
     let saved_stack = 
       if has_stack then
-        match ro.ro_rsp with
-        | Some x -> Expr.SavedStackReg (Conv.cvar_of_var x)
-        | None   -> Expr.SavedStackStk (Conv.cz_of_int (List.assoc rsp extrapos))
+        match no_room_for_rsp with
+        | false -> Expr.SavedStackReg (Conv.cvar_of_var Arch.rip)
+        | true   -> Expr.SavedStackStk (Conv.cz_of_int (List.assoc rsp extrapos))
       else Expr.SavedStackNone in
 
     let conv_to_save x =

--- a/compiler/src/stackAlloc.mli
+++ b/compiler/src/stackAlloc.mli
@@ -7,6 +7,7 @@ module StackAlloc (Arch: Arch_full.Arch) : sig
     (Stack_alloc.sub_region -> Compiler_util.pp_error) ->
     (Format.formatter -> Compiler_util.pp_error -> unit) ->
     debug:bool ->
+    Utils.callee_saved_strategy ->
     (Arch.reg, Arch.regx, Arch.xreg, Arch.rflag, Arch.cond, Arch.asm_op, Arch.extra_op) Arch_extra.extended_op Expr._uprog -> Compiler.stack_alloc_oracles
 
 end

--- a/compiler/src/utils.ml
+++ b/compiler/src/utils.ml
@@ -207,6 +207,11 @@ type model =
   | ConstantTimeGlobal
   | Normal
 
+type callee_saved_strategy =
+  | CSS_Tight
+  | CSS_Pessimistic
+  | CSS_Optimistic
+
 (* -------------------------------------------------------------------- *)
 (* Functions used to add colors to errors and warnings.                 *)
 
@@ -380,6 +385,7 @@ let pp_now =
 (* -------------------------------------------------------------------- *)
 
 type warning =
+  | CalleeSavedNotTight
   | ExtraAssignment (* -wea *)
   | UseLea (* -wlea *)
   | IntroduceArrayCopy (* -winsertarraycopy *)
@@ -409,7 +415,7 @@ let default_warnings =
       Linter;
     ]
 
-let all_warnings = ExtraAssignment :: UseLea :: KeptRenaming :: default_warnings
+let all_warnings = CalleeSavedNotTight :: ExtraAssignment :: UseLea :: KeptRenaming :: default_warnings
 
 let warns = ref default_warnings
 

--- a/compiler/src/utils.mli
+++ b/compiler/src/utils.mli
@@ -117,6 +117,11 @@ type model =
   | ConstantTimeGlobal
   | Normal
 
+type callee_saved_strategy =
+  | CSS_Tight (* run register allocation to compute the precise count of needed callee-saved registers *)
+  | CSS_Pessimistic (* assume all callee-saved registers are used *)
+  | CSS_Optimistic (* assume no callee-saved registers are used *)
+
 (* -------------------------------------------------------------------- *)
 (* Enables colors in errors and warnings.                               *)
 val enable_colors : unit -> unit
@@ -147,8 +152,9 @@ val hierror :
 val pp_now  : Format.formatter -> unit
 
 (* -------------------------------------------------------------------- *)
-type warning = 
-  | ExtraAssignment 
+type warning =
+  | CalleeSavedNotTight
+  | ExtraAssignment
   | UseLea
   | IntroduceArrayCopy
   | InlinedCallToExport

--- a/compiler/tests/fail/register_allocation/x86-64/callee_saved-too-small.jazz
+++ b/compiler/tests/fail/register_allocation/x86-64/callee_saved-too-small.jazz
@@ -1,0 +1,19 @@
+param int R = 10;
+
+/* This function needs:
+  - all volatile registers,
+  - two callee-saved registers,
+  - the stack pointer register.
+  Therefore, the compiler should reject this program as it claims
+  to only use only two callee-saved registers (RSP included).
+*/
+#[callee_saved = 2]
+export
+fn main() -> reg u64 {
+  inline int i;
+  reg u64[R] t;
+  for i = 0 to R { t[i] = i; }
+  reg u64 r = i;
+  for i = 0 to R { r += t[i]; }
+  return r;
+}

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -952,6 +952,12 @@ fail/register_allocation/x86-64/bug_523.jazz:
 compilation error:
 register allocation: variable rot2 must be allocated to register RCX due to architectural constraints; this register already holds conflicting variable: rot1
 
+fail/register_allocation/x86-64/callee_saved-too-small.jazz:
+
+"fail/register_allocation/x86-64/callee_saved-too-small.jazz", line 10 (0) to line 19 (1):
+programming error in function main:
+Not enough slots for saving callee-saved registers; annotate the function with “callee_saved = 3”
+
 fail/register_allocation/x86-64/conflicting_register.jazz:
 
 "fail/register_allocation/x86-64/conflicting_register.jazz", line 9 (0-27):
@@ -1704,4 +1710,4 @@ Statistics:
 	Pretyping:  47
 	Parsing:     4
 	Typing:      5
-	Compile:   212
+	Compile:   213

--- a/compiler/tests/success/common/unaligned.jazz
+++ b/compiler/tests/success/common/unaligned.jazz
@@ -9,7 +9,7 @@ fn main(reg u32 x) -> reg u32 {
 
 /* This example shows that the unaligned 16-bit access is taken into account
   * when computing the alignment for the stack variable. */
-#[stackalign=u16]
+#[stackalign=u16, callee_saved = 0]
 export
 fn instack(reg u32 x) -> reg u32 {
   reg u32 r;

--- a/compiler/tests/success/x86-64/stacksize.jazz
+++ b/compiler/tests/success/x86-64/stacksize.jazz
@@ -1,7 +1,7 @@
 param int N = 7;
 
 /* Does not use the stack. */
-#[stacksize=0, stackallocsize= 0]
+#[stacksize=0, stackallocsize= 0, callee_saved = 0]
 export
 fn zero() -> reg u64 {
   reg u64 x;
@@ -14,7 +14,7 @@ fn zero() -> reg u64 {
 }
 
 /* Uses two callee-saved registers: saves them on the stack. */
-#[stacksize=0, stackallocsize=16]
+#[stacksize=0, stackallocsize=16, callee_saved = 2]
 export
 fn one() -> reg u64 {
   reg u64 x y;

--- a/docs/source/compiler/advanced/memory_layout.md
+++ b/docs/source/compiler/advanced/memory_layout.md
@@ -31,3 +31,59 @@ Therefore there are three kinds of *padding*:
   - initially to align the “external” stack pointer (the exact quantity is statically unknown but bounded by the alignment constraint);
   - internally to each stack frame, between the data and extra parts; statically known, seven bytes at most;
   - on each (internal) function call to preserve the alignment of the stack pointer; statically known, bounded by the alignment constraint.
+
+## Callee-saved registers
+
+When an export function makes use of some callee-saved registers, either
+directly or through the function it (transitively) calls, the values of these
+registers are saved in its stack frame (in the “extra” part, as described above)
+at the beginning of the function and restored at the end.
+
+Since July 2026 (versions 2026.03.2 and 2026.07.0), the Jasmin compiler provides
+some *eperimental* facility to control how much memory is allocated in the stack
+frame of `export` functions to save the values of callee-saved registers. A
+global option controls the general “strategy” which can be locally overridden by an
+annotation.
+
+### The `callee_saved = n` annotation
+
+When an `export` function is annotated with `callee_saved = n` where `n` is some
+non-negative value, the compiler will trust this information and provide room in
+the stack frame for exactly n values. Do not forget to take into account the
+stack-pointer register which is also a callee-saved register.
+
+If the value given in the annotation is too large (i.e., pessimistic), then some
+space is *wasted* in the frame but the spuriously reserved slots are not used.
+A warning (disabled by default) can tell you when this happens.
+
+If the value given in the annotation is too small, then compilation will fail,
+with an error message providing a good value.
+
+Note that when annotated with `callee_saved = 0`, a function may still use the
+stack (and therefore modify the stack-pointer register). In this case, the
+original value of the stack pointer will be saved in a free volatile register.
+
+### Global strategies
+
+For `export` functions that are not annotated with the number of calle-saved registers to use,
+the compiler defaults to some strategy which can be selected through the `-callee-saved` command-line
+flag which accepts one of the following values:
+- `tight`
+- `pessimistic`
+- `optimistic`
+
+The “tight” strategy is the default one: prior to stack-allocation, the compiler
+runs register allocation to precisely compute how many callee-saved registers
+will be used. This is costly as during compilation, register-allocation is run
+twice.
+
+The “pessimistic” strategy is safe and assumes that every function needs all
+callee-saved registers; therefore, enough room is provided in the stack frame to
+save *all* these registers, which are many in some architectures. This also
+implies that each function has a prologue that sets up a stack frame, aligns the
+stack pointer, etc.
+
+The “optimistic” strategy assumes that no callee-saved register is required:
+this produces assembly code that might be more efficient (no tampering with the
+stack pointer, less stack usage) but is prone to failure (if volatile registers
+are not enough).


### PR DESCRIPTION
# Description

This provides a way to skip the first run of register-allocation.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [ ] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed