### PR TITLE
Register allocation: allocate volatile registers first

### DIFF
--- a/changes/01-feature/1507-regalloc-volatile-first.md
+++ b/changes/01-feature/1507-regalloc-volatile-first.md
@@ -1,0 +1,2 @@
+- Register allocation chooses volatile registers before callee-saved ones
+  ([PR 1507](https://github.com/jasmin-lang/jasmin/pull/1507)).

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -1013,6 +1013,11 @@ let two_phase_coloring
           match get_friend_registers fr a i regs with
           | y -> y
           | exception Not_found ->
+             let regs =
+               let is_callee_saved r = List.mem r Arch.callee_save_vars in
+               let calle_saved, volatile = List.partition is_callee_saved regs in
+               if volatile = [] then calle_saved else volatile
+             in
              (* Pick a register that is currently allocated to a maximal number of variables with the same name. *)
              let same_names r = A.rfind r a |> snd |> Ss.inter names in
              let y, _ =

--- a/compiler/tests/success/arm-m4/set_up_stack.jazz
+++ b/compiler/tests/success/arm-m4/set_up_stack.jazz
@@ -5,6 +5,7 @@ param int NREGISTERS_CALLEE_SAVED = 8;
 param int n = NREGISTERS - NREGISTERS_CALLEE_SAVED - 1;
 
 /* Many free registers. */
+#[stackallocsize = 4]
 export
 fn onregister0(reg u32 x) -> reg u32 {
     reg u32 result;
@@ -27,9 +28,10 @@ fn onregister0(reg u32 x) -> reg u32 {
 }
 
 /* One free register. */
+#[stackallocsize = 4]
 export
 fn onregister1(reg u32 x) -> reg u32 {
-    reg u32 result;
+    reg u32 answer;
     reg u32[n-1] tab;
     inline int i;
     stack u32 t;
@@ -40,14 +42,15 @@ fn onregister1(reg u32 x) -> reg u32 {
         tab[i] = x;
     }
 
-    result = t;
+    answer = t;
     for i = 0 to n - 1 {
-        result += tab[i];
+        answer += tab[i];
     }
 
-    return result;
+    return answer;
 }
 
+#[stackallocsize = 8]
 export
 fn onstack0(reg u32 x) -> reg u32 {
     reg u32 result;
@@ -69,6 +72,7 @@ fn onstack0(reg u32 x) -> reg u32 {
     return result;
 }
 
+#[stackallocsize = 40]
 export
 fn onstack1(reg u32 x) -> reg u32 {
     reg u32 result;
@@ -89,4 +93,3 @@ fn onstack1(reg u32 x) -> reg u32 {
 
     return result;
 }
-


### PR DESCRIPTION
# Description

This partially addresses a regression introduced in #1295: in the `set-up-stack` program, all `result` variables are allocated to the same register (because they have the same names), which is not a very good idea in that case. So this PR changes slightly this “same-name” heuristic to always pick a volatile register (unless all such registers are in conflict).

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
