### PR TITLE
Regalloc: use “inplace” annotation as hint

### DIFF
--- a/changes/01-feature/1509-inplace-annotation.md
+++ b/changes/01-feature/1509-inplace-annotation.md
@@ -1,0 +1,3 @@
+- Register allocation takes into account `inplace` annotations by merging
+  the destination with the first argument
+  ([PR 1509](https://github.com/jasmin-lang/jasmin/pull/1509)).

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -212,6 +212,19 @@ let kind_compatible (x: v_kind) (y: v_kind) : bool =
     -> pointer_compatible a b
   | _, _ -> false
 
+(** Add extra constraints for operators (Copn) annotated with “inplace”. The
+  first argument shall be allocated to the same register as the destination. The
+  annotation is ignored if the operation has several destinations. *)
+let process_inplace_annotation addv (i: ('info, 'asm) instr) : unit =
+  if Annotations.has_symbol "inplace" i.i_annot then
+    begin
+      match i.i_desc with
+      | Copn ([ Lvar x ], _, _, Pvar { gs = E.Slocal; gv = y } :: _) when kind_i x = kind_i y ->
+         addv i x y
+      | Copn _ -> warning Always i.i_loc "ignored “inplace” annotation"
+      | _ -> ()
+    end
+
 let collect_equality_constraints_in_func
       (asmOp:'asm Sopn.asmOp)
       is_move_op
@@ -248,6 +261,7 @@ let collect_equality_constraints_in_func
   let names = ref (Puf.create nv) in
   let renames = Hv.create 97 in
   let first_pass ii =
+    process_inplace_annotation addv ii;
     match ii.i_desc with
     | Copn (lvs, _, op, es) ->
         copn_constraints

--- a/compiler/tests/fail/register_allocation/arm-m4/inplace.jazz
+++ b/compiler/tests/fail/register_allocation/arm-m4/inplace.jazz
@@ -1,0 +1,6 @@
+// Since the xor instruction is “in-place“,
+// the value of b is no longer available after it
+export fn xor(reg u32 a b) -> reg u32 {
+  #[keep, inplace] a = b ^ a;
+  return b;
+}

--- a/compiler/tests/negative.expected
+++ b/compiler/tests/negative.expected
@@ -872,6 +872,15 @@ fail/register_allocation/arm-m4/bug_201.jazz:
 compilation error in function main:
 register allocation: too many large parameters according to the ABI (only 0 available on this architecture)
 
+fail/register_allocation/arm-m4/inplace.jazz:
+
+"fail/register_allocation/arm-m4/inplace.jazz", line 4 (19-29):
+compilation error:
+register allocation: conflicting variables “b” and “a” must be merged due to:
+  at "fail/register_allocation/arm-m4/inplace.jazz", line 4 (19-29):
+    #[keep, inplace]
+  a = #EOR(b, a); /* :k */
+
 fail/register_allocation/arm-m4/no_mmx.jazz:
 
 compilation error:
@@ -1695,4 +1704,4 @@ Statistics:
 	Pretyping:  47
 	Parsing:     4
 	Typing:      5
-	Compile:   211
+	Compile:   212

--- a/docs/source/compiler/harmony/regalloc.md
+++ b/docs/source/compiler/harmony/regalloc.md
@@ -345,7 +345,39 @@ export fn h (reg u64 x, reg u64 y, reg u64 w) -> reg u64 {
 }
 ```
 
+## In-place operations
 
+Instructions that have a single destination can be annotated as `inplace`:
+the register allocation will choose the same register for the destination
+and for the first argument.
 
+In the example below, the result of the exclusive or will be written to the
+register that holds the value of `z` at the beginning of the `forget` function.
 
+~~~
+inline fn forget (reg u32 z) {
+  #[keep, inplace]
+  _ = z ^ z;
+}
+
+export fn copy_u32(reg ptr u32[1] d s) -> reg ptr u32[1] {
+  reg u32 a = s[0];
+  d[0] = a;
+  forget(a);
+  return d;
+}
+~~~
+
+When targeting the `arm-m4` architecture, the compiler produces the following
+code. After the call to `forget`, the register `r1` no longer contains the
+value loaded from memory.
+
+~~~
+copy_u32:
+	push	{lr}
+	LDR 	r1, [r1]
+	STR 	r1, [r0]
+	EOR 	r1, r1, r1
+	pop 	{pc}
+~~~
 


### PR DESCRIPTION
# Description

Register allocation understands an “inplace” annotation on operations as follows. The first argument shall be allocated to the same register as the destination. The annotation is ignored if the operation has several destinations.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed
