### PR TITLE
Always introduce array copies, with a warning

### DIFF
--- a/changes/03-other/1511-exit-noinsertarraycopy.md
+++ b/changes/03-other/1511-exit-noinsertarraycopy.md
@@ -1,0 +1,3 @@
+- `jasminc` no longer supports the `-noinsertarraycopy` command-line flag;
+  warning `IntroduceArrayCopy` is on by default
+  ([PR 1511](https://github.com/jasmin-lang/jasmin/pull/1511)).

--- a/compiler/examples/x86-64/al3.jazz
+++ b/compiler/examples/x86-64/al3.jazz
@@ -15,7 +15,7 @@ x[1] = 1;
 x[0] = 0;
 
 y = swap(x);
-x = y;
+x = #copy(y);
 r = x[0];
 return r;
 }

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -25,7 +25,6 @@ let lea = ref false
 let set0 = ref false
 let print_stack_alloc = ref false
 let print_export_info_json = ref false
-let introduce_array_copy = ref true
 let introduce_export_renaming = ref true
 let print_dependencies = ref false
 let lazy_regalloc = ref false
@@ -218,7 +217,6 @@ let options = [
     "-winsertarraycopy", Arg.Unit (add_warning IntroduceArrayCopy), " Print warning when array copy is introduced";
     "-wduplicatevar", Arg.Unit (add_warning DuplicateVar), " Print warning when two variables share the same name";
     "-wunusedvar", Arg.Unit (add_warning UnusedVar), " Print warning when a variable is not used";
-    "-noinsertarraycopy", Arg.Clear introduce_array_copy, " Do not automatically insert array copy";
     "-noinsertrenaming", Arg.Clear introduce_export_renaming, " Do not automatically insert renaming assignments at export function boundaries";
     "-wall", Arg.Unit enable_all_warnings, " Enable all warnings";
     "-nowarning", Arg.Unit (nowarning), " Do no print warnings";

--- a/compiler/src/insert_copy_and_fix_length.ml
+++ b/compiler/src/insert_copy_and_fix_length.ml
@@ -49,15 +49,14 @@ and iac_instr pd i = { i with i_desc = iac_instr_r pd i.i_loc i.i_desc }
 and iac_instr_r pd loc ir =
   match ir with
   | Cassgn (x, t, _, e) ->
-    if !Glob_options.introduce_array_copy then
-      match is_array_copy x e with
+    begin match is_array_copy x e with
       | None -> ir
       | Some (ws, n) ->
           warning IntroduceArrayCopy
             loc "an array copy is introduced";
           let op = Pseudo_operator.Ocopy(ws, Conv.cz_of_int n) in
           Copn([x], t, Sopn.Opseudo_op op, [e])
-    else ir
+    end
   | Cif (b, th, el) -> Cif (b, iac_stmt pd th, iac_stmt pd el)
   | Cfor (i, r, s) -> Cfor (i, r, iac_stmt pd s)
   | Cwhile (a, c1, t, info, c2) -> Cwhile (a, iac_stmt pd c1, t, info, iac_stmt pd c2)

--- a/compiler/src/utils.ml
+++ b/compiler/src/utils.ml
@@ -397,6 +397,7 @@ type warning =
 
 let default_warnings =
     [
+      IntroduceArrayCopy;
       InlinedCallToExport;
       SimplifyVectorSuffix;
       DuplicateVar;
@@ -408,7 +409,7 @@ let default_warnings =
       Linter;
     ]
 
-let all_warnings = ExtraAssignment :: UseLea :: IntroduceArrayCopy :: KeptRenaming :: default_warnings
+let all_warnings = ExtraAssignment :: UseLea :: KeptRenaming :: default_warnings
 
 let warns = ref default_warnings
 

--- a/compiler/tests/success/x86-64/bug_1158.jazz
+++ b/compiler/tests/success/x86-64/bug_1158.jazz
@@ -5,7 +5,7 @@ export fn test1(reg ptr u8[10] t) {
 
 inline
 fn test2(reg u8[T] t) {
-  reg u8[T] r = t;
+  reg u8[T] r = #copy_8(t);
 }
 
 param int N = 0;

--- a/compiler/tests/success/x86-64/return-local-stack-array.jazz
+++ b/compiler/tests/success/x86-64/return-local-stack-array.jazz
@@ -4,7 +4,7 @@ fn squarea(stack u64[1] x) -> stack u64[1] {
   stack u64[1] ra;
   inline int i;
   for i = 0 to 1 { r[i] = x[i]; }
-  ra = r;
+  ra = #copy(r);
   return ra;
 }
 
@@ -12,7 +12,7 @@ inline
 fn invert(stack u64[1] xa) {
   stack u64[1] t;
   reg u64 k;
-  t = xa;
+  t = #copy(xa);
   k = 1; while { t = squarea(t); k+=1; } (k<5)
 }
 


### PR DESCRIPTION
# Description

This option is remove without being deprecated first because:
- it is already possible to write compatible code (just don’t use the option, it serves no purpose; use `-winsertarraycopy` instead)
- this option is stupid (and whoever uses it got bad advice)

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
