### PR TITLE
fs_uincl_initialize and fs_uincl_finalize: relax hypotheses on f_params & f_res

### DIFF
--- a/proofs/compiler/array_copy_proof.v
+++ b/proofs/compiler/array_copy_proof.v
@@ -368,7 +368,7 @@ Proof using Hp.
       [/\ f_tyin fd1 = f_tyin fd2
         , f_tyout fd1 = f_tyout fd2
         , f_extra fd1 = f_extra fd2
-        , f_params fd1 = f_params fd2
+        , eq_var_is (f_params fd1) (f_params fd2)
         , not_tmp fi X
         , array_copy_c X (array_copy_i fresh_var_ident fi) (f_body fd1) = ok (f_body fd2)
         & f_res fd1 = f_res fd2

--- a/proofs/compiler/array_init_proof.v
+++ b/proofs/compiler/array_init_proof.v
@@ -54,7 +54,7 @@ Proof.
  move=> s hinit.
  have [t -> hu] :=
    [elaborate fs_uincl_initialize (p:=p) (p':=p') (fd:=fd) (fd':=remove_init_fd is_reg_array fd)
-           erefl erefl erefl erefl hfsu hinit].
+           erefl erefl eq_var_is_refl erefl hfsu hinit].
  exists t=> //; exists (st_uincl tt), (st_uincl tt); split => //; last by apply fs_uincl_finalize.
  clear fn fs ft hfsu hget s hinit t hu.
  rewrite /remove_init_fd /=.

--- a/proofs/compiler/constant_prop_proof.v
+++ b/proofs/compiler/constant_prop_proof.v
@@ -1094,7 +1094,7 @@ Local Opaque opp_word.
       [/\ f_tyin fd = f_tyin (const_prop_fun gd fd)
         , f_tyout fd = f_tyout (const_prop_fun gd fd)
         , f_extra fd = f_extra (const_prop_fun gd fd)
-        , f_params fd = f_params (const_prop_fun gd fd)
+        , eq_var_is (f_params fd) (f_params (const_prop_fun gd fd))
         & f_res fd = f_res (const_prop_fun gd fd)
        ] by done.
   have : exists2 t1, initialize_funcall p' ev (const_prop_fun gd fd) ft = ok t1 &

--- a/proofs/compiler/dead_code_proof.v
+++ b/proofs/compiler/dead_code_proof.v
@@ -289,7 +289,7 @@ Section PROOF.
     rewrite /dead_code_fd /=; t_xrbindP; set O := read_es _; move=> [I c'] hc ?; subst fd'.
     set fd' := {| f_info := _ |}.
     move=> s1 hinit.
-    have [s1' hinit' hu1] := fs_uincl_initialize (fd':= fd') erefl erefl erefl eq_p_extra hfsu hinit.
+    have [s1' hinit' hu1] := fs_uincl_initialize (fd':= fd') erefl erefl eq_var_is_refl eq_p_extra hfsu hinit.
     exists s1' => //.
     exists (st_uincl_on I), (st_uincl_on O).
     split => //;first (by case: hu1 => *; split); last first.

--- a/proofs/compiler/inline_proof.v
+++ b/proofs/compiler/inline_proof.v
@@ -272,7 +272,7 @@ Proof using uniq_funname inline_fd_ok.
   + move=> hfn ->; exists fd1 => //.
     move=> s1 hinit.
     have [s1' hinit' hus1] :=
-      [elaborate fs_uincl_initialize (p:=p1) (p':=p2) (fs:= fs1) (fs':= fs2) erefl erefl erefl erefl hu hinit].
+      [elaborate fs_uincl_initialize (p:=p1) (p':=p2) (fs:= fs1) (fs':= fs2) erefl erefl eq_var_is_refl erefl hu hinit].
     exists s1' => //.
     exists (st_uincl ev), (st_uincl ev); split => //; last first.
     + by apply fs_uincl_finalize.
@@ -295,7 +295,7 @@ Proof using uniq_funname inline_fd_ok.
   move=> hc' -> /= s1 hinit.
   have [s1' hinit' hus1] :=
       [elaborate fs_uincl_initialize (p:=p1) (p':=p2) (fd:=fd) (fd':= with_body fd c')
-                 (fs:= fs1) (fs':= fs2) erefl erefl erefl erefl hu hinit].
+                 (fs:= fs1) (fs':= fs2) erefl erefl eq_var_is_refl erefl hu hinit].
   exists s1' => //.
   exists (st_uincl_on X1), (st_uincl_on X2); split => //;
     first (by case hus1 => ?? h; split); last first.

--- a/proofs/compiler/insert_renaming_proof.v
+++ b/proofs/compiler/insert_renaming_proof.v
@@ -74,7 +74,7 @@ Section WITH_PARAMS.
     Proof. by rewrite /insert_renaming_fd; case: ifP. Qed.
 
     Lemma insert_renaming_fd_params fd :
-      f_params (insert_renaming_fd insert_renaming_p fd) = f_params fd.
+      eq_var_is (f_params fd) (f_params (insert_renaming_fd insert_renaming_p fd)).
     Proof. by rewrite /insert_renaming_fd; case: ifP. Qed.
 
     Lemma insert_renaming_fd_res fd :
@@ -167,7 +167,7 @@ Section WITH_PARAMS.
       have htyin := insert_renaming_fd_tyin insert_renaming_p fd.
       have hextra := insert_renaming_fd_extra insert_renaming_p fd.
       have hparams := insert_renaming_fd_params insert_renaming_p fd.
-      have := [elaborate fs_uincl_initialize (p' := p') (sym_eq htyin) (sym_eq hextra) (sym_eq hparams) erefl hfsu hinit].
+      have := [elaborate fs_uincl_initialize (p' := p') (sym_eq htyin) (sym_eq hextra) hparams erefl hfsu hinit].
       case => t -> hu.
       eexists; first reflexivity.
       exists (st_uincl_at_init fd), (st_uincl tt).

--- a/proofs/compiler/propagate_inline_proof.v
+++ b/proofs/compiler/propagate_inline_proof.v
@@ -617,7 +617,7 @@ Section PROOF.
         [/\ f_tyin fd1 = f_tyin fd2
           , f_tyout fd1 = f_tyout fd2
           , f_extra fd1 = f_extra fd2
-          , f_params fd1 = f_params fd2
+          , eq_var_is (f_params fd1) (f_params fd2)
           , f_res fd1 = f_res fd2
           & exists2 dc, pi_c pi_i piempty (f_body fd1) = ok dc & f_body fd2 = dc.2
          ].
@@ -628,7 +628,7 @@ Section PROOF.
     exists t1 => //; exists (st_pi piempty), (st_pi dc_.1); split => //; last first.
     + apply wrequiv_weaken with (st_uincl tt) fs_uincl => //.
       + by move=> > [].
-      by apply fs_uincl_finalize.
+      by apply: fs_uincl_finalize => //; rewrite hres.
     rewrite hbody => {hbody hfun hin hout hex hpar hres hinit hst1 s1 t1 hfsu fs ft fd2 fn}.
     move: (f_body fd1) piempty dc_ hc => {fd1}.
     apply (cmd_rect (Pr := Pi_r) (Pi:=Pi) (Pc:=Pc)) => //.

--- a/proofs/compiler/remove_globals_proof.v
+++ b/proofs/compiler/remove_globals_proof.v
@@ -778,7 +778,7 @@ Module RGP. Section PROOFS.
     have fsi := fs_uincl_initialize (fd := fd) (fd' := fd').
     exists fd' => //.
     move: hfd'; rewrite /remove_glob_fundef; t_xrbindP => _tt hparams res1 hres1 [m' c'] hrm ?;subst fd' => /=.
-    move=> s1 /fsi /= /(_ _ _ erefl erefl erefl erefl hfs)[] s1' hinit hs1.
+    move=> s1 /fsi /= /(_ _ _ erefl erefl eq_var_is_refl erefl hfs)[] s1' hinit hs1.
     exists s1'; first exact: hinit.
     exists (valid (Mvar.empty var)), (valid m'); split => // {hfs fsi hget hinit}; cycle -1.
     + move=> {hs1} s1 s2 {} fs [/= hscse hmem hm _ _]; rewrite /finalize_funcall /=; t_xrbindP.

--- a/proofs/compiler/wint_word_proof.v
+++ b/proofs/compiler/wint_word_proof.v
@@ -246,7 +246,7 @@ Proof.
   + by rewrite get_map_prog hget.
   move=> s hinit.
   have [t -> hu] :=
-    [elaborate fs_uincl_initialize (p':=p') (fd:=fd) (fd':=wi2w_fun fd) erefl erefl erefl erefl hfsu hinit].
+    [elaborate fs_uincl_initialize (p':=p') (fd:=fd) (fd':=wi2w_fun fd) erefl erefl eq_var_is_refl erefl hfsu hinit].
   exists t => //; exists (st_uincl tt), (st_uincl tt); split => //; last by apply fs_uincl_finalize.
   rewrite /=; move: (f_body fd).
   clear fn fs ft hfsu fd hget s hinit t hu.

--- a/proofs/lang/psem.v
+++ b/proofs/lang/psem.v
@@ -644,33 +644,55 @@ Lemma eq_initialize p' fd fd' fs s:
   initialize_funcall p' ev fd' fs = ok s.
 Proof. by rewrite /initialize_funcall => <- <- <- <-. Qed.
 
+Lemma get_eq_var_is wdb xs ys vm :
+  eq_var_is xs ys →
+  get_var_is wdb vm xs = get_var_is wdb vm ys.
+Proof.
+  elim: xs ys; first by case.
+  by move => x xs ih [] // y ys /andP[] /eqP /= -> /ih ->.
+Qed.
+
+Lemma write_vars_eq_var_is wdb xs ys vs s :
+  eq_var_is xs ys →
+  write_vars wdb xs vs s = write_vars wdb ys vs s.
+Proof.
+  elim: xs ys vs s; first by case.
+  move => x xs ih [] // y ys [] // v vs s /andP[] /eqP h /ih{}ih.
+  rewrite /= /write_var h.
+  case: set_var => ?; last done.
+  exact: ih.
+Qed.
+
 (* TODO: Can we generalize this to different semantic ? *)
 Lemma fs_uincl_initialize p' fd fd' fs fs' s:
   f_tyin fd = f_tyin fd' ->
   f_extra fd = f_extra fd' ->
-  f_params fd = f_params fd' ->
+  eq_var_is (f_params fd) (f_params fd') ->
   p_extra p = p_extra p' ->
   fs_uincl fs fs' ->
   initialize_funcall p ev fd fs = ok s ->
   exists2 s', initialize_funcall p' ev fd' fs' = ok s' & st_uincl tt s s'.
 Proof.
-  move=> hty hex hpa hpex hfs; rewrite /initialize_funcall -hty -hex -hpa -hpex /estate0 /=.
+  move=> hty hex hpa hpex hfs; rewrite /initialize_funcall -hty -hex -hpex /estate0 /=.
   case: hfs => <- <- hu.
   t_xrbindP => vs htr s0 -> hw.
   have [vs' -> {}hu /=] := mapM2_dc_truncate_val htr hu.
   have [vm] := [elaborate write_vars_uincl (vm_uincl_refl (evm s0)) hu hw].
-  by rewrite with_vm_same => -> ? /=; eexists; eauto.
+  rewrite with_vm_same (write_vars_eq_var_is _ _ _ hpa) => -> ? /=.
+  eexists; first reflexivity.
+  split; eauto.
 Qed.
 
 (* TODO: Can we generalize this to different semantic ? *)
 Lemma fs_uincl_finalize fd fd' :
   f_tyout fd = f_tyout fd' ->
   f_extra fd = f_extra fd' ->
-  f_res fd = f_res fd' ->
+  eq_var_is (f_res fd) (f_res fd') ->
   wrequiv (st_uincl tt) (finalize_funcall fd) (finalize_funcall fd') fs_uincl.
 Proof.
-  rewrite /finalize_funcall => <- <- <- /= s t fs [<- <- hvm].
+  rewrite /finalize_funcall => <- <- hres /= s t fs [<- <- hvm].
   t_xrbindP => vs hget vs' htr <-.
+  rewrite -(get_eq_var_is _ _ hres).
   have [vs1 -> hu /=] := get_var_is_uincl hvm hget.
   have [vs1' -> {}hu /=] := mapM2_dc_truncate_val htr hu.
   by eexists; eauto.
@@ -696,7 +718,7 @@ Lemma it_sem_uincl_f fn :
   wiequiv_f p p ev ev (rpreF (eS:= uincl_spec)) fn fn (rpostF (eS:=uincl_spec)).
 Proof.
 apply wequiv_fun_ind => {}fn _ fs1 fs2 [<-] hu fd ->.
-exists fd => // s /(fs_uincl_initialize erefl erefl erefl erefl hu) [t] -> {}hu.
+exists fd => // s /(fs_uincl_initialize erefl erefl eq_var_is_refl erefl hu) [t] -> {}hu.
 exists t => //; exists (st_uincl tt), (st_uincl tt); split=> //.
 + apply it_sem_uincl_aux => // ii fn' fs1' fs2' h; exact/wequiv_fun_rec.
 exact/fs_uincl_finalize.

--- a/proofs/lang/psem_core.v
+++ b/proofs/lang/psem_core.v
@@ -1513,3 +1513,9 @@ Ltac t_get_var :=
     || (rewrite get_var_neq; last by [|apply/nesym])
   ).
 
+Lemma eq_var_is_refl : ssrbool.reflexive eq_var_is.
+Proof. exact: all2_refl. Qed.
+
+Arguments eq_var_is_refl {_}.
+
+Hint Resolve eq_var_is_refl : core.

--- a/proofs/lang/psem_defs.v
+++ b/proofs/lang/psem_defs.v
@@ -160,6 +160,10 @@ Fixpoint sem_pexpr (s:estate) (e : pexpr) : exec value :=
 
 Definition sem_pexprs s := mapM (sem_pexpr s).
 
+(* Equality of variable lists up to var_infos *)
+Definition eq_var_is (x y: seq var_i) : bool :=
+  all2 (λ x y : var_i, x == y :> var) x y.
+
 Definition write_var (x:var_i) (v:value) (s:estate) : exec estate :=
   Let vm := set_var wdb s.(evm) x v in
   ok (with_vm s vm).


### PR DESCRIPTION
There is no need to constrain the metadata that occurs in the parameters & returned variables.

This makes these theorems reusable even in contexts where the equality on metadata is not available (remember: `var_i` is not `EqType`).