### PR TITLE
BSR_16 uses MSB_MERGE

### DIFF
--- a/changes/02-bugfix/1518-fix-bsr-msb-merge.md
+++ b/changes/02-bugfix/1518-fix-bsr-msb-merge.md
@@ -1,0 +1,1 @@
+- The semantics of `BSR_16` leaves the upper 48 bits unchanged instead of clearing them ([PR 1518](https://github.com/jasmin-lang/jasmin/pull/1518)).

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -943,10 +943,15 @@ Qed.
 
 Definition Ox86_BSR_instr :=
   (fun sz =>
-     mk_instr (pp_sz "BSR" sz) [:: lword sz ] (b5w_ty sz) [:: Eu 1 ] (implicit_flags ++ [:: Ea 0 ]) MSB_CLEAR
-       (@x86_BSR sz) [:: r_rm ] 2 [:: NotZero sz 0 ] (size_16_64 sz) (pp_iname "bsr" sz)
-       erefl (@x86_BSR_errty sz) (@x86_BSR_safe sz),
-     ("BSR"%string, prim_16_64 BSR)).
+     mk_instr
+       (pp_sz "BSR" sz)
+       [:: lword sz ] (b5w_ty sz) [:: Eu 1 ] (implicit_flags ++ [:: Ea 0 ])
+       (reg_msb_flag sz)
+       (@x86_BSR sz)
+       [:: r_rm ] 2
+       [:: NotZero sz 0 ] (size_16_64 sz)
+       (pp_iname "bsr" sz) erefl (@x86_BSR_errty sz) (@x86_BSR_safe sz)
+  , ("BSR"%string, prim_16_64 BSR)).
 
 Definition check_setcc := [:: [::c; rm false]].
 


### PR DESCRIPTION
# Description

The description of `BSR` uses `mk_instr` instead of one of the more complex notations and as a result it forgets to use `MSB_MERGE` for 16bit writes.

I am pretty sure we can't test this with the current suite. Maybe out of scope for now, but in case we want to discuss: in my OTBN branch I added a file `otbn_validation.v` with a bunch of
```
Goal (desc <MNEMONIC>).(id_semi) (wrepr U32 <n>) ... (wrepr U32 <m>) = wrepr U32 <k>. by [].
```
for tricky or random test vectors taken from OTBN's python reference interpreter. This kind of test would be able to see the problem.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change