### PR TITLE
CI: add libjade/curve25519 job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,7 +219,7 @@ libjade:
   stage: test
   parallel:
     matrix:
-      - PRIMITIVE: [ mldsa, mlkem, xmss ]
+      - PRIMITIVE: [ curve25519, mldsa, mlkem, xmss ]
   variables:
     EXTRA_NIX_ARGUMENTS: --arg ocamlDeps true
   extends: .common

--- a/scripts/test-curve25519.sh
+++ b/scripts/test-curve25519.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+REPO=formosa-crypto
+NAME=formosa-25519
+BRANCH=main
+
+FILE="$NAME.tar.gz"
+ROOT=$(echo -n $NAME-$BRANCH | tr / -)
+
+DIR=libjade
+
+curl -v -o $FILE https://codeload.github.com/$REPO/$NAME/tar.gz/$BRANCH
+tar xvf $FILE
+rm -rf $DIR/
+mv $ROOT $DIR
+
+
+JASMINC=$PWD/compiler/jasminc
+JASMIN_CT=$PWD/compiler/jasmin-ct
+
+cd $DIR
+
+for x in ref4 ref5 mulx
+do
+  FILE=src/crypto_scalarmult/curve25519/amd64/$x/scalarmult.jazz
+  echo -n Compile $x
+  $JASMINC -wall -o $x.s $FILE && echo ... OK
+  echo Check $x for Constant-Time
+  $JASMIN_CT --print $FILE
+  echo -n Check $x for DOIT Constant-Time
+  $JASMIN_CT --doit $FILE >/dev/null && echo ... OK
+  echo -n Check $x for Speculative Constant-Time
+  $JASMIN_CT --speculative $FILE > $x_sct.log && echo ... OK
+  echo
+done


### PR DESCRIPTION
New CI job that compiles and checks for CT, DOIT, and SCT three implementations of curve25519 for x86_64