### PR TITLE
Update mathcomp-word

### DIFF
--- a/proofs/lang/memory_model.v
+++ b/proofs/lang/memory_model.v
@@ -98,13 +98,26 @@ Fixpoint pos_is_aligned_to (p: positive) (n: nat) {struct n} : bool :=
     else false)%positive
   else true.
 
+Lemma mod_pow2S p n :
+  mod_pow2 p n.+1 =
+    match p with
+    | p~1 => Pos.Nsucc_double (mod_pow2 p n)
+    | p~0 => Pos.Ndouble (mod_pow2 p n)
+    | 1 => 1%N
+    end%positive.
+Proof.
+  rewrite mod_pow2E.
+  case: p => // p; rewrite !mod_pow2E /=; zify; rewrite Z.mod_mul_r => //; rewrite (Z.mul_comm 2 p).
+  2: by rewrite Z.quot_mul // Z.rem_mul.
+  rewrite Z.quot_add_l // Z.add_0_r (Z.add_comm (p * 2) 1) Z.rem_add //.
+  exact: Z.add_comm.
+Qed.
+
 Lemma pos_is_aligned_toE p n :
   pos_is_aligned_to p n = (mod_pow2 p n == 0)%N.
 Proof.
-  elim: n p => // n ih [] // p /=.
-  - by case: (_ p n).
-  rewrite ih.
-  by case: (_ p n).
+  elim: n p => // n ih [] // p; rewrite mod_pow2S /= ?ih;
+  by case: (mod_pow2 _ _).
 Qed.
 
 Definition is_aligned_to (z: Z) (n: nat) : bool :=

--- a/scripts/mathcomp-word.nix
+++ b/scripts/mathcomp-word.nix
@@ -1,21 +1,21 @@
-{ stdenv, lib, fetchFromGitHub, coqPackages, ocaml, dune_3 }:
+{ stdenv, lib, fetchFromGitHub, coqPackages, ocaml, dune }:
 
 let inherit (coqPackages) coq; in
 
-let rev = "3ba8484ae779a2178ea3c6a470f102a0dd57a8a9"; in
+let rev = "8a69be8d171dbc6479d0df6371428e2beac6a3cd"; in
 
 stdenv.mkDerivation rec {
-  version = "3.4-git-${builtins.substring 0 8 rev}";
+  version = "3.5-git-${builtins.substring 0 8 rev}";
   pname = "coq${coq.coq-version}-mathcomp-word";
 
   src = fetchFromGitHub {
     owner = "jasmin-lang";
     repo = "coqword";
     inherit rev;
-    hash = "sha256-M2Yw1aPhJlXhmJJhHpuQZnhGDV4YdJhtc2RwJzqAVcI=";
+    hash = "sha256-Wyoa0rj38qxR9lLLC1MN+QCZZgKuXMtW9h5jA1AjoQE=";
   };
 
-  buildInputs = [ coq ocaml dune_3 ];
+  buildInputs = [ coq ocaml dune ];
 
   propagatedBuildInputs = (with coqPackages.mathcomp; [ algebra fingroup ssreflect ])
   ++ [ coqPackages.stdlib ];


### PR DESCRIPTION
The current development (after this PR) is compatible with both latest (3.5) and previous (3.4) versions of mathcomp-word.