### PR TITLE
VPSLLV and VPSRLV reject 16 bit

### DIFF
--- a/changes/02-bugfix/1529-vpsllv-vpsrlv-16.md
+++ b/changes/02-bugfix/1529-vpsllv-vpsrlv-16.md
@@ -1,0 +1,1 @@
+- `VPSLLV` and `VPSRLV` no longer accept 16 bits as a size.

--- a/compiler/tests/success/x86-64/vector.jazz
+++ b/compiler/tests/success/x86-64/vector.jazz
@@ -200,6 +200,8 @@ c = #VPSLL_4u32(b, 2);
 a = #VPSLL_2u64(c, 3);
 b = #VPSLLV_4u32(c, a);
 c = #VPSLLV_2u64(a, b);
+a = #VPSRLV_4u32(c, b);
+c = #VPSRLV_2u64(b, a);
 [:u128 p + 0] = c;
 
 x = [:u256 p + 32];
@@ -208,6 +210,8 @@ z = #VPSLL_8u32(y, 2);
 x = #VPSLL_4u64(z, 3);
 y = #VPSLLV_8u32(z, x);
 z = #VPSLLV_4u64(x, y);
+x = #VPSRLV_8u32(z, y);
+z = #VPSRLV_4u64(y, x);
 [:u256 p + 32] = z;
 
 }

--- a/proofs/compiler/x86_instr_decl.v
+++ b/proofs/compiler/x86_instr_decl.v
@@ -352,6 +352,7 @@ Definition primV_8_32 := primV_range [seq PVv ve sz | ve <- [:: VE8; VE16; VE32 
 Definition primV_16 := primV_range [seq PVv VE16 sz | sz <- [:: U128; U256 ]].
 Definition primV_16_32 := primV_range [seq PVv ve sz | ve <- [:: VE16; VE32 ], sz <- [:: U128; U256 ]].
 Definition primV_16_64 := primV_range [seq PVv ve sz | ve <- [:: VE16; VE32; VE64 ], sz <- [:: U128; U256 ]].
+Definition primV_32_64 := primV_range [seq PVv ve sz | ve <- [:: VE32; VE64 ], sz <- [:: U128; U256 ]].
 Definition primV_128 := primV_range [seq PVv ve U128 | ve <- [:: VE8; VE16; VE32; VE64 ]].
 
 Definition primMMX := primV_range [seq PVv ve sz | ve <- [:: VE8; VE16; VE32; VE64 ], sz <- [:: U64; U128 ]].
@@ -1538,14 +1539,14 @@ Arguments x86_u128_shift_variable : clear implicits.
 Definition x86_VPSLLV ve sz := x86_u128_shift_variable ve sz (@wshl _).
 
 Definition Ox86_VPSLLV_instr :=
-  mk_ve_instr_w2_w_120 "VPSLLV" x86_VPSLLV check_xmm_xmm_xmmm (primV_16_64 VPSLLV)
-  (fun (ve:velem)  sz => size_16_64 ve && size_128_256 sz) (fun=> DOIT) (pp_viname "vpsllv").
+  mk_ve_instr_w2_w_120 "VPSLLV" x86_VPSLLV check_xmm_xmm_xmmm (primV_32_64 VPSLLV)
+  (fun (ve:velem) sz => size_32_64 ve && size_128_256 sz) (fun=> DOIT) (pp_viname "vpsllv").
 
 Definition x86_VPSRLV ve sz := x86_u128_shift_variable ve sz (@wshr _).
 
 Definition Ox86_VPSRLV_instr :=
-  mk_ve_instr_w2_w_120 "VPSRLV" x86_VPSRLV check_xmm_xmm_xmmm (primV_16_64 VPSRLV)
-  (fun (ve:velem) sz => size_16_64 ve && size_128_256 sz) (fun=> DOIT) (pp_viname "vpsrlv").
+  mk_ve_instr_w2_w_120 "VPSRLV" x86_VPSRLV check_xmm_xmm_xmmm (primV_32_64 VPSRLV)
+  (fun (ve:velem) sz => size_32_64 ve && size_128_256 sz) (fun=> DOIT) (pp_viname "vpsrlv").
 
 Definition x86_vpsxldq sz op (v1: word sz) (v2: u8) : tpl (w_ty sz) :=
   op v1 v2.


### PR DESCRIPTION
# Description

`VPSLLVW` and `VPSRLVW` are only valid for AVX-512 (https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=VPSLLVW). These programs
```
export fn mock_vpsllv() -> reg u128 {
  reg u128 a = #set0_128();
  reg u128 b = #set0_128();
  reg u128 c = #VPSLLV(a, b);
  return c;
}
export fn mock_vpsrlv() -> reg u128 {
  reg u128 a = #set0_128();
  reg u128 b = #set0_128();
  reg u128 c = #VPSRLV(a, b);
  return c;
}
```
run ok with `exec` but when linked with C and executed they segfault. We should not accept 16 bit as a size for them, 32 and 64 are fine.

I added `VPSRL` to the generic tests for vector instructions. I don't think we need a negative test but I can add one if needed. I think it's not necessary to update eclib, although `VPSLLV` and `VPSRLV` are begin instantiated for 16 bits as part of the module in JWord.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
