### PR TITLE
CI: fix job push-compiler-code

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -287,7 +287,6 @@ push-compiler-code:
   needs:
   - tarball
   before_script:
-  - nix-env -iA nixpkgs.git
   - nix-env -iA nixpkgs.openssh
   - eval $(ssh-agent -s)
   - mkdir -p ~/.ssh


### PR DESCRIPTION
This fixes the `deploy/push-compiler-code` CI job that has been broken (my mistake: this job is not tested in CI) by a previous PR.