### PR TITLE
Linearization params: make lload and llstore more general

### DIFF
--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -133,13 +133,11 @@ Definition arm_lmove (xd xs : var_i) :=
 
 Definition arm_check_ws ws := ws == reg_size.
 
-Definition arm_lstore (xd : var_i) (ofs : Z) (xs : var_i) :=
-  let ws := reg_size in
+Definition arm_lstore (ws: wsize) (xd : var_i) (ofs : Z) (xs : var_i) :=
   let mn := STR in
   ([:: Store Aligned ws (faddv Uptr xd (fconst ws ofs))], Oarm (ARM_op mn default_opts), [:: Rexpr (Fvar xs)]).
 
-Definition arm_lload (xd : var_i) (xs: var_i) (ofs : Z) :=
-  let ws := reg_size in
+Definition arm_lload (ws: wsize) (xd : var_i) (xs: var_i) (ofs : Z) :=
   let mn := LDR in
   ([:: LLvar xd], Oarm (ARM_op mn default_opts), [:: Load Aligned ws (faddv Uptr xs (fconst ws ofs))]).
 

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -295,7 +295,7 @@ Qed.
 
 Lemma arm_lstore_correct : lstore_correct_aux arm_check_ws arm_lstore.
 Proof.
-  move=> xd xs ofs ws w wp s m htxs /eqP hchk; t_xrbindP; subst ws.
+  move=> xd xs ofs ws w wp s m /eqP hchk; t_xrbindP; subst ws.
   move=> vd hgetd htrd vs hgets htrs hwr.
   rewrite /arm_lstore /= hgets hgetd /= /exec_sopn /= htrs /=.
   rewrite /sem_sop2 /= htrd /= !truncate_word_u /= truncate_word_u /=.
@@ -317,7 +317,7 @@ Qed.
 
 Lemma arm_lload_correct : lload_correct_aux (lip_check_ws arm_liparams) arm_lload.
 Proof.
-  move=> xd xs ofs ws top s w vm heq hcheck; t_xrbindP => ? hgets hto hread hset.
+  move=> xd xs ofs ws top s w vm hcheck; t_xrbindP => ? hgets hto hread hset.
   move/eqP: hcheck => ?; subst ws.
   rewrite /arm_lload /= hgets /= /sem_sop2 /= hto /= !truncate_word_u /= truncate_word_u /= hread /=.
   by rewrite /exec_sopn /= truncate_word_u /= zero_extend_u hset.

--- a/proofs/compiler/it_linearization_proof.v
+++ b/proofs/compiler/it_linearization_proof.v
@@ -667,17 +667,18 @@ Section HLIPARAMS.
     by rewrite (spec_lip_lmove hliparams (s:= to_estate ls) htx hty hget (truncate_word_u w)).
   Qed.
 
-  Lemma spec_lstore {lp ii ls m ofs} {x y:var_i} {wx ws' wy'} {wy : word ws'} :
+  Lemma spec_lstore {lp ii ls m ofs} {x y:var_i} {wx ws ws' wy'} {wy : word ws'} :
+    lip_check_ws liparams ws ->
     get_var true (lvm ls) y = ok (Vword wy) ->
-    truncate_word Uptr wy = ok wy' ->
+    truncate_word ws wy = ok wy' ->
     get_var true (lvm ls) x >>= to_pointer = ok wx ->
     write (lmem ls) Aligned (wx + wrepr Uptr ofs)%R wy' = ok m ->
-    let: li := lstore liparams ii Uptr x ofs y in
+    let: li := lstore liparams ii ws x ofs y in
     eval_instr lp li ls = ok (lnext_pc (lset_mem ls m)).
   Proof using hliparams.
-    move=> hgy htr hgx hw /=.
+    move=> hws hgy htr hgx hw /=.
     apply sem_fopn_args_eval_instr => /=.
-    apply: (spec_lip_lstore hliparams (s:= to_estate ls) (spec_lip_check_ws hliparams) hgx _ hw).
+    apply: (spec_lip_lstore hliparams (s:= to_estate ls) hws hgx _ hw).
     by rewrite hgy /= htr.
   Qed.
 
@@ -4880,7 +4881,8 @@ Qed.
         + rewrite (step_mix_ilsteps ok_body) //=.
           set x := eval_instr _ _ _.
           have -> : x = ok (lnext_pc (lset_mem t1 m1s)).
-          + apply: (spec_lstore hliparams) => //=.
+          + apply: (spec_lstore hliparams) => //.
+            * exact: spec_lip_check_ws.
             * by rewrite /get_var ok_ra.
             * by rewrite truncate_word_u.
             * by rewrite /get_var ok_rsp; exact: truncate_word_u.

--- a/proofs/compiler/it_linearization_proof.v
+++ b/proofs/compiler/it_linearization_proof.v
@@ -390,7 +390,7 @@ Definition lstore_correct_aux lip_check_ws lip_lstore :=
     (get_var true (evm s) xd >>= to_word Uptr) = ok wp ->
     (get_var true (evm s) xs >>= to_word ws) = ok w ->
     write (emem s) Aligned (wp + wrepr Uptr ofs)%R w = ok m ->
-    sem_fopn_args (lip_lstore xd ofs xs) s = ok (with_mem s m).
+    sem_fopn_args (lip_lstore ws xd ofs xs) s = ok (with_mem s m).
 
 Definition lstore_correct := lstore_correct_aux (lip_check_ws liparams) (lip_lstore liparams).
 
@@ -401,7 +401,7 @@ Definition lload_correct_aux lip_check_ws lip_lload :=
     (get_var true (evm s) xs >>= to_word Uptr) = ok wp ->
     read (emem s) Aligned (wp + wrepr Uptr ofs)%R ws = ok w ->
     set_var true (evm s) xd (Vword w) = ok vm ->
-    sem_fopn_args (lip_lload xd xs ofs) s = ok (with_vm s vm).
+    sem_fopn_args (lip_lload ws xd xs ofs) s = ok (with_vm s vm).
 
 Definition lload_correct := lload_correct_aux (lip_check_ws liparams) (lip_lload liparams).
 
@@ -490,8 +490,8 @@ Section DEFAULT.
 
 Context (lip_tmp2 : Ident.ident).
 Context (lip_check_ws : wsize -> bool)
-        (lip_lstore  : var_i -> Z -> var_i -> fopn_args)
-        (lip_lload   : var_i -> var_i -> Z -> fopn_args)
+        (lip_lstore  : wsize -> var_i -> Z -> var_i -> fopn_args)
+        (lip_lload   : wsize -> var_i -> var_i -> Z -> fopn_args)
         (lip_add_imm : var_i -> var_i -> Z -> seq fopn_args)
         (lip_imm_small : Z -> bool).
 
@@ -601,7 +601,7 @@ Proof using lload_correct.
   move=> vm2' hchk w hread hset ?; subst vm2'.
   have [+ hget2]:= lloads_aux_correct hnin hget hf.
   rewrite /lloads_aux map_cat sem_fopns_args_cat => -> /=.
-  rewrite
+  rewrite heqt
     (lload_correct
       (xd := VarI rspi dummy_var_info) (s:= with_vm s vm1)
       _ hchk hget2 hread hset);
@@ -678,7 +678,7 @@ Section HLIPARAMS.
     truncate_word Uptr wy = ok wy' ->
     get_var true (lvm ls) x >>= to_pointer = ok wx ->
     write (lmem ls) Aligned (wx + wrepr Uptr ofs)%R wy' = ok m ->
-    let: li := lstore liparams ii x ofs y in
+    let: li := lstore liparams ii Uptr x ofs y in
     eval_instr lp li ls = ok (lnext_pc (lset_mem ls m)).
   Proof using hliparams.
     move=> hty hgy htr hgx hw /=.
@@ -691,7 +691,7 @@ Section HLIPARAMS.
     convertible (vtype x) (aword Uptr) ->
     get_var true (lvm ls) y >>= to_pointer = ok wy ->
     read (lmem ls) Aligned (wy + wrepr Uptr ofs)%R Uptr = ok wx ->
-    let: li := lload liparams ii x y ofs in
+    let: li := lload liparams ii Uptr x y ofs in
     eval_instr lp li ls = ok (lnext_pc (lset_vm ls ls.(lvm).[x <- Vword wx])).
   Proof using hliparams.
     move=> hty hgy hread /=.
@@ -3303,8 +3303,8 @@ End ILSTEPS_END.
     find_label xH (lfd_body (linear_fd f fd).2) = ok 0.
   Proof. by rewrite /linear_fd /linear_body; case: sf_return_address. Qed.
 
-  Lemma is_label_lstore ii lbl x ofs y :
-    is_label lbl (lstore liparams ii x ofs y) = false.
+  Lemma is_label_lstore ii lbl ws x ofs y :
+    is_label lbl (lstore liparams ii ws x ofs y) = false.
   Proof. done. Qed.
 
   Lemma preserved_metadata_store_top_stack m1 ws sz ioff sz' m1' m2 (ptr : word Uptr) m2' :

--- a/proofs/compiler/it_linearization_proof.v
+++ b/proofs/compiler/it_linearization_proof.v
@@ -385,7 +385,6 @@ Definition lmove_correct :=
 
 Definition lstore_correct_aux lip_check_ws lip_lstore :=
   forall (xd xs : var_i) ofs ws (w: word ws) wp s m,
-    convertible (vtype xs) (aword ws) ->
     lip_check_ws ws ->
     (get_var true (evm s) xd >>= to_word Uptr) = ok wp ->
     (get_var true (evm s) xs >>= to_word ws) = ok w ->
@@ -396,7 +395,6 @@ Definition lstore_correct := lstore_correct_aux (lip_check_ws liparams) (lip_lst
 
 Definition lload_correct_aux lip_check_ws lip_lload :=
   forall (xd xs : var_i) ofs ws wp s w vm,
-    convertible (vtype xd) (aword ws) ->
     lip_check_ws ws ->
     (get_var true (evm s) xs >>= to_word Uptr) = ok wp ->
     read (emem s) Aligned (wp + wrepr Uptr ofs)%R ws = ok w ->
@@ -526,8 +524,7 @@ Proof using lstore_correct.
   elim: to_save s => /= [ | [x ofs] to_save ih] s hget.
   + by move=> [<-]; rewrite with_mem_same.
   t_xrbindP; case heq: vtype => [|||ws]// m' _ [<-] hchk w v hgetx htow hw hf.
-  have := lstore_correct (xd:= rspi) (xs:= VarI x dummy_var_info) _ hchk hget _ hw.
-  rewrite heq => /(_ (convertible_refl _)) ->.
+  have -> := lstore_correct (xd:= rspi) (xs:= VarI x dummy_var_info) hchk hget _ hw.
   + by have /= -> := ih (with_mem s m') hget hf.
   by rewrite hgetx /= htow.
 Qed.
@@ -584,8 +581,7 @@ Proof using lload_correct.
   move=> [x ofs] to_restore ih s /= hnin hget.
   case heqt: vtype => [|||ws] //=; t_xrbindP.
   move=> vm1 hchk w hread hset hf.
-  rewrite (lload_correct (xd := VarI x dummy_var_info) _ hchk hget hread hset);
-    last by rewrite heqt; apply convertible_refl.
+  rewrite (lload_correct (xd := VarI x dummy_var_info) hchk hget hread hset).
   apply: ih => //.
   + by move: hnin; rewrite in_cons negb_or => /andP [].
   rewrite -(get_var_eq_ex _ _ (set_var_eq_ex hset)) //.
@@ -604,8 +600,7 @@ Proof using lload_correct.
   rewrite heqt
     (lload_correct
       (xd := VarI rspi dummy_var_info) (s:= with_vm s vm1)
-      _ hchk hget2 hread hset);
-    last by rewrite heqt; apply convertible_refl.
+      hchk hget2 hread hset).
   by exists vm2.
 Qed.
 
@@ -673,7 +668,6 @@ Section HLIPARAMS.
   Qed.
 
   Lemma spec_lstore {lp ii ls m ofs} {x y:var_i} {wx ws' wy'} {wy : word ws'} :
-    convertible (vtype y) (aword Uptr) ->
     get_var true (lvm ls) y = ok (Vword wy) ->
     truncate_word Uptr wy = ok wy' ->
     get_var true (lvm ls) x >>= to_pointer = ok wx ->
@@ -681,9 +675,9 @@ Section HLIPARAMS.
     let: li := lstore liparams ii Uptr x ofs y in
     eval_instr lp li ls = ok (lnext_pc (lset_mem ls m)).
   Proof using hliparams.
-    move=> hty hgy htr hgx hw /=.
+    move=> hgy htr hgx hw /=.
     apply sem_fopn_args_eval_instr => /=.
-    apply: (spec_lip_lstore hliparams (s:= to_estate ls) hty (spec_lip_check_ws hliparams) hgx _ hw).
+    apply: (spec_lip_lstore hliparams (s:= to_estate ls) (spec_lip_check_ws hliparams) hgx _ hw).
     by rewrite hgy /= htr.
   Qed.
 
@@ -696,7 +690,7 @@ Section HLIPARAMS.
   Proof using hliparams.
     move=> hty hgy hread /=.
     apply sem_fopn_args_eval_instr => /=.
-    apply: (spec_lip_lload hliparams (s:= to_estate ls) hty (spec_lip_check_ws hliparams) hgy hread).
+    apply: (spec_lip_lload hliparams (s:= to_estate ls) (spec_lip_check_ws hliparams) hgy hread).
     by apply set_var_eq_type => //; rewrite (convertible_eval_atype hty).
   Qed.
 

--- a/proofs/compiler/it_linearization_proof.v
+++ b/proofs/compiler/it_linearization_proof.v
@@ -676,15 +676,14 @@ Section HLIPARAMS.
     convertible (vtype y) (aword Uptr) ->
     get_var true (lvm ls) y = ok (Vword wy) ->
     truncate_word Uptr wy = ok wy' ->
-    get_var true (lvm ls) x = ok (Vword wx) ->
+    get_var true (lvm ls) x >>= to_pointer = ok wx ->
     write (lmem ls) Aligned (wx + wrepr Uptr ofs)%R wy' = ok m ->
     let: li := lstore liparams ii x ofs y in
     eval_instr lp li ls = ok (lnext_pc (lset_mem ls m)).
   Proof using hliparams.
     move=> hty hgy htr hgx hw /=.
     apply sem_fopn_args_eval_instr => /=.
-    apply: (spec_lip_lstore hliparams (s:= to_estate ls) hty (spec_lip_check_ws hliparams) _ _ hw).
-    + by rewrite hgx /= truncate_word_u.
+    apply: (spec_lip_lstore hliparams (s:= to_estate ls) hty (spec_lip_check_ws hliparams) hgx _ hw).
     by rewrite hgy /= htr.
   Qed.
 
@@ -4888,7 +4887,7 @@ Qed.
           + apply: (spec_lstore hliparams) => //=.
             * by rewrite /get_var ok_ra.
             * by rewrite truncate_word_u.
-            * by rewrite /get_var ok_rsp.
+            * by rewrite /get_var ok_rsp; exact: truncate_word_u.
             rewrite wrepr0 GRing.addr0.
             exact: ok_m1s.
           rewrite mix_ilsteps_b0 //=.

--- a/proofs/compiler/it_linearization_proof.v
+++ b/proofs/compiler/it_linearization_proof.v
@@ -690,15 +690,14 @@ Section HLIPARAMS.
 
   Lemma spec_lload {lp ii ls ofs} {x y:var_i} {wx wy} :
     convertible (vtype x) (aword Uptr) ->
-    get_var true (lvm ls) y = ok (Vword wy) ->
+    get_var true (lvm ls) y >>= to_pointer = ok wy ->
     read (lmem ls) Aligned (wy + wrepr Uptr ofs)%R Uptr = ok wx ->
     let: li := lload liparams ii x y ofs in
     eval_instr lp li ls = ok (lnext_pc (lset_vm ls ls.(lvm).[x <- Vword wx])).
   Proof using hliparams.
     move=> hty hgy hread /=.
     apply sem_fopn_args_eval_instr => /=.
-    apply: (spec_lip_lload hliparams (s:= to_estate ls) hty (spec_lip_check_ws hliparams) _ hread).
-    + by rewrite hgy /= truncate_word_u.
+    apply: (spec_lip_lload hliparams (s:= to_estate ls) hty (spec_lip_check_ws hliparams) hgy hread).
     by apply set_var_eq_type => //; rewrite (convertible_eval_atype hty).
   Qed.
 
@@ -5027,7 +5026,7 @@ Qed.
             set x := (eval_instr _ _ _).
             have -> : x = ok (lnext_pc (lset_vm ls2 (lvm ls2).[(mk_var_i ra_return) <- Vword retptr])).
             + apply: (spec_lload hliparams) => //=.
-              * by rewrite /get_var ok_rsp2; reflexivity.
+              * by rewrite /get_var ok_rsp2 /= truncate_word_u; reflexivity.
               rewrite wrepr0 GRing.addr0 hreadf.
               exact: hreadi.
             move: ok_body; rewrite /Q -[[:: _; _]]cat1s catA => ok_body.

--- a/proofs/compiler/it_linearization_proof.v
+++ b/proofs/compiler/it_linearization_proof.v
@@ -681,17 +681,19 @@ Section HLIPARAMS.
     by rewrite hgy /= htr.
   Qed.
 
-  Lemma spec_lload {lp ii ls ofs} {x y:var_i} {wx wy} :
-    convertible (vtype x) (aword Uptr) ->
+  Lemma spec_lload {lp ii ls ofs} {x y:var_i} {sx} {wx wy} :
+    subatype (aword sx) (vtype x) ->
+    lip_check_ws liparams sx ->
     get_var true (lvm ls) y >>= to_pointer = ok wy ->
-    read (lmem ls) Aligned (wy + wrepr Uptr ofs)%R Uptr = ok wx ->
-    let: li := lload liparams ii Uptr x y ofs in
+    read (lmem ls) Aligned (wy + wrepr Uptr ofs)%R sx = ok wx ->
+    let: li := lload liparams ii sx x y ofs in
     eval_instr lp li ls = ok (lnext_pc (lset_vm ls ls.(lvm).[x <- Vword wx])).
   Proof using hliparams.
-    move=> hty hgy hread /=.
+    move=> hty hsx hgy hread /=.
     apply sem_fopn_args_eval_instr => /=.
-    apply: (spec_lip_lload hliparams (s:= to_estate ls) (spec_lip_check_ws hliparams) hgy hread).
-    by apply set_var_eq_type => //; rewrite (convertible_eval_atype hty).
+    apply: (spec_lip_lload hliparams (s:= to_estate ls) hsx hgy hread).
+    apply: set_var_truncate; first by [].
+    by case: vtype hty.
   Qed.
 
   Lemma set_up_sp_register_ok {E E0: Type -> Type} {wE: with_Error E E0}
@@ -5018,7 +5020,9 @@ Qed.
             rewrite (step_mix_ilsteps ok_body) //=; last by simpl_size;lia.
             set x := (eval_instr _ _ _).
             have -> : x = ok (lnext_pc (lset_vm ls2 (lvm ls2).[(mk_var_i ra_return) <- Vword retptr])).
-            + apply: (spec_lload hliparams) => //=.
+            + apply: (spec_lload hliparams) => //.
+              * apply: convertible_subatype; apply: convertible_sym; exact: ra_return_ty.
+              * exact: spec_lip_check_ws.
               * by rewrite /get_var ok_rsp2 /= truncate_word_u; reflexivity.
               rewrite wrepr0 GRing.addr0 hreadf.
               exact: hreadi.

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -134,7 +134,8 @@ Record linearization_params {asm_op : Type} {asmop : asmOp asm_op} :=
                [xd + ofs] := xs
      *)
     lip_lstore :
-      var_i        (* Base register. *)
+      wsize        (* Size of the stored value *)
+      -> var_i     (* Base register. *)
       -> Z         (* Offset. *)
       -> var_i     (* Source register. *)
       -> fopn_args;
@@ -146,7 +147,8 @@ Record linearization_params {asm_op : Type} {asmop : asmOp asm_op} :=
                xd = [xs + ofs]
      *)
     lip_lload :
-      var_i        (* Destination register. *)
+      wsize        (* Size of the loaded value *)
+      -> var_i     (* Destination register. *)
       -> var_i     (* Base register. *)
       -> Z         (* Offset. *)
       -> fopn_args;
@@ -244,13 +246,13 @@ Record linearization_params {asm_op : Type} {asmop : asmOp asm_op} :=
 Section DEFAULT.
 Context {asm_op : Type} {pd : PointerData} {asmop : asmOp asm_op}.
 Context (lip_tmp2 : Ident.ident).
-Context (lip_lstore  : var_i -> Z -> var_i -> fopn_args)
-        (lip_lload   : var_i -> var_i -> Z -> fopn_args)
+Context (lip_lstore  : wsize -> var_i -> Z -> var_i -> fopn_args)
+        (lip_lload   : wsize -> var_i -> var_i -> Z -> fopn_args)
         (lip_add_imm : var_i -> var_i -> Z -> seq fopn_args)
         (lip_imm_small : Z -> bool).
 
 Definition lstores_dfl (rsp: var_i) (to_save : seq (var * Z)) :=
-  map (fun '(x,ofs) => lip_lstore rsp ofs (VarI x dummy_var_info)) to_save.
+  map (fun '(x,ofs) => lip_lstore (wsize_of_atype (vtype x)) rsp ofs (VarI x dummy_var_info)) to_save.
 
 Definition lstores_imm_dfl (rsp : var_i) (to_save : seq (var * Z)) :=
   if all (fun '(_,ofs) => lip_imm_small ofs) to_save then
@@ -262,7 +264,7 @@ Definition lstores_imm_dfl (rsp : var_i) (to_save : seq (var * Z)) :=
     lip_add_imm tmp2 rsp ofs0 ++ lstores_dfl tmp2 to_save.
 
 Definition lloads_aux (rsp:var_i) (to_restore : seq (var * Z)) :=
-  map (fun '(x, ofs) => lip_lload (VarI x dummy_var_info) rsp ofs) to_restore.
+  map (fun '(x, ofs) => lip_lload (wsize_of_atype (vtype x)) (VarI x dummy_var_info) rsp ofs) to_restore.
 
 Definition lloads_dfl (rsp:var_i) (to_restore : seq (var * Z)) (spofs:Z) :=
   lloads_aux rsp (to_restore ++ [:: (v_var rsp, spofs)]).
@@ -304,11 +306,12 @@ Definition lmove
  *)
 Definition lload
   (ii: instr_info)
+  (ws: wsize)
   (rd : var_i) (* Destination register. *)
   (rs : var_i) (* Base register. *)
   (ofs : Z)    (* Offset. *)
   : linstr :=
-  li_of_fopn_args ii (lip_lload liparams rd rs ofs).
+  li_of_fopn_args ii (lip_lload liparams ws rd rs ofs).
 
 (* Return a linear instruction that corresponds to storing to memory.
    The linear instruction [lstore rd ofs rs] corresponds to
@@ -316,11 +319,12 @@ Definition lload
  *)
 Definition lstore
   (ii: instr_info)
+  (ws: wsize)
   (rd : var_i)      (* Base register. *)
   (ofs : Z)         (* Offset. *)
   (rs : var_i)      (* Source register. *)
   : linstr :=
-  li_of_fopn_args ii (lip_lstore liparams rd ofs rs).
+  li_of_fopn_args ii (lip_lstore liparams ws rd ofs rs).
 
 Definition set_up_sp_register
   (ii: instr_info)
@@ -778,12 +782,12 @@ Definition linear_body (fi: fun_info) (e: stk_fun_extra) (body: cmd) : label * l
        )
      | RAstack ra_call ra_return z _ =>
        ( if ra_return is Some ra_return
-         then [:: lload ret_ii (mk_var_i ra_return) rspi z;
+         then [:: lload ret_ii Uptr (mk_var_i ra_return) rspi z;
                   MkLI ret_ii (Ligoto (Rexpr (Fvar (mk_var_i ra_return)))) ]
          else [:: MkLI ret_ii Lret ]
        , MkLI fentry_ii (Llabel 1) ::
          (if ra_call is Some ra_call
-          then [:: lstore fentry_ii rspi z (mk_var_i ra_call) ]
+          then [:: lstore fentry_ii Uptr rspi z (mk_var_i ra_call) ]
           else [::])
        , 2%positive
        )

--- a/proofs/compiler/riscv_params.v
+++ b/proofs/compiler/riscv_params.v
@@ -125,12 +125,10 @@ Definition riscv_lmove (xd xs : var_i) :=
 
 Definition riscv_check_ws ws := ws == reg_size.
 
-Definition riscv_lstore (xd : var_i) (ofs : Z) (xs : var_i) :=
-  let ws := reg_size in
+Definition riscv_lstore (ws: wsize) (xd : var_i) (ofs : Z) (xs : var_i) :=
   ([:: Store Aligned ws (faddv Uptr xd (fconst ws ofs))], Oriscv (STORE ws), [:: Rexpr (Fvar xs)]).
 
-Definition riscv_lload (xd : var_i) (xs: var_i) (ofs : Z) :=
-  let ws := reg_size in
+Definition riscv_lload (ws: wsize) (xd : var_i) (xs: var_i) (ofs : Z) :=
   ([:: LLvar xd], Oriscv (LOAD Signed ws), [:: Load Aligned ws (faddv Uptr xs (fconst ws ofs))]).
 
 Definition riscv_liparams : linearization_params :=

--- a/proofs/compiler/riscv_params_proof.v
+++ b/proofs/compiler/riscv_params_proof.v
@@ -272,7 +272,7 @@ Qed.
 
 Lemma riscv_lstore_correct : lstore_correct_aux riscv_check_ws riscv_lstore.
 Proof.
-  move=> xd xs ofs ws w wp s m htxs /eqP hchk; t_xrbindP; subst ws.
+  move=> xd xs ofs ws w wp s m /eqP hchk; t_xrbindP; subst ws.
   move=> vd hgetd htrd vs hgets htrs hwr.
   rewrite /riscv_lstore /= hgets hgetd /= /exec_sopn /= htrs /=.
   rewrite /sem_sop2 /= htrd /= !truncate_word_u /= truncate_word_u /=.
@@ -294,7 +294,7 @@ Qed.
 
 Lemma riscv_lload_correct : lload_correct_aux (lip_check_ws riscv_liparams) riscv_lload.
 Proof.
-  move=> xd xs ofs ws top s w vm heq hcheck.
+  move=> xd xs ofs ws top s w vm hcheck.
   t_xrbindP => ? hgets hto hread hset.
   move/eqP: hcheck => ?; subst ws.
   rewrite /riscv_lload /= hgets /= /sem_sop2 /= hto /=.

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -99,12 +99,10 @@ Definition x86_lmove (xd xs: var_i) :=
 
 Definition x86_check_ws (_: wsize) := true.
 
-Definition x86_lstore (xd : var_i) (ofs : Z) (xs :  var_i) :=
-  let ws := wsize_of_atype (vtype xs) in
+Definition x86_lstore (ws: wsize) (xd : var_i) (ofs : Z) (xs :  var_i) :=
   x86_lassign (Store Aligned ws (faddv Uptr xd (fconst Uptr ofs))) ws (Rexpr (Fvar xs)).
 
-Definition x86_lload (xd xs: var_i) (ofs : Z) :=
-  let ws := wsize_of_atype (vtype xd) in
+Definition x86_lload (ws: wsize) (xd xs: var_i) (ofs : Z) :=
   x86_lassign (LLvar xd) ws (Load Aligned ws (faddv Uptr xs (fconst Uptr ofs))).
 
 Definition x86_tmp := vname (v_var vtmpi).

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -224,7 +224,7 @@ Qed.
 
 Lemma x86_lstore_correct : lstore_correct_aux x86_check_ws x86_lstore.
 Proof.
-  move=> xd xs ofs ws w wp s m _ _ hgetd hgets hwr.
+  move=> xd xs ofs ws w wp s m _ hgetd hgets hwr.
   apply: x86_lassign_correct => /=; first by apply hgets.
   move: hgetd; t_xrbindP => ? hgetd hto.
   by rewrite hgetd /= /sem_sop2 /= hto /= !truncate_word_u /= truncate_word_u /= hwr.
@@ -235,7 +235,7 @@ Proof. apply/lstores_dfl_correct/x86_lstore_correct. Qed.
 
 Lemma x86_lload_correct : lload_correct_aux (lip_check_ws x86_liparams) x86_lload.
 Proof.
-  move=> xd xs ofs ws top s w vm _ hcheck; t_xrbindP => ? hgets hto hread hset.
+  move=> xd xs ofs ws top s w vm hcheck; t_xrbindP => ? hgets hto hread hset.
   apply: x86_lassign_correct => /=.
   + rewrite hgets /= /sem_sop2 /= hto /=.
     by rewrite !truncate_word_u /= truncate_word_u /= hread /= truncate_word_u.

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -224,8 +224,7 @@ Qed.
 
 Lemma x86_lstore_correct : lstore_correct_aux x86_check_ws x86_lstore.
 Proof.
-  move=> xd xs ofs ws w wp s m htxs _ hgetd hgets hwr.
-  rewrite /x86_lstore (wsize_of_atypeP (convertible_eval_atype htxs)).
+  move=> xd xs ofs ws w wp s m _ _ hgetd hgets hwr.
   apply: x86_lassign_correct => /=; first by apply hgets.
   move: hgetd; t_xrbindP => ? hgetd hto.
   by rewrite hgetd /= /sem_sop2 /= hto /= !truncate_word_u /= truncate_word_u /= hwr.
@@ -236,8 +235,7 @@ Proof. apply/lstores_dfl_correct/x86_lstore_correct. Qed.
 
 Lemma x86_lload_correct : lload_correct_aux (lip_check_ws x86_liparams) x86_lload.
 Proof.
-  move=> xd xs ofs ws top s w vm hc hcheck; t_xrbindP => ? hgets hto hread hset.
-  rewrite /x86_lload (wsize_of_atypeP (convertible_eval_atype hc)).
+  move=> xd xs ofs ws top s w vm _ hcheck; t_xrbindP => ? hgets hto hread hset.
   apply: x86_lassign_correct => /=.
   + rewrite hgets /= /sem_sop2 /= hto /=.
     by rewrite !truncate_word_u /= truncate_word_u /= hread /= truncate_word_u.


### PR DESCRIPTION
The parameters `lip_lload` and `lip_lstore` currently are specialized to memory accesses with size `Uptr`. This PR generalize them to take the access size as argument. This is in preparation of an other change that will reuse these functions in an other part of the linearization pass.

The PR is split in small commits to ease review.