### PR TITLE
Make linearization params more general

### DIFF
--- a/proofs/compiler/arm_params.v
+++ b/proofs/compiler/arm_params.v
@@ -128,7 +128,7 @@ Definition arm_set_up_sp_register
 Definition arm_tmp  : Ident.ident := vname (v_var vtmpi).
 Definition arm_tmp2 : Ident.ident := vname (v_var vtmp2i).
 
-Definition arm_lmove (xd xs : var_i) :=
+Definition arm_lmove (_: wsize) (xd xs : var_i) :=
   ([:: LLvar xd], Oarm (ARM_op MOV default_opts), [:: Rexpr (Fvar xs)]).
 
 Definition arm_check_ws ws := ws == reg_size.

--- a/proofs/compiler/arm_params_proof.v
+++ b/proofs/compiler/arm_params_proof.v
@@ -287,10 +287,10 @@ Qed.
 
 Lemma arm_lmove_correct : lmove_correct arm_liparams.
 Proof.
-  move=> xd xs w ws w' s htxd htxs hget htr.
+  move=> xd xs ws w s /eqP hws htxd; t_xrbindP => z hget htr; subst.
   rewrite /arm_liparams /lip_lmove /arm_lmove /= hget /=.
-  rewrite /exec_sopn /= htr /=.
-  by rewrite set_var_eq_type ?htxd.
+  rewrite /exec_sopn /= htr /= /set_var /=.
+  by case: vtype htxd.
 Qed.
 
 Lemma arm_lstore_correct : lstore_correct_aux arm_check_ws arm_lstore.

--- a/proofs/compiler/it_linearization_proof.v
+++ b/proofs/compiler/it_linearization_proof.v
@@ -377,11 +377,11 @@ Definition free_stack_frame_correct :=
   Eval hnf in sf_correct free_stack_frame (fun x y => x + y)%R.
 
 Definition lmove_correct :=
-  forall (xd xs : var_i) w ws (w':word ws) s,
-    vtype xd = aword Uptr -> convertible (vtype xs) (aword Uptr) ->
-    get_var true (evm s) xs = ok (Vword w') ->
-    truncate_word Uptr w' = ok w ->
-    sem_fopn_args (lip_lmove liparams xd xs) s = ok (with_vm s (evm s).[xd <- Vword w]).
+  forall (xd xs : var_i) ws w s,
+    lip_check_ws liparams ws ->
+    subatype (aword ws) (vtype xd) ->
+    get_var true (evm s) xs >>= to_word ws = ok w ->
+    sem_fopn_args (lip_lmove liparams ws xd xs) s = ok (with_vm s (evm s).[xd <- Vword w]).
 
 Definition lstore_correct_aux lip_check_ws lip_lstore :=
   forall (xd xs : var_i) ofs ws (w: word ws) wp s m,
@@ -654,17 +654,17 @@ Section HLIPARAMS.
   Context
     (hliparams : h_linearization_params).
 
-  Lemma spec_lmove {lp ii ls} {x y:var_i} (w : word Uptr) :
-    vtype x = aword Uptr ->
-    convertible (vtype y) (aword Uptr) ->
-    get_var true (lvm ls) (v_var y) = ok (Vword w) ->
-    let li := lmove liparams ii x y in
+  Lemma spec_lmove {lp ii ls} {x y:var_i} {ws} (w : word ws) :
+    lip_check_ws liparams ws ->
+    subatype (aword ws) (vtype x) ->
+    get_var true (lvm ls) (v_var y) >>= to_word ws = ok w ->
+    let li := lmove liparams ii ws x y in
     let s := to_estate ls in
     eval_instr lp li ls = ok (lnext_pc (lset_estate' ls (with_vm s (evm s).[x <- Vword w]))).
   Proof using hliparams.
-    move=> htx hty hget /=; rewrite -(lset_estate_same ls).
+    move=> hws htx hget /=; rewrite -(lset_estate_same ls).
     apply sem_fopn_args_eval_instr.
-    by rewrite (spec_lip_lmove hliparams (s:= to_estate ls) htx hty hget (truncate_word_u w)).
+    by rewrite (spec_lip_lmove hliparams (s:= to_estate ls) hws htx hget).
   Qed.
 
   Lemma spec_lstore {lp ii ls m ofs} {x y:var_i} {wx ws ws' wy'} {wy : word ws'} :
@@ -4302,11 +4302,11 @@ Qed.
         rewrite (mix_ilsteps_split_handle_call_cond (P:=P ++ lbody) (lc:=Q) _ ok_body); last by simpl_size; lia.
         rewrite catA in ok_body.
         rewrite (step_mix_ilsteps ok_body) //=; last by simpl_size;lia.
-        have hgetr2 : get_var true (lvm ls2) (mk_var_i {| vtype := stty; vname := saved_stack|}) = ok (Vword (top_stack (emem s1))).
-        + rewrite  -(get_var_eq_ex _ saved_stack_not_written K2); exact: hgetr.
+        have hgetr2 : get_var true (lvm ls2) (mk_var_i {| vtype := stty; vname := saved_stack|}) >>= to_word Uptr = ok (top_stack (emem s1)).
+        + by rewrite  -(get_var_eq_ex _ saved_stack_not_written K2) hgetr /= truncate_word_u.
         rewrite (@spec_lmove _ hliparams p' _ ls2
                   (vid (sp_rsp (p_extra p))) (mk_var_i {| vtype := stty; vname := saved_stack|}) _
-                  erefl hc hgetr2).
+                  _ (spec_lip_check_ws hliparams) (subatype_refl _) hgetr2).
         rewrite mix_ilsteps_b0 => //; last by rewrite /lnext_pc /= hpc2 addn1.
         rewrite bind_ret_l mix_ilsteps_0; last first.
         + by rewrite /handle_call_cond if_arg /in_fn /endpc /lnext_pc /= hfn2 eqxx ok_fd' /= hpc2 catA !size_cat /Q /= addn1 eqxx; case: ifP.

--- a/proofs/compiler/linearization.v
+++ b/proofs/compiler/linearization.v
@@ -113,13 +113,14 @@ Record linearization_params {asm_op : Type} {asmop : asmOp asm_op} :=
       -> seq fopn_args;
 
     (* Return the arguments for a linear instruction that corresponds to
-       a move between two registers.
-       In symbols, the linear instruction derived from [lip_lmove xd xs]
+       a move of the given size between two registers.
+       In symbols, the linear instruction derived from [lip_lmove ws xd xs]
        corresponds to:
-               xd := (Uptr)xs
+               xd := (ws)xs
      *)
     lip_lmove :
-      var_i       (* Destination variable. *)
+      wsize       (* Size of the moved value *)
+      -> var_i    (* Destination variable. *)
       -> var_i    (* Source variable. *)
       -> fopn_args;
 
@@ -295,10 +296,11 @@ Context
  *)
 Definition lmove
   (ii: instr_info)
+  (ws: wsize)
   (rd : var_i)      (* Destination register. *)
   (rs : var_i)       (* Source register. *)
   : linstr :=
-  li_of_fopn_args ii (lip_lmove liparams rd rs).
+  li_of_fopn_args ii (lip_lmove liparams ws rd rs).
 
 (* Return a linear instruction that corresponds to loading from memory.
    The linear instruction [lload rd rs ofs] corresponds to
@@ -802,7 +804,7 @@ Definition linear_body (fi: fun_info) (e: stk_fun_extra) (body: cmd) : label * l
           *       Setup stack.
           *)
          let r := mk_var_i x in
-         ( [:: lmove ret_ii rspi r ]
+         ( [:: lmove ret_ii Uptr rspi r ]
          , set_up_sp_register fentry_ii rspi sf_sz (sf_align e) r (mk_var_i var_tmp)
          , 1%positive
          )

--- a/proofs/compiler/riscv_params.v
+++ b/proofs/compiler/riscv_params.v
@@ -120,7 +120,7 @@ Definition riscv_set_up_sp_register
 Definition riscv_tmp  : Ident.ident := vname (v_var vtmpi).
 Definition riscv_tmp2 : Ident.ident := vname (v_var vtmp2i).
 
-Definition riscv_lmove (xd xs : var_i) :=
+Definition riscv_lmove (_: wsize) (xd xs : var_i) :=
   ([:: LLvar xd], Oriscv MV, [:: Rexpr (Fvar xs)]).
 
 Definition riscv_check_ws ws := ws == reg_size.

--- a/proofs/compiler/riscv_params_proof.v
+++ b/proofs/compiler/riscv_params_proof.v
@@ -264,10 +264,10 @@ Qed.
 
 Lemma riscv_lmove_correct : lmove_correct riscv_liparams.
 Proof.
-  move=> xd xs w ws w' s htxd htxs hget htr.
+  move=> xd xs ws w s /eqP hws htxd; t_xrbindP => z hget htr; subst.
   rewrite /riscv_liparams /lip_lmove /riscv_lmove /= hget /=.
-  rewrite /exec_sopn /= htr /=.
-  by rewrite set_var_eq_type ?htxd.
+  rewrite /exec_sopn /= htr /= /set_var /=.
+  by case: vtype htxd.
 Qed.
 
 Lemma riscv_lstore_correct : lstore_correct_aux riscv_check_ws riscv_lstore.

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -81,10 +81,18 @@ Definition x86_free_stack_frame (rspi: var_i) (tmp: option var_i) (sz: Z) :=
   let p := Fapp2 (Oadd (Op_w Uptr)) (Fvar rspi) (fconst Uptr sz) in
   [:: ([:: LLvar rspi ], Ox86 (LEA Uptr), [:: Rexpr p ])].
 
+Definition is_regx_e (e: rexpr) :=
+  if e is Rexpr (Fvar x) then is_regx x
+  else false.
+
+Definition is_regx_l (x: lexpr) :=
+  if x is LLvar x then is_regx x
+  else false.
+
 (* TODO: consider using VMOVDQA when the address is known to be aligned *)
 Definition x86_lassign (x: lexpr) (ws: wsize) (e: rexpr) :=
   let op := if (ws <= U64)%CMP
-            then MOV ws
+            then (if (is_regx_e e || is_regx_l x) && (U32 ≤ ws)%CMP then MOVX else MOV) ws
             else VMOVDQU ws
   in ([:: x ], Ox86 op, [:: e ]).
 

--- a/proofs/compiler/x86_params.v
+++ b/proofs/compiler/x86_params.v
@@ -102,8 +102,8 @@ Definition x86_set_up_sp_register
   let i2 := x86_op_align rspi Uptr al in
   i0 :: rcons (if sf_sz != 0%Z then x86_allocate_stack_frame rspi None sf_sz else [::]) i2.
 
-Definition x86_lmove (xd xs: var_i) :=
-  x86_lassign (LLvar xd) (wsize_of_atype (vtype xd)) (Rexpr (Fvar xs)).
+Definition x86_lmove ws (xd xs: var_i) :=
+  x86_lassign (LLvar xd) ws (Rexpr (Fvar xs)).
 
 Definition x86_check_ws (_: wsize) := true.
 

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -142,7 +142,10 @@ Lemma x86_lassign_correct s x ws e (w : word ws) s':
 Proof.
   move=> /=; t_xrbindP => v -> /= hv hwr.
   rewrite /exec_sopn /=.
-  case: ifP => /= h; rewrite hv /= /sopn_sem /sopn_sem_ /= /semi_to_atype computational_eq_refl.
+  case: ifP => /= h.
+  1: case: andP => [ [] hregx hws32 | hmov ] /=.
+  all: rewrite hv /= /sopn_sem /sopn_sem_ /= /semi_to_atype computational_eq_refl.
+  + by rewrite /x86_MOVX /size_32_64 hws32 h /= hwr.
   + by rewrite /x86_MOV /= /size_8_64 h /= hwr.
   by rewrite /x86_VMOVDQ (wsize_nle_u64_size_128_256 h) /= hwr.
 Qed.

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -222,11 +222,12 @@ Qed.
 
 Lemma x86_lmove_correct : lmove_correct x86_liparams.
 Proof.
-  move=> xd xs w ws w' s htxd htxs hget htr.
+  move=> xd xs ws w s _ htxd hget.
   rewrite /x86_liparams /lip_lmove /x86_lmove.
-  rewrite htxd; apply: x86_lassign_correct => /=.
-  + by rewrite hget /= htr.
-  by rewrite set_var_eq_type ?htxd.
+  apply: x86_lassign_correct => /=.
+  + exact: hget.
+  rewrite /set_var /=.
+  by case: vtype htxd.
 Qed.
 
 Lemma x86_lstore_correct : lstore_correct_aux x86_check_ws x86_lstore.

--- a/proofs/compiler/x86_params_proof.v
+++ b/proofs/compiler/x86_params_proof.v
@@ -134,6 +134,21 @@ Definition vm_op_align
     .[to_var ZF <- ZF_of_word w]
     .[x <- Vword w].
 
+Lemma x86_lassign_correct s x ws e (w : word ws) s':
+  let lcmd := x86_lassign x ws e in
+  sem_rexpr (emem s) (evm s) e >>= to_word ws = ok w ->
+  write_lexpr x (Vword w) s = ok s' ->
+  sem_fopn_args lcmd s = ok s'.
+Proof.
+  move=> /=; t_xrbindP => v -> /= hv hwr.
+  rewrite /exec_sopn /=.
+  case: ifP => /= h; rewrite hv /= /sopn_sem /sopn_sem_ /= /semi_to_atype computational_eq_refl.
+  + by rewrite /x86_MOV /= /size_8_64 h /= hwr.
+  by rewrite /x86_VMOVDQ (wsize_nle_u64_size_128_256 h) /= hwr.
+Qed.
+
+Opaque x86_lassign.
+
 Context {call_conv : calling_convention}.
 
 Lemma x86_spec_lip_allocate_stack_frame :
@@ -163,7 +178,9 @@ Proof.
   move=> [ [? nrsp] vi1] [[tyr nr] vi2] tmp ts al sz s + /= ? hc _ _ +  _ /=; subst.
   set vrsp := {| vname := nrsp |}; set rsp := {| v_var := vrsp |}.
   set r := {| vname := nr |} => hget hne.
-  rewrite hget /= /exec_sopn /= truncate_word_u /= /set_var /= (convertible_eval_atype hc) /=.
+  erewrite x86_lassign_correct => /=; last first.
+  + by rewrite /set_var /= (convertible_eval_atype hc).
+  + by rewrite hget /= truncate_word_u.
   rewrite -cats1 sem_fopns_args_cat.
   set vm0 := (evm s).[r <- Vword ts].
   set vm2 := if sz != 0%Z then vm0.[vrsp <- Vword (ts - wrepr Uptr sz)] else vm0.
@@ -198,19 +215,6 @@ Proof.
   rewrite Vm.setP_neq //.
   case: f;
     by repeat (rewrite Vm.setP_neq; last by apply /eqP => h; have := inj_to_var h); rewrite Vm.setP_eq.
-Qed.
-
-Lemma x86_lassign_correct s x ws e (w : word ws) s':
-  let lcmd := x86_lassign x ws e in
-  sem_rexpr (emem s) (evm s) e >>= to_word ws = ok w ->
-  write_lexpr x (Vword w) s = ok s' ->
-  sem_fopn_args lcmd s = ok s'.
-Proof.
-  move=> /=; t_xrbindP => v -> /= hv hwr.
-  rewrite /exec_sopn /=.
-  case: ifP => /= h; rewrite hv /= /sopn_sem /sopn_sem_ /= /semi_to_atype computational_eq_refl.
-  + by rewrite /x86_MOV /= /size_8_64 h /= hwr.
-  by rewrite /x86_VMOVDQ (wsize_nle_u64_size_128_256 h) /= hwr.
 Qed.
 
 Lemma x86_lmove_correct : lmove_correct x86_liparams.


### PR DESCRIPTION
The changes in this PR are meant to prepare future changes to linearization.

1. On x86, assignments (load/store/move) now emit `MOVX` instead of `MOV` when MMX registers are involved.
2. The `lip_lmove` parameter now takes a wsize as argument (and its correctness conditions are slightly modified).