### PR TITLE
Update mathcomp-word

### DIFF
--- a/docs/source/misc/installation_guide.md
+++ b/docs/source/misc/installation_guide.md
@@ -198,7 +198,7 @@ The dependencies of the Coq development are as follows:
 
   - [Coq](https://coq.inria.fr/) at version 9.0
   - The [Mathematical Components](https://math-comp.github.io/) library, at version 2.4 (only the following sub-libraries are required: ssreflect, fingroup, algebra)
-  - The [mathcomp-word](https://github.com/jasmin-lang/coqword) library, at version 3.4
+  - The [mathcomp-word](https://github.com/jasmin-lang/coqword) library, at version 3.5
   - The [Interaction Trees](https://github.com/DeepSpec/InteractionTrees) library, at version 5.2.1
 
 The file `default.nix` at the root of the repository contains a precise description of these dependencies.

--- a/opam
+++ b/opam
@@ -38,7 +38,7 @@ depends: [
   "coq-elpi" {>= "2.5.1"}
   "coq-mathcomp-ssreflect" {>= "2.4" & < "2.7~"}
   "coq-mathcomp-algebra"
-  "coq-mathcomp-word" {>= "3.4"}
+  "coq-mathcomp-word" {>= "3.5"}
   "coq-paco"
   "coq-itree"
 ]

--- a/proofs/lang/word.v
+++ b/proofs/lang/word.v
@@ -647,7 +647,7 @@ Proof. exact: wN1E. Qed.
 
 Lemma w0E sz i :
   @wbit_n sz 0%R i  = false.
-Proof. exact: Z.testbit_0_l. Qed.
+Proof. exact: wbit0. Qed.
 
 Lemma wnotE sz (w: word sz) (i: 'I_(wsize_size_minus_1 sz).+1) :
   wbit_n (wnot w) i = ~~ wbit_n w i.
@@ -682,7 +682,7 @@ Proof.
   congr wunsigned.
   rewrite wshr_alt /wshr_naive -urepr_lsr ureprK.
   apply/eqP/eq_from_wbit_n => i.
-  rewrite /wbit_n wbit_lsr wunsigned_repr /wbit.
+  rewrite /wbit_n wbit_lsr wunsigned_repr !wbit_spec.
   rewrite Z.mod_small //.
   rewrite Z.div_pow2_bits.
   2-3: lia.
@@ -713,12 +713,12 @@ Proof.
   congr wunsigned.
   apply/eqP/eq_from_wbit_n => i.
   rewrite /wbit_n wunsigned_repr /modulus two_power_nat_equiv.
-  rewrite {2}/wbit Z.mod_pow2_bits_low; last first.
+  rewrite (wbit_spec (_ mod _)) Z.mod_pow2_bits_low; last first.
   - move/ltP: (ltn_ord i); lia.
   case: (@ltP i c); last first.
   - move => c_le_i.
     have i_eq : nat_of_ord i = (c + (i - c))%nat by lia.
-    rewrite i_eq wbit_lsl -i_eq ltn_ord /wbit.
+    rewrite i_eq wbit_lsl -i_eq ltn_ord wbit_spec.
     rewrite Z.mul_pow2_bits; last by lia.
     congr Z.testbit.
     lia.
@@ -1005,7 +1005,7 @@ rewrite /zero_extend /wbit_n /wunsigned /wrepr.
 move: (urepr w) => {w} z.
 rewrite mkwordK.
 set m := wsize_size_minus_1 _.
-rewrite /mathcomp.word.word.wbit /=.
+rewrite !wbit_spec.
 rewrite /modulus two_power_nat_equiv.
 case: leP => hi.
 + rewrite Z.mod_pow2_bits_low //; lia.
@@ -1858,7 +1858,7 @@ Proof. have := pow2pos q; lia. Qed.
 Lemma wbit_n_pow2m1 sz (n i: nat) :
   wbit_n (wrepr sz (2 ^ Z.of_nat n - 1)) i = (i < Nat.min n (wsize_size_minus_1 sz).+1)%nat.
 Proof.
-  rewrite /wbit_n /mathcomp.word.word.wbit wunsigned_repr /modulus two_power_nat_equiv.
+  rewrite /wbit_n wbit_spec wunsigned_repr /modulus two_power_nat_equiv.
   case: (le_lt_dec (wsize_size_minus_1 sz).+1 i) => hi.
   - rewrite Z.mod_pow2_bits_high; last lia.
     symmetry; apply/negbTE/negP => /ltP.
@@ -2262,9 +2262,9 @@ Lemma subword_make_vec_bits_low (n m : nat) x y :
 Proof.
   move=> h.
   apply/eqP/word.eq_from_wbit => i.
-  rewrite subwordE wbit_t2wE /word.word.wbit mkword_valK /=.
+  rewrite subwordE wbit_t2wE mkword_valK /=.
   rewrite (nth_map i); last by rewrite size_enum_ord.
-  rewrite addn0 nth_ord_enum modulusZE.
+  rewrite !wbit_spec addn0 nth_ord_enum modulusZE.
   rewrite Z.shiftl_0_l Z.lor_0_r.
   rewrite Z.mod_pow2_bits_low.
   - rewrite Z.lor_spec Z.shiftl_spec_low; first by rewrite orbF.

--- a/scripts/mathcomp-word.nix
+++ b/scripts/mathcomp-word.nix
@@ -2,7 +2,7 @@
 
 let inherit (coqPackages) coq; in
 
-let rev = "3df23a6ea0bffdeaf9211368cf6d4b46e2d0ebd0"; in
+let rev = "86ed49aeca65a8d32e81bb386778f49b45ee505b"; in
 
 stdenv.mkDerivation rec {
   version = "3.5-git-${builtins.substring 0 8 rev}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "jasmin-lang";
     repo = "coqword";
     inherit rev;
-    hash = "sha256-tPrVwYn783LKzkbW0aDX3frpgW7uFOh/z0wOZQhZaao=";
+    hash = "sha256-TdjMp/4Eo9uEcUWhV3OSy/eX1GzQO2nhym3MNTzNvwY=";
   };
 
   buildInputs = [ coq ocaml dune ];


### PR DESCRIPTION
The first commit makes use of `wbit_spec` (therefore requires version 3.5), allowing the second commit that brings a new implementation of `testbit`.