### PR TITLE
eclib: remove deprecated JModel.ec

### DIFF
--- a/changes/03-other/1543-exit-jmodel.md
+++ b/changes/03-other/1543-exit-jmodel.md
@@ -1,0 +1,3 @@
+- The EasyCrypt theory `JModel` has been removed after being deprecated since
+  version 2023.06.0
+  ([PR #1543](https://github.com/jasmin-lang/jasmin/pull/1543)).

--- a/eclib/JModel.ec
+++ b/eclib/JModel.ec
@@ -1,3 +1,0 @@
-(** This module has been deprecated since May 2023 and is only provided for compatibility purposes.
-  * Please use JModel_x86 or JLeakage directly instead. *)
-require export JModel_x86 JLeakage.


### PR DESCRIPTION
# Description

This file has been deprecated since version 2023.06.0 (see #417). Let’s remove it.

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
