### PR TITLE
CI: use packaged mathcomp-word

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,7 @@ let coqPackages =
       coq = super.coq.override { version = "master"; inherit rocqPackages; };
       inherit (rocqPackages) stdlib;
       mathcomp = super.mathcomp.override { version = "master"; };
+      mathcomp-word = super.mathcomp-word.override { version = "master"; };
       mathcomp-zify = super.mathcomp-zify.override { version = "master"; };
       coq-elpi = super.coq-elpi.override { version = "master"; inherit elpi-version; };
       hierarchy-builder = super.hierarchy-builder.override { version = "master"; };
@@ -43,10 +44,9 @@ let coqPackages =
       };
       hierarchy-builder = super.hierarchy-builder.override { version = "1.9.1"; };
       mathcomp = super.mathcomp.override { version = "2.4.0"; };
-  })
+      mathcomp-word = callPackage scripts/mathcomp-word.nix { inherit super; };
+    })
 ; in
-
-let mathcomp-word = callPackage scripts/mathcomp-word.nix { inherit coqPackages; }; in
 
 let easycrypt = callPackage scripts/easycrypt.nix {
   inherit ecRef;
@@ -80,7 +80,7 @@ stdenv.mkDerivation {
   buildInputs = []
     ++ optionals coqDeps [
       coqPackages.coq
-      mathcomp-word
+      coqPackages.mathcomp-word
       coqPackages.ITree
     ]
     ++ optionals testDeps ([ curl.bin oP.apron.out llvmPackages.bintools-unwrapped ] ++ (with python3Packages; [ python pyyaml ]))

--- a/scripts/mathcomp-word.nix
+++ b/scripts/mathcomp-word.nix
@@ -1,43 +1,13 @@
-{ stdenv, lib, fetchFromGitHub, coqPackages, ocaml, dune }:
-
-let inherit (coqPackages) coq; in
+{ super, lib, fetchFromGitHub, }:
 
 let rev = "86ed49aeca65a8d32e81bb386778f49b45ee505b"; in
 
-stdenv.mkDerivation rec {
-  version = "3.5-git-${builtins.substring 0 8 rev}";
-  pname = "coq${coq.coq-version}-mathcomp-word";
-
+super.mathcomp-word.overrideAttrs (o: {
+  name = "${(lib.parseDrvName o.name).name}-3.5-git-${builtins.substring 0 8 rev}";
   src = fetchFromGitHub {
     owner = "jasmin-lang";
     repo = "coqword";
     inherit rev;
     hash = "sha256-TdjMp/4Eo9uEcUWhV3OSy/eX1GzQO2nhym3MNTzNvwY=";
   };
-
-  buildInputs = [ coq ocaml dune ];
-
-  propagatedBuildInputs = (with coqPackages.mathcomp; [ algebra fingroup ssreflect ])
-  ++ [ coqPackages.stdlib ];
-
-  buildPhase = ''
-    runHook preBuild
-    dune build -p coq-mathcomp-word
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    dune install --prefix=$out
-    mkdir -p $out/lib/coq/${coq.coq-version}/
-    mv $out/lib/coq/user-contrib $out/lib/coq/${coq.coq-version}/
-    runHook postInstall
-  '';
-
-  meta = {
-    description = "Yet Another Coq Library on Machine Words";
-    license = lib.licenses.mit;
-    inherit (src.meta) homepage;
-    inherit (coq.meta) platforms;
-  };
-}
+})


### PR DESCRIPTION
This should help with two things (conjecture):

- maintenance of the build script for mathcomp-word (which is no longer in this repo and delegated to <placeholder>);
- keeping the `coq-master` consistent with what other CI use (the development version of everything — well, sort of).