### PR TITLE
Stack allocation: enforce a per-architecture minimal stack-pointer alignment

### DIFF
--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -35,6 +35,14 @@ module type Core_arch = sig
 
   val callstyle : reg callstyle
 
+  (* Minimal alignment of every stack frame. Frame sizes are rounded up to
+     the frame's alignment (see [stack_frame_allocation_size]), so this
+     bounds the alignment the stack pointer keeps across calls. Armv7-M
+     forces stack-pointer writes to 4-byte alignment (Arm v7-M Architecture
+     Reference Manual, B1.5.7); the other architectures have no requirement
+     beyond the one of the stack slots themselves. *)
+  val sp_min_align : Wsize.wsize
+
   val known_implicits : (Name.t * string) list
 
   val is_ct_asm_op : asm_op -> bool

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -37,6 +37,9 @@ module type Core_arch = sig
 
   val callstyle : reg callstyle
 
+  (* Minimal alignment of every stack frame; see arch_full.ml. *)
+  val sp_min_align : Wsize.wsize
+
   val known_implicits : (Name.t * string) list
 
   val is_ct_asm_op : asm_op -> bool

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -56,7 +56,11 @@ module Arm (Lowering_params : Arm_input) : Arch_full.Core_arch
 
   let callstyle = Arch_full.ByReg { call = Some LR; return = false }
 
-  let sp_min_align = Wsize.U8
+  (* Armv7-M guarantees that stack pointer values are at least 4-byte
+     aligned: writes to SP force bits [1:0] to zero (Arm v7-M Architecture
+     Reference Manual, B1.5.7), so a frame moving SP by a non-multiple of 4
+     would be silently rounded by the hardware. *)
+  let sp_min_align = Wsize.U32
 
   let internal_call_conv = Arm_decl.arm_internal_call_conv
 end

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -56,5 +56,7 @@ module Arm (Lowering_params : Arm_input) : Arch_full.Core_arch
 
   let callstyle = Arch_full.ByReg { call = Some LR; return = false }
 
+  let sp_min_align = Wsize.U8
+
   let internal_call_conv = Arm_decl.arm_internal_call_conv
 end

--- a/compiler/src/riscv_arch_full.ml
+++ b/compiler/src/riscv_arch_full.ml
@@ -50,5 +50,7 @@ module Riscv (Lowering_params : Riscv_input) : Arch_full.Core_arch
 
   let callstyle = Arch_full.ByReg { call = Some RA; return = true }
 
+  let sp_min_align = Wsize.U8
+
   let internal_call_conv = Riscv_decl.riscv_internal_call_conv
 end

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -106,6 +106,19 @@ module StackAlloc (Arch: Arch_full.Arch) = struct
 
 module Regalloc = Regalloc (Arch)
 
+(* Keep the stack pointer [Arch.sp_min_align]-aligned across calls: frame
+   sizes are rounded up to the frame alignment
+   ([stack_frame_allocation_size]), so raise the alignment of every function
+   that actually uses the stack. Functions with no stack footprint at all
+   keep their alignment (an export function may only use SavedStackNone when
+   its alignment is U8). *)
+let enforce_sp_min_align ~stack_size ~extra_size ~max_stk align =
+  if Z.equal max_stk Z.zero
+     && Z.equal stack_size Z.zero
+     && extra_size = 0
+  then align
+  else Utils0.cmp_max wsize_cmp align Arch.sp_min_align
+
 let memory_analysis pp_sr pp_err ~debug callee_saved_strategy up =
   if debug then Format.eprintf "START memory analysis@.";
   let p = Conv.prog_of_cuprog up in
@@ -286,6 +299,12 @@ let memory_analysis pp_sr pp_err ~debug callee_saved_strategy up =
           align, max_stk, max_call_depth
         ) sao.sao_calls (align, Z.zero, Z.zero) in
 
+    let align =
+      enforce_sp_min_align
+        ~stack_size:(Conv.z_of_cz csao.Stack_alloc.sao_size)
+        ~extra_size ~max_stk align
+    in
+
     (* if we zeroize the stack, we ensure that the max size is a multiple of the
        size of the clear step. We use [fd.f_annot.stack_zero_strategy] and not
        [align], this is on purpose! We know that the first one divides the
@@ -387,6 +406,12 @@ let memory_analysis pp_sr pp_err ~debug callee_saved_strategy up =
           let max_call_depth = Z.max max_call_depth fn_max_call_depth in
           align, max_stk, max_call_depth
         ) sao.sao_calls (align, Z.zero, Z.zero) in
+
+    let align =
+      enforce_sp_min_align
+        ~stack_size:(Conv.z_of_cz csao.Stack_alloc.sao_size)
+        ~extra_size ~max_stk align
+    in
     (* if we zeroize the stack, we may have to increase the alignment *)
     let align =
       match fd.f_cc, fd.f_annot.stack_zero_strategy with

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -38,6 +38,8 @@ module X86_core = struct
 
   let callstyle = Arch_full.StackDirect
 
+  let sp_min_align = Wsize.U8
+
   let known_implicits = ["OF","_of_"; "CF", "_cf_"; "SF", "_sf_"; "ZF", "_zf_"]
 
   let alloc_stack_need_extra _ = false

--- a/compiler/tests/success/arm-m4/unaligned_stackalign.jazz
+++ b/compiler/tests/success/arm-m4/unaligned_stackalign.jazz
@@ -1,0 +1,15 @@
+/* The unaligned 16-bit access is taken into account when computing the
+ * alignment for the stack variable, but the frame alignment is floored at
+ * u32: Armv7-M forces stack-pointer writes to 4-byte alignment (Arm v7-M
+ * Architecture Reference Manual, B1.5.7). */
+#[stackalign=u32, callee_saved = 0]
+export
+fn instack(reg u32 x) -> reg u32 {
+  reg u32 r;
+  stack u8[3] s;
+  r = 0;
+  s[0] = r;
+  s.[:u16 1] = (16u)x;
+  r = (32s)s[:u8 1];
+  return r;
+}

--- a/compiler/tests/success/common/unaligned.jazz
+++ b/compiler/tests/success/common/unaligned.jazz
@@ -6,17 +6,3 @@ fn main(reg u32 x) -> reg u32 {
   x = a.[#unaligned 2];
   return x;
 }
-
-/* This example shows that the unaligned 16-bit access is taken into account
-  * when computing the alignment for the stack variable. */
-#[stackalign=u16, callee_saved = 0]
-export
-fn instack(reg u32 x) -> reg u32 {
-  reg u32 r;
-  stack u8[3] s;
-  r = 0;
-  s[0] = r;
-  s.[:u16 1] = (16u)x;
-  r = (32s)s[:u8 1];
-  return r;
-}

--- a/compiler/tests/success/risc-v/unaligned_stackalign.jazz
+++ b/compiler/tests/success/risc-v/unaligned_stackalign.jazz
@@ -1,0 +1,13 @@
+/* This example shows that the unaligned 16-bit access is taken into account
+ * when computing the alignment for the stack variable. */
+#[stackalign=u16, callee_saved = 0]
+export
+fn instack(reg u32 x) -> reg u32 {
+  reg u32 r;
+  stack u8[3] s;
+  r = 0;
+  s[0] = r;
+  s.[:u16 1] = (16u)x;
+  r = (32s)s[:u8 1];
+  return r;
+}

--- a/compiler/tests/success/x86-64/unaligned_stackalign.jazz
+++ b/compiler/tests/success/x86-64/unaligned_stackalign.jazz
@@ -1,0 +1,13 @@
+/* This example shows that the unaligned 16-bit access is taken into account
+ * when computing the alignment for the stack variable. */
+#[stackalign=u16, callee_saved = 0]
+export
+fn instack(reg u32 x) -> reg u32 {
+  reg u32 r;
+  stack u8[3] s;
+  r = 0;
+  s[0] = r;
+  s.[:u16 1] = (16u)x;
+  r = (32s)s[:u8 1];
+  return r;
+}


### PR DESCRIPTION
Split out of #1541, as suggested in review: the mechanism is independent of the ARMv8-A backend.

- **First commit**: add an `sp_min_align` architecture parameter bounding the alignment the stack pointer keeps across calls; stack allocation raises the frame alignment of every function that actually uses the stack up to it (frame sizes are rounded up to the frame alignment, so this bounds the SP alignment itself). All architectures declare `U8`, so no generated code changes.
- **Second commit**: set it to `U32` on arm-m4. Armv7-M guarantees that stack pointer values are at least 4-byte aligned — writes to SP force bits [1:0] to zero (Arm v7-M Architecture Reference Manual, B1.5.7) — so a frame that is only 1- or 2-byte aligned lets the export prologue write a non-4-byte-aligned SP (`BIC r12, r12, #1` before `MOV sp, r12`), which the hardware silently rounds, shifting every subsequent SP-relative access. The new `tests/success/arm-m4/unaligned_stackalign.jazz` asserts the computed alignment with `#[stackalign=u32]` and fails without this commit; the `instack` function of `tests/success/common/unaligned.jazz` moves to per-architecture copies since the expected alignment is now architecture-dependent.

No command-line override: the per-architecture default is the only value with a real use case.

The ARMv8-A backend (#1541) relies on this mechanism with a 16-byte floor (AArch64 SP alignment checking); once this lands, the corresponding hunks disappear from that PR.
