### PR TITLE
Extract global

### DIFF
--- a/changes/01-feature/1549-extract-global.md
+++ b/changes/01-feature/1549-extract-global.md
@@ -1,0 +1,8 @@
+- Global variables can now be extracted to EasyCrypt as operators
+  instead of abbreviations, and their machine words can be printed as
+  signed or unsigned integers. The default is selected by the
+  `--global-model` command line argument of `jasmin2ec` and can be
+  overridden for each global variable by the `#[abbrev]`, `#[op]`, and
+  `#[sign=...]` annotations; see the
+  [documentation](https://jasmin-lang.readthedocs.io/en/latest/tools/jasmin2ec.html#extraction-of-global-variables)
+  ([PR #1549](https://github.com/jasmin-lang/jasmin/pull/1549)).

--- a/compiler/entry/jasmin2ec.ml
+++ b/compiler/entry/jasmin2ec.ml
@@ -3,8 +3,8 @@ open Cmdliner
 open CommonCLI
 open Utils
 
-let extract_to_file prog arch pd msfsz asmOp model amodel fnames array_dir
-    outfile =
+let extract_to_file prog arch pd msfsz asmOp model amodel global_options
+    fnames array_dir outfile =
   let array_dir =
     if array_dir = None then Option.map Filename.dirname outfile else array_dir
   in
@@ -20,7 +20,8 @@ let extract_to_file prog arch pd msfsz asmOp model amodel fnames array_dir
     BatPervasives.finally
       (fun () -> close ())
       (fun () ->
-        ToEC.extract prog arch pd msfsz asmOp model amodel fnames array_dir fmt)
+        ToEC.extract prog arch pd msfsz asmOp model amodel global_options
+          fnames array_dir fmt)
       ()
   with e ->
     BatPervasives.ignore_exceptions
@@ -30,14 +31,19 @@ let extract_to_file prog arch pd msfsz asmOp model amodel fnames array_dir
 
 let parse_and_extract arch call_conv idirs =
   let module A = (val CoreArchFactory.get_arch_module arch call_conv) in
-  let extract model amodel functions array_dir output pass file =
+  let extract model amodel global_options functions array_dir output pass file =
     let prog = parse_and_compile (module A) ~wi2i:true pass file idirs in
-    extract_to_file prog arch A.reg_size A.msf_size A.asmOp model amodel
-      functions array_dir output
+    try
+      extract_to_file prog arch A.reg_size A.msf_size A.asmOp model amodel
+        global_options functions array_dir output
+    with Annot.AnnotationError (loc, code) ->
+      hierror ~loc:(Lone loc) ~kind:"annotation error" "%t" code
   in
-  fun model amodel functions array_dir output pass file warn ->
+  fun model amodel global_options functions array_dir output pass file warn ->
     if not warn then nowarning ();
-    match extract model amodel functions array_dir output pass file with
+    match
+      extract model amodel global_options functions array_dir output pass file
+    with
     | () -> ()
     | exception HiError e ->
         Format.eprintf "%a@." pp_hierror e;
@@ -70,6 +76,80 @@ let array_model =
      (Deprecated) $(b,old): old representation for array operations (anonymous functions instead of eclib functions)."
   in
   Arg.(value & opt (Arg.enum alts) ToEC.BArray & info [ "array-model" ] ~doc)
+
+(* The extraction of global variables is configured by the repeatable
+   --global-model option, whose value selects either the kind of the EasyCrypt
+   declaration (abbrev, op, op=OPTIONS) or how the machine words are printed
+   (sign=signed, sign=unsigned). *)
+let global_model =
+  (* Each occurrence of the option is a “key” or a “key = value”; the spaces
+     around the “=” are ignored. *)
+  let alts = [ "abbrev"; "op"; "op=OPTIONS"; "sign=signed"; "sign=unsigned" ] in
+  let sign =
+    Arg.enum [ ("signed", ToEC.GlobSigned); ("unsigned", ToEC.GlobUnsigned) ]
+  in
+  (* the shell usually removes the quotes of “op="opaque smt_opaque"”, but they
+     reach us when written as --global-model='op="opaque smt_opaque"' *)
+  let unquote s =
+    let n = String.length s in
+    if n >= 2 && s.[0] = '"' && s.[n - 1] = '"' then
+      String.trim (String.lchop (String.rchop s))
+    else s
+  in
+  let parse s =
+    let key, value =
+      match String.split s ~by:"=" with
+      | key, value -> (String.trim key, Some (String.trim value))
+      | exception Not_found -> (String.trim s, None)
+    in
+    match (key, value) with
+    | "abbrev", None -> Ok (`Model ToEC.GlobAbbrev)
+    | "op", None -> Ok (`Model (ToEC.GlobOp ""))
+    | "op", Some opts -> Ok (`Model (ToEC.GlobOp (unquote opts)))
+    | "sign", Some v -> (
+        match Arg.conv_parser sign v with
+        | Ok s -> Ok (`Sign s)
+        | Error (`Msg e) -> Error (`Msg e))
+    | _ ->
+        Error
+          (`Msg
+            (Format.sprintf "invalid value “%s”, must be %s" s
+               (Arg.doc_alts ~quoted:true alts)))
+  in
+  let pp fmt = function
+    | `Model g -> Format.pp_print_string fmt (ToEC.string_of_gmodel g)
+    | `Sign g -> Format.fprintf fmt "sign=%s" (ToEC.string_of_gsign g)
+  in
+  let doc =
+    "How global variables are extracted; this option may be repeated, the last
+     value of each kind wins (the spaces around the '=' are optional).
+     $(b,abbrev) (the default): as EasyCrypt abbreviations.
+     $(b,op): as EasyCrypt operators.
+     $(b,op)=$(i,OPTIONS): as EasyCrypt operators declared with the given
+     options, e.g. $(b,op=\"opaque smt_opaque\"); the options are passed to
+     EasyCrypt as such.
+     These defaults can be overridden for each global variable using the
+     $(b,#[abbrev]) and $(b,#[op]) annotations.
+     $(b,sign=signed) (the default): the machine words are printed as integers
+     in [-2^(n-1), 2^(n-1)), e.g. $(b,W64.of_int (-1)).
+     $(b,sign=unsigned): they are printed as integers in [0, 2^n), e.g.
+     $(b,W64.of_int 18446744073709551615).
+     Both denote the same words, but the unsigned form avoids the unary minus,
+     which is cheaper to handle in EasyCrypt."
+  in
+  let global_options =
+    List.fold_left
+      (fun (global_options : ToEC.global_options) -> function
+        | `Sign gsign -> { global_options with gsign }
+        | `Model gmodel -> { global_options with gmodel })
+      ToEC.default_global_options
+  in
+  Term.(
+    const global_options
+    $ Arg.(
+        value
+        & opt_all (conv (parse, pp)) []
+        & info [ "global-model" ] ~docv:"MODEL" ~doc))
 
 let functions =
   let doc =
@@ -117,5 +197,6 @@ let () =
   Cmd.v info
     Term.(
       const parse_and_extract $ arch $ call_conv $ idirs $ model $ array_model
-      $ functions $ array_dir $ output $ after_pass $ file $ warn)
+      $ global_model $ functions $ array_dir $ output $ after_pass
+      $ file $ warn)
   |> Cmd.eval |> exit

--- a/compiler/examples/extraction-unit-tests/.gitignore
+++ b/compiler/examples/extraction-unit-tests/.gitignore
@@ -5,3 +5,7 @@ sdiv.ec
 string.ec
 Array2.ec
 BArray2.ec
+globals.ec
+globals_unsigned.ec
+BArray16.ec
+WArray16.ec

--- a/compiler/examples/extraction-unit-tests/Makefile
+++ b/compiler/examples/extraction-unit-tests/Makefile
@@ -13,7 +13,9 @@ all: proofs.ec $(EXTRACTED)
 clean:
 	$(RM) $(EXTRACTED)
 
+globals_unsigned.ec: JASMIN2ECFLAGS = --global-model sign=unsigned
+
 %.ec: %.jazz $(JASMIN2EC)
-	$(JASMIN2EC) -o $@ $<
+	$(JASMIN2EC) $(JASMIN2ECFLAGS) -o $@ $<
 
 .PHONY: all

--- a/compiler/examples/extraction-unit-tests/globals.jazz
+++ b/compiler/examples/extraction-unit-tests/globals.jazz
@@ -1,0 +1,41 @@
+/* Extraction of global variables: abbrev (the default) or op, with options. */
+
+u64 g_dflt = 37;
+
+#[abbrev]
+u64 g_abbrev = 38;
+
+#[op]
+u64 g_op = 39;
+
+#[op=opaque]
+u64 g_opaque = 40;
+
+#[op="opaque smt_opaque"]
+u64 g_both = 41;
+
+#[op=smt_opaque]
+u64[2] g_array = {42, 43};
+
+/* The #[sign] annotation overrides --global-model sign=... (here: signed). */
+u64 g_signed = -1;
+
+#[sign=unsigned]
+u64 g_unsigned = -1;
+
+#[op=opaque, sign=unsigned]
+u64[2] g_opaque_unsigned = {-1, 45};
+
+export fn main() -> reg u64 {
+  reg u64 r;
+  r = g_dflt;
+  r += g_abbrev;
+  r += g_op;
+  r += g_opaque;
+  r += g_both;
+  r += g_array[1];
+  r += g_signed;
+  r += g_unsigned;
+  r += g_opaque_unsigned[0];
+  return r;
+}

--- a/compiler/examples/extraction-unit-tests/globals_unsigned.jazz
+++ b/compiler/examples/extraction-unit-tests/globals_unsigned.jazz
@@ -1,0 +1,19 @@
+/* Extraction of the words of global variables as unsigned integers:
+   this file is extracted with --global-model sign=unsigned (see the Makefile). */
+
+u64 g_neg = -1;
+
+u64[2] g_array = {-1, 2};
+
+/* … except for the variables carrying a #[sign] annotation. */
+#[sign=signed]
+u64 g_signed = -1;
+
+export fn main() -> reg u64 {
+  reg u64 r;
+  r = g_neg;
+  r += g_array[0];
+  r += g_array[1];
+  r += g_signed;
+  return r;
+}

--- a/compiler/src/conv.ml
+++ b/compiler/src/conv.ml
@@ -332,11 +332,12 @@ let prog_of_csprog p =
 
 
 (* ---------------------------------------------------------------------------- *)
-let to_array ty len t =
+let to_array ?(signed = true) ty len t =
   let ws, n = array_kind ty in
+  let of_word = if signed then z_of_word else z_unsigned_of_word in
   let get i =
     match Warray_.WArray.get len Aligned Warray_.AAscale ws t (cz_of_int i) with
-    | Utils0.Ok w -> z_of_word ws w
+    | Utils0.Ok w -> of_word ws w
     | _    -> assert false in
   ws, Array.init n get
 

--- a/compiler/src/conv.mli
+++ b/compiler/src/conv.mli
@@ -55,7 +55,10 @@ val fdef_of_csfdef : Var0.funname * 'asm Expr._sfundef -> (unit, 'asm) sfundef
 
 val prog_of_csprog : 'asm Expr._sprog -> (unit, 'asm) sprog
 
-val to_array : 
+(* [signed] (true by default) tells whether the elements are returned as signed
+   integers (in [-2^(n-1), 2^(n-1))) or as unsigned ones (in [0, 2^n)). *)
+val to_array :
+  ?signed:bool ->
   Prog.ty -> BinNums.coq_Z -> Warray_.WArray.array -> wsize * Z.t array
 
 val error_of_cerror :

--- a/compiler/src/latex_printer.ml
+++ b/compiler/src/latex_printer.ml
@@ -345,8 +345,9 @@ let pp_pgexpr fmt = function
       (pp_list ",@ " pp_expr) es
       closebrace ()
 
-let pp_global fmt { pgd_type ; pgd_name ; pgd_val } =
-  F.fprintf fmt "%a %a = %a;"
+let pp_global fmt { pgd_annot ; pgd_type ; pgd_name ; pgd_val } =
+  F.fprintf fmt "%a%a %a = %a;"
+    pp_annotations pgd_annot
     pp_type pgd_type
     dname (L.unloc pgd_name)
     pp_pgexpr pgd_val

--- a/compiler/src/parser.mly
+++ b/compiler/src/parser.mly
@@ -502,8 +502,8 @@ pgexpr:
 | LBRACE es = rtuple(pexpr) RBRACE { GEarray es }
 
 pglobal:
-| pgd_type=ptype pgd_name=ident EQ pgd_val=pgexpr SEMICOLON
-  { { pgd_type ; pgd_name ; pgd_val  } }
+| pgd_annot=annotations pgd_type=ptype pgd_name=ident EQ pgd_val=pgexpr SEMICOLON
+  { { pgd_annot ; pgd_type ; pgd_name ; pgd_val  } }
 
 (* -------------------------------------------------------------------- *)
 pexec:

--- a/compiler/src/pretyping.ml
+++ b/compiler/src/pretyping.ml
@@ -2581,7 +2581,8 @@ let tt_global pd (env : 'asm Env.env) _loc (gd: S.pglobal) : 'asm Env.env =
     | ty,_ -> rs_tyerror ~loc:(L.loc gd.S.pgd_type) (InvalidTypeForGlobal ty)
   in
 
-  let x = mk_var (L.unloc gd.S.pgd_name) W.Global ty (L.loc gd.S.pgd_name) [] in
+  let annot = pannot_to_annotations gd.S.pgd_annot in
+  let x = mk_var (L.unloc gd.S.pgd_name) W.Global ty (L.loc gd.S.pgd_name) annot in
 
   Env.Vars.push_global env (x,ty,d)
 

--- a/compiler/src/printer.ml
+++ b/compiler/src/printer.ml
@@ -340,7 +340,8 @@ let pp_pitem ~debug pp_len pp_opn pp_var =
         (pp_var_decl pp_var pp_len) x
         (pp_ge ~debug pp_len pp_var) e
    | MIglobal (x, e) ->
-      F.fprintf fmt "%a %a = %a;"
+      F.fprintf fmt "%a%a %a = %a;"
+        pp_annotations x.v_annot
         (pp_gtype pp_len) x.v_ty
         pp_var x
         (pp_gexpr ~debug pp_len pp_var) e
@@ -452,7 +453,8 @@ let pp_glob pp_var fmt (x, gd) =
       Format.fprintf fmt "@[{%a}@]"
         (pp_list ",@ " pp_print_X)
         (Array.to_list t)  in
-  Format.fprintf fmt "@[%a %a =@ %a;@]"
+  Format.fprintf fmt "@[%a%a %a =@ %a;@]"
+    pp_annotations x.v_annot
     (pp_gtype pp_len) x.v_ty
     pp_var x pp_gd gd
 

--- a/compiler/src/syntax.ml
+++ b/compiler/src/syntax.ml
@@ -455,7 +455,12 @@ type gpexpr =
   | GEexpr  of pexpr
   | GEarray of pexpr list
 
-type pglobal = { pgd_type: ptype; pgd_name: pident ; pgd_val: gpexpr }
+type pglobal = {
+  pgd_annot: pannotations;
+  pgd_type: ptype;
+  pgd_name: pident ;
+  pgd_val: gpexpr
+}
 
 (* -------------------------------------------------------------------- *)
 type pexec = {

--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -9,6 +9,78 @@ type amodel =
   | WArray
   | BArray
 
+(* How a Jasmin global variable is extracted: either as an EasyCrypt
+   abbreviation, or as an EasyCrypt operator declared with the given options
+   (the options are not interpreted, they are printed as such between brackets:
+   "op [opaque] x = e."). *)
+type gmodel =
+  | GlobAbbrev
+  | GlobOp of string
+
+let string_of_gmodel = function
+  | GlobAbbrev -> "abbrev"
+  | GlobOp "" -> "op"
+  | GlobOp opts when String.contains opts ' ' -> Format.asprintf "op=%S" opts
+  | GlobOp opts -> Format.asprintf "op=%s" opts
+
+(* How the machine words of global variables are printed: as signed integers
+   (in [-2^(n-1), 2^(n-1))) or as unsigned ones (in [0, 2^n)).  The two are
+   equal modulo 2^n, so this does not change the meaning of the extracted
+   model; unsigned values avoid the unary minus, which is convenient when the
+   tables are used by reduction. *)
+type gsign =
+  | GlobSigned
+  | GlobUnsigned
+
+let string_of_gsign = function
+  | GlobSigned -> "signed"
+  | GlobUnsigned -> "unsigned"
+
+(* How global variables are extracted, as given by the --global-model
+   command-line option of jasmin2ec. *)
+type global_options = {
+  gmodel : gmodel;
+  gsign : gsign;
+}
+
+let default_global_options = { gmodel = GlobAbbrev; gsign = GlobSigned }
+
+(* Extraction of a global variable can be selected by an annotation on its
+   declaration:
+     #[abbrev]                    u64 g = 1;   (* abbrev g = ... *)
+     #[op]                        u64 g = 1;   (* op g = ... *)
+     #[op=opaque]                 u64 g = 1;   (* op [opaque] g = ... *)
+     #[op="opaque smt_opaque"]    u64 g = 1;   (* op [opaque smt_opaque] g = ... *)
+   When no such annotation is given, the default given on the command line is
+   used. *)
+let gmodel_of_annot annot =
+  let op_options =
+    Annot.on_attribute
+      ~on_empty:(fun _loc _nid () -> "")
+      ~on_id:(fun _loc _nid s -> s)
+      ~on_string:(fun _loc _nid s -> s)
+      (fun loc nid ->
+        Annot.error ~loc
+          "attribute for “%s” should be the options of the operator, given as \
+           an identifier or a string" nid)
+  in
+  Annot.ensure_uniq
+    [ ("abbrev", fun a -> Annot.none a; GlobAbbrev);
+      ("op", fun a -> GlobOp (op_options a)) ]
+    annot
+
+(* The printing of the machine words of a global variable can be
+   selected by an annotation on its declaration:
+     #[sign=signed]      u64 g = -1;   (* W64.of_int (-1) *)
+     #[sign=unsigned]    u64 g = -1;   (* W64.of_int 18446744073709551615 *)
+   When no such annotation is given, the default given on the command line is
+   used. *)
+let gsign_of_annot annot =
+  Annot.ensure_uniq1 "sign"
+    (Annot.filter_string_list None
+       [ ("signed", GlobSigned); ("unsigned", GlobUnsigned) ])
+    annot
+
 let ws2bytes ws = (int_of_ws ws) / 8
 
 module Scmp = struct
@@ -361,6 +433,7 @@ type ec_item =
     | Iimport of string list
     | IfromRequireImport of string * (string list)
     | Iabbrev of string * ec_expr
+    | Iop of string * string * ec_expr
     | ImoduleType of ec_module_type
     | Imodule of ec_module
 
@@ -776,6 +849,12 @@ let pp_ec_item fmt it =
     Format.fprintf fmt "@[from %s require import@ @[%a@].@]" m (pp_list "@ " pp_string) is
   | Iabbrev (a, e) ->
     Format.fprintf fmt "@[abbrev %s =@ @[%a@].@]" a pp_ec_ast_expr e
+  | Iop (a, opts, e) ->
+    let pp_opts fmt = function
+      | "" -> ()
+      | opts -> Format.fprintf fmt " [%s]" opts
+    in
+    Format.fprintf fmt "@[op%a %s =@ @[%a@].@]" pp_opts opts a pp_ec_ast_expr e
   | ImoduleType mt ->
     Format.fprintf fmt "@[<v>@[module type %s = {@]@   @[<v>%a@]@ }.@]"
       mt.name (pp_list "@ " pp_ec_fun_decl) mt.funs
@@ -1980,15 +2059,24 @@ struct
     | ARMv8A -> "SLH64"
     | RISCV  -> "SLH32"
 
-  let ec_glob_decl env (x,d) =
+  let ec_glob_decl env global_options (x,d) =
+    let gsign = Option.default global_options.gsign (gsign_of_annot x.v_annot) in
+    let signed = gsign = GlobSigned in
     let w_of_z ws z = Eapp (Eident [fmt_Wsz ws; "of_int"], [Econst z]) in
-    let mk_abbrev e = Iabbrev (ec_vars env x, e) in
+    let gmodel = Option.default global_options.gmodel (gmodel_of_annot x.v_annot) in
+    let mk_decl e =
+      match gmodel with
+      | GlobAbbrev -> Iabbrev (ec_vars env x, e)
+      | GlobOp opts -> Iop (ec_vars env x, opts, e)
+    in
     match d with
-    | Global.Gword(ws, w) -> mk_abbrev (w_of_z ws (Conv.z_of_word ws w))
+    | Global.Gword(ws, w) ->
+      let z = if signed then Conv.z_of_word ws w else Conv.z_unsigned_of_word ws w in
+      mk_decl (w_of_z ws z)
     | Global.Garr(p,t) ->
-      let ws, t = Conv.to_array x.v_ty p t in
-      mk_abbrev (Eapp (EA.of_list env ws (Array.length t),
-                       [Elist (List.map (w_of_z ws) (Array.to_list t))]))
+      let ws, t = Conv.to_array ~signed x.v_ty p t in
+      mk_decl (Eapp (EA.of_list env ws (Array.length t),
+                     [Elist (List.map (w_of_z ws) (Array.to_list t))]))
 
   let ec_randombytes env =
       let randombytes_decl a n =
@@ -2024,7 +2112,7 @@ struct
           }
         ]
 
-  let toec_prog env asmOp globs funcs =
+  let toec_prog env asmOp global_options globs funcs =
       let add_glob_env env (x, d) =
         add_glob_arrsz env (x, d);
         Env.set_var env x
@@ -2067,12 +2155,12 @@ struct
       glob_imports @
       (leakage_imports env) @
       pp_array_theories (Env.array_theories env) @
-      (List.map (fun glob -> ec_glob_decl env glob) globs) @
+      (List.map (fun glob -> ec_glob_decl env global_options glob) globs) @
       (ec_randombytes env) @
       [top_mod]
 
-  let pp_prog env asmOp fmt globs funcs =
-    Format.fprintf fmt "%a@." pp_ec_prog (toec_prog env asmOp globs funcs)
+  let pp_prog env asmOp global_options fmt globs funcs =
+    Format.fprintf fmt "%a@." pp_ec_prog (toec_prog env asmOp global_options globs funcs)
 
 end
 
@@ -2093,7 +2181,7 @@ and used_func_i used i =
   | Cwhile(_, c1, _, _, c2) -> used_func_c (used_func_c used c1) c2
   | Ccall (_,f,_)   -> Ss.add f.fn_name used
 
-let extract ((globs,funcs):('info, 'asm) prog) arch pd msfsz asmOp (model: model) amodel fnames array_dir fmt =
+let extract ((globs,funcs):('info, 'asm) prog) arch pd msfsz asmOp (model: model) amodel (global_options: global_options) fnames array_dir fmt =
   let save_array_theories array_theories =
     match array_dir with
     | Some prefix ->
@@ -2131,6 +2219,6 @@ let extract ((globs,funcs):('info, 'asm) prog) arch pd msfsz asmOp (model: model
         (module EcLeakConstantTimeGlobal(EE): EcLeakage)
   ) in
   let module E = Extraction(EA)(EL) in
-  let prog = E.pp_prog env asmOp fmt globs funcs in
+  let prog = E.pp_prog env asmOp global_options fmt globs funcs in
   save_array_theories (Env.array_theories env);
   prog

--- a/compiler/src/toEC.mli
+++ b/compiler/src/toEC.mli
@@ -3,6 +3,34 @@ type amodel =
   | WArray
   | BArray
 
+(* How a Jasmin global variable is extracted: either as an EasyCrypt
+   abbreviation, or as an EasyCrypt operator declared with the given options
+   (the options are not interpreted, they are printed as such between brackets:
+   "op [opaque] x = e."). *)
+type gmodel =
+  | GlobAbbrev
+  | GlobOp of string
+
+val string_of_gmodel : gmodel -> string
+
+(* How the machine words of global variables are printed: as signed integers
+   (in [-2^(n-1), 2^(n-1))) or as unsigned ones (in [0, 2^n)).  Both denote the
+   same words; unsigned values avoid the unary minus. *)
+type gsign =
+  | GlobSigned
+  | GlobUnsigned
+
+val string_of_gsign : gsign -> string
+
+(* How global variables are extracted, as given by the --global-model
+   command-line option of jasmin2ec. *)
+type global_options = {
+  gmodel : gmodel;
+  gsign : gsign;
+}
+
+val default_global_options : global_options
+
 val ty_expr : Prog.expr -> Prog.ty
 val ty_lval : Prog.lval -> Prog.ty
 val extract :
@@ -13,6 +41,7 @@ val extract :
   ('asm_op, 'extra_op) Arch_extra.extended_op_gen Sopn.asmOp ->
   Utils.model ->
   amodel ->
+  global_options ->
   string list ->
   string option ->
   Format.formatter ->

--- a/compiler/tests/success/x86-64/global_annotations.jazz
+++ b/compiler/tests/success/x86-64/global_annotations.jazz
@@ -1,0 +1,28 @@
+/* Annotations selecting how global variables are extracted to EasyCrypt. */
+
+#[abbrev]
+u64 g_abbrev = 38;
+
+#[op]
+u64 g_op = 39;
+
+#[op=opaque]
+u64 g_opaque = 40;
+
+#[op="opaque smt_opaque"]
+u64 g_both = 41;
+
+#[op=smt_opaque]
+u64[2] g_array = {42, 43};
+
+export
+fn main(reg u64 x) -> reg u64 {
+  reg u64 r;
+  r = x;
+  r += g_abbrev;
+  r += g_op;
+  r += g_opaque;
+  r += g_both;
+  r += g_array[1];
+  return r;
+}

--- a/docs/source/language/syntax/structure.md
+++ b/docs/source/language/syntax/structure.md
@@ -160,6 +160,12 @@ only its type, name, and value. For instance:
 In this example, the value is a 128-bit machine-word, described as a vector
 of 16 8-bit machine-words.
 
+Global variable declarations can be prefixed by annotations, for instance to
+choose how they are extracted to EasyCrypt
+(see [EasyCrypt extraction](../../tools/jasmin2ec.md)):
+
+    #[op=smt_opaque] u64[2] table = { 0, 1 };
+
 ## Functions
 
 A function is introduced using the `fn` keyword, followed by the function name,

--- a/docs/source/tools/jasmin2ec.md
+++ b/docs/source/tools/jasmin2ec.md
@@ -11,6 +11,9 @@ The command to extract EasyCrypt programs is the following:
 jasmin2ec -o extracted.ec source.jazz
 ```
 
+The complete list of the options is given by `jasmin2ec --help`; the most useful
+ones are described below.
+
 By default, `jasmin2ec` will extract all the functions in a file, however a
 (set of) specific function(s) can be extract using the `--function`
 command-line parameter one of multiple times (this also extracts the functions
@@ -24,11 +27,104 @@ The `--output-array` parameter allows to specify a separate directory to store
 the generated auxiliary EasyCrypt theories. By default this is the same
 directory as the directory of the output file.
 
+The `--array-model` parameter selects how Jasmin arrays are represented in the
+extracted model. With `barray` (the default), an array is a byte array: a
+`stack u64[4]` variable is extracted as a value of type `BArray32.t` (32 being
+the size of the array in bytes) and all its accesses, whatever their word size,
+are operators of the `BArray32` theory. With `warray`, an array is a polymorphic
+array of machine words: the same variable is extracted as a value of type
+`W64.t Array4.t`; the accesses whose word size differs from the one of the array
+go through auxiliary theories, generated together with the model. The `old`
+model is deprecated: it uses the same representation as `warray`, but such
+accesses are expanded into anonymous functions instead of using the functions of
+the EasyCrypt library.
+
 By specifying `--model=CT`, the extracted EasyCrypt model allows to verify that
 the Jasmin program satisfies the cryptographic constant time property, as an alternative to `jasmin-ct`.
 For more explanation on how to verify that a program is constant time, see the [Constant-time verification](ct) page.
 
-For other parameters, see `jasmin2ec --help`.
+The `--global-model` parameter selects how global variables are extracted: as
+abbreviations (`abbrev`, the default), as operators (`op`), or as operators
+declared with some options (`op=opaque`, `op="opaque smt_opaque"`, …).
+It also selects how the machine words of global variables are printed: as
+signed integers (`sign=signed`, the default) or as unsigned ones
+(`sign=unsigned`). The parameter may be given several times to set both, e.g.
+`--global-model op=smt_opaque --global-model sign=unsigned`; the last value of
+each kind wins. The spaces around the `=` are optional, so `--global-model
+"sign = unsigned"` is also accepted. See [Extraction of global
+variables](#extraction-of-global-variables) below.
+
+## Extraction of global variables
+
+Each global variable is extracted as one EasyCrypt declaration, either an
+abbreviation or an operator. The default is given by the `--global-model`
+parameter described above; it can be overridden for a specific global variable
+by annotating its declaration with `#[abbrev]` or `#[op]` (and, for the sign,
+with `#[sign=signed]` or `#[sign=unsigned]`).
+
+The `#[op]` annotation takes as (optional) attribute the options of the
+EasyCrypt operator, written as an identifier or, when there are several of them,
+as a string. For instance, the following declarations
+
+```
+#[abbrev]                  u64    g0 = 0;
+#[op]                      u64    g1 = 1;
+#[op=opaque]               u64    g2 = 2;
+#[op="opaque smt_opaque"]  u64    g3 = 3;
+#[op=smt_opaque]           u64[2] t  = { 4, 5 };
+```
+
+are extracted as
+
+```
+abbrev g0 = (W64.of_int 0).
+op g1 = (W64.of_int 1).
+op [opaque] g2 = (W64.of_int 2).
+op [opaque smt_opaque] g3 = (W64.of_int 3).
+op [smt_opaque] t = (BArray16.of_list64 [(W64.of_int 4); (W64.of_int 5)]).
+```
+
+The options are not interpreted by Jasmin, they are printed as such between
+brackets; therefore any option understood by EasyCrypt can be used. The most
+useful ones are `opaque`, which prevents the definition from being unfolded by
+reduction, and `smt_opaque`, which prevents it from being sent to the SMT
+solvers. Declaring large tables as `#[op=smt_opaque]` usually speeds up the
+proofs a lot.
+
+The values stored in global variables are machine words; the integer given to
+`of_int` in the extracted model is, by default, the *signed* value of the word,
+so that it may be negative. The `--global-model sign=unsigned` command-line
+parameter asks for the *unsigned* value instead, and the `#[sign=signed]` and
+`#[sign=unsigned]` annotations override that default for a specific global
+variable. For instance, the declaration
+
+```
+u64[2] t = { 1, -1 };
+```
+
+is extracted as
+
+```
+abbrev t = (BArray16.of_list64 [(W64.of_int 1); (W64.of_int (-1))]).
+```
+
+by default, and as
+
+```
+abbrev t = (BArray16.of_list64 [(W64.of_int 1); (W64.of_int 18446744073709551615)]).
+```
+
+with `--global-model sign=unsigned` (or when the declaration is annotated with
+`#[sign=unsigned]`). Both denote the same words, since `of_int` works modulo
+2^n, but the second form does not use the unary minus: this makes large tables
+noticeably cheaper to handle in EasyCrypt, in particular when they are computed
+by reduction.
+
+The two kinds of annotations can be combined, as in
+
+```
+#[op=smt_opaque, sign=unsigned] u64[2] t = { 1, -1 };
+```
 
 ## Configure EasyCrypt to verify Jasmin programs
 


### PR DESCRIPTION
# Description

Allows to have annotations on global variables.
Use it to select how global variables are extracted (abbrev or op).

# Checklist

- [x] Add a changelog entry in `changes` if the PR is a user-visible change
- [x] Add one or several tests to `compiler/tests` if it makes sense, especially if it is a bug fix
- [x] Update the documentation if needed
