### PR TITLE
Save the return address of export functions in the stack frame (arm64, risc-v)

### DIFF
--- a/changes/01-feature/1541-armv8a-backend.md
+++ b/changes/01-feature/1541-armv8a-backend.md
@@ -1,0 +1,3 @@
+- Add an ARMv8-A (AArch64) backend: new target architecture `-arch armv8a`,
+  modeled at the full 64-bit register width, with lowering and correctness
+  proofs ([PR #1541](https://github.com/jasmin-lang/jasmin/pull/1541)).

--- a/changes/03-other/1550-export-return-address-save.md
+++ b/changes/03-other/1550-export-return-address-save.md
@@ -1,0 +1,12 @@
+- On architectures where the caller passes the return address in a register
+  and that register is available (ARM64, RISC-V), export functions now save
+  and restore it through the same verified mechanism as callee-saved registers
+  (a slot in the stack frame), instead of unverified glue emitted by the
+  assembly printer around the function body. The one-varmap checker enforces
+  that an export function whose body kills the return-address register saves
+  it. Export functions that do not kill it (e.g. leaf functions) no longer
+  touch the stack at all to save it. Note that the `callee_saved = n`
+  annotation must now account for the return-address register when the
+  function kills it. On ARM (Cortex-M4), LR is used as a scratch register by
+  the compiler itself, so it is still saved around the body by the printer
+  ([PR #1550](https://github.com/jasmin-lang/jasmin/pull/1550)).

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -10,11 +10,14 @@ CHECKCATS ?= \
 	x86-64-Intel \
 	x86-64-nolea \
 	arm-m4 \
+	armv8a \
 	risc-v \
 	x86-64-stack-zero-loop \
 	x86-64-stack-zero-unrolled \
 	arm-m4-stack-zero-loop \
 	arm-m4-stack-zero-unrolled \
+	armv8a-stack-zero-loop \
+	armv8a-stack-zero-unrolled \
 	risc-v-stack-zero-loop \
 	risc-v-stack-zero-unrolled \
 	CCT CCT-DOIT SCT

--- a/compiler/config/tests.config
+++ b/compiler/config/tests.config
@@ -54,6 +54,11 @@ bin = ./scripts/check
 args = -arch riscv
 okdirs = examples/**/risc-v tests/success/**/risc-v tests/success/**/common
 
+[test-armv8a]
+bin = ./scripts/check
+args = -arch armv8a
+okdirs = tests/success/**/armv8a
+
 [test-risc-v-extraction]
 bin = ./scripts/extract-and-check
 args = riscv
@@ -79,6 +84,16 @@ okdirs  = tests/success/stack_zeroization/**/arm-m4
 bin     = ./scripts/check
 args    = -arch arm-m4 -stack-zero=unrolled
 okdirs  = tests/success/stack_zeroization/**/arm-m4
+
+[test-armv8a-stack-zero-loop]
+bin     = ./scripts/check
+args    = -arch armv8a -stack-zero=loop
+okdirs  = tests/success/stack_zeroization/**/armv8a
+
+[test-armv8a-stack-zero-unrolled]
+bin     = ./scripts/check
+args    = -arch armv8a -stack-zero=unrolled
+okdirs  = tests/success/stack_zeroization/**/armv8a
 
 [test-risc-v-stack-zero-loop]
 bin     = ./scripts/check

--- a/compiler/entry/commonCLI.ml
+++ b/compiler/entry/commonCLI.ml
@@ -5,7 +5,8 @@ open Utils
 let arch =
   let alts =
     [
-      ("x86-64", Utils.X86_64); ("arm-m4", Utils.ARM_M4); ("riscv", Utils.RISCV);
+      ("x86-64", Utils.X86_64); ("arm-m4", Utils.ARM_M4);
+      ("armv8a", Utils.ARMv8A); ("riscv", Utils.RISCV);
     ]
   in
   let doc =

--- a/compiler/safetylib/safetyMain.ml
+++ b/compiler/safetylib/safetyMain.ml
@@ -60,3 +60,12 @@ let get_arch_with_analyze arch call_conv : (module ArchWithAnalyze) =
 
         let analyze = Safety.analyze
       end)
+  | ARMv8A ->
+      (module struct
+        module C = CoreArchFactory.Core_arch_ARMV8A
+        module A = Arch_full.Arch_from_Core_arch (C)
+
+        let analyze ?fmt:_ ~safety_param:_ _ _ =
+          hierror ~loc:Lnone ~kind:"safety analysis"
+            "the safety checker is not implemented for ARMv8-A"
+      end)

--- a/compiler/scripts/check
+++ b/compiler/scripts/check
@@ -32,6 +32,9 @@ elif [ $ARCH = "riscv" ]
 then
      # +m enables integer multiplication
      ASARGS="--triple=riscv32 --mcpu=generic-rv32 -mattr=+m"
+elif [ $ARCH = "armv8a" ]
+then
+    ASARGS="--triple=aarch64"
 else
     ASARGS="--triple=x86_64"
 fi

--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -43,6 +43,11 @@ module type Core_arch = sig
      beyond the one of the stack slots themselves. *)
   val sp_min_align : Wsize.wsize
 
+  (* Widest store the architecture can perform in one instruction. Used to
+     cap the default stack-zeroization clear step when [sp_min_align]
+     raises the frame alignment beyond it. *)
+  val max_store_size : Wsize.wsize
+
   val known_implicits : (Name.t * string) list
 
   val is_ct_asm_op : asm_op -> bool

--- a/compiler/src/arch_full.ml
+++ b/compiler/src/arch_full.ml
@@ -82,6 +82,10 @@ module type Arch = sig
   val extra_allocatable_vars : var list
   val xmm_allocatable_vars : var list
   val callee_save_vars : var list
+  (* Register in which export functions receive the return address, when the
+     compiled body is in charge of preserving it (spilled to the stack frame
+     like a callee-saved register when the body kills it). *)
+  val ra_to_save_var : var option
   val not_saved_stack : var list
   val rsp_var : var
   val all_registers : var list
@@ -158,8 +162,16 @@ module Arch_from_Core_arch (A : Core_arch) :
 
   let allocatable =
     let good_order = mk_allocatable (Arch_decl.registers arch_decl) callee_save_reg in
-    (* be sure that rsp is not used *)
-    List.filter (fun r -> r <> rsp) good_order
+    (* be sure that rsp is not used; when the body of export functions is in
+       charge of preserving the return-address register (call_reg_ra), it is
+       not a general-purpose scratch register either (it would needlessly
+       consume a spill slot in the stack frame of export functions) *)
+    let reserved =
+      match call_conv.call_reg_ra with
+      | Some ra -> [rsp; ra]
+      | None -> [rsp]
+    in
+    List.filter (fun r -> not (List.mem r reserved)) good_order
 
   let extra_allocatable =
     mk_allocatable (Arch_decl.registerxs arch_decl) callee_save_regx
@@ -204,6 +216,8 @@ module Arch_from_Core_arch (A : Core_arch) :
       | AXReg r -> var_of_xreg r
       | ABReg r -> var_of_flag r in
     List.map var_of_typed callee_save
+
+  let ra_to_save_var = Option.map var_of_reg call_conv.call_reg_ra
 
   let rsp_var = var_of_reg rsp
 

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -40,6 +40,10 @@ module type Core_arch = sig
   (* Minimal alignment of every stack frame; see arch_full.ml. *)
   val sp_min_align : Wsize.wsize
 
+  (* Widest store the architecture can perform in one instruction; see
+     arch_full.ml. *)
+  val max_store_size : Wsize.wsize
+
   val known_implicits : (Name.t * string) list
 
   val is_ct_asm_op : asm_op -> bool

--- a/compiler/src/arch_full.mli
+++ b/compiler/src/arch_full.mli
@@ -78,6 +78,10 @@ module type Arch = sig
   val extra_allocatable_vars : var list
   val xmm_allocatable_vars : var list
   val callee_save_vars : var list
+  (* Register in which export functions receive the return address, when the
+     compiled body is in charge of preserving it (spilled to the stack frame
+     like a callee-saved register when the body kills it). *)
+  val ra_to_save_var : var option
   val not_saved_stack : var list
   val rsp_var : var
   val all_registers : var list

--- a/compiler/src/arm_arch_full.ml
+++ b/compiler/src/arm_arch_full.ml
@@ -63,5 +63,7 @@ module Arm (Lowering_params : Arm_input) : Arch_full.Core_arch
      would be silently rounded by the hardware. *)
   let sp_min_align = Wsize.U32
 
+  let max_store_size = Wsize.U32
+
   let internal_call_conv = Arm_decl.arm_internal_call_conv
 end

--- a/compiler/src/armv8a_arch_full.ml
+++ b/compiler/src/armv8a_arch_full.ml
@@ -1,0 +1,63 @@
+(* ARMv8A architecture full integration *)
+open Arch_decl
+
+module type Armv8a_input = sig
+  val call_conv : (Armv8a_decl.register, Arch_utils.empty, Arch_utils.empty, Arm_common.rflag, Arm_common.condt) calling_convention
+end
+
+(* Create arch_toIdent for ARMv8A *)
+let atoI armv8a_decl =
+  let open Prog in
+  let mk_var k t s =
+    V.mk s (Reg(k,Direct)) (Conv.ty_of_cty (Type.atype_of_ltype t)) L._dummy [] in
+  match Arch_extra.MkAToIdent.mk armv8a_decl mk_var with
+  | Utils0.Error e ->
+      let e = Conv.error_of_cerror (Printer.pp_err ~debug:true) e in
+      raise (Utils.HiError e)
+  | Utils0.Ok atoI -> atoI
+
+module Armv8a (Lowering_params : Armv8a_input) = struct
+  module AD = Armv8a_decl
+
+  type reg = AD.register
+  type regx = Arch_utils.empty
+  type xreg = Arch_utils.empty
+  type nonrec rflag = Arm_common.rflag
+  type cond = Arm_common.condt
+  type asm_op = Armv8a_instr_decl.armv8a_asm_op
+  type extra_op = Armv8a_extra.armv8a_extra_op
+
+  let atoI = atoI AD.armv8a_decl
+
+  let asm_e = Armv8a_extra.armv8a_extra atoI
+
+  let aparams = Armv8a_params.armv8a_params atoI
+
+  let known_implicits = ["NF", "_nf_"; "ZF", "_zf_"; "CF", "_cf_"; "VF", "_vf_"]
+
+  let alloc_stack_need_extra _ = false
+
+  let is_ct_asm_op (o : asm_op) =
+    match o with
+    | Armv8a_instr_decl.ARMv8A_op ((Armv8a_instr_decl.SDIV | Armv8a_instr_decl.UDIV), _) -> false
+    | _ -> true
+
+  let is_ct_asm_extra (_o : extra_op) = true
+
+  let not_saved_stack = []
+
+  let pp_asm = Pp_arm_v8a.print_prog
+
+  let callstyle = Arch_full.ByReg { call = Some Armv8a_decl.R30; return = true }
+
+  (* SP must stay 16-byte aligned: SP alignment checking, Arm ARM
+     DDI0487M.a, D1.4.10.2 (see also the AAPCS64 stack constraints). *)
+  let sp_min_align = Wsize.U128
+
+  (* One X-register store; SIMD (NEON) stores would raise this to u128. *)
+  let max_store_size = Wsize.U64
+
+  let internal_call_conv = Armv8a_decl.armv8a_internal_call_conv
+
+  include Lowering_params
+end

--- a/compiler/src/compile.ml
+++ b/compiler/src/compile.ml
@@ -360,7 +360,14 @@ let compile (type reg regx xreg rflag cond asm_op extra_op)
   in
 
   let szs_of_fn fn =
-    (get_annot fn).stack_zero_strategy
+    match (get_annot fn).stack_zero_strategy with
+    | Some (szs, None) when wsize_lt Arch.max_store_size Arch.sp_min_align ->
+        (* The default clear step is the frame alignment, which
+           [sp_min_align] may raise beyond the widest store the
+           architecture can perform in one instruction (u128 vs u64 on
+           armv8a): cap the default at that width. *)
+        Some (szs, Some Arch.max_store_size)
+    | szs -> szs
   in
 
   (* This implements an analysis returning the set of variables becoming dead

--- a/compiler/src/coreArchFactory.ml
+++ b/compiler/src/coreArchFactory.ml
@@ -10,6 +10,10 @@ module Core_arch_RISCV = Riscv_arch_full.Riscv (struct
   let call_conv = Riscv_decl.riscv_linux_call_conv
 end)
 
+module Core_arch_ARMV8A = Armv8a_arch_full.Armv8a (struct
+  let call_conv = Armv8a_decl.armv8a_call_conv
+end)
+
 let core_arch_x86 call_conv :
     (module Arch_full.Core_arch
        with type reg = register
@@ -35,4 +39,5 @@ let get_arch_module arch call_conv : (module Arch_full.Arch) =
                       (module (val core_arch_x86 call_conv)
                       : Arch_full.Core_arch)
                   | ARM_M4 -> (module Core_arch_ARM : Arch_full.Core_arch)
+                  | ARMv8A -> (module Core_arch_ARMV8A : Arch_full.Core_arch)
                   | RISCV -> (module Core_arch_RISCV : Arch_full.Core_arch))))

--- a/compiler/src/coreArchFactory.mli
+++ b/compiler/src/coreArchFactory.mli
@@ -16,6 +16,15 @@ module Core_arch_RISCV : Arch_full.Core_arch
    and type asm_op = Riscv_instr_decl.riscv_op
    and type extra_op = Riscv_extra.riscv_extra_op
 
+module Core_arch_ARMV8A : Arch_full.Core_arch
+  with type reg = Armv8a_decl.register
+   and type regx = Arch_utils.empty
+   and type xreg = Arch_utils.empty
+   and type rflag = Arm_common.rflag
+   and type cond = Arm_common.condt
+   and type asm_op = Armv8a_instr_decl.armv8a_asm_op
+   and type extra_op = Armv8a_extra.armv8a_extra_op
+
 open X86_decl
 
 val core_arch_x86 :

--- a/compiler/src/glob_options.ml
+++ b/compiler/src/glob_options.ml
@@ -80,6 +80,7 @@ let set_target_arch a =
     match a with
     | "x86-64" -> X86_64
     | "arm-m4" -> ARM_M4
+    | "armv8a" -> ARMv8A
     | "riscv" -> RISCV
     | _ -> assert false
   in target_arch := a'
@@ -238,7 +239,7 @@ let options = [
     "-intel", Arg.Unit (set_syntax `Intel), " Use intel syntax (default is AT&T)"; 
     "-ATT", Arg.Unit (set_syntax `ATT), " Use AT&T syntax (default is AT&T)"; 
     "-call-conv", Arg.Symbol (["windows"; "linux"], set_cc), " Select calling convention (default depends on host architecture)";
-    "-arch", Arg.Symbol (["x86-64"; "arm-m4"; "riscv"], set_target_arch), " Select target arch (default is x86-64)";
+    "-arch", Arg.Symbol (["x86-64"; "arm-m4"; "armv8a"; "riscv"], set_target_arch), " Select target arch (default is x86-64)";
     "-system", Arg.Symbol (["macosx"; "linux"], set_target_system), " Select target system (default is "^ Config.target_system^")";
     "-stack-zero",
       Arg.Symbol (List.map fst stack_zero_strategies, set_stack_zero_strategy),

--- a/compiler/src/pp_arm_v8a.ml
+++ b/compiler/src/pp_arm_v8a.ml
@@ -139,16 +139,13 @@ module Armv8aTarget : AsmTargetBuilder.AsmTarget with
   (* A64 instructions must be 4-byte aligned. *)
   let function_directives = [ Instr (".p2align", ["2"]) ]
 
-  (* The return address (X30) is saved on the stack around the body of
-     export functions; SP must stay 16-byte aligned. *)
-  let function_header =
-    [
-      Instr ("str", [ "x30"; "[sp, #-16]!" ])
-    ]
+  let function_header = []
 
+  (* The body of an export function preserves X30: when it is killed, it is
+     saved to and restored from the stack frame (sf_to_save), so returning is
+     a single indirect jump. *)
   let function_tail =
     [
-      Instr ("ldr", [ "x30"; "[sp], #16" ]);
       Instr ("ret", [])
     ]
 

--- a/compiler/src/pp_arm_v8a.ml
+++ b/compiler/src/pp_arm_v8a.ml
@@ -1,0 +1,230 @@
+(* Assembly printer for ARMv8-A (AArch64).
+
+   GNU assembler (ELF) syntax. General-purpose registers are printed in
+   their 64-bit X form except for the instruction operands that require the
+   32-bit W form (narrow loads and stores, 32-bit multiplies, zero
+   extensions). Immediate values are printed as nonnegative integers. *)
+
+open Arch_decl
+open Utils
+open PrintASM
+open Asm_utils
+
+(* Architecture imports*)
+open Arm_common
+open Armv8a_decl
+open Armv8a_instr_decl
+
+let arch = armv8a_decl
+
+let imm_pre = "#"
+
+(* We support the following AArch64 memory accesses.
+   Offset addressing:
+     - A base register and an immediate offset (displacement):
+       [<reg>, #<imm>].
+     - A base register and a register offset: [<reg>, <reg>].
+     - A base register and a scaled register offset:
+       [<reg>, <reg>, LSL #<imm>].
+*)
+let pp_reg_address_aux base disp off scal =
+  match (disp, off, scal) with
+  | None, None, None ->
+      Format.asprintf "[%s]" base
+  | Some disp, None, None ->
+      Format.asprintf "[%s, %s%s]" base imm_pre disp
+  | None, Some off, None ->
+      Format.asprintf "[%s, %s]" base off
+  | None, Some off, Some scal ->
+      Format.asprintf "[%s, %s, lsl %s%s]" base off imm_pre scal
+  | _, _, _ ->
+      hierror
+        ~loc:Lnone
+        ~kind:"assembly printing"
+        ~internal:true
+        "the address computation is too complex: an intermediate variable might be needed"
+
+let pp_imm = pp_imm imm_pre
+
+let pp_register = pp_register arch
+
+(* The 32-bit (W) view of a general-purpose register. *)
+let pp_wregister r =
+  match pp_register r with
+  | "xzr" -> "wzr"
+  | "sp" -> "wsp"
+  | s -> "w" ^ String.sub s 1 (String.length s - 1)
+
+let pp_reg_address addr =
+  let addr = parse_reg_address arch addr in
+  pp_reg_address_aux addr.base addr.displacement addr.offset addr.scale
+
+let pp_condt = hash_to_string string_of_condt
+
+(* A64 has no conditional execution: a condition is always a proper operand
+   (CSEL, CSET, ...), declared last in the argument list, so it is printed
+   in place like any other operand. *)
+let pp_asm_arg ?(wform = false) (arg : (register, Arch_utils.empty, Arch_utils.empty, rflag, condt) asm_arg) =
+  match arg with
+  | Condt ct -> pp_condt ct
+  | Imm (ws, w) -> pp_imm (Conv.z_unsigned_of_word ws w)
+  | Reg r -> if wform then pp_wregister r else pp_register r
+  | Regx _ -> .
+  | Addr (Areg ra) -> pp_reg_address ra
+  | Addr (Arip r) -> pp_rip_address r
+  | XReg _ -> .
+
+(* -------------------------------------------------------------------- *)
+
+let pp_shift_kind = hash_to_string string_of_shift_kind
+
+(* Append the optional shift to the last (immediate) operand:
+   [..., <shift> #<amount>]. *)
+let pp_shift (ARMv8A_op (_, opts)) args =
+  match has_shift opts with
+  | None ->
+      args
+  | Some sk ->
+      let sh = pp_shift_kind sk in
+      List.modify_last (Format.asprintf "%s %s" sh) args
+
+(* The last operand of MOVZ/MOVN/MOVK is the halfword shift: print it as
+   [LSL #<sh>], dropping it when it is zero. *)
+let pp_mov_wide_shift args =
+  match List.rev args with
+  | "#0" :: rest -> List.rev rest
+  | sh :: rest -> List.rev (Format.asprintf "lsl %s" sh :: rest)
+  | [] -> []
+
+let pp_mnemonic (ARMv8A_op (mn, _) as op) =
+  let id = instr_desc Armv8a_decl.armv8a_decl Armv8a_instr_decl.armv8a_op_decl (None, op) in
+  let pp = id.id_pp_asm [] in
+  match mn with
+  | UXTW -> "mov" (* [UXTW] is written [MOV <Wd>, <Wn>]. *)
+  | _ -> String.lowercase_ascii pp.pp_aop_name
+
+(* Split an [ADR] instruction to a global symbol into an [ADRP]/[ADD]
+   pair using :lo12: relocations. *)
+let pp_ADR args =
+  match args with
+  | dst :: addr :: _ ->
+      [ Instr ("adrp", [ dst; addr ]);
+        Instr ("add", [ dst; dst; ":lo12:" ^ addr ]) ]
+  | _ -> assert false
+
+module Armv8aTarget : AsmTargetBuilder.AsmTarget with
+  type reg = Armv8a_decl.register
+  and type regx = Arch_utils.empty
+  and type xreg = Arch_utils.empty
+  and type rflag = Arm_common.rflag
+  and type cond = Arm_common.condt
+  and type asm_op = armv8a_asm_op
+= struct
+
+  type reg = Armv8a_decl.register
+  type regx = Arch_utils.empty
+  type xreg = Arch_utils.empty
+  type rflag = Arm_common.rflag
+  type cond = Arm_common.condt
+  type asm_op = armv8a_asm_op
+
+  let headers = []
+
+  let data_segment_header =
+    [
+      Instr (".p2align", ["5"]);
+      Label global_datas_label
+    ]
+
+  (* A64 instructions must be 4-byte aligned. *)
+  let function_directives = [ Instr (".p2align", ["2"]) ]
+
+  (* The return address (X30) is saved on the stack around the body of
+     export functions; SP must stay 16-byte aligned. *)
+  let function_header =
+    [
+      Instr ("str", [ "x30"; "[sp, #-16]!" ])
+    ]
+
+  let function_tail =
+    [
+      Instr ("ldr", [ "x30"; "[sp], #16" ]);
+      Instr ("ret", [])
+    ]
+
+  let pp_instr_r fn i =
+    match i with
+    | ALIGN ->
+        (* A64 instructions are fixed-width: code is always 4-byte
+           aligned, there is nothing to emit. *)
+        []
+
+    | LABEL (_, lbl) ->
+        [ Label (string_of_label fn lbl) ]
+
+    | STORELABEL (dst, lbl) ->
+        [ Instr ("adr", [ pp_register dst; string_of_label fn lbl ]) ]
+
+    | JMP lbl ->
+        [ Instr ("b", [ pp_remote_label lbl ]) ]
+
+    | JMPI arg ->
+        begin match arg with
+        | Reg R30 -> [ Instr ("ret", []) ]
+        | Reg r -> [ Instr ("br", [ pp_register r ]) ]
+        | _ ->
+            hierror ~loc:Lnone ~kind:"assembly printing"
+              "unsupported indirect jump argument"
+        end
+
+    | Jcc (lbl, ct) ->
+        let iname = Format.asprintf "b.%s" (pp_condt ct) in
+        [ Instr (iname, [ string_of_label fn lbl ]) ]
+
+    | JAL (R30, lbl) ->
+        [ Instr ("bl", [ pp_remote_label lbl ]) ]
+
+    | CALL _
+    | JAL _ -> assert false
+
+    | POPPC ->
+        [ Instr ("ldr", [ "x30"; "[sp], #16" ]); Instr ("ret", []) ]
+
+    | SysCall op ->
+        [ Instr ("bl", [ pp_syscall op ]) ]
+
+    | Declassify_val (lty, a) ->
+        declassify_val (fun _lty a -> pp_asm_arg a) lty a
+
+    | Declassify_mem (len, a) ->
+        declassify_mem arch len a
+
+    | AsmOp (op, args) ->
+        let (ARMv8A_op (mn, _)) = op in
+        let id = instr_desc Armv8a_decl.armv8a_decl Armv8a_instr_decl.armv8a_op_decl (None, op) in
+        let pp = id.id_pp_asm args in
+        match op, args with
+        | ARMv8A_op (ADR, _), _ :: Addr (Arip _) :: _ ->
+            let args = List.map (fun (_, a) -> pp_asm_arg a) pp.pp_aop_args in
+            pp_ADR args
+        | _, _ ->
+            let name = pp_mnemonic op in
+            (* Registers are printed in the W form when the instruction
+               declaration pairs them with a width of at most [U32]. *)
+            let pargs =
+              List.map
+                (fun (sz, a) -> pp_asm_arg ~wform:(Wsize.size_8_32 sz) a)
+                pp.pp_aop_args
+            in
+            let pargs =
+              match mn with
+              | MOVZ | MOVN | MOVK -> pp_mov_wide_shift pargs
+              | _ -> pp_shift op pargs
+            in
+            [ Instr (name, pargs) ]
+
+end
+
+module Armv8aBuilder = AsmTargetBuilder.Make(Armv8aTarget)
+
+let print_prog fmt prog = PrintASM.pp_asm fmt (Armv8aBuilder.asm_of_prog prog)

--- a/compiler/src/pp_arm_v8a.mli
+++ b/compiler/src/pp_arm_v8a.mli
@@ -1,0 +1,4 @@
+(* ARMv8A assembly printer *)
+
+val print_prog :
+  Format.formatter -> Armv8a_instr_decl.armv8a_prog -> unit

--- a/compiler/src/pp_riscv.ml
+++ b/compiler/src/pp_riscv.ml
@@ -105,16 +105,13 @@ module RiscVTarget: AsmTarget
 
   let function_directives = []
 
-  let function_header =
-    [
-      Instr ("addi", [ pp_register SP; pp_register SP; "-4"]);
-      Instr ("sw", [ pp_register RA;  pp_reg_address_aux (pp_register SP) None None None])
-    ]
+  let function_header = []
 
+  (* The body of an export function preserves RA: when it is killed, it is
+     saved to and restored from the stack frame (sf_to_save), so returning is
+     a single indirect jump. *)
   let function_tail =
     [
-      Instr ("lw", [ pp_register RA;  pp_reg_address_aux (pp_register SP) None None None]);
-      Instr ("addi", [ pp_register SP; pp_register SP; "4"]);
       Instr ("ret", [ ])
     ]
 

--- a/compiler/src/regalloc.ml
+++ b/compiler/src/regalloc.ml
@@ -1484,9 +1484,18 @@ let allocatable_vars = Sv.of_list Arch.allocatable_vars
 let callee_save_vars = Sv.of_list Arch.callee_save_vars
 let not_saved_stack = Sv.of_list (Arch.not_saved_stack @ Arch.callee_save_vars)
 
+(* The register in which export functions receive the return address, if any:
+   it is not callee-saved, but must be spilled like one when the body kills it
+   so that the final return jump can use it. *)
+let to_save_vars =
+  match Arch.ra_to_save_var with
+  | Some ra -> Sv.add ra callee_save_vars
+  | None -> callee_save_vars
+
 (** Computes all callee-saved registers overwritten by this function (including
-    rsp) and, if the function has a stack but no register to save, picks a free
-    register to hold the stack pointer of the caller (aka environment). *)
+    rsp and the return-address register), and, if the function has a stack but
+    no register to save, picks a free register to hold the stack pointer of the
+    caller (aka environment). *)
 let get_reg_oracle
       (has_stack: ('info, 'asm) func -> bool)
       subst
@@ -1495,7 +1504,7 @@ let get_reg_oracle
   assert (FInfo.is_export f.f_cc);
   let killed_in_f = killed f.f_name |> Sv.map subst in
   let ro_to_save =
-    Sv.elements (Sv.inter callee_save_vars killed_in_f)
+    Sv.elements (Sv.inter to_save_vars killed_in_f)
   in
   let ro_rsp =
     if has_stack f && ro_to_save = []

--- a/compiler/src/riscv_arch_full.ml
+++ b/compiler/src/riscv_arch_full.ml
@@ -52,5 +52,7 @@ module Riscv (Lowering_params : Riscv_input) : Arch_full.Core_arch
 
   let sp_min_align = Wsize.U8
 
+  let max_store_size = Wsize.U32
+
   let internal_call_conv = Riscv_decl.riscv_internal_call_conv
 end

--- a/compiler/src/sct_checker_forward.ml
+++ b/compiler/src/sct_checker_forward.ml
@@ -713,7 +713,7 @@ let expr_equal a b =
     let open Glob_options in
     match !target_arch with
     | X86_64 -> X86_decl.x86_fcp
-    | ARM_M4 -> Arm_common.arm_fcp
+    | ARM_M4 | ARMv8A -> Arm_common.arm_fcp
     | RISCV  -> Riscv_decl.riscv_fcp
   in
   let normalize e =

--- a/compiler/src/stackAlloc.ml
+++ b/compiler/src/stackAlloc.ml
@@ -382,8 +382,17 @@ let memory_analysis pp_sr pp_err ~debug callee_saved_strategy up =
     let csao = get_sao fn in 
 
     let to_save =
-      List.take num_callee_saved
-      (List.remove Arch.callee_save_vars Arch.rsp_var) in
+      (* Placeholders sized like the registers to save; only their number and
+         types matter, actual names are filled in after register allocation.
+         On architectures where the return address is passed in a register,
+         that register may need a slot too. *)
+      let pool = List.remove Arch.callee_save_vars Arch.rsp_var in
+      let pool =
+        match Arch.ra_to_save_var with
+        | Some ra -> ra :: pool
+        | None -> pool
+      in
+      List.take num_callee_saved pool in
     let has_stack = has_stack fd || to_save <> [] in
 
     let rsp = V.clone Arch.rsp_var in

--- a/compiler/src/toEC.ml
+++ b/compiler/src/toEC.ml
@@ -1971,11 +1971,13 @@ struct
   let jmodel env = match Env.arch env with
     | X86_64 -> "JModel_x86"
     | ARM_M4 -> "JModel_m4"
+    | ARMv8A -> "JModel_armv8a"
     | RISCV  -> "JModel_riscv"
 
   let lib_slh env = match Env.arch env with
     | X86_64 -> "SLH64"
     | ARM_M4 -> "SLH32"
+    | ARMv8A -> "SLH64"
     | RISCV  -> "SLH32"
 
   let ec_glob_decl env (x,d) =

--- a/compiler/src/utils.ml
+++ b/compiler/src/utils.ml
@@ -176,12 +176,14 @@ let pp_string fmt s =
 type architecture =
   | X86_64
   | ARM_M4
+  | ARMv8A
   | RISCV
 
 let architecture_to_string arch =
   match arch with
   | X86_64 -> "x86-64"
   | ARM_M4 -> "arm-m4"
+  | ARMv8A -> "armv8a"
   | RISCV -> "riscv"
 
 (* -------------------------------------------------------------------- *)

--- a/compiler/src/utils.mli
+++ b/compiler/src/utils.mli
@@ -104,6 +104,7 @@ val pp_string : string pp
 type architecture =
   | X86_64
   | ARM_M4
+  | ARMv8A
   | RISCV
 val architecture_to_string : architecture -> string
 

--- a/compiler/src/x86_arch_full.ml
+++ b/compiler/src/x86_arch_full.ml
@@ -40,6 +40,9 @@ module X86_core = struct
 
   let sp_min_align = Wsize.U8
 
+  (* One YMM store. *)
+  let max_store_size = U256
+
   let known_implicits = ["OF","_of_"; "CF", "_cf_"; "SF", "_sf_"; "ZF", "_zf_"]
 
   let alloc_stack_need_extra _ = false

--- a/compiler/tests/success/armv8a/add.jazz
+++ b/compiler/tests/success/armv8a/add.jazz
@@ -1,0 +1,21 @@
+export
+fn add(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x;
+
+    // Registers.
+    x = arg0 + arg1;
+
+    // Immediates.
+    x = x + 1;
+    x = x + 4095;          // Largest imm12.
+    x = x + 0x1000;        // imm12, LSL #12.
+    x = x + 0xfff000;      // Largest imm12, LSL #12.
+    x = x + 0xdeadbeef;    // Needs a MOVZ/MOVK sequence.
+
+    // Shifted registers.
+    x = x + (arg1 << 2);
+    x = x + (arg1 >> 3);
+    x = x + (arg1 >>s 4);
+
+    return x;
+}

--- a/compiler/tests/success/armv8a/addcarry.jazz
+++ b/compiler/tests/success/armv8a/addcarry.jazz
@@ -1,0 +1,9 @@
+export
+fn addcarry(reg u64 a, reg u64 b) -> reg u64 {
+    reg bool c;
+
+    c, a = a + b;       // ADDS
+    _, a += b + c;      // ADC
+    _, a += b + c;      // `c` is still available here
+    return a;
+}

--- a/compiler/tests/success/armv8a/and.jazz
+++ b/compiler/tests/success/armv8a/and.jazz
@@ -1,0 +1,9 @@
+export
+fn and(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x;
+
+    x = arg0 & arg1;
+    x = x & 0xff;            // Bitmask immediate.
+    x = x & (arg1 << 1);     // Shifted register.
+    return x;
+}

--- a/compiler/tests/success/armv8a/call.jazz
+++ b/compiler/tests/success/armv8a/call.jazz
@@ -1,0 +1,20 @@
+fn double(reg u64 x) -> reg u64 {
+    x = x + x;
+    return x;
+}
+
+inline
+fn triple(reg u64 x) -> reg u64 {
+    reg u64 y;
+    y = x + x;
+    y = y + x;
+    return y;
+}
+
+export
+fn call(reg u64 arg0) -> reg u64 {
+    reg u64 x;
+    x = double(arg0);
+    x = triple(x);
+    return x;
+}

--- a/compiler/tests/success/armv8a/csel.jazz
+++ b/compiler/tests/success/armv8a/csel.jazz
@@ -1,0 +1,21 @@
+export
+fn csel(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x;
+    reg bool b;
+
+    b = arg0 < arg1;         // Unsigned.
+    x = arg0;
+    x = arg1 if b;
+
+    b = arg0 <s arg1;        // Signed.
+    x = arg1 if b;
+
+    b = arg0 == arg1;
+    x = arg0 if b;
+
+    b = arg0 >= arg1;
+    x = arg1 if b;
+
+    x = #CSEL(arg0, arg1, b);
+    return x;
+}

--- a/compiler/tests/success/armv8a/div.jazz
+++ b/compiler/tests/success/armv8a/div.jazz
@@ -1,0 +1,8 @@
+export
+fn div(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x;
+
+    x = arg0 / arg1;         // UDIV.
+    x = x /s arg1;           // SDIV.
+    return x;
+}

--- a/compiler/tests/success/armv8a/intrinsics.jazz
+++ b/compiler/tests/success/armv8a/intrinsics.jazz
@@ -1,0 +1,37 @@
+export
+fn intrinsics(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x y;
+    reg bool nf zf cf vf;
+
+    x = #ADD(arg0, arg1);
+    x = #SUB(x, arg1);
+    x = #AND(x, arg1);
+    x = #ORR(x, arg1);
+    x = #EOR(x, arg1);
+    x = #MVN(x);
+    x = #NEG(x);
+    x = #MOV(arg0);
+    x = #MUL(x, arg1);
+    x = #UDIV(x, arg1);
+    x = #SDIV(x, arg1);
+    x = #LSL(x, 2);
+    x = #LSR(x, 3);
+    x = #ASR(x, 1);
+    y = #SXTB(x);
+    y = #SXTH(y);
+    y = #SXTW(y);
+    y = #UXTB(y);
+    y = #UXTH(y);
+    x = x + y;
+
+    nf, zf, cf, vf = #CMP(x, arg1);
+    y = arg1 if zf;
+    x = x + y;
+
+    nf, zf, cf, vf, x = #ADDS(x, arg1);
+    nf, zf, cf, vf, x = #SUBS(x, arg1);
+    x = #ADC(x, arg1, cf);
+    nf, zf, cf, vf, x = #ADCS(x, arg1, cf);
+    x = x + y;
+    return x;
+}

--- a/compiler/tests/success/armv8a/ldst.jazz
+++ b/compiler/tests/success/armv8a/ldst.jazz
@@ -1,0 +1,28 @@
+export
+fn ldst(reg u64 p) -> reg u64 {
+    reg u64 a b;
+    stack u64[2] s;
+
+    a = [p];
+    b = [p + 8];
+    a = a + b;
+    [p] = a;
+    [p + 16] = b;
+
+    [:u8 p + 24] = a;
+    [:u16 p + 26] = a;
+    a = (64u)[:u8 p + 24];
+    b = (64s)[:u16 p + 26];
+    a = a + b;
+    b = (64u)[:u16 p + 26];
+    a = a + b;
+    b = (64s)[:u8 p + 24];
+    a = a + b;
+
+    s[0] = a;
+    s[1] = b;
+    a = s[0];
+    b = s[1];
+    a = a + b;
+    return a;
+}

--- a/compiler/tests/success/armv8a/loop.jazz
+++ b/compiler/tests/success/armv8a/loop.jazz
@@ -1,0 +1,18 @@
+export
+fn loop(reg u64 n) -> reg u64 {
+    reg u64 acc i;
+
+    acc = 0;
+    i = 0;
+    while (i < n) {
+        acc = acc + i;
+        i = i + 1;
+    }
+
+    if (acc > n) {
+        acc = acc - n;
+    } else {
+        acc = n - acc;
+    }
+    return acc;
+}

--- a/compiler/tests/success/armv8a/mul.jazz
+++ b/compiler/tests/success/armv8a/mul.jazz
@@ -1,0 +1,12 @@
+export
+fn mul(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x y;
+
+    x = arg0 * arg1;
+    y = x + arg0 * arg1;     // MADD.
+    y = y - arg0 * arg1;     // MSUB.
+    x = #MADD(arg0, arg1, y);
+    x = #MSUB(arg0, arg1, x);
+    x = x + y;
+    return x;
+}

--- a/compiler/tests/success/armv8a/or.jazz
+++ b/compiler/tests/success/armv8a/or.jazz
@@ -1,0 +1,12 @@
+export
+fn or(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x;
+
+    x = arg0 | arg1;
+    x = x | 0xff00;          // Bitmask immediate.
+    x = x | (arg1 >> 2);     // Shifted register.
+    x = x ^ arg0;
+    x = x ^ (arg1 << 3);
+    x = !x;
+    return x;
+}

--- a/compiler/tests/success/armv8a/shift.jazz
+++ b/compiler/tests/success/armv8a/shift.jazz
@@ -1,0 +1,16 @@
+export
+fn shift(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x;
+
+    x = arg0 << 1;
+    x = x << 63;
+    x = x >> 2;
+    x = x >>s 3;
+    // Variable shifts: the amount must be masked to the operand size
+    // (the A64 register shifts reduce it modulo the operand size).
+    x = x << (arg1 & 63);
+    x = x >> (arg1 & 63);
+    x = x >>s (arg1 & 63);
+    x = #ROR(x, 7);
+    return x;
+}

--- a/compiler/tests/success/armv8a/sub.jazz
+++ b/compiler/tests/success/armv8a/sub.jazz
@@ -1,0 +1,12 @@
+export
+fn sub(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x;
+
+    x = arg0 - arg1;
+    x = x - 1;
+    x = x - 4095;
+    x = x - 0xcafebabe;    // Needs a MOVZ/MOVK sequence.
+    x = x - (arg1 << 5);
+    x = -x;
+    return x;
+}

--- a/compiler/tests/success/armv8a/swap.jazz
+++ b/compiler/tests/success/armv8a/swap.jazz
@@ -1,0 +1,9 @@
+export
+fn swap(reg u64 arg0, reg u64 arg1) -> reg u64 {
+    reg u64 x y;
+
+    x = arg0; y = arg1;
+    x, y = #swap(x, y);
+    x = x - y;
+    return x;
+}

--- a/compiler/tests/success/armv8a/unaligned_stackalign.jazz
+++ b/compiler/tests/success/armv8a/unaligned_stackalign.jazz
@@ -1,0 +1,15 @@
+/* The unaligned 16-bit access is taken into account when computing the
+ * alignment for the stack variable, but the frame alignment is floored at
+ * u128: AArch64 checks that SP-based accesses use a 16-byte aligned SP
+ * (Arm ARM DDI0487M.a, D1.4.10.2). */
+#[stackalign=u128, callee_saved = 0]
+export
+fn instack(reg u32 x) -> reg u32 {
+  reg u32 r;
+  stack u8[3] s;
+  r = 0;
+  s[0] = r;
+  s.[:u16 1] = (16u)x;
+  r = (32s)s[:u8 1];
+  return r;
+}

--- a/compiler/tests/success/armv8a/word32.jazz
+++ b/compiler/tests/success/armv8a/word32.jazz
@@ -1,0 +1,145 @@
+/* Operations on u32 values: on AArch64 these must use the W (32-bit)
+   register forms. This mirrors the u64 tests at the other width. */
+
+export
+fn arith32(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x y;
+
+    // MOV of immediates.
+    x = 1;
+    y = 0xffff;              // Largest MOVZ immediate.
+    x = x + y;
+    y = 0xdeadbeef;          // Needs a MOVZ/MOVK sequence.
+    x = x + y;
+    y = 0x0f0f0f0f;          // A 32-bit bitmask immediate.
+    x = x + y;
+
+    // Additions and subtractions: registers and immediates.
+    y = arg0 + arg1;
+    x = x + y;
+    x = x + 1;
+    x = x + 4095;            // Largest imm12.
+    x = x + 0x1000;          // imm12, LSL #12.
+    x = x + 0xfff000;        // Largest imm12, LSL #12.
+    x = x - arg1;
+    x = x - 4095;
+
+    // Shifted registers.
+    x = x + (arg1 << 2);
+    x = x + (arg1 >> 3);
+    x = x + (arg1 >>s 4);
+    x = x - (arg1 << 5);
+
+    // Multiplications: MUL, MADD, MSUB.
+    y = x * arg1;
+    x = x + y;
+    y = x + arg0 * arg1;
+    x = x + y;
+    y = x - arg0 * arg1;
+
+    // Divisions: UDIV, SDIV.
+    y = y / arg1;
+    x = x + y;
+    y = x /s arg1;
+
+    x = x + y;
+    return x;
+}
+
+export
+fn logic32(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x;
+
+    // Registers and 32-bit bitmask immediates.
+    x = arg0 & arg1;
+    x = x & 0xff;
+    x = x | arg1;
+    x = x | 0xff00;
+    x = x ^ arg1;
+    x = x ^ 0x0f0f0f0f;
+
+    // Shifted registers.
+    x = x & (arg1 << 1);
+    x = x | (arg1 >> 2);
+    x = x ^ (arg1 >>s 3);
+
+    return x;
+}
+
+export
+fn shift32(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x;
+
+    // Constant shifts, in [0, 32).
+    x = arg0 << 1;
+    x = x << 31;
+    x = x >> 2;
+    x = x >>s 3;
+
+    // Variable shifts: the amount must be masked to the operand size
+    // (the A64 register shifts reduce it modulo the operand size).
+    x = x << (arg1 & 31);
+    x = x >> (arg1 & 31);
+    x = x >>s (arg1 & 31);
+
+    // Rotations: constant, and by a register (rotation is periodic, so no
+    // mask is needed).
+    x = x >>r 7;
+    x = x >>r arg1;
+    x = x <<r 5;
+
+    return x;
+}
+
+export
+fn csel32(reg u32 arg0, reg u32 arg1) -> reg u32 {
+    reg u32 x;
+    reg bool b;
+
+    b = arg0 < arg1;         // Unsigned.
+    x = arg0;
+    x = arg1 if b;
+
+    b = arg0 <s arg1;        // Signed.
+    x = arg1 if b;
+
+    b = arg0 == arg1;
+    x = arg0 if b;
+
+    b = arg0 >= arg1;
+    x = arg1 if b;
+
+    return x;
+}
+
+export
+fn ldst32(reg u64 p) -> reg u32 {
+    reg u32 a b;
+    stack u32[2] s;
+
+    // 32-bit loads and stores.
+    a = [:u32 p];
+    b = [:u32 p + 4];
+    a = a + b;
+    [:u32 p] = a;
+    [:u32 p + 8] = b;
+
+    // Narrow stores and extending loads at the W width.
+    [:u8 p + 12] = a;
+    [:u16 p + 14] = a;
+    a = (32u)[:u8 p + 12];
+    b = (32s)[:u16 p + 14];
+    a = a + b;
+    b = (32u)[:u16 p + 14];
+    a = a + b;
+    b = (32s)[:u8 p + 12];
+    a = a + b;
+
+    // Stack slots.
+    s[0] = a;
+    s[1] = b;
+    a = s[0];
+    b = s[1];
+    a = a + b;
+    return a;
+}

--- a/compiler/tests/success/stack_zeroization/armv8a/stack-zeroization.jazz
+++ b/compiler/tests/success/stack_zeroization/armv8a/stack-zeroization.jazz
@@ -1,0 +1,39 @@
+inline
+fn f(reg u64 p) {
+    reg u64 r_s;
+    r_s = 1;
+    stack u64 s;
+    s = r_s;
+    r_s = s;
+    [p] = r_s;
+}
+
+#[stackzero=loop]
+export fn main0(reg u64 p) { f(p); }
+
+#[stackzero=loop, stackzerosize=u8]
+export fn main1(reg u64 p) { f(p); }
+
+#[stackzero=loop, stackzerosize=u16]
+export fn main2(reg u64 p) { f(p); }
+
+#[stackzero=loop, stackzerosize=u32]
+export fn main3(reg u64 p) { f(p); }
+
+#[stackzero=loop, stackzerosize=u64]
+export fn main4(reg u64 p) { f(p); }
+
+#[stackzero=unrolled]
+export fn main7(reg u64 p) { f(p); }
+
+#[stackzero=unrolled, stackzerosize=u8]
+export fn main8(reg u64 p) { f(p); }
+
+#[stackzero=unrolled, stackzerosize=u16]
+export fn main9(reg u64 p) { f(p); }
+
+#[stackzero=unrolled, stackzerosize=u32]
+export fn main10(reg u64 p) { f(p); }
+
+#[stackzero=unrolled, stackzerosize=u64]
+export fn main11(reg u64 p) { f(p); }

--- a/compiler/tests/warnings.t
+++ b/compiler/tests/warnings.t
@@ -2,7 +2,7 @@
   warning: support of the RISC-V architecture is experimental
   "warning/risc-v/load_constant_warning.jazz", line 3 (9-15)
   warning: extra assignment introduced:
-             ra = #LI((32u) 10); /* :r */
+             x5 = #LI((32u) 10); /* :r */
 
   $ ../jasminc -wea warning/x86-64/extra_assignment.jazz
   "warning/x86-64/extra_assignment.jazz", line 9 (2-12)

--- a/docs/source/compiler/advanced/armv8a_register_model.md
+++ b/docs/source/compiler/advanced/armv8a_register_model.md
@@ -1,0 +1,143 @@
+# ARMv8-A (AArch64) register model and stack-pointer handling — rationale and sources
+
+This note documents the modeling decisions in the Jasmin AArch64 backend that
+concern the **architecture declaration** (`proofs/compiler/armv8a_decl.v`) and
+the **stack-pointer handling** in the linearization parameters
+(`proofs/compiler/armv8a_params.v`). Each decision departs from a naive "one
+Coq constructor per hardware register" model for a documented architectural or
+ABI reason; the citations below let a reviewer check every claim.
+
+Primary sources:
+
+- **Arm ARM** — *Arm Architecture Reference Manual, A-profile*, Arm DDI 0487M.a
+  (`DDI0487_M.a.a_a-profile_architecture_reference_manual.pdf`,
+  sha256 `c07b1302a3db0c6bc0490808c771d66684ddd5adfb2ef64fd23e6beeb7b22e48`).
+  Page ids below are the manual's own `Sn-NNNN` labels.
+- **AAPCS64** — *Procedure Call Standard for the Arm 64-bit Architecture
+  (AArch64)*, Arm IHI 0055F.
+- **Apple** — *Writing ARM64 Code for Apple Platforms*, Apple Developer
+  documentation.
+
+---
+
+## 1. The general-purpose register set
+
+AArch64 has 31 general-purpose registers `R0..R30`, each addressable as a 64-bit
+`X` register or a 32-bit `W` register, plus a dedicated stack pointer `SP`.
+`R30` is the procedure-call link register.
+
+> Arm ARM, **B1.2 "Registers in AArch64 Execution state"**, p. B1-203:
+> "31 general-purpose registers, R0 to R30 ... The X30 general-purpose register
+> is used as the procedure call link register. SP — A 64-bit dedicated Stack
+> Pointer register."
+
+The model keeps `R0..R30` and `RSP`. Two registers that a hardware-faithful
+model might include are deliberately omitted (§2, §3).
+
+## 2. The zero register (XZR/WZR) is not modeled
+
+In an instruction encoding the 5-bit register field value `31` (`0b11111`) does
+**not** name a physical register; its meaning depends on which register accessor
+the instruction uses:
+
+> Arm ARM, **B1.2**, p. B1-206:
+> "For the general-purpose register X[] accessor, register number 31 accesses
+> the zero register, ZR, which reads as zero and ignores writes."
+
+The stack pointer is reached through a **separate `SP[]` accessor**, so the same
+field value `31` means `SP` only for the instructions that select it (ADD/SUB in
+their SP forms, MOV-to/from-SP, and loads/stores that allow `SP` as base).
+
+Consequences for the model:
+
+- Modeling `ZR` as an allocatable register would be **unsound**: a value written
+  to it is discarded and any read returns 0. The register allocator, treating it
+  as ordinary storage, produced code such as `mov sp, xzr` (setting SP to 0).
+- We therefore omit it entirely, exactly as the Jasmin RISC-V backend omits the
+  hardwired `x0`/`zero`. The handful of operations that genuinely need `ZR` as an
+  operand — `CMP` (`SUBS` to `ZR`), `NEG`, `TST`, etc. — are emitted as dedicated
+  assembler mnemonics by the printer, never as writes to a `ZR` register.
+- `RSP` is the single encoding-31 register we keep, and it always denotes `SP`.
+
+## 3. The platform register (x18) is not modeled
+
+`x18` is not an architectural special register; it is reserved by the software
+ABI:
+
+> AAPCS64 (IHI 0055F), *General-purpose registers*: r18 is
+> "The Platform Register, if needed; otherwise a temporary register", and a
+> platform ABI may reserve it.
+>
+> Apple, *Writing ARM64 Code for Apple Platforms*:
+> "The platforms reserve register x18. Don't use this register."
+
+On Apple platforms, under Windows, and under shadow-call-stack Linux, the OS or
+runtime may overwrite `x18` **asynchronously** (i.e. between two instructions of
+otherwise straight-line user code). Jasmin's register allocator chooses the
+register that holds a function's saved stack pointer by proving the program does
+not clobber it (`get_reg_oracle` in `compiler/src/regalloc.ml`); that analysis
+cannot see writes performed outside the program, so it happily picked `x18` and
+the saved SP was corrupted to 0 at run time.
+
+Keeping `x18` out of the allocation pool is the only safe choice across these
+platforms. On a platform where `x18` is a plain temporary this merely forgoes
+one scratch register; correctness is unaffected.
+
+## 4. The stack pointer must stay 16-byte aligned
+
+Whenever `SP` is used as the base of a memory access it must be 16-byte aligned.
+This is an **architectural** check (an exception), not just an ABI convention:
+
+> Arm ARM, **D1.4.10.2 "SP alignment checking"**, p. D1-7135:
+> - rule **RRDMXG**: "When the SP is used as the base address of a calculation,
+>   regardless of any offset applied by the instruction, if bits [3:0] of the SP
+>   are not 0b0000, there is a misaligned SP."
+> - rule **RTFVSM**: "If SP alignment checking is enabled, then the execution of
+>   a load or store using the SP with a misaligned SP generates a synchronous SP
+>   Alignment exception on that load or store."
+> - rule **RSTDYJ**: the check is enabled by `SCTLR_EL1.SA` (EL1),
+>   `SCTLR_EL1.SA0`/`SCTLR_EL2.SA0` (EL0), etc.
+
+The check is enabled for EL0 on the platforms we target. The 16-byte alignment
+of `SP` at public interfaces is also mandated by the AAPCS64 (IHI 0055F, *The
+stack*: "SP mod 16 = 0"), which B1.2 (p. B1-203) cross-references.
+
+Jasmin sizes each stack frame to the alignment of the objects it holds
+(`sao_align`), which for pure 64-bit code is only 8 bytes, so a raw frame size
+need not be a multiple of 16. The backend therefore:
+
+- rounds every frame allocation/deallocation up to a multiple of 16
+  (`round_up_16`, used by `armv8a_allocate_stack_frame` /
+  `armv8a_free_stack_frame`), so nested calls preserve the invariant; and
+- never aligns a re-aligned frame to less than 16 bytes
+  (`armv8a_set_up_sp_register`).
+
+The extra padding lands at the top of the frame and is never accessed.
+
+## 5. The stack pointer cannot be an LDR destination
+
+Because a load writes its result through the general-purpose `X[]` accessor, and
+register number 31 in that accessor is `ZR` (§2), an A64 `LDR` can never write
+`SP`: its destination operand is `<Xt>`, not `<Xt|SP>`. (This differs from
+ARMv7, where R13/SP is an ordinary register that `LDR` can target — which is why
+the shared linearization default, `lloads_imm_dfl`, is fine for the 32-bit Arm
+backend but not here.)
+
+When the saved stack pointer has been spilled to the stack (the usual case for a
+function that saves callee-saved registers), it must therefore be reloaded into
+a scratch register and then copied to `SP` with a `MOV` (which reaches `SP` via
+the `SP[]` accessor). This is what the backend's custom `armv8a_lloads` does: it
+restores the ordinary saved registers first (relative to the still-live `SP`),
+then loads the saved `SP` into `X17` and issues `MOV SP, X17`.
+
+---
+
+### Cross-reference to the code
+
+| Decision | File / definition | Source |
+|---|---|---|
+| Omit `XZR` | `armv8a_decl.v` — `register`, `registers`, `register_to_string` | Arm ARM B1.2, p. B1-206 |
+| Omit `x18` | `armv8a_decl.v` — `register`, `registers`, `armv8a_internal_call_conv` | AAPCS64 IHI 0055F; Apple ABI |
+| Round frames to 16 | `armv8a_params.v` — `round_up_16`, `armv8a_allocate_stack_frame`, `armv8a_free_stack_frame` | Arm ARM D1.4.10.2 (RRDMXG, RTFVSM) |
+| Re-align frames ≥ 16 | `armv8a_params.v` — `armv8a_set_up_sp_register` | Arm ARM D1.4.10.2; AAPCS64 |
+| Restore `SP` via scratch + `MOV` | `armv8a_params.v` — `armv8a_lloads` | Arm ARM B1.2, p. B1-206 |

--- a/docs/source/compiler/advanced/index.md
+++ b/docs/source/compiler/advanced/index.md
@@ -4,4 +4,5 @@
 
 add_instructions
 memory_layout
+armv8a_register_model
 :::

--- a/docs/source/compiler/advanced/memory_layout.md
+++ b/docs/source/compiler/advanced/memory_layout.md
@@ -39,6 +39,15 @@ directly or through the function it (transitively) calls, the values of these
 registers are saved in its stack frame (in the “extra” part, as described above)
 at the beginning of the function and restored at the end.
 
+On architectures where the caller passes the return address in a register
+(ARM64, RISC-V), that register is treated in the same way: although it is not
+callee-saved, an export function that kills it (typically because it calls
+other functions or performs system calls) saves it in its stack frame and
+restores it before returning through it. On ARM (Cortex-M4), the LR register
+is used as a scratch register by the compiler itself, so it is instead saved
+around the function body (with `push {lr}`/`pop {pc}`), outside the stack
+frame described here.
+
 Since July 2026 (versions 2026.03.2 and 2026.07.0), the Jasmin compiler provides
 some *eperimental* facility to control how much memory is allocated in the stack
 frame of `export` functions to save the values of callee-saved registers. A
@@ -50,7 +59,9 @@ annotation.
 When an `export` function is annotated with `callee_saved = n` where `n` is some
 non-negative value, the compiler will trust this information and provide room in
 the stack frame for exactly n values. Do not forget to take into account the
-stack-pointer register which is also a callee-saved register.
+stack-pointer register which is also a callee-saved register, and, on ARM64
+and RISC-V, the return-address register when the function kills it (e.g. by
+making calls).
 
 If the value given in the annotation is too large (i.e., pessimistic), then some
 space is *wasted* in the frame but the spuriously reserved slots are not used.

--- a/eclib/JModel_armv8a.ec
+++ b/eclib/JModel_armv8a.ec
@@ -1,0 +1,288 @@
+(* -------------------------------------------------------------------- *)
+(* EasyCrypt model of the Jasmin ARMv8-A (AArch64) instructions.
+
+   The instructions that exist in both the 32-bit (W) and 64-bit (X) forms
+   are size-suffixed (ADD_32 / ADD_64, ...), matching the names generated
+   by the Jasmin extraction; fixed-size instructions keep their bare name
+   (UMULL, SXTW, ...). The 32-bit operations whose semantics coincide with
+   AArch32 live in JModel_arm (re-exported below); this file only defines
+   the 64-bit forms and the AArch64-specific 32-bit ones (flag-setting
+   logical instructions, shifts, extensions, ...). *)
+require import AllCore List Bool IntDiv.
+require export JModel_common JArray JWord_array JMemory JLeakage Jslh.
+require export JModel_arm.
+
+abbrev ptr_modulus = 2^64.
+
+(* -------------------------------------------------------------------- *)
+(* Flags. *)
+
+op nzcv_64 (r: W64.t) (u s: int) : bool * bool * bool * bool =
+  (W64.msb r,
+   r = W64.zero,
+   to_uint r <> u,
+   to_sint r <> s).
+
+abbrev with_nzcv_64 r u s =
+  let (n, z, c, v) = nzcv_64 r u s in
+  (n, z, c, v, r).
+
+(* Flags of the flag-setting logical instructions:
+   N and Z from the result, C and V cleared. *)
+abbrev with_nzcv_log_64 (r: W64.t) =
+  (W64.msb r, r = W64.zero, false, false, r).
+
+abbrev with_nzcv_log_32 (r: W32.t) =
+  (W32.msb r, r = W32.zero, false, false, r).
+
+(* -------------------------------------------------------------------- *)
+(* Arithmetic. *)
+
+op ADD_64 (x y: W64.t) : W64.t = x + y.
+
+op ADDS_64 (x y: W64.t) : bool * bool * bool * bool * W64.t =
+  with_nzcv_64 (x + y) (to_uint x + to_uint y) (to_sint x + to_sint y).
+
+op ADC_64 (x y: W64.t) (c: bool) : W64.t =
+  x + y + (if c then W64.one else W64.zero).
+
+op ADCS_64 (x y: W64.t) (c: bool) : bool * bool * bool * bool * W64.t =
+  let r = ADC_64 x y c in
+  with_nzcv_64 r (to_uint x + to_uint y + b2i c) (to_sint x + to_sint y + b2i c).
+
+op SUB_64 (x y: W64.t) : W64.t = x - y.
+
+op SUBS_64 (x y: W64.t) : bool * bool * bool * bool * W64.t =
+  ADCS_64 x (invw y) true.
+
+op SBC_64 (x y: W64.t) (c: bool) : W64.t = ADC_64 x (invw y) c.
+
+op SBCS_64 (x y: W64.t) (c: bool) : bool * bool * bool * bool * W64.t =
+  ADCS_64 x (invw y) c.
+
+op NEG_64 (x: W64.t) : W64.t = invw x + W64.one.
+op NEG_32 (x: W32.t) : W32.t = invw x + W32.one.
+
+op MUL_64 (x y: W64.t) : W64.t = x * y.
+
+op MADD_64 (x y a: W64.t) : W64.t = a + x * y.
+op MADD_32 (x y a: W32.t) : W32.t = a + x * y.
+
+op MSUB_64 (x y a: W64.t) : W64.t = a - x * y.
+op MSUB_32 (x y a: W32.t) : W32.t = a - x * y.
+
+op SDIV_64 (x y: W64.t) : W64.t = x \sdiv y.
+
+op UDIV_64 (x y: W64.t) : W64.t = x \udiv y.
+
+op UMULL (x y: W32.t) : W64.t = zeroextu64 x * zeroextu64 y.
+op SMULL (x y: W32.t) : W64.t = sigextu64 x * sigextu64 y.
+op UMADDL (x y: W32.t) (a: W64.t) : W64.t = a + zeroextu64 x * zeroextu64 y.
+op SMADDL (x y: W32.t) (a: W64.t) : W64.t = a + sigextu64 x * sigextu64 y.
+
+op UMULH (x y: W64.t) : W64.t =
+  W64.of_int ((to_uint x * to_uint y) %/ 2^64).
+op SMULH (x y: W64.t) : W64.t =
+  W64.of_int ((to_sint x * to_sint y) %/ 2^64).
+
+(* -------------------------------------------------------------------- *)
+(* Logical. *)
+
+op AND_64 (x y: W64.t) : W64.t = andw x y.
+
+op ANDS_64 (x y: W64.t) : bool * bool * bool * bool * W64.t =
+  with_nzcv_log_64 (andw x y).
+op ANDS_32 (x y: W32.t) : bool * bool * bool * bool * W32.t =
+  with_nzcv_log_32 (andw x y).
+
+op BIC_64 (x y: W64.t) : W64.t = andw x (invw y).
+
+op BICS_64 (x y: W64.t) : bool * bool * bool * bool * W64.t =
+  with_nzcv_log_64 (andw x (invw y)).
+op BICS_32 (x y: W32.t) : bool * bool * bool * bool * W32.t =
+  with_nzcv_log_32 (andw x (invw y)).
+
+op ORR_64 (x y: W64.t) : W64.t = orw x y.
+
+op EOR_64 (x y: W64.t) : W64.t = x +^ y.
+
+op MVN_64 (x: W64.t) : W64.t = invw x.
+
+(* -------------------------------------------------------------------- *)
+(* Shifts. The shift amount is taken modulo the operand size. *)
+
+op ASR_64 (x: W64.t) (sham: W8.t) : W64.t = x `|>>` W8.of_int (to_uint sham %% 64).
+op ASR_32 (x: W32.t) (sham: W8.t) : W32.t = x `|>>` W8.of_int (to_uint sham %% 32).
+
+op LSL_64 (x: W64.t) (sham: W8.t) : W64.t = x `<<` W8.of_int (to_uint sham %% 64).
+op LSL_32 (x: W32.t) (sham: W8.t) : W32.t = x `<<` W8.of_int (to_uint sham %% 32).
+
+op LSR_64 (x: W64.t) (sham: W8.t) : W64.t = x `>>` W8.of_int (to_uint sham %% 64).
+op LSR_32 (x: W32.t) (sham: W8.t) : W32.t = x `>>` W8.of_int (to_uint sham %% 32).
+
+op ROR_64 (x: W64.t) (sham: W8.t) : W64.t = x `|>>>|` (to_uint sham %% 64).
+op ROR_32 (x: W32.t) (sham: W8.t) : W32.t = x `|>>>|` (to_uint sham %% 32).
+
+(* -------------------------------------------------------------------- *)
+(* Bit field operations. *)
+
+op BFC_64 (x: W64.t) (lsb width: W8.t) : W64.t =
+  let lsbit = to_uint lsb in
+  let msbit = lsbit + to_uint width - 1 in
+  W64.init (fun i => if lsbit <= i <= msbit then false else x.[i]).
+
+op BFI_64 (x y: W64.t) (lsb width: W8.t) : W64.t =
+  let lsbit = to_uint lsb in
+  let msbit = lsbit + to_uint width - 1 in
+  W64.init (fun i => if lsbit <= i <= msbit then y.[i - lsbit] else x.[i]).
+
+op BFXIL_64 (x y: W64.t) (lsb width: W8.t) : W64.t =
+  let lsbit = to_uint lsb in
+  let nbits = to_uint width in
+  W64.init (fun i => if i < nbits then y.[i + lsbit] else x.[i]).
+op BFXIL_32 (x y: W32.t) (lsb width: W8.t) : W32.t =
+  let lsbit = to_uint lsb in
+  let nbits = to_uint width in
+  W32.init (fun i => if i < nbits then y.[i + lsbit] else x.[i]).
+
+op UBFX_64 (x: W64.t) (lsb width: W8.t) : W64.t =
+  (x `<<` W8.of_int (64 - to_uint width - to_uint lsb))
+    `>>` W8.of_int (64 - to_uint width).
+
+op SBFX_64 (x: W64.t) (lsb width: W8.t) : W64.t =
+  (x `<<` W8.of_int (64 - to_uint width - to_uint lsb))
+    `|>>` W8.of_int (64 - to_uint width).
+
+op EXTR_64 (x y: W64.t) (lsb: W8.t) : W64.t =
+  let l = to_uint lsb %% 64 in
+  if l = 0 then y else orw (y `>>` W8.of_int l) (x `<<` W8.of_int (64 - l)).
+op EXTR_32 (x y: W32.t) (lsb: W8.t) : W32.t =
+  let l = to_uint lsb %% 32 in
+  if l = 0 then y else orw (y `>>` W8.of_int l) (x `<<` W8.of_int (32 - l)).
+
+(* -------------------------------------------------------------------- *)
+(* Moves. *)
+
+op MOV_64 (x: W64.t) : W64.t = x.
+
+op MOVZ_64 (imm: W16.t) (sh: W8.t) : W64.t =
+  zeroextu64 imm `<<` sh.
+op MOVZ_32 (imm: W16.t) (sh: W8.t) : W32.t =
+  zeroextu32 imm `<<` sh.
+
+op MOVN_64 (imm: W16.t) (sh: W8.t) : W64.t =
+  invw (zeroextu64 imm `<<` sh).
+op MOVN_32 (imm: W16.t) (sh: W8.t) : W32.t =
+  invw (zeroextu32 imm `<<` sh).
+
+op MOVK_64 (old: W64.t) (imm: W16.t) (sh: W8.t) : W64.t =
+  let mask = zeroextu64 (W16.of_int (-1)) `<<` sh in
+  orw (zeroextu64 imm `<<` sh) (andw old (invw mask)).
+op MOVK_32 (old: W32.t) (imm: W16.t) (sh: W8.t) : W32.t =
+  let mask = zeroextu32 (W16.of_int (-1)) `<<` sh in
+  orw (zeroextu32 imm `<<` sh) (andw old (invw mask)).
+
+op ADR (x: W64.t) : W64.t = x.
+
+(* -------------------------------------------------------------------- *)
+(* Extensions. *)
+
+op SXTB_64 (x: W8.t)  : W64.t = W64.of_int (W8.to_sint x).
+op SXTB_32 (x: W8.t)  : W32.t = W32.of_int (W8.to_sint x).
+
+op SXTH_64 (x: W16.t) : W64.t = W64.of_int (W16.to_sint x).
+op SXTH_32 (x: W16.t) : W32.t = W32.of_int (W16.to_sint x).
+
+op SXTW (x: W32.t) : W64.t = W64.of_int (W32.to_sint x).
+
+op UXTB_64 (x: W8.t)  : W64.t = W64.of_int (W8.to_uint x).
+op UXTB_32 (x: W8.t)  : W32.t = W32.of_int (W8.to_uint x).
+
+op UXTH_64 (x: W16.t) : W64.t = W64.of_int (W16.to_uint x).
+op UXTH_32 (x: W16.t) : W32.t = W32.of_int (W16.to_uint x).
+
+op UXTW (x: W32.t) : W64.t = W64.of_int (W32.to_uint x).
+
+(* -------------------------------------------------------------------- *)
+(* Bit manipulation. *)
+
+op RBIT_64 (x: W64.t) : W64.t =
+  W64.init (fun i => x.[63 - i]).
+op RBIT_32 (x: W32.t) : W32.t =
+  W32.init (fun i => x.[31 - i]).
+
+op REV_64 (x: W64.t) : W64.t =
+  W64.init (fun i => x.[8 * (7 - i %/ 8) + i %% 8]).
+
+op REV16_64 (x: W64.t) : W64.t =
+  W64.init (fun i => x.[16 * (i %/ 16) + 8 * (1 - (i %% 16) %/ 8) + i %% 8]).
+
+op REV32 (x: W64.t) : W64.t =
+  W64.init (fun i => x.[32 * (i %/ 32) + 8 * (3 - (i %% 32) %/ 8) + i %% 8]).
+
+op CLZ_64 (x: W64.t) : W64.t =
+  W64.of_int (lzcnt (rev (w2bits x))).
+
+op CLS_64 (x: W64.t) : W64.t =
+  let t = andw ((x `>>` W8.one) +^ x) (W64.of_int (2^63 - 1)) in
+  W64.of_int (lzcnt (rev (w2bits t)) - 1).
+op CLS_32 (x: W32.t) : W32.t =
+  let t = andw ((x `>>` W8.one) +^ x) (W32.of_int (2^31 - 1)) in
+  W32.of_int (lzcnt (rev (w2bits t)) - 1).
+
+(* -------------------------------------------------------------------- *)
+(* Comparisons: the flag-only aliases of SUBS, ADDS and ANDS. *)
+
+op CMP_64 (x y: W64.t) : bool * bool * bool * bool =
+  let (n, z, c, v, _) = SUBS_64 x y in (n, z, c, v).
+
+op CMN_64 (x y: W64.t) : bool * bool * bool * bool =
+  let (n, z, c, v, _) = ADDS_64 x y in (n, z, c, v).
+
+op TST_64 (x y: W64.t) : bool * bool * bool * bool =
+  let (n, z, c, v, _) = ANDS_64 x y in (n, z, c, v).
+op TST_32 (x y: W32.t) : bool * bool * bool * bool =
+  let (n, z, c, v, _) = ANDS_32 x y in (n, z, c, v).
+
+(* -------------------------------------------------------------------- *)
+(* Conditional selection. *)
+
+op CSEL_64  (x y: W64.t) (b: bool) : W64.t = if b then x else y.
+op CSEL_32  (x y: W32.t) (b: bool) : W32.t = if b then x else y.
+
+op CSINC_64 (x y: W64.t) (b: bool) : W64.t = if b then x else y + W64.one.
+op CSINC_32 (x y: W32.t) (b: bool) : W32.t = if b then x else y + W32.one.
+
+op CSINV_64 (x y: W64.t) (b: bool) : W64.t = if b then x else invw y.
+op CSINV_32 (x y: W32.t) (b: bool) : W32.t = if b then x else invw y.
+
+op CSNEG_64 (x y: W64.t) (b: bool) : W64.t = if b then x else invw y + W64.one.
+op CSNEG_32 (x y: W32.t) (b: bool) : W32.t = if b then x else invw y + W32.one.
+
+op CSET_64  (b: bool) : W64.t = if b then W64.one else W64.zero.
+op CSET_32  (b: bool) : W32.t = if b then W32.one else W32.zero.
+
+op CSETM_64 (b: bool) : W64.t = if b then W64.of_int (-1) else W64.zero.
+op CSETM_32 (b: bool) : W32.t = if b then W32.of_int (-1) else W32.zero.
+
+(* -------------------------------------------------------------------- *)
+(* Loads and stores. The memory access itself is part of the Jasmin
+   semantics; these operators only extend the transferred value. *)
+
+op LDR_64 (x: W64.t) : W64.t = x.
+
+op LDRB_64 (x: W8.t) : W64.t = W64.of_int (W8.to_uint x).
+
+op LDRH_64 (x: W16.t) : W64.t = W64.of_int (W16.to_uint x).
+
+op LDRSB_64 (x: W8.t) : W64.t = W64.of_int (W8.to_sint x).
+
+op LDRSH_64 (x: W16.t) : W64.t = W64.of_int (W16.to_sint x).
+
+op LDRSW (x: W32.t) : W64.t = W64.of_int (W32.to_sint x).
+
+op STR_64 (x: W64.t) : W64.t = x.
+
+op STRB_64 (x: W8.t) : W8.t = x.
+
+op STRH_64 (x: W16.t) : W16.t = x.

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -65,6 +65,7 @@ compiler/arm_params_core_proof.v
 compiler/arm_stack_zeroization.v
 compiler/arm_stack_zeroization_proof.v
 compiler/arm.v
+compiler/armv8a_decl.v
 compiler/array_expansion.v
 compiler/array_expansion_proof.v
 compiler/array_copy.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -65,7 +65,9 @@ compiler/arm_params_core_proof.v
 compiler/arm_stack_zeroization.v
 compiler/arm_stack_zeroization_proof.v
 compiler/arm.v
+compiler/armv8a.v
 compiler/armv8a_decl.v
+compiler/armv8a_instr_decl.v
 compiler/array_expansion.v
 compiler/array_expansion_proof.v
 compiler/array_copy.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -72,9 +72,11 @@ compiler/armv8a_instr_decl.v
 compiler/armv8a_lowering.v
 compiler/armv8a_lowering_proof.v
 compiler/armv8a_params.v
+compiler/armv8a_params_common_proof.v
 compiler/armv8a_params_core.v
 compiler/armv8a_params_core_proof.v
 compiler/armv8a_stack_zeroization.v
+compiler/armv8a_stack_zeroization_proof.v
 compiler/array_expansion.v
 compiler/array_expansion_proof.v
 compiler/array_copy.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -71,6 +71,7 @@ compiler/armv8a_extra.v
 compiler/armv8a_instr_decl.v
 compiler/armv8a_lowering.v
 compiler/armv8a_lowering_proof.v
+compiler/armv8a_params.v
 compiler/armv8a_params_core.v
 compiler/armv8a_params_core_proof.v
 compiler/armv8a_stack_zeroization.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -67,6 +67,7 @@ compiler/arm_stack_zeroization_proof.v
 compiler/arm.v
 compiler/armv8a.v
 compiler/armv8a_decl.v
+compiler/armv8a_extra.v
 compiler/armv8a_instr_decl.v
 compiler/armv8a_params_core.v
 compiler/armv8a_params_core_proof.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -69,6 +69,7 @@ compiler/armv8a.v
 compiler/armv8a_decl.v
 compiler/armv8a_extra.v
 compiler/armv8a_instr_decl.v
+compiler/armv8a_lowering.v
 compiler/armv8a_params_core.v
 compiler/armv8a_params_core_proof.v
 compiler/array_expansion.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -68,6 +68,8 @@ compiler/arm.v
 compiler/armv8a.v
 compiler/armv8a_decl.v
 compiler/armv8a_instr_decl.v
+compiler/armv8a_params_core.v
+compiler/armv8a_params_core_proof.v
 compiler/array_expansion.v
 compiler/array_expansion_proof.v
 compiler/array_copy.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -70,6 +70,7 @@ compiler/armv8a_decl.v
 compiler/armv8a_extra.v
 compiler/armv8a_instr_decl.v
 compiler/armv8a_lowering.v
+compiler/armv8a_lowering_proof.v
 compiler/armv8a_params_core.v
 compiler/armv8a_params_core_proof.v
 compiler/armv8a_stack_zeroization.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -75,6 +75,7 @@ compiler/armv8a_params.v
 compiler/armv8a_params_common_proof.v
 compiler/armv8a_params_core.v
 compiler/armv8a_params_core_proof.v
+compiler/armv8a_params_proof.v
 compiler/armv8a_stack_zeroization.v
 compiler/armv8a_stack_zeroization_proof.v
 compiler/array_expansion.v

--- a/proofs/_CoqProject
+++ b/proofs/_CoqProject
@@ -72,6 +72,7 @@ compiler/armv8a_instr_decl.v
 compiler/armv8a_lowering.v
 compiler/armv8a_params_core.v
 compiler/armv8a_params_core_proof.v
+compiler/armv8a_stack_zeroization.v
 compiler/array_expansion.v
 compiler/array_expansion_proof.v
 compiler/array_copy.v

--- a/proofs/arch/arch_decl.v
+++ b/proofs/arch/arch_decl.v
@@ -687,6 +687,14 @@ Class calling_convention :=
   ; call_reg_ret   : seq reg_t
   ; call_xreg_ret  : seq xreg_t
   ; call_reg_ret_uniq : uniq (T:= @ceqT_eqType _ _) call_reg_ret
+    (* Register in which the caller passes the return address to export
+       functions, when the compiled body is in charge of preserving it (it is
+       spilled to the stack frame, together with the killed callee-saved
+       registers, when the body kills it; this is enforced by the one-varmap
+       checker). [None] when the return address is passed on the stack (x86)
+       or preserved outside of the model (arm-m4, where LR is also the
+       linearization scratch register). *)
+  ; call_reg_ra    : option reg_t
   }.
 
 Definition get_ARReg (a:asm_typed_reg) :=

--- a/proofs/arch/asm_gen.v
+++ b/proofs/arch/asm_gen.v
@@ -702,6 +702,7 @@ Definition all_vars :=
          scs_vout := map to_var (take (size sig.(scs_tout)) call_reg_ret) |};
   all_vars     := all_vars;
   callee_saved := sv_of_list var_of_asm_typed_reg callee_saved;
+  call_ra      := oapp (fun r => Sv.singleton (to_var r)) Sv.empty call_reg_ra;
   vflags       := vflags;
   vflagsP      := vflagsP;
 }.

--- a/proofs/compiler/arm_decl.v
+++ b/proofs/compiler/arm_decl.v
@@ -206,7 +206,13 @@ Definition arm_linux_call_conv : calling_convention :=
    ; call_xreg_args := [::]
    ; call_reg_ret   := [:: R00; R01 ]
    ; call_xreg_ret  := [::]
-   ; call_reg_ret_uniq := erefl true;
+   ; call_reg_ret_uniq := erefl true
+     (* The return address is passed in LR, but LR is also the linearization
+        scratch register (lip_tmp2): the prologue of an export function kills
+        it before it could be spilled to the stack frame, so it is saved
+        around the function body by the assembly printer instead (see
+        pp_arm_m4). *)
+   ; call_reg_ra    := None
   |}.
 
 Definition is_expandable (n : Z) : bool :=

--- a/proofs/compiler/armv8a.v
+++ b/proofs/compiler/armv8a.v
@@ -1,0 +1,18 @@
+(* ARMv8-A (AArch64) architecture: condition evaluation and [asm] instance. *)
+
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype.
+
+Require Import utils.
+Require Import arch_decl.
+Require Import
+  armv8a_decl
+  armv8a_instr_decl.
+
+(* The evaluation of condition codes ([arm_eval_cond]) is shared with the
+   other Arm architectures: see arm_common.v. *)
+
+#[ export ]
+Instance armv8a : asm register register_ext xregister rflag condt armv8a_asm_op :=
+  {
+    eval_cond := fun _ => arm_eval_cond;
+  }.

--- a/proofs/compiler/armv8a_decl.v
+++ b/proofs/compiler/armv8a_decl.v
@@ -1,0 +1,357 @@
+(* ARMv8-A (AArch64) architecture declaration.
+
+ * Description of the A64 base architecture (no SIMD/FP, no extensions).
+ * General-purpose registers are modeled at their full 64-bit width (X
+ * registers); instructions come in 64-bit (X) and 32-bit (W) forms.
+ *)
+From elpi.apps Require Import derive.std.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype fintype ssralg.
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  expr
+  flag_combination
+  sem_type
+  shift_kind
+  strings
+  utils
+  wsize
+  word.
+
+Require Import
+  arch_decl
+  arch_utils.
+
+Require Export arm_common.
+
+(* --------------------------------------------- *)
+Definition armv8a_reg_size  := U64.
+Definition armv8a_xreg_size := U128.
+
+(* -------------------------------------------------------------------- *)
+(* Registers.
+
+   AArch64 exposes 31 general-purpose registers R0..R30, each addressable as a
+   64-bit X or 32-bit W register, plus a dedicated stack pointer SP. R30 is the
+   procedure-call link register (Arm ARM DDI0487M.a, B1.2 "Registers in AArch64
+   Execution state", p. B1-203).
+
+   This model deliberately deviates from the raw register file in two places.
+
+   - XZR (the zero register) is NOT modeled as a register. In an instruction
+     encoding, the 5-bit register field value 31 (0b11111) denotes, for the
+     general-purpose (X[]/W[]) accessor, the zero register ZR, which "reads as
+     zero and ignores writes" (DDI0487M.a, B1.2, p. B1-206); the stack pointer
+     is reached through a *separate* SP[] accessor, so the same value 31 means
+     SP only for the instructions that select it (ADD/SUB/MOV-to-SP, loads and
+     stores). Modeling ZR as an allocatable register is therefore unsound: a
+     value written to it is discarded and reads return 0. As with RISC-V's
+     hardwired X0, we simply omit it; the few instructions that need ZR as an
+     operand (CMP = SUBS to ZR, NEG, TST, ...) are emitted as dedicated
+     mnemonics by the assembly printer. [RSP] below is the only encoding-31
+     register we keep, and it always denotes SP.
+
+   - X18 is NOT modeled either. The Procedure Call Standard for the Arm 64-bit
+     Architecture (AAPCS64, Arm IHI 0055F, section "General-purpose registers")
+     designates r18 as "The Platform Register, if needed; otherwise a temporary
+     register", and states that platform ABIs may reserve it. It is reserved in
+     practice on Apple platforms ("Writing ARM64 Code for Apple Platforms":
+     "The platforms reserve register x18. Don't use this register.") and under
+     Windows and shadow-call-stack Linux, where the OS/runtime may overwrite it
+     asynchronously. Since Jasmin's clobber analysis cannot see such external
+     writes, keeping x18 out of the allocation pool is the only safe choice; on
+     platforms where x18 is a plain temporary this merely forgoes one register. *)
+
+#[only(eqbOK)] derive
+Variant register : Type :=
+| R0 | R1 | R2 | R3 | R4 | R5 | R6 | R7
+| R8 | R9 | R10 | R11 | R12 | R13 | R14 | R15
+| R16 | R17
+| R19 | R20 | R21 | R22 | R23 | R24
+| R25 | R26 | R27 | R28
+| R29                           (* Frame pointer. *)
+| R30                           (* Link register. *)
+| RSP.                          (* Stack pointer. *)
+
+#[ export ]
+Instance eqTC_register : eqTypeC register :=
+  { ceqP := register_eqb_OK }.
+
+Canonical armv8a_register_eqType := @ceqT_eqType _ eqTC_register.
+
+Definition registers :=
+  [:: R0; R1; R2; R3; R4; R5; R6; R7;
+      R8; R9; R10; R11; R12; R13; R14; R15;
+      R16; R17;
+      R19; R20; R21; R22; R23; R24;
+      R25; R26; R27; R28;
+      R29; R30; RSP ].
+
+Lemma register_fin_axiom : Finite.axiom registers.
+Proof. by case. Qed.
+
+#[ export ]
+Instance finTC_register : finTypeC register :=
+  {
+    cenum  := registers;
+    cenumP := register_fin_axiom;
+  }.
+
+Canonical register_finType := @cfinT_finType _ finTC_register.
+
+Definition register_to_string (r : register) : string :=
+  match r with
+  | R0 => "x0"   | R1 => "x1"   | R2 => "x2"   | R3 => "x3"
+  | R4 => "x4"   | R5 => "x5"   | R6 => "x6"   | R7 => "x7"
+  | R8 => "x8"   | R9 => "x9"   | R10 => "x10" | R11 => "x11"
+  | R12 => "x12" | R13 => "x13" | R14 => "x14" | R15 => "x15"
+  | R16 => "x16" | R17 => "x17"
+  | R19 => "x19" | R20 => "x20" | R21 => "x21" | R22 => "x22"
+  | R23 => "x23" | R24 => "x24" | R25 => "x25" | R26 => "x26"
+  | R27 => "x27" | R28 => "x28"
+  | R29 => "x29" | R30 => "x30"
+  | RSP => "sp"
+  end.
+
+#[ export ]
+Instance reg_toS : ToString (lword armv8a_reg_size) register :=
+  {| category  := "register"
+   ; to_string := register_to_string
+  |}.
+
+(* The flags ([rflag]) and conditions ([condt]) are shared with the other
+   Arm architectures: see arm_common.v. *)
+
+(* -------------------------------------------------------------------- *)
+(* Register shifts.
+ * Data-processing (shifted register) instructions can shift a register
+ * operand before performing the operation. The shift amount ranges over
+ * 0..63 for 64-bit operands and 0..31 for 32-bit operands.
+ *
+ * Source: the "Decode for all variants" pseudocode shared by the shifted-
+ * register data-processing instructions (Arm ARM DDI0487M.a, C6.2, e.g. AND
+ * (shifted register), p. C6-1813) reads the amount as [shift_amount =
+ * UInt(imm6)] over the operand width [datasize = 32 << UInt(sf)], and rejects
+ * an out-of-range 32-bit amount with
+ *   [if sf == '0' && imm6<5> == '1' then UNDEFINED].
+ * Hence the amount is [0 <= amount < datasize] (0..31 for W, 0..63 for X),
+ * the same range for every shift type (LSL/LSR/ASR/ROR) — unlike AArch32,
+ * where the range depends on the shift type (see [shift_amount_bounds] in
+ * shift_kind.v). This is why the AArch64 immediate checker
+ * [CAimmC_armv8a_shift_amount] (arch_decl.v) is keyed on the operand [wsize]
+ * rather than on the [shift_kind]. *)
+
+#[ export ]
+Instance eqTC_shift_kind : eqTypeC shift_kind :=
+  { ceqP := shift_kind_eqb_OK }.
+
+Canonical shift_kind_eqType := @ceqT_eqType _ eqTC_shift_kind.
+
+Definition shift_kinds :=
+  [:: SLSL; SLSR; SASR; SROR ].
+
+Definition string_of_shift_kind (sk : shift_kind) : string :=
+  match sk with
+  | SLSL => "lsl"
+  | SLSR => "lsr"
+  | SASR => "asr"
+  | SROR => "ror"
+  end.
+
+Definition check_shift_amount (ws : wsize) (z : Z) : bool :=
+  (0 <=? z)%Z && (z <? wsize_bits ws)%Z.
+
+Definition shift_op (sk : shift_kind) :
+  forall (sz : wsize), word sz -> Z -> word sz :=
+  match sk with
+  | SLSL => wshl
+  | SLSR => wshr
+  | SASR => wsar
+  | SROR => wror
+  end.
+
+Definition shift_of_sop2 (ws : wsize) (op : sop2) : option shift_kind :=
+  let%opt _ := oassert ((ws == U64) || (ws == U32)) in
+  match op with
+  | Olsl (Op_w ws') => if ws' == ws then Some SLSL else None
+  | Olsr ws' => if ws' == ws then Some SLSR else None
+  | Oasr (Op_w ws') => if ws' == ws then Some SASR else None
+  | Oror ws' => if ws' == ws then Some SROR else None
+  | _ => None
+  end.
+
+(* The flag combinations ([arm_fcp]) are shared with the other Arm
+   architectures: see arm_common.v. *)
+
+(* -------------------------------------------------------------------- *)
+(* Immediate encodings.
+
+   Executable versions of the A64 immediate-encoding rules, used by the
+   [CAimm] argument checkers so that assembly generation rejects operands
+   the assembler cannot encode. All predicates take the immediate as its
+   unsigned value ([wunsigned]) and, where the rule depends on it, the
+   operand width [ws]. *)
+
+(* [C6.2.5 ADD (immediate)] (ARM DDI 0487 M.a): a 12-bit unsigned
+   immediate, optionally shifted left by 12 bits. *)
+Definition is_arith_imm (z : Z) : bool :=
+  [&& 0 <=? z & z <? 4096]%Z
+  || [&& 0 <=? z, z <? 4096 * 4096 & z mod 4096 =? 0]%Z.
+
+(* Rotate [x] right by [r] within [e] bits.
+   Precondition: [0 <= x < 2^e] and [0 <= r <= e]. *)
+Definition z_rotr (e x r : Z) : Z :=
+  ((x / 2 ^ r) + (x mod 2 ^ r) * 2 ^ (e - r)) mod 2 ^ e.
+
+(* [y = 2^s - 1] for some [0 < s < e]: a contiguous run of ones starting
+   at bit 0, neither empty nor filling all [e] bits. The run shape is
+   equivalent to [y] and [y + 1] having no common bit. *)
+Definition is_ones_run (e y : Z) : bool :=
+  [&& 0 <? y, y <? 2 ^ e - 1 & Z.land y (y + 1) =? 0]%Z.
+
+(* [DecodeBitMasks] (ARM DDI 0487 M.a, aarch64/instrs/integer/bitmasks):
+   [x] is a logical (bitmask) immediate for operand width [ws] iff it is
+   the replication of an [e]-bit element ([e] in {2,4,8,16,32,64},
+   [e <= width]) that is a rotation of a contiguous run of ones (neither
+   zero nor all ones). Replication is tested as invariance under rotation
+   by [e]; the element is tested against every rotation, which is bounded
+   ([e <= 64]) so the predicate stays executable. *)
+Definition is_bitmask_imm (ws : wsize) (x : Z) : bool :=
+  let n := wsize_bits ws in
+  has
+    (fun e =>
+       [&& e <=? n,
+           z_rotr n x e =? x
+         & has
+             (fun r => is_ones_run e (z_rotr e (x mod 2 ^ e) r))
+             (map Z.of_nat (iota 0 (Z.to_nat e))) ])%Z
+    [:: 2; 4; 8; 16; 32; 64 ]%Z.
+
+(* MOV (wide immediate) [C6.2.193]: a 16-bit immediate at a 16-bit-aligned
+   position within the operand. *)
+Definition is_wide_imm (ws : wsize) (x : Z) : bool :=
+  has
+    (fun sh => (x mod 2 ^ sh =? 0) && (x / 2 ^ sh <? 2 ^ 16))%Z
+    (filter (fun sh => (sh <? wsize_bits ws)%Z) [:: 0; 16; 32; 48 ]%Z).
+
+(* Immediates accepted by the MOV alias [C6.2.192–C6.2.194]: a wide
+   immediate (MOVZ), an inverted wide immediate (MOVN) or a bitmask
+   immediate (ORR with the zero register). This accepts any value for
+   which one of the three encodings exists; the alias preferences that
+   pick among them only matter for disassembly. *)
+Definition is_mov_imm (ws : wsize) (x : Z) : bool :=
+  [|| is_wide_imm ws x,
+      is_wide_imm ws (Z.lnot x mod wbase ws)
+    | is_bitmask_imm ws x ].
+
+(* -------------------------------------------------------------------- *)
+(* Architecture declaration. *)
+
+Notation register_ext := empty.
+Notation xregister := empty.
+
+(* Immediate-argument conditions (see [caimm_cond] in arch_decl.v).
+   Each constructor is a validity predicate for an immediate operand and
+   carries the datum its rule depends on:
+   - [CAimmC_armv8a_shift_amount] carries a [wsize]: the amount range is
+     [0, datasize) for every shift type, but there are two operand widths
+     (W = 32, X = 64). See [check_shift_amount] above, grounded in the
+     C6.2 shifted-register decode.
+   - [CAimmC_armv8a_halfword_shift] carries a [wsize]: the MOVZ/MOVN/MOVK
+     halfword shift (hw field, C6.2.192-C6.2.194) is a multiple of 16 below
+     the operand width, so 32 and 48 only exist in the X form.
+   The immediate-encoding conditions take the operand width from the
+   [wsize] of the immediate itself (the [CAimm] argument kind carries it),
+   so they need no payload:
+   - [CAimmC_armv8a_arith_imm]: 12-bit unsigned immediate, optionally shifted
+     left by 12 (ADD/SUB/CMP/CMN immediate class, C6.2.5).
+   - [CAimmC_armv8a_bitmask_imm]: logical (bitmask) immediates - a run of ones
+     rotated within an element of 2/4/8/16/32/64 bits, replicated across the
+     operand (AND/ORR/EOR/ANDS/TST immediate class, DecodeBitMasks, J1.1).
+   - [CAimmC_armv8a_mov_imm]: immediates accepted by the MOV alias - a wide
+     immediate (MOVZ), an inverted wide immediate (MOVN) or a bitmask
+     immediate (ORR), C6.2.192-C6.2.194. *)
+#[only(eqbOK)] derive
+Variant armv8a_caimm_cond :=
+  | CAimmC_armv8a_shift_amount of wsize
+  | CAimmC_armv8a_halfword_shift of wsize
+  | CAimmC_armv8a_arith_imm
+  | CAimmC_armv8a_bitmask_imm
+  | CAimmC_armv8a_mov_imm.
+
+#[ export ]
+Instance eqTC_armv8a_caimm_cond : eqTypeC armv8a_caimm_cond :=
+  { ceqP := armv8a_caimm_cond_eqb_OK }.
+
+Definition armv8a_check_CAimm (checker : armv8a_caimm_cond) ws (w : word ws) : bool :=
+  match checker with
+  | CAimmC_armv8a_shift_amount ws' => check_shift_amount ws' (wunsigned w)
+  | CAimmC_armv8a_halfword_shift ws' =>
+    let x := wunsigned w in (x \in [:: 0; 16; 32; 48 ]%Z) && (x <? wsize_bits ws')%Z
+  | CAimmC_armv8a_arith_imm => is_arith_imm (wunsigned w)
+  | CAimmC_armv8a_bitmask_imm => is_bitmask_imm ws (wunsigned w)
+  | CAimmC_armv8a_mov_imm => is_mov_imm ws (wunsigned w)
+  end.
+
+Definition armv8a_caimm_cond_pp (checker : armv8a_caimm_cond) : string :=
+  match checker with
+  | CAimmC_armv8a_shift_amount ws => if ws == U64 then "[0, 63]" else "[0, 31]"
+  | CAimmC_armv8a_halfword_shift ws =>
+      if ws == U64 then "[0; 16; 32; 48]" else "[0; 16]"
+  | CAimmC_armv8a_arith_imm => "(arith imm12, optionally << 12)"
+  | CAimmC_armv8a_bitmask_imm => "(logical bitmask immediate)"
+  | CAimmC_armv8a_mov_imm => "(wide, inverted wide or bitmask immediate)"
+  end%string.
+
+#[ export ]
+Instance armv8a_decl : arch_decl register register_ext xregister rflag condt :=
+  { reg_size  := armv8a_reg_size
+  ; xreg_size := armv8a_xreg_size
+  ; cond_eqC  := eqTC_condt
+  ; toS_r     := reg_toS
+  ; toS_rx    := empty_toS lword64
+  ; toS_x     := empty_toS lword128
+  ; toS_f     := rflag_toS
+  ; reg_size_neq_xreg_size := refl_equal
+  ; ad_rsp := RSP
+  ; ad_fcp := arm_fcp
+  ; caimm_cond := armv8a_caimm_cond
+  ; caimm_cond_eqC := eqTC_armv8a_caimm_cond
+  ; caimm_cond_pp := armv8a_caimm_cond_pp
+  ; check_CAimm := armv8a_check_CAimm
+  }.
+
+(* -------------------------------------------------------------------- *)
+(* Calling convention (AAPCS64).
+   There is a single convention: AAPCS64 is the same on Linux, macOS and
+   Windows for everything Jasmin uses (arguments in R0-R7, results in
+   R0/R1, callee-saved R19-R30). The only platform-dependent register is
+   x18 (reserved on Windows, on Apple platforms and under
+   shadow-call-stack Linux), and it is excluded from the register file
+   altogether (see the [register] declaration above), so this convention
+   is valid on all platforms. *)
+
+Definition armv8a_call_conv : calling_convention :=
+  {| callee_saved :=
+      map ARReg [:: R19; R20; R21; R22; R23; R24; R25; R26; R27; R28
+                  ; R29; RSP ]
+   ; callee_saved_not_bool := erefl true
+   ; callee_saved_has_rsp  := erefl true
+   ; call_reg_args  := [:: R0; R1; R2; R3; R4; R5; R6; R7 ]
+   ; call_xreg_args := [::]
+   ; call_reg_ret   := [:: R0; R1; R2; R3; R4; R5; R6; R7 ]
+   ; call_xreg_ret  := [::]
+   ; call_reg_ret_uniq := erefl true
+   |}.
+
+Definition armv8a_internal_call_conv : internal_calling_convention :=
+  {| icall_reg   :=
+      [:: R0; R1; R2; R3; R4; R5; R6; R7;
+          R8; R9; R10; R11; R12; R13; R14; R15;
+          R16; R17;
+          R19; R20; R21; R22; R23; R24;
+          R25; R26; R27; R28; R29 ]
+   ; icall_regx  := [::]
+   ; icall_xreg  := [::]
+   ; icall_rflag := [:: CF; NF; ZF; VF ]
+  |}.

--- a/proofs/compiler/armv8a_decl.v
+++ b/proofs/compiler/armv8a_decl.v
@@ -342,6 +342,7 @@ Definition armv8a_call_conv : calling_convention :=
    ; call_reg_ret   := [:: R0; R1; R2; R3; R4; R5; R6; R7 ]
    ; call_xreg_ret  := [::]
    ; call_reg_ret_uniq := erefl true
+   ; call_reg_ra    := Some R30
    |}.
 
 Definition armv8a_internal_call_conv : internal_calling_convention :=

--- a/proofs/compiler/armv8a_extra.v
+++ b/proofs/compiler/armv8a_extra.v
@@ -1,0 +1,209 @@
+(* ARMv8-A (AArch64) extra (pseudo-)operations, expanded into base
+   instructions at assembly generation. *)
+
+From elpi.apps Require Import derive.std.
+From HB Require Import structures.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssralg.
+
+Require Import
+  compiler_util
+  expr
+  fexpr
+  sopn
+  utils.
+Require Export
+  arch_decl
+  arch_extra
+  armv8a_params_core.
+Require Import
+  armv8a_decl
+  armv8a_instr_decl
+  armv8a.
+
+
+#[only(eqbOK)] derive
+Variant armv8a_extra_op : Type :=
+  | Oarmv8a_swap of wsize
+  | Oarmv8a_add_large_imm
+  | Oarmv8a_smart_li of wsize (* Load an immediate to a register. *)
+.
+
+HB.instance Definition _ := hasDecEq.Build armv8a_extra_op armv8a_extra_op_eqb_OK.
+
+#[ export ]
+Instance eqTC_armv8a_extra_op : eqTypeC armv8a_extra_op :=
+  { ceqP := armv8a_extra_op_eqb_OK }.
+
+(* Extra instructions descriptions. *)
+
+Local Notation E n := (sopn.ADExplicit n sopn.ACR_any).
+
+(* [conflicts] ensures that the returned register is distinct from the first
+   argument. *)
+Definition Oarmv8a_add_large_imm_instr : instruction_desc :=
+  let ty := aword armv8a_reg_size in
+  let cty := eval_atype ty in
+  let ctin := [:: cty; cty] in
+  let semi := fun (x y : word armv8a_reg_size) => (x + y)%w in
+  {| str    := (fun _ => "add_large_imm"%string)
+   ; tin    := [:: ty; ty]
+   ; i_in   := [:: E 1; E 2]
+   ; tout   := [:: ty]
+   ; i_out  := [:: E 0]
+   ; conflicts := [:: (APout 0, APin 0)]
+   ; semi   := sem_prod_ok ctin semi
+   ; semu   := @values.vuincl_app_sopn_v ctin [:: cty] (sem_prod_ok ctin semi) refl_equal
+   ; i_safe := [::]
+   ; i_valid := true
+   ; i_doit := DOIT
+   ; i_safe_wf := refl_equal
+   ; i_semi_errty :=  fun _ => sem_prod_ok_error (tin:=ctin) semi _
+   ; i_semi_safe := fun _ => values.sem_prod_ok_safe (tin:=ctin) semi
+ |}.
+
+Definition smart_li_instr (ws : wsize) : instruction_desc :=
+  mk_instr_desc_safe
+    (pp_sz "smart_li" ws)
+    [:: aword ws ] [:: E 0 ]
+    [:: aword ws ] [:: E 1 ]
+    (fun x => x)
+    true DOIT.
+
+Definition get_instr_desc (o: armv8a_extra_op) : instruction_desc :=
+  match o with
+  | Oarmv8a_swap sz => Oswap_instr (aword sz)
+  | Oarmv8a_add_large_imm => Oarmv8a_add_large_imm_instr
+  | Oarmv8a_smart_li ws => smart_li_instr ws
+  end.
+
+(* Without priority 1, this instance is selected when looking for an [asmOp],
+ * meaning that extra ops are the only possible ops. With that priority,
+ * [arch_extra.asm_opI] is selected first and we have both base and extra ops.
+*)
+#[ export ]
+Instance armv8a_extra_op_decl : asmOp armv8a_extra_op | 1 :=
+  {
+    asm_op_instr := get_instr_desc;
+    prim_string := [::];
+  }.
+
+Module E.
+
+Definition pass_name := "asmgen"%string.
+
+Definition internal_error (ii : instr_info) (msg : string) :=
+  {|
+    pel_msg := compiler_util.pp_s msg;
+    pel_fn := None;
+    pel_fi := None;
+    pel_ii := Some ii;
+    pel_vi := None;
+    pel_pass := Some pass_name;
+    pel_internal := true;
+  |}.
+
+Definition error (ii : instr_info) (msg : string) :=
+  {|
+    pel_msg := compiler_util.pp_s msg;
+    pel_fn := None;
+    pel_fi := None;
+    pel_ii := Some ii;
+    pel_vi := None;
+    pel_pass := Some pass_name;
+    pel_internal := false;
+  |}.
+
+End E.
+
+Definition asm_args_of_opn_args
+  : seq ARMv8AFopn_core.opn_args -> seq (asm_op_msb_t * lexprs * rexprs) :=
+  map (fun '(les, aop, res) => ((None, aop), les, res)).
+
+Definition uncons_LLvar
+  (ii : instr_info) (les : seq lexpr) : cexec (var_i * seq lexpr) :=
+  if les is LLvar x :: les
+  then ok (x, les)
+  else Error (E.internal_error ii "invalid lvals").
+
+Definition uncons_wconst
+  (ii : instr_info) (res : seq rexpr) : cexec (Z * seq rexpr) :=
+  if res is Rexpr (Fapp1 (Oword_of_int _) (Fconst imm)) :: res'
+  then ok (imm, res')
+  else Error (E.internal_error ii "invalid arguments").
+
+Definition smart_li_args ii ws les res :=
+  (* [ARMv8AFopn_core.li] materializes immediates at the two A64 operand
+     widths (X and W); other sizes have no MOVZ/MOVK form, so they are
+     rejected here by design. *)
+  Let _ :=
+    assert
+      ((ws == U64) || (ws == U32))
+      (E.error ii "smart immediate assignment is only valid for u64 and u32 variables")
+  in
+  Let: (x, les) := uncons_LLvar ii les in
+  (* After register allocation the destination is a machine register
+     variable, whose type is always the full register size. *)
+  Let _ :=
+    assert (convertible (vtype (v_var x)) (aword reg_size)) (E.internal_error ii "invalid type")
+  in
+  Let _ := assert (nilp les) (E.internal_error ii "invalid lvals") in
+  Let: (imm, res) := uncons_wconst ii res in
+  ok (x, imm, res).
+
+Definition assemble_smart_li ii ws les res :=
+  Let: (x, imm, _) := smart_li_args ii ws les res in
+  ok (asm_args_of_opn_args (ARMv8AFopn_core.li ws x imm)).
+
+Definition assemble_extra
+           (ii: instr_info)
+           (o: armv8a_extra_op)
+           (outx: lexprs)
+           (inx: rexprs)
+           : cexec (seq (asm_op_msb_t * lexprs * rexprs)) :=
+  match o with
+  | Oarmv8a_swap sz =>
+    if (sz == U64)%CMP then
+      match outx, inx with
+      | [:: LLvar x; LLvar y], [:: Rexpr (Fvar z); Rexpr (Fvar w)] =>
+        (* x, y = swap(z, w) *)
+        Let _ := assert (v_var x != v_var w)
+          (E.internal_error ii "bad armv8a swap : x = w") in
+        Let _ := assert (v_var y != v_var x)
+          (E.internal_error ii "bad armv8a swap : y = x") in
+        Let _ := assert (all (fun (x:var_i) => convertible (vtype x) (aword U64)) [:: x; y; z; w])
+          (E.error ii "armv8a swap is only valid for registers of type u64") in
+
+        ok [:: ((None, ARMv8A_op EOR default_opts), [:: LLvar x], [:: Rexpr (Fvar z); Rexpr (Fvar w)]);
+               (* x = z ^ w *)
+               ((None, ARMv8A_op EOR default_opts), [:: LLvar y], [:: Rexpr (Fvar x); Rexpr (Fvar w)]);
+               (* y = x ^ w = z ^ w ^ w = z *)
+               ((None, ARMv8A_op EOR default_opts), [:: LLvar x], [:: Rexpr (Fvar x); Rexpr (Fvar y)])
+           ]   (* x = x ^ y = z ^ w ^ z = w *)
+      | _, _ => Error (E.error ii "only registers are accepted on source and destination of the swap instruction on armv8a")
+      end
+    else
+      Error (E.error ii "armv8a swap is only valid for registers of type u64")
+  | Oarmv8a_add_large_imm =>
+    match outx, inx with
+    | [:: LLvar x], [:: Rexpr (Fvar y); Rexpr (Fapp1 (Oword_of_int ws) (Fconst imm))] =>
+      Let _ := assert (v_var x != v_var y)
+         (E.internal_error ii "bad armv8a_add_large_imm: invalid register") in
+      Let _ := assert (all (fun (x:var_i) => convertible (vtype x) (aword U64)) [:: x; y])
+          (E.error ii "armv8a_add_large_imm is only valid for registers of type u64") in
+      ok (asm_args_of_opn_args (ARMv8AFopn_core.smart_addi x y imm))
+    | _, _ =>
+      Error (E.internal_error ii "bad armv8a_add_large_imm: invalid args or dests")
+    end
+  | Oarmv8a_smart_li ws => assemble_smart_li ii ws outx inx
+  end.
+
+#[ export ]
+Instance armv8a_extra {atoI : arch_toIdent} :
+  asm_extra register register_ext xregister rflag condt armv8a_asm_op armv8a_extra_op :=
+  { to_asm := assemble_extra }.
+
+(* This concise name is convenient in OCaml code. *)
+Definition armv8a_extended_op {atoI : arch_toIdent} :=
+  @extended_op _ _ _ _ _ _ _ armv8a_extra.
+
+Definition Oarmv8a {atoI : arch_toIdent} o : @sopn armv8a_extended_op _ := Oasm (BaseOp (None, o)).

--- a/proofs/compiler/armv8a_instr_decl.v
+++ b/proofs/compiler/armv8a_instr_decl.v
@@ -1,0 +1,2007 @@
+(* ARMv8-A (AArch64) instruction set.
+
+   A64 base instructions. Data-processing instructions come in two forms
+   selected by the [opts_size] option: the 64-bit (X registers) form and
+   the 32-bit (W registers) form, which zeroes the upper 32 bits of
+   destination registers. Instruction documentation is quoted from the ARM
+   Architecture Reference Manual for A-profile architecture, ARM DDI 0487
+   M.a (the machine-readable extraction lives in
+   compiler/doc/armv8a_isa_docs.json). *)
+
+From elpi.apps Require Import derive.std.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq eqtype fintype.
+From mathcomp Require Import ssralg word_ssrZ.
+
+Require Import
+  sem_type
+  shift_kind
+  strings
+  utils
+  word.
+Require xseq.
+Require Import
+  values
+  sopn
+  arch_decl
+  arch_utils.
+Require Import armv8a_decl.
+
+
+Module E.
+  Definition no_semantics : error := ErrSemUndef.
+End E.
+
+
+(* -------------------------------------------------------------------- *)
+(* ARMv8-A instruction options.
+   Unlike ARMv7-M, A64 has no conditional execution and flag-setting
+   variants are distinct mnemonics (ADDS, SUBS, ...). The options select
+   the operand size ([U64] for the X form, [U32] for the W form) and an
+   optional shift of the last register operand of data-processing
+   instructions. *)
+
+#[only(eqbOK)] derive
+Record armv8a_options :=
+  {
+    has_shift : option shift_kind;
+    opts_size : wsize;
+  }.
+
+#[ export ]
+Instance eqTC_armv8a_options : eqTypeC armv8a_options :=
+  { ceqP := armv8a_options_eqb_OK }.
+
+Canonical armv8a_options_eqType := @ceqT_eqType _ eqTC_armv8a_options.
+
+Definition default_opts : armv8a_options :=
+  {|
+    has_shift := None;
+    opts_size := U64;
+  |}.
+
+Definition opts_at (ws : wsize) : armv8a_options :=
+  {|
+    has_shift := None;
+    opts_size := ws;
+  |}.
+
+
+(* -------------------------------------------------------------------- *)
+(* ARMv8-A instruction mnemonics. *)
+
+#[only(eqbOK)] derive
+Variant armv8a_mnemonic : Type :=
+(* Arithmetic *)
+| ADD                            (* Add without carry *)
+| ADDS                           (* Add without carry, setting flags *)
+| ADC                            (* Add with carry *)
+| ADCS                           (* Add with carry, setting flags *)
+| SUB                            (* Subtract without carry *)
+| SUBS                           (* Subtract without carry, setting flags *)
+| NEG                            (* Negate *)
+| MUL                            (* Multiply and write the least significant
+                                    bits of the result *)
+| MADD                           (* Multiply and add *)
+| MSUB                           (* Multiply and subtract *)
+| SDIV                           (* Signed division *)
+| UDIV                           (* Unsigned division *)
+
+(* Logical *)
+| AND                            (* Bitwise AND *)
+| ORR                            (* Bitwise OR *)
+| EOR                            (* Bitwise XOR *)
+| MVN                            (* Bitwise NOT *)
+
+(* Shifts *)
+| ASR                            (* Arithmetic shift right *)
+| LSL                            (* Logical shift left *)
+| LSR                            (* Logical shift right *)
+| ROR                            (* Rotate right *)
+
+(* Bit field operations *)
+
+(* Other data processing instructions *)
+| MOV                            (* Copy operand to destination *)
+| MOVN                           (* Move wide with NOT *)
+| MOVZ                           (* Move wide with zero *)
+| MOVK                           (* Move wide with keep *)
+| ADR                            (* Form PC-relative address *)
+| SXTB                           (* Sign extend byte *)
+| SXTH                           (* Sign extend halfword *)
+| SXTW                           (* Sign extend word *)
+| UXTB                           (* Zero extend byte *)
+| UXTH                           (* Zero extend halfword *)
+| UXTW                           (* Zero extend word *)
+
+(* Comparisons *)
+| CMP                            (* Compare *)
+| TST                            (* Test *)
+
+(* Conditional selection *)
+| CSEL                           (* Conditional select *)
+
+(* Loads *)
+| LDR                            (* Load a word or doubleword *)
+| LDRB                           (* Load a zero extended byte *)
+| LDRH                           (* Load a zero extended halfword *)
+| LDRSB                          (* Load a sign extended byte *)
+| LDRSH                          (* Load a sign extended halfword *)
+| LDRSW                          (* Load a sign extended word *)
+
+(* Stores *)
+| STR                            (* Store a word or doubleword *)
+| STRB                           (* Store a byte *)
+| STRH.                          (* Store a halfword *)
+
+#[ export ]
+Instance eqTC_armv8a_mnemonic : eqTypeC armv8a_mnemonic :=
+  { ceqP := armv8a_mnemonic_eqb_OK }.
+
+Canonical armv8a_mnemonic_eqType := @ceqT_eqType _ eqTC_armv8a_mnemonic.
+
+Definition armv8a_mnemonics : seq armv8a_mnemonic :=
+  [:: ADD; ADDS; ADC; ADCS; SUB; SUBS; NEG
+    ; MUL; MADD; MSUB; SDIV; UDIV
+    ; AND; ORR; EOR; MVN
+    ; ASR; LSL; LSR; ROR
+    ; MOV; MOVN; MOVZ; MOVK; ADR
+    ; SXTB; SXTH; SXTW; UXTB; UXTH; UXTW
+    ; CMP; TST
+    ; CSEL
+    ; LDR; LDRB; LDRH; LDRSB; LDRSH; LDRSW
+    ; STR; STRB; STRH
+  ].
+
+Lemma armv8a_mnemonic_fin_axiom : Finite.axiom armv8a_mnemonics.
+Proof. by case. Qed.
+
+#[ export ]
+Instance finTC_armv8a_mnemonic : finTypeC armv8a_mnemonic :=
+  {
+    cenum := armv8a_mnemonics;
+    cenumP := armv8a_mnemonic_fin_axiom;
+  }.
+
+Canonical armv8a_mnemonic_finType := @cfinT_finType _ finTC_armv8a_mnemonic.
+
+(* Mnemonics whose last register operand can be optionally shifted. *)
+Definition has_shift_mnemonics : seq armv8a_mnemonic :=
+  [:: ADD; ADDS; SUB; SUBS; NEG
+    ; AND; ORR; EOR; MVN
+    ; CMP; TST
+  ].
+
+(* The arithmetic instructions (ADD/ADDS/SUB/SUBS/NEG/CMP) only admit
+   LSL, LSR and ASR on their shifted-register operand; ROR is reserved
+   (C6.2.5 "ADD (shifted register)"). The logical instructions admit all
+   four shifts (C6.2.14 "AND (shifted register)"). *)
+Definition ror_shift_mnemonics : seq armv8a_mnemonic :=
+  [:: AND; ORR; EOR; MVN; TST ].
+
+Definition shift_allowed (mn : armv8a_mnemonic) (sk : shift_kind) : bool :=
+  if sk is SROR then mn \in ror_shift_mnemonics else true.
+
+(* Mnemonics available in both the 32-bit (W) and 64-bit (X) forms; the
+   remaining mnemonics are only valid with [opts_size = U64]. *)
+Definition sized_mnemonics : seq armv8a_mnemonic :=
+  [:: ADD; ADDS; ADC; ADCS; SUB; SUBS; NEG
+    ; MUL; MADD; MSUB; SDIV; UDIV
+    ; AND; ORR; EOR; MVN
+    ; ASR; LSL; LSR; ROR
+    ; MOV; MOVN; MOVZ; MOVK
+    ; SXTB; SXTH; UXTB; UXTH
+    ; CMP; TST
+    ; CSEL
+    ; LDR; LDRB; LDRH; LDRSB; LDRSH
+    ; STR; STRB; STRH
+  ].
+
+Definition wsize_uload_mn : seq (wsize * armv8a_mnemonic) :=
+  [:: (U8, LDRB); (U16, LDRH); (U32, LDR); (U64, LDR) ].
+
+Definition uload_mn_of_wsize (ws : wsize) : option armv8a_mnemonic :=
+  xseq.assoc wsize_uload_mn ws.
+
+Definition wsize_sload_mn : seq (wsize * armv8a_mnemonic) :=
+  [:: (U8, LDRSB); (U16, LDRSH); (U32, LDRSW) ].
+
+Definition sload_mn_of_wsize (ws : wsize) : option armv8a_mnemonic :=
+  xseq.assoc wsize_sload_mn ws.
+
+Definition wsize_of_sload_mn (mn : armv8a_mnemonic) : option wsize :=
+  xseq.assoc ([seq (x.2, x.1) | x <- wsize_sload_mn]) mn.
+
+(* Memory access width of narrow loads; [LDR] accesses at the operand
+   size. *)
+Definition wsize_of_narrow_load_mn (mn : armv8a_mnemonic) : option wsize :=
+  match mn with
+  | LDRB | LDRSB => Some U8
+  | LDRH | LDRSH => Some U16
+  | LDRSW => Some U32
+  | _ => None
+  end.
+
+Definition wsize_store_mn : seq (wsize * armv8a_mnemonic) :=
+  [:: (U8, STRB); (U16, STRH); (U32, STR); (U64, STR) ].
+
+Definition store_mn_of_wsize (ws : wsize) : option armv8a_mnemonic :=
+  xseq.assoc wsize_store_mn ws.
+
+Definition wsize_of_narrow_store_mn (mn : armv8a_mnemonic) : option wsize :=
+  match mn with
+  | STRB => Some U8
+  | STRH => Some U16
+  | _ => None
+  end.
+
+Definition string_of_armv8a_mnemonic (mn : armv8a_mnemonic) : string :=
+  match mn with
+  | ADD => "ADD"
+  | ADDS => "ADDS"
+  | ADC => "ADC"
+  | ADCS => "ADCS"
+  | SUB => "SUB"
+  | SUBS => "SUBS"
+  | NEG => "NEG"
+  | MUL => "MUL"
+  | MADD => "MADD"
+  | MSUB => "MSUB"
+  | SDIV => "SDIV"
+  | UDIV => "UDIV"
+  | AND => "AND"
+  | ORR => "ORR"
+  | EOR => "EOR"
+  | MVN => "MVN"
+  | ASR => "ASR"
+  | LSL => "LSL"
+  | LSR => "LSR"
+  | ROR => "ROR"
+  | MOV => "MOV"
+  | MOVN => "MOVN"
+  | MOVZ => "MOVZ"
+  | MOVK => "MOVK"
+  | ADR => "ADR"
+  | SXTB => "SXTB"
+  | SXTH => "SXTH"
+  | SXTW => "SXTW"
+  | UXTB => "UXTB"
+  | UXTH => "UXTH"
+  | UXTW => "UXTW"
+  | CMP => "CMP"
+  | TST => "TST"
+  | CSEL => "CSEL"
+  | LDR => "LDR"
+  | LDRB => "LDRB"
+  | LDRH => "LDRH"
+  | LDRSB => "LDRSB"
+  | LDRSH => "LDRSH"
+  | LDRSW => "LDRSW"
+  | STR => "STR"
+  | STRB => "STRB"
+  | STRH => "STRH"
+  end%string.
+
+
+(* -------------------------------------------------------------------- *)
+(* ARMv8-A operators are pairs of mnemonics and options. *)
+
+#[only(eqbOK)] derive
+Variant armv8a_asm_op :=
+| ARMv8A_op : armv8a_mnemonic -> armv8a_options -> armv8a_asm_op.
+
+#[ export ]
+Instance eqTC_armv8a_asm_op : eqTypeC armv8a_asm_op :=
+  { ceqP := armv8a_asm_op_eqb_OK }.
+
+Canonical armv8a_asm_op_eqType := @ceqT_eqType _ eqTC_armv8a_asm_op.
+
+
+(* -------------------------------------------------------------------- *)
+(* Common semantic types. *)
+
+Notation sflag := (lbool) (only parsing).
+Notation snzcv := ([:: sflag; sflag; sflag; sflag ]) (only parsing).
+
+Notation ty_nzcv := (sem_ltuple snzcv) (only parsing).
+Notation ty_r := (sem_ltuple [:: lreg ]) (only parsing).
+Notation ty_w ws := (sem_ltuple [:: lword ws ]) (only parsing).
+
+Notation ty_nzcv_w ws := (sem_ltuple (snzcv ++ [:: lword ws ])) (only parsing).
+
+
+(* -------------------------------------------------------------------- *)
+(* Common argument descriptions. *)
+
+Definition ad_nzcv : seq arg_desc := map F [:: NF; ZF; CF; VF ].
+
+
+(* -------------------------------------------------------------------- *)
+(* Common flag definitions. *)
+
+Definition NF_of_word (ws : wsize) (w : word ws) := msb w.
+Definition ZF_of_word (ws : wsize) (w : word ws) := w == 0%w.
+
+(* Compute the value of the flags for an arithmetic operation.
+   For instance, for <+> a binary operation, this function should be called
+   with
+     res = w <+> w'
+     res_unsigned = wunsigned w Z.<+> wunsigned w'
+     res_signed = wsigned w Z.<+> wsigned w'
+*)
+Definition nzcv_of_aluop
+  {ws : wsize}
+  (res : word ws)     (* Actual result. *)
+  (res_unsigned : Z)  (* Result with unsigned interpretation. *)
+  (res_signed : Z)    (* Result with signed interpretation. *)
+  : ty_nzcv :=
+  (:: Some (NF_of_word res)                 (* NF *)
+    , Some (ZF_of_word res)                 (* ZF *)
+    , Some (wunsigned res != res_unsigned)  (* CF *)
+    & Some (wsigned res != res_signed)      (* VF *)
+  ).
+
+(* Flags of A64 flag-setting logical instructions (ANDS, BICS, TST):
+   PSTATE.<N,Z,C,V> = result<msb>:IsZeroBit(result):'00'. *)
+Definition nzcv_of_logop {ws : wsize} (res : word ws) : ty_nzcv :=
+  (:: Some (NF_of_word res)
+    , Some (ZF_of_word res)
+    , Some false
+    & Some false
+  ).
+
+Definition nzcv_w_of_aluop {ws : wsize} (w : word ws) (wun wsi : Z) :=
+  merge_tuple (nzcv_of_aluop w wun wsi) (w : ty_w ws).
+
+Definition nzcv_w_of_logop {ws : wsize} (w : word ws) :=
+  merge_tuple (nzcv_of_logop w) (w : ty_w ws).
+
+
+(* -------------------------------------------------------------------- *)
+(* Shift transformations.
+   Instruction descriptions are defined without optionally shifted registers.
+   The following transformation adds a shift argument to an instruction
+   and updates the semantics and the rest of the fields accordingly. *)
+
+Definition mk_semi1_shifted
+  {A} {ws : wsize} (sk : shift_kind) (semi : sem_lprod [:: lword ws ] (exec A)) :
+  sem_lprod [:: lword ws; lword8 ] (exec A) :=
+  fun wn shift_amount =>
+    let sham := wunsigned shift_amount in
+    semi (shift_op sk wn sham).
+
+Definition mk_semi2_2_shifted
+  {A} {o : ltype} {ws : wsize} (sk : shift_kind) (semi : sem_lprod [:: o; lword ws ] (exec A)) :
+  sem_lprod [:: o; lword ws; lword8 ] (exec A) :=
+  fun x wm shift_amount =>
+    let sham := wunsigned shift_amount in
+    semi x (shift_op sk wm sham).
+
+#[ local ]
+Lemma mk_shifted_eq_size {A B} {x y} {xs0 : seq A} {ys0 : seq B} {p} :
+  (size xs0 == size ys0) && p
+  -> (size (xs0 ++ [:: x ]) == size (ys0 ++ [:: y ])) && p.
+Proof.
+  move=> /andP [] /eqP H0 Hp.
+  rewrite 2!size_cat H0.
+  by apply/andP.
+Qed.
+
+Lemma mk_semi1_shifted_errty A ws sk (semi : sem_lprod [:: lword ws] (exec A)) :
+  sem_lforall (fun r : exec A => r <> Error ErrType) [:: lword ws] semi ->
+  sem_lforall (fun r : exec A => r <> Error ErrType)
+         ([:: lword ws] ++ [:: lword8]) (mk_semi1_shifted sk semi).
+Proof. by rewrite /mk_semi1_shifted /= => h *; apply h. Qed.
+
+Lemma mk_semi2_2_shifted_errty A (t : ltype) ws sk (semi : sem_lprod [:: t; lword ws] (exec A)) :
+  sem_lforall (fun r : exec A => r <> Error ErrType) [:: t; lword ws] semi ->
+  sem_lforall (fun r : exec A => r <> Error ErrType)
+         ([:: t; lword ws] ++ [:: lword8]) (mk_semi2_2_shifted sk semi).
+Proof. rewrite /mk_semi2_2_shifted /= => h *; apply h. Qed.
+
+Lemma mk_semi1_shifted_safe A ws sk (semi : sem_lprod [:: lword ws] (exec A)) :
+  interp_safe_cond_ty [::] semi ->
+  interp_safe_cond_ty [::] (mk_semi1_shifted sk semi).
+Proof. move=> h > _; apply h; constructor. Qed.
+
+Lemma mk_semi2_2_shifted_safe A sk (t : ltype) ws (semi : sem_lprod [:: t; lword ws] (exec A)) :
+  interp_safe_cond_ty [::] semi ->
+  interp_safe_cond_ty [::] (mk_semi2_2_shifted sk semi).
+Proof. move=> h > _; apply h; constructor. Qed.
+
+Lemma safe_wf_cat (tin tin' : seq ltype) sc :
+  all (fun sc => sc_needed_args sc <= size tin) sc ->
+  all (fun sc => sc_needed_args sc <= size (tin ++ tin')) sc.
+Proof. apply sub_all => c h; rewrite size_cat; apply: (leq_trans h); apply leq_addr. Qed.
+
+(* On A64 a shifted operand exists only in the register form of an
+   instruction (C6.2.5 "ADD (shifted register)" and friends). The immediate
+   forms admit either no shift at all (logical instructions, whose bitmask
+   immediate is checked by [CAimmC_armv8a_bitmask_imm]) or only
+   [LSL #0]/[LSL #12], which is part of the immediate encoding itself and
+   folded into [CAimmC_armv8a_arith_imm]. The shifted variant of an
+   instruction therefore keeps only the register alternatives of the base
+   instruction and appends the shift amount to those. *)
+Definition args_kinds_no_imm (x : args_kinds) : bool :=
+  ~~ has (has (fun k => if k is CAimm _ _ then true else false)) x.
+
+Definition mk_shifted
+  (ws : wsize) (sk : shift_kind) (mn : armv8a_mnemonic)
+  (idt : instr_desc_t) semi' semi_errty' semi_safe' : instr_desc_t :=
+  {|
+    id_msb_flag := idt.(id_msb_flag);
+    id_tin := (id_tin idt) ++ [:: lword8 ];
+    id_in := (id_in idt) ++ [:: Ea (id_nargs idt) ];
+    id_tout := id_tout idt;
+    id_out := id_out idt;
+    id_semi := semi';
+    id_nargs := (id_nargs idt).+1;
+    id_args_kinds :=
+      map (fun x => x ++ [:: [:: CAimm (Some (CAimmC_armv8a_shift_amount ws)) U8] ])
+        (filter args_kinds_no_imm (id_args_kinds idt));
+    id_eq_size := mk_shifted_eq_size (id_eq_size idt);
+    id_check_dest := id_check_dest idt;
+    id_str_jas := id_str_jas idt;
+    id_safe := id_safe idt;
+    id_doit := id_doit idt;
+    id_pp_asm := id_pp_asm idt;
+    (* The descriptor itself rejects a shift kind that the instruction
+       does not admit (ROR on the arithmetic class). *)
+    id_valid := id_valid idt && shift_allowed mn sk;
+    id_safe_wf := safe_wf_cat _ (id_safe_wf idt);
+    id_semi_errty := semi_errty';
+    id_semi_safe := semi_safe'
+  |}.
+
+Arguments mk_shifted : clear implicits.
+
+
+(* -------------------------------------------------------------------- *)
+(* Printing. *)
+
+(* The [wsize] paired with each argument is the width of the register form
+   to print: W for widths up to [U32], X for [U64]. It only matters for
+   register operands. *)
+Definition pp_armv8a_op
+  (mn : armv8a_mnemonic) (opts : armv8a_options) (args : seq asm_arg) : pp_asm_op :=
+  {|
+    pp_aop_name := string_of_armv8a_mnemonic mn;
+    pp_aop_ext := PP_name;
+    pp_aop_args := map (fun a => (opts_size opts, a)) args;
+  |}.
+
+(* Same as [pp_armv8a_op] with an explicit width per argument, for the
+   instructions whose operands are not all [opts_size]-wide (narrow loads
+   and stores, 32-bit multiplies, extensions). *)
+Definition pp_armv8a_op_szs
+  (mn : armv8a_mnemonic) (szs : seq wsize) (args : seq asm_arg) : pp_asm_op :=
+  {|
+    pp_aop_name := string_of_armv8a_mnemonic mn;
+    pp_aop_ext := PP_name;
+    pp_aop_args := zip szs args;
+  |}.
+
+
+(* -------------------------------------------------------------------- *)
+(* Instruction descriptions.
+   Descriptions are parameterized by the options: the operand size [osz]
+   selects the W or X form (W-form instructions clear the upper 32 bits of
+   their destination registers, [MSB_CLEAR]), and data-processing
+   instructions gain a shift operand with [mk_shifted] when [has_shift]
+   is set.
+   Each instruction's semantics ([*_semi], parametric in the operand size
+   [ws] unless the instruction exists at a single size) is defined right
+   before the description that uses it. *)
+
+Section ARMV8A_INSTR.
+
+Context
+  (opts : armv8a_options).
+
+Notation osz := (opts_size opts).
+
+Let string_of_armv8a_mnemonic mn :=
+  string_of_armv8a_mnemonic mn.
+
+Notation osz_valid := ((osz == U32) || (osz == U64)) (only parsing).
+Notation msbf := (if osz == U64 then MSB_MERGE else MSB_CLEAR) (only parsing).
+
+(* Jasmin-source and EasyCrypt name of the operation: the mnemonics that
+   exist in both the W and X forms are size-suffixed (ADD_32 / ADD_64, as
+   on x86), matching the intrinsic parser ([armv8a_prim_string] below);
+   fixed-size mnemonics keep their bare name. *)
+Let armv8a_mn_str (mn : armv8a_mnemonic) : unit -> string :=
+  if mn \in sized_mnemonics
+  then pp_sz (string_of_armv8a_mnemonic mn) osz
+  else pp_s (string_of_armv8a_mnemonic mn).
+
+(* Argument kinds.
+   Immediate operands are checked against the A64 encoding rules
+   (armv8a_decl.v): [CAimmC_armv8a_arith_imm] (imm12, optionally shifted
+   by 12) for the arithmetic class, [CAimmC_armv8a_bitmask_imm] for the
+   logical class, [CAimmC_armv8a_mov_imm] for the MOV alias. Instructions
+   without an immediate form (BIC, MVN, ...) only accept registers, which
+   the [option] parameter of [ak_rr_or_imm]/[ak_rrr_or_imm] expresses
+   with [None]. The immediate forms are only available without a shifted
+   operand: [mk_shifted] drops them from the shifted variant. *)
+
+Let ak_rr := ak_reg_reg.
+Let ak_rrr := ak_reg_reg_reg.
+Let ak_rrrr := ak_reg_reg_reg_reg.
+
+Let ak_rr_or_imm (ick : option armv8a_caimm_cond) :=
+  if ick is Some ic
+  then ak_reg_reg ++ [:: [:: [:: CAreg ]; [:: CAimm (Some ic) osz ] ] ]
+  else ak_reg_reg.
+
+Let ak_rrr_or_imm (ick : option armv8a_caimm_cond) :=
+  if ick is Some ic
+  then ak_reg_reg_reg ++ [:: [:: [:: CAreg ]; [:: CAreg ]; [:: CAimm (Some ic) osz ] ] ]
+  else ak_reg_reg_reg.
+
+Let ak_rr_imm_shift :=
+  [:: [:: [:: CAreg ]; [:: CAreg ]; [:: CAimm (Some (CAimmC_armv8a_shift_amount osz)) U8 ] ] ].
+
+Let ak_r_imm16_shift :=
+  [:: [:: [:: CAreg ]; [:: CAimm_sz U16 ]; [:: CAimm (Some (CAimmC_armv8a_halfword_shift osz)) U8 ] ] ].
+
+Let ak_rrr_imm_shift :=
+  [:: [:: [:: CAreg ]; [:: CAreg ]; [:: CAreg ]; [:: CAimm (Some (CAimmC_armv8a_shift_amount osz)) U8 ] ] ].
+
+Let ak_rrr_cond :=
+  [:: [:: [:: CAreg ]; [:: CAreg ]; [:: CAreg ]; [:: CAcond ] ] ].
+
+Let ak_r_cond :=
+  [:: [:: [:: CAreg ]; [:: CAcond ] ] ].
+
+Let ak_rr_imm8_imm8 :=
+  [:: [:: [:: CAreg ]; [:: CAreg ]; [:: CAimm_sz U8 ]; [:: CAimm_sz U8 ] ] ].
+
+Let ak_r_imm8_imm8 :=
+  [:: [:: [:: CAreg ]; [:: CAimm_sz U8 ]; [:: CAimm_sz U8 ] ] ].
+
+Let ak_rr_imm_imm_extr :=
+  [:: [:: [:: CAreg ]; [:: CAreg ]; [:: CAimm (Some (CAimmC_armv8a_shift_amount osz)) U8 ]; [:: CAimm_sz U8 ] ] ].
+
+(* -------------------------------------------------------------------- *)
+(* Arithmetic instructions. *)
+
+(* A binary data-processing instruction without flag outputs, accepting
+   an optionally shifted register or an immediate as its last operand. *)
+(* [ick] is the immediate-encoding checker for the instruction's immediate
+   form ([None] for instructions with no immediate form). *)
+Definition mk_arith_instr mn (ick : option armv8a_caimm_cond)
+  (semi : word osz -> word osz -> ty_w osz)
+  : instr_desc_t :=
+  let tin := [:: lword osz; lword osz ] in
+  let x :=
+    {|
+      id_msb_flag := msbf;
+      id_tin := tin;
+      id_in := [:: Ea 1; Ea 2 ];
+      id_tout := [:: lword osz ];
+      id_out := [:: Ea 0 ];
+      id_semi := sem_lprod_ok tin semi;
+      id_nargs := 3;
+      id_args_kinds := ak_rrr_or_imm ick;
+      id_eq_size := refl_equal;
+      id_check_dest := refl_equal;
+      id_str_jas := armv8a_mn_str mn;
+      id_safe := [::];
+      id_doit := DOIT;
+      id_pp_asm := pp_armv8a_op mn opts;
+      id_valid := osz_valid;
+      id_safe_wf := refl_equal;
+      id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+      id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+    |}
+  in
+  if has_shift opts is Some sk
+  then mk_shifted osz sk mn x (mk_semi2_2_shifted sk (id_semi x))
+                       (fun h => mk_semi2_2_shifted_errty
+                                   (x.(id_semi_errty) (proj1 (andb_prop _ _ h))))
+                       (fun h => mk_semi2_2_shifted_safe sk
+                                   (x.(id_semi_safe) (proj1 (andb_prop _ _ h))))
+  else x.
+
+(* Same as [mk_arith_instr], with the NZCV flags as extra outputs. *)
+Definition mk_ariths_instr mn (ick : option armv8a_caimm_cond)
+  (semi : word osz -> word osz -> ty_nzcv_w osz)
+  : instr_desc_t :=
+  let tin := [:: lword osz; lword osz ] in
+  let x :=
+    {|
+      id_msb_flag := msbf;
+      id_tin := tin;
+      id_in := [:: Ea 1; Ea 2 ];
+      id_tout := snzcv ++ [:: lword osz ];
+      id_out := ad_nzcv ++ [:: Ea 0 ];
+      id_semi := sem_lprod_ok tin semi;
+      id_nargs := 3;
+      id_args_kinds := ak_rrr_or_imm ick;
+      id_eq_size := refl_equal;
+      id_check_dest := refl_equal;
+      id_str_jas := armv8a_mn_str mn;
+      id_safe := [::];
+      id_doit := DOIT;
+      id_pp_asm := pp_armv8a_op mn opts;
+      id_valid := osz_valid;
+      id_safe_wf := refl_equal;
+      id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+      id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+    |}
+  in
+  if has_shift opts is Some sk
+  then mk_shifted osz sk mn x (mk_semi2_2_shifted sk (id_semi x))
+                       (fun h => mk_semi2_2_shifted_errty
+                                   (x.(id_semi_errty) (proj1 (andb_prop _ _ h))))
+                       (fun h => mk_semi2_2_shifted_safe sk
+                                   (x.(id_semi_safe) (proj1 (andb_prop _ _ h))))
+  else x.
+
+Notation arith_imm := (Some CAimmC_armv8a_arith_imm) (only parsing).
+Notation bitmask_imm := (Some CAimmC_armv8a_bitmask_imm) (only parsing).
+Notation no_imm := (None : option armv8a_caimm_cond) (only parsing).
+
+(* [C6.2.6 ADD (shifted register)] ARM DDI 0487 M.a, p. 1798
+   Add optionally-shifted register  This instruction adds a register value and
+   an optionally-shifted register value, and writes the result to the
+   destination register.
+   Syntax: ADD <Xd>, <Xn>, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = ShiftReg(m, shift_type, shift_amount, datasize);
+     bits(datasize) result;
+     (result, -) = AddWithCarry(operand1, operand2, '0');
+     X[d, datasize] = result;
+*)
+Definition armv8a_ADD_semi {ws : wsize} (wn wm : word ws) : ty_w ws :=
+  (wn + wm)%w.
+
+Definition armv8a_ADD_instr : instr_desc_t :=
+  mk_arith_instr ADD arith_imm armv8a_ADD_semi.
+(* [C6.2.11 ADDS (shifted register)] ARM DDI 0487 M.a, p. 1807
+   Add optionally-shifted register, setting flags  This instruction adds a
+   register value and an optionally-shifted register value, and writes the
+   result to the destination register. It updates the condition flags based on
+   the result.  This instruction is used by the alias CMN (shifted register).
+   Syntax: ADDS <Xd>, <Xn>, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = ShiftReg(m, shift_type, shift_amount, datasize);
+     bits(datasize) result;
+     bits(4) nzcv;
+     (result, nzcv) = AddWithCarry(operand1, operand2, '0');
+     X[d, datasize] = result;
+     PSTATE.<N,Z,C,V> = nzcv;
+*)
+Definition armv8a_ADDS_semi {ws : wsize} (wn wm : word ws) : ty_nzcv_w ws :=
+  nzcv_w_of_aluop
+    (wn + wm)%w
+    (wunsigned wn + wunsigned wm)%Z
+    (wsigned wn + wsigned wm)%Z.
+
+Definition armv8a_ADDS_instr : instr_desc_t :=
+  mk_ariths_instr ADDS arith_imm armv8a_ADDS_semi.
+(* [C6.2.457 SUB (shifted register)] ARM DDI 0487 M.a, p. 2785
+   Subtract optionally-shifted register  This instruction subtracts an
+   optionally-shifted register value from a register value, and writes the
+   result to the destination register.  This instruction is used by the alias
+   NEG (shifted register).
+   Syntax: SUB <Xd>, <Xn>, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = NOT(ShiftReg(m, shift_type, shift_amount, datasize));
+     bits(datasize) result;
+     (result, -) = AddWithCarry(operand1, operand2, '1');
+     X[d, datasize] = result;
+*)
+Definition armv8a_SUB_semi {ws : wsize} (wn wm : word ws) : ty_w ws :=
+  (wn - wm)%w.
+
+Definition armv8a_SUB_instr : instr_desc_t :=
+  mk_arith_instr SUB arith_imm armv8a_SUB_semi.
+(* [C6.2.464 SUBS (shifted register)] ARM DDI 0487 M.a, p. 2797
+   Subtract optionally-shifted register, setting flags  This instruction
+   subtracts an optionally-shifted register value from a register value, and
+   writes the result to the destination register. It updates the condition
+   flags based on the result.  This instruction is used by the aliases CMP
+   (shifted register) and NEGS.
+   Syntax: SUBS <Xd>, <Xn>, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = NOT(ShiftReg(m, shift_type, shift_amount, datasize));
+     bits(datasize) result;
+     bits(4) nzcv;
+     (result, nzcv) = AddWithCarry(operand1, operand2, '1');
+     X[d, datasize] = result;
+     PSTATE.<N,Z,C,V> = nzcv;
+*)
+Definition armv8a_SUBS_semi {ws : wsize} (wn wm : word ws) : ty_nzcv_w ws :=
+  let wmnot := wnot wm in
+  nzcv_w_of_aluop
+    (wn + wmnot + 1)%w
+    (wunsigned wn + wunsigned wmnot + 1)%Z
+    (wsigned wn + wsigned wmnot + 1)%Z.
+
+Definition armv8a_SUBS_instr : instr_desc_t :=
+  mk_ariths_instr SUBS arith_imm armv8a_SUBS_semi.
+
+(* Add/subtract with carry (no shifted or immediate forms in A64). *)
+Definition mk_carry_instr mn (semi : word osz -> word osz -> bool -> ty_w osz)
+  : instr_desc_t :=
+  let tin := [:: lword osz; lword osz; lbool ] in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 1; Ea 2; F CF ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 3;
+    id_args_kinds := ak_rrr;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+Definition mk_carrys_instr mn (semi : word osz -> word osz -> bool -> ty_nzcv_w osz)
+  : instr_desc_t :=
+  let tin := [:: lword osz; lword osz; lbool ] in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 1; Ea 2; F CF ];
+    id_tout := snzcv ++ [:: lword osz ];
+    id_out := ad_nzcv ++ [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 3;
+    id_args_kinds := ak_rrr;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.2 ADC] ARM DDI 0487 M.a, p. 1789
+   Add with carry  This instruction adds two register values and the Carry flag
+   value, and writes the result to the destination register.
+   Syntax: ADC <Xd>, <Xn>, <Xm>
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = X[m, datasize];
+     bits(datasize) result;
+     (result, -) = AddWithCarry(operand1, operand2, PSTATE.C);
+     X[d, datasize] = result;
+*)
+Definition armv8a_ADC_semi {ws : wsize} (wn wm : word ws) (cf : bool) : ty_w ws :=
+  let c := Z.b2z cf in
+  (wn + wm + wrepr ws c)%w.
+
+Definition armv8a_ADC_instr : instr_desc_t := mk_carry_instr ADC armv8a_ADC_semi.
+(* [C6.2.3 ADCS] ARM DDI 0487 M.a, p. 1791
+   Add with carry, setting flags  This instruction adds two register values and
+   the Carry flag value, and writes the result to the destination register. It
+   updates the condition flags based on the result.
+   Syntax: ADCS <Xd>, <Xn>, <Xm>
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = X[m, datasize];
+     bits(datasize) result;
+     bits(4) nzcv;
+     (result, nzcv) = AddWithCarry(operand1, operand2, PSTATE.C);
+     X[d, datasize] = result;
+     PSTATE.<N,Z,C,V> = nzcv;
+*)
+Definition armv8a_ADCS_semi {ws : wsize} (wn wm : word ws) (cf : bool) : ty_nzcv_w ws :=
+  let c := Z.b2z cf in
+  nzcv_w_of_aluop
+    (wn + wm + wrepr ws c)%w
+    (wunsigned wn + wunsigned wm + c)%Z
+    (wsigned wn + wsigned wm + c)%Z.
+
+Definition armv8a_ADCS_instr : instr_desc_t := mk_carrys_instr ADCS armv8a_ADCS_semi.
+(* [C6.2.294 NEG (shifted register)] ARM DDI 0487 M.a, p. 2440
+   Negate (shifted register)  This instruction negates an optionally-shifted
+   register value, and writes the result to the destination register.  This is
+   an alias of SUB (shifted register). This means:  • The encodings in this
+   description are named to match the encodings of SUB (shifted register). •
+   The description of SUB (shifted register) gives the operational pseudocode,
+   any CONSTRAINED UNPREDICTABLE behavior, and any operational information for
+   this instruction.
+   Note: NEG is an alias of SUB (shifted register) with Rn = ZR; the SUB entry carries the operational pseudocode.
+   Syntax: NEG <Xd>, <Xm>{, <shift> #<amount>}  ==  SUB <Xd>, XZR, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     The description of SUB (shifted register) gives the operational pseudocode for this instruction.
+   Base instruction [C6.2.457 SUB (shifted register)] p. 2785, Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = NOT(ShiftReg(m, shift_type, shift_amount, datasize));
+     bits(datasize) result;
+     (result, -) = AddWithCarry(operand1, operand2, '1');
+     X[d, datasize] = result;
+*)
+Definition armv8a_NEG_semi {ws : wsize} (wm : word ws) : ty_w ws :=
+  (wnot wm + 1)%w.
+
+Definition armv8a_NEG_instr : instr_desc_t :=
+  let mn := NEG in
+  let tin := [:: lword osz ] in
+  let semi := armv8a_NEG_semi (ws := osz) in
+  let x :=
+    {|
+      id_msb_flag := msbf;
+      id_tin := tin;
+      id_in := [:: Ea 1 ];
+      id_tout := [:: lword osz ];
+      id_out := [:: Ea 0 ];
+      id_semi := sem_lprod_ok tin semi;
+      id_nargs := 2;
+      id_args_kinds := ak_rr;
+      id_eq_size := refl_equal;
+      id_check_dest := refl_equal;
+      id_str_jas := armv8a_mn_str mn;
+      id_safe := [::];
+      id_doit := DOIT;
+      id_pp_asm := pp_armv8a_op mn opts;
+      id_valid := osz_valid;
+      id_safe_wf := refl_equal;
+      id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+      id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+    |}
+  in
+  if has_shift opts is Some sk
+  then mk_shifted osz sk mn x (mk_semi1_shifted sk (id_semi x))
+                       (fun h => mk_semi1_shifted_errty
+                                   (x.(id_semi_errty) (proj1 (andb_prop _ _ h))))
+                       (fun h => mk_semi1_shifted_safe sk
+                                   (x.(id_semi_safe) (proj1 (andb_prop _ _ h))))
+  else x.
+
+(* A three-register instruction without flags (MUL, SDIV, UDIV, ...). *)
+Definition mk_rrr_instr mn (doit_v : doit_t)
+  (semi : word osz -> word osz -> ty_w osz)
+  : instr_desc_t :=
+  let tin := [:: lword osz; lword osz ] in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 1; Ea 2 ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 3;
+    id_args_kinds := ak_rrr;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := doit_v;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.292 MUL] ARM DDI 0487 M.a, p. 2436
+   Multiply  This instruction multiplies two register values and writes the
+   result to the destination register.  This is an alias of MADD. This means:
+   • The encodings in this description are named to match the encodings of
+   MADD. • The description of MADD gives the operational pseudocode, any
+   CONSTRAINED UNPREDICTABLE behavior, and any operational information for this
+   instruction.
+   Note: MUL is an alias of MADD with Ra = ZR (see the MADD entry for the operational pseudocode).
+   Syntax: MUL <Xd>, <Xn>, <Xm>  ==  MADD <Xd>, <Xn>, <Xm>, XZR
+   Operation (ASL):
+     The description of MADD gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_MUL_semi {ws : wsize} (wn wm : word ws) : ty_w ws :=
+  (wn * wm)%w.
+
+Definition armv8a_MUL_instr : instr_desc_t := mk_rrr_instr MUL DOIT armv8a_MUL_semi.
+(* [C6.2.356 SDIV] ARM DDI 0487 M.a, p. 2558
+   Signed divide  This instruction divides the first signed source register
+   value by the second signed source register value, and writes the result to
+   the destination register. Dividing by zero writes the value zero to the
+   destination register. The condition flags are not affected.
+   Syntax: SDIV <Xd>, <Xn>, <Xm>
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = X[m, datasize];
+     constant integer dividend = SInt(operand1);
+     constant integer divisor = SInt(operand2);
+     integer result;
+     if divisor == 0 then
+         result = 0;
+     elsif (dividend < 0) == (divisor < 0) then
+         result = Abs(dividend) DIV Abs(divisor); // same signs - positive result
+     else
+         result = -(Abs(dividend) DIV Abs(divisor)); // different signs - negative result
+     X[d, datasize] = result<datasize-1:0>;
+*)
+Definition armv8a_SDIV_semi {ws : wsize} (wn wm : word ws) : ty_w ws :=
+  wdivi wn wm.
+
+Definition armv8a_SDIV_instr : instr_desc_t :=
+  mk_rrr_instr SDIV NOT_DOIT (* Not DIT *) armv8a_SDIV_semi.
+(* [C6.2.489 UDIV] ARM DDI 0487 M.a, p. 2846
+   Unsigned divide  This instruction divides the first unsigned source register
+   value by the second unsigned source register value, and writes the result to
+   the destination register. Dividing by zero writes the value zero to the
+   destination register. The condition flags are not affected.
+   Syntax: UDIV <Xd>, <Xn>, <Xm>
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = X[m, datasize];
+     constant integer dividend = UInt(operand1);
+     constant integer divisor = UInt(operand2);
+     integer result;
+     if divisor == 0 then
+         result = 0;
+     else
+         result = dividend DIV divisor;
+     X[d, datasize] = result<datasize-1:0>;
+*)
+Definition armv8a_UDIV_semi {ws : wsize} (wn wm : word ws) : ty_w ws :=
+  wdiv wn wm.
+
+Definition armv8a_UDIV_instr : instr_desc_t :=
+  mk_rrr_instr UDIV NOT_DOIT (* Not DIT *) armv8a_UDIV_semi.
+
+(* Multiply-add and multiply-subtract. *)
+Definition mk_madd_instr mn (semi : word osz -> word osz -> word osz -> ty_w osz)
+  : instr_desc_t :=
+  let tin := [:: lword osz; lword osz; lword osz ] in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 1; Ea 2; Ea 3 ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 4;
+    id_args_kinds := ak_rrrr;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.274 MADD] ARM DDI 0487 M.a, p. 2401
+   Multiply-add  This instruction multiplies two register values, adds a third
+   register value, and writes the result to the destination register.  This
+   instruction is used by the alias MUL.
+   Syntax: MADD <Xd>, <Xn>, <Xm>, <Xa>
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = X[m, datasize];
+     constant bits(datasize) operand3 = X[a, datasize];
+     constant integer result = UInt(operand3) + (UInt(operand1) * UInt(operand2));
+     X[d, datasize] = result<datasize-1:0>;
+*)
+Definition armv8a_MADD_semi {ws : wsize} (wn wm wa : word ws) : ty_w ws :=
+  (wa + wn * wm)%w.
+
+Definition armv8a_MADD_instr : instr_desc_t := mk_madd_instr MADD armv8a_MADD_semi.
+(* [C6.2.290 MSUB] ARM DDI 0487 M.a, p. 2432
+   Multiply-subtract  This instruction multiplies two register values,
+   subtracts the product from a third register value, and writes the result to
+   the destination register.  This instruction is used by the alias MNEG.
+   Syntax: MSUB <Xd>, <Xn>, <Xm>, <Xa>
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = X[m, datasize];
+     constant bits(datasize) operand3 = X[a, datasize];
+     constant integer result = UInt(operand3) - (UInt(operand1) * UInt(operand2));
+     X[d, datasize] = result<datasize-1:0>;
+*)
+Definition armv8a_MSUB_semi {ws : wsize} (wn wm wa : word ws) : ty_w ws :=
+  (wa - wn * wm)%w.
+
+Definition armv8a_MSUB_instr : instr_desc_t := mk_madd_instr MSUB armv8a_MSUB_semi.
+
+(* -------------------------------------------------------------------- *)
+(* Bitwise instructions. *)
+
+Definition armv8a_bitwise_semi
+  {ws : wsize}
+  (op0 op1 : word ws -> word ws)
+  (op : word ws -> word ws -> word ws)
+  (wn wm : word ws) :
+  ty_w ws :=
+  op (op0 wn) (op1 wm).
+
+(* [C6.2.15 AND (shifted register)] ARM DDI 0487 M.a, p. 1813
+   Bitwise AND (shifted register)  This instruction performs a bitwise AND of a
+   register value and an optionally-shifted register value, and writes the
+   result to the destination register.
+   Syntax: AND <Xd>, <Xn>, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = ShiftReg(m, shift_type, shift_amount, datasize);
+     X[d, datasize] = operand1 AND operand2;
+*)
+Definition armv8a_AND_instr : instr_desc_t :=
+  mk_arith_instr AND bitmask_imm (armv8a_bitwise_semi id id wand).
+
+(* [C6.2.301 ORR (shifted register)] ARM DDI 0487 M.a, p. 2453
+   Bitwise OR (shifted register)  This instruction performs a bitwise
+   (inclusive) OR of a register value and an optionally-shifted register value,
+   and writes the result to the destination register.  This instruction is used
+   by the alias MOV (register).
+   Syntax: ORR <Xd>, <Xn>, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = ShiftReg(m, shift_type, shift_amount, datasize);
+     X[d, datasize] = operand1 OR operand2;
+*)
+Definition armv8a_ORR_instr : instr_desc_t :=
+  mk_arith_instr ORR bitmask_imm (armv8a_bitwise_semi id id wor).
+
+(* [C6.2.156 EOR (shifted register)] ARM DDI 0487 M.a, p. 2169
+   Bitwise exclusive-OR (shifted register)  This instruction performs a bitwise
+   exclusive-OR of a register value and an optionally-shifted register value,
+   and writes the result to the destination register.
+   Syntax: EOR <Xd>, <Xn>, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     constant bits(datasize) operand1 = X[n, datasize];
+     constant bits(datasize) operand2 = ShiftReg(m, shift_type, shift_amount, datasize);
+     X[d, datasize] = operand1 EOR operand2;
+*)
+Definition armv8a_EOR_instr : instr_desc_t :=
+  mk_arith_instr EOR bitmask_imm (armv8a_bitwise_semi id id wxor).
+
+(* [C6.2.293 MVN] ARM DDI 0487 M.a, p. 2438
+   Bitwise NOT  This instruction writes the bitwise inverse of a register value
+   to the destination register.  This is an alias of ORN (shifted register).
+   This means:  • The encodings in this description are named to match the
+   encodings of ORN (shifted register). • The description of ORN (shifted
+   register) gives the operational pseudocode, any CONSTRAINED UNPREDICTABLE
+   behavior, and any operational information for this instruction.
+   Syntax: MVN <Xd>, <Xm>{, <shift> #<amount>}  ==  ORN <Xd>, XZR, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     The description of ORN (shifted register) gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_MVN_semi {ws : wsize} (wm : word ws) : ty_w ws :=
+  wnot wm.
+
+(* MVN is an alias of ORN (shifted register); it has no immediate form
+   (an inverted immediate is a MOV with the complemented value). *)
+Definition armv8a_MVN_instr : instr_desc_t :=
+  let mn := MVN in
+  let tin := [:: lword osz ] in
+  let semi := armv8a_MVN_semi (ws := osz) in
+  let x :=
+    {|
+      id_msb_flag := msbf;
+      id_tin := tin;
+      id_in := [:: Ea 1 ];
+      id_tout := [:: lword osz ];
+      id_out := [:: Ea 0 ];
+      id_semi := sem_lprod_ok tin semi;
+      id_nargs := 2;
+      id_args_kinds := ak_rr;
+      id_eq_size := refl_equal;
+      id_check_dest := refl_equal;
+      id_str_jas := armv8a_mn_str mn;
+      id_safe := [::];
+      id_doit := DOIT;
+      id_pp_asm := pp_armv8a_op mn opts;
+      id_valid := osz_valid;
+      id_safe_wf := refl_equal;
+      id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+      id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+    |}
+  in
+  if has_shift opts is Some sk
+  then mk_shifted osz sk mn x (mk_semi1_shifted sk (id_semi x))
+                       (fun h => mk_semi1_shifted_errty
+                                   (x.(id_semi_errty) (proj1 (andb_prop _ _ h))))
+                       (fun h => mk_semi1_shifted_safe sk
+                                   (x.(id_semi_safe) (proj1 (andb_prop _ _ h))))
+  else x.
+
+(* -------------------------------------------------------------------- *)
+(* Shift instructions.
+   The shift amount is the value of the second operand modulo the operand
+   size; the immediate forms are restricted by the argument checker. Only
+   the alias mnemonics (ASR, ...) are provided: they accept registers and
+   immediates, subsuming the base variable forms (ASRV, ...), which accept
+   only registers and are otherwise identical. *)
+
+(* Shift semantics: the shift amount is the value of the last operand
+   modulo the operand size in bits. *)
+Definition armv8a_shift_semi
+  {ws : wsize} (op : forall sz, word sz -> Z -> word sz)
+  (wn : word ws) (wsham : word U8) : ty_w ws :=
+  let sham := (wunsigned wsham mod wsize_bits ws)%Z in
+  op ws wn sham.
+
+Definition mk_shift_instr mn (op : forall sz, word sz -> Z -> word sz)
+  : instr_desc_t :=
+  let tin := [:: lword osz; lword U8 ] in
+  let semi := armv8a_shift_semi (ws := osz) op in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 1; Ea 2 ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 3;
+    id_args_kinds := ak_rrr ++ ak_rr_imm_shift;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.19 ASR (register)] ARM DDI 0487 M.a, p. 1820
+   Arithmetic shift right (register)  This instruction shifts a register value
+   right by a variable number of bits, shifting in copies of its sign bit, and
+   writes the result to the destination register. The value of the second
+   source register modulo the register size in bits gives the number of bits by
+   which the first source register is right-shifted.
+   Syntax: ASR <Xd>, <Xn>, <Xm>
+   Operation (ASL):
+     constant bits(datasize) operand2 = X[m, datasize];
+     X[d, datasize] = ShiftReg(n, shift_type, UInt(operand2) MOD datasize, datasize);
+*)
+Definition armv8a_ASR_instr : instr_desc_t := mk_shift_instr ASR (@wsar).
+(* [C6.2.268 LSL (register)] ARM DDI 0487 M.a, p. 2389
+   Logical shift left (register)  This instruction shifts a register value left
+   by a variable number of bits, shifting in zeros, and writes the result to
+   the destination register. The value of the second source register modulo the
+   register size in bits gives the number of bits by which the first source
+   register is left-shifted.
+   Syntax: LSL <Xd>, <Xn>, <Xm>
+   Operation (ASL):
+     constant bits(datasize) operand2 = X[m, datasize];
+     X[d, datasize] = ShiftReg(n, shift_type, UInt(operand2) MOD datasize, datasize);
+*)
+Definition armv8a_LSL_instr : instr_desc_t := mk_shift_instr LSL (@wshl).
+(* [C6.2.271 LSR (register)] ARM DDI 0487 M.a, p. 2395
+   Logical shift right (register)  This instruction shifts a register value
+   right by a variable number of bits, shifting in zeros, and writes the result
+   to the destination register. The value of the second source register modulo
+   the register size in bits gives the number of bits by which the first source
+   register is right-shifted.
+   Syntax: LSR <Xd>, <Xn>, <Xm>
+   Operation (ASL):
+     constant bits(datasize) operand2 = X[m, datasize];
+     X[d, datasize] = ShiftReg(n, shift_type, UInt(operand2) MOD datasize, datasize);
+*)
+Definition armv8a_LSR_instr : instr_desc_t := mk_shift_instr LSR (@wshr).
+(* [C6.2.347 ROR (register)] ARM DDI 0487 M.a, p. 2541
+   Rotate right (register)  This instruction provides the value of the contents
+   of a register rotated by a variable number of bits. The bits that are
+   rotated off the right end are inserted into the vacated bit positions on the
+   left. The value of the second source register modulo the register size in
+   bits gives the number of bits by which the first source register is right-
+   shifted.
+   Syntax: ROR <Xd>, <Xn>, <Xm>
+   Operation (ASL):
+     constant bits(datasize) operand2 = X[m, datasize];
+     X[d, datasize] = ShiftReg(n, shift_type, UInt(operand2) MOD datasize, datasize);
+*)
+Definition armv8a_ROR_instr : instr_desc_t := mk_shift_instr ROR (@wror).
+
+(* -------------------------------------------------------------------- *)
+(* Bit field instructions. *)
+
+
+(* -------------------------------------------------------------------- *)
+(* Moves. *)
+
+(* [C6.2.281 MOV (register)] ARM DDI 0487 M.a, p. 2413
+   Move register value  This instruction copies the value in a source register
+   to the destination register.  This is an alias of ORR (shifted register).
+   This means:  • The encodings in this description are named to match the
+   encodings of ORR (shifted register). • The description of ORR (shifted
+   register) gives the operational pseudocode, any CONSTRAINED UNPREDICTABLE
+   behavior, and any operational information for this instruction.
+   Syntax: MOV <Xd>, <Xm>  ==  ORR <Xd>, XZR, <Xm>
+   Operation (ASL):
+     The description of ORR (shifted register) gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_MOV_semi {ws : wsize} (wn : word ws) : ty_w ws :=
+  wn.
+
+Definition armv8a_MOV_instr : instr_desc_t :=
+  let mn := MOV in
+  let tin := [:: lword osz ] in
+  let semi := armv8a_MOV_semi (ws := osz) in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 1 ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 2;
+    id_args_kinds :=
+      ak_reg_reg ++ [:: [:: [:: CAreg ]; [:: CAimm (Some CAimmC_armv8a_mov_imm) osz ] ] ];
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+Definition mk_movw_instr mn (semi : word U16 -> word U8 -> ty_w osz)
+  : instr_desc_t :=
+  let tin := [:: lword U16; lword U8 ] in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 1; Ea 2 ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 3;
+    id_args_kinds := ak_r_imm16_shift;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.284 MOVZ] ARM DDI 0487 M.a, p. 2418
+   Move wide with zero  This instruction moves an optionally-shifted 16-bit
+   immediate value to a register.  This instruction is used by the alias MOV
+   (wide immediate).
+   Syntax: MOVZ <Xd>, #<imm>{, LSL #<shift>}
+   Operation (ASL):
+     bits(datasize) result = Zeros(datasize);
+     result<pos+15:pos> = imm;
+     X[d, datasize] = result;
+*)
+Definition armv8a_MOVZ_semi {ws : wsize} (imm : word U16) (wsh : word U8) : ty_w ws :=
+  wshl (zero_extend ws imm) (wunsigned wsh).
+
+Definition armv8a_MOVZ_instr : instr_desc_t :=
+  mk_movw_instr MOVZ (armv8a_MOVZ_semi (ws := osz)).
+
+(* [C6.2.283 MOVN] ARM DDI 0487 M.a, p. 2416
+   Move wide with NOT  This instruction moves the inverse of an optionally-
+   shifted 16-bit immediate value to a register.  This instruction is used by
+   the alias MOV (inverted wide immediate).
+   Syntax: MOVN <Xd>, #<imm>{, LSL #<shift>}
+   Operation (ASL):
+     bits(datasize) result = Zeros(datasize);
+     result<pos+15:pos> = imm;
+     X[d, datasize] = NOT(result);
+*)
+Definition armv8a_MOVN_semi {ws : wsize} (imm : word U16) (wsh : word U8) : ty_w ws :=
+  wnot (wshl (zero_extend ws imm) (wunsigned wsh)).
+
+Definition armv8a_MOVN_instr : instr_desc_t :=
+  mk_movw_instr MOVN (armv8a_MOVN_semi (ws := osz)).
+
+(* [C6.2.282 MOVK] ARM DDI 0487 M.a, p. 2415
+   Move wide with keep  This instruction moves an optionally-shifted 16-bit
+   immediate value into a register, keeping other bits unchanged.
+   Syntax: MOVK <Xd>, #<imm>{, LSL #<shift>}
+   Operation (ASL):
+     bits(datasize) result = X[d, datasize];
+     result<pos+15:pos> = imm;
+     X[d, datasize] = result;
+*)
+Definition armv8a_MOVK_semi {ws : wsize} (old : word ws) (imm : word U16) (wsh : word U8) : ty_w ws :=
+  let sh := wunsigned wsh in
+  let mask := wshl (zero_extend ws (wrepr U16 (-1))) sh in
+  wor (wshl (zero_extend ws imm) sh) (wand old (wnot mask)).
+
+Definition armv8a_MOVK_instr : instr_desc_t :=
+  let mn := MOVK in
+  let tin := [:: lword osz; lword U16; lword U8 ] in
+  let semi := armv8a_MOVK_semi (ws := osz) in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 0; Ea 1; Ea 2 ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 3;
+    id_args_kinds := ak_r_imm16_shift;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+
+(* -------------------------------------------------------------------- *)
+(* Extensions.
+   [in_ws] is the width of the extracted low bits; the result is extended
+   to the operand size. SXTW and UXTW only exist in the X form. *)
+
+Definition armv8a_extend_semi
+  {ws : wsize} (sign : bool) (ws' : wsize) (wn : word ws) : word ws' :=
+  let f := if sign then sign_extend else zero_extend in
+  (f ws' ws wn).
+
+Definition mk_extend_instr mn (in_ws : wsize) (sign : bool) (valid : bool)
+  : instr_desc_t :=
+  let tin := [:: lword in_ws ] in
+  let semi := armv8a_extend_semi (ws := in_ws) sign osz in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 1 ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 2;
+    id_args_kinds := ak_reg_reg;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    (* [SXTB <Xd>, <Wn>] / [UXTB <Wd>, <Wn>]: the source is always a W
+       register, and so is the destination of the zero-extensions. *)
+    id_pp_asm := pp_armv8a_op_szs mn [:: (if sign then osz else U32); U32 ];
+    id_valid := valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.12 ADR] ARM DDI 0487 M.a, p. 1809
+   Form PC-relative address  This instruction adds an immediate value to the PC
+   value to form a PC-relative address, and writes the result to the
+   destination register.
+   Syntax: ADR <Xd>, <label>
+   Operation (ASL):
+     X[d, 64] = PC64 + imm;
+*)
+Definition armv8a_ADR_semi (wn : word U64) : ty_r :=
+  wn.
+
+Definition armv8a_ADR_instr : instr_desc_t :=
+  let mn := ADR in
+  let tin := [:: lreg ] in
+  let semi := armv8a_ADR_semi in
+  {|
+    id_msb_flag := MSB_MERGE;
+    id_tin := tin;
+    id_in := [:: Ec 1 ];
+    id_tout := [:: lreg ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 2;
+    id_args_kinds := ak_reg_addr;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := NOT_DOIT;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz == U64;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.471 SXTB] ARM DDI 0487 M.a, p. 2812
+   Signed extend byte  This instruction extracts an 8-bit value from a
+   register, sign-extends it to the size of the register, and writes the result
+   to the destination register.  This is an alias of SBFM. This means:  • The
+   encodings in this description are named to match the encodings of SBFM. •
+   The description of SBFM gives the operational pseudocode, any CONSTRAINED
+   UNPREDICTABLE behavior, and any operational information for this
+   instruction.
+   Syntax: SXTB <Xd>, <Wn>  ==  SBFM <Xd>, <Xn>, #0, #7
+   Operation (ASL):
+     The description of SBFM gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_SXTB_instr : instr_desc_t := mk_extend_instr SXTB U8 true osz_valid.
+(* [C6.2.472 SXTH] ARM DDI 0487 M.a, p. 2813
+   Sign extend halfword  This instruction extracts a 16-bit value, sign-extends
+   it to the size of the register, and writes the result to the destination
+   register.  This is an alias of SBFM. This means:  • The encodings in this
+   description are named to match the encodings of SBFM. • The description of
+   SBFM gives the operational pseudocode, any CONSTRAINED UNPREDICTABLE
+   behavior, and any operational information for this instruction.
+   Syntax: SXTH <Xd>, <Wn>  ==  SBFM <Xd>, <Xn>, #0, #15
+   Operation (ASL):
+     The description of SBFM gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_SXTH_instr : instr_desc_t := mk_extend_instr SXTH U16 true osz_valid.
+(* [C6.2.473 SXTW] ARM DDI 0487 M.a, p. 2814
+   Sign extend word  This instruction sign-extends a word to the size of the
+   register, and writes the result to the destination register.  This is an
+   alias of SBFM. This means:  • The encodings in this description are named to
+   match the encodings of SBFM. • The description of SBFM gives the operational
+   pseudocode, any CONSTRAINED UNPREDICTABLE behavior, and any operational
+   information for this instruction.
+   Syntax: SXTW <Xd>, <Wn>  ==  SBFM <Xd>, <Xn>, #0, #31
+   Operation (ASL):
+     The description of SBFM gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_SXTW_instr : instr_desc_t := mk_extend_instr SXTW U32 true (osz == U64).
+(* [C6.2.499 UXTB] ARM DDI 0487 M.a, p. 2863
+   Unsigned extend byte  This instruction extracts an 8-bit value from a
+   register, zero-extends it to the size of the register, and writes the result
+   to the destination register.  This is an alias of UBFM. This means:  • The
+   encodings in this description are named to match the encodings of UBFM. •
+   The description of UBFM gives the operational pseudocode, any CONSTRAINED
+   UNPREDICTABLE behavior, and any operational information for this
+   instruction.
+   Syntax: UXTB <Wd>, <Wn>  ==  UBFM <Wd>, <Wn>, #0, #7
+   Operation (ASL):
+     The description of UBFM gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_UXTB_instr : instr_desc_t := mk_extend_instr UXTB U8 false osz_valid.
+(* [C6.2.500 UXTH] ARM DDI 0487 M.a, p. 2864
+   Unsigned extend halfword  This instruction extracts a 16-bit value from a
+   register, zero-extends it to the size of the register, and writes the result
+   to the destination register.  This is an alias of UBFM. This means:  • The
+   encodings in this description are named to match the encodings of UBFM. •
+   The description of UBFM gives the operational pseudocode, any CONSTRAINED
+   UNPREDICTABLE behavior, and any operational information for this
+   instruction.
+   Syntax: UXTH <Wd>, <Wn>  ==  UBFM <Wd>, <Wn>, #0, #15
+   Operation (ASL):
+     The description of UBFM gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_UXTH_instr : instr_desc_t := mk_extend_instr UXTH U16 false osz_valid.
+(* [C6.2.281 MOV (register)] ARM DDI 0487 M.a, p. 2413
+   Move register value  This instruction copies the value in a source register
+   to the destination register.  This is an alias of ORR (shifted register).
+   This means:  • The encodings in this description are named to match the
+   encodings of ORR (shifted register). • The description of ORR (shifted
+   register) gives the operational pseudocode, any CONSTRAINED UNPREDICTABLE
+   behavior, and any operational information for this instruction.
+   Note: The ARM ARM defines no UXTW entry: UXTW #0 is equivalent to a 32-bit register MOV (alias of ORR (shifted register)), whose 32-bit result is zero-extended to 64 bits; the MOV (register) entry is recorded here in its place.
+   Syntax: MOV <Xd>, <Xm>  ==  ORR <Xd>, XZR, <Xm>
+   Operation (ASL):
+     The description of ORR (shifted register) gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_UXTW_instr : instr_desc_t := mk_extend_instr UXTW U32 false (osz == U64).
+
+(* -------------------------------------------------------------------- *)
+(* Bit-manipulation instructions. *)
+
+(* -------------------------------------------------------------------- *)
+(* Comparisons. *)
+
+Definition mk_cmp_instr mn (ick : option armv8a_caimm_cond)
+  (semi : word osz -> word osz -> ty_nzcv)
+  : instr_desc_t :=
+  let tin := [:: lword osz; lword osz ] in
+  let x :=
+    {|
+      id_msb_flag := MSB_MERGE;
+      id_tin := tin;
+      id_in := [:: Ea 0; Ea 1 ];
+      id_tout := snzcv;
+      id_out := ad_nzcv;
+      id_semi := sem_lprod_ok tin semi;
+      id_nargs := 2;
+      id_args_kinds := ak_rr_or_imm ick;
+      id_eq_size := refl_equal;
+      id_check_dest := refl_equal;
+      id_str_jas := armv8a_mn_str mn;
+      id_safe := [::];
+      id_doit := DOIT;
+      id_pp_asm := pp_armv8a_op mn opts;
+      id_valid := osz_valid;
+      id_safe_wf := refl_equal;
+      id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+      id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+    |}
+  in
+  if has_shift opts is Some sk
+  then mk_shifted osz sk mn x (mk_semi2_2_shifted sk (id_semi x))
+                       (fun h => mk_semi2_2_shifted_errty
+                                   (x.(id_semi_errty) (proj1 (andb_prop _ _ h))))
+                       (fun h => mk_semi2_2_shifted_safe sk
+                                   (x.(id_semi_safe) (proj1 (andb_prop _ _ h))))
+  else x.
+
+(* [C6.2.97 CMP (shifted register)] ARM DDI 0487 M.a, p. 1953
+   Compare (shifted register)  This instruction subtracts an optionally-shifted
+   register value from a register value. It updates the condition flags based
+   on the result, and discards the result.  This is an alias of SUBS (shifted
+   register). This means:  • The encodings in this description are named to
+   match the encodings of SUBS (shifted register). • The description of SUBS
+   (shifted register) gives the operational pseudocode, any CONSTRAINED
+   UNPREDICTABLE behavior, and any operational information for this
+   instruction.
+   Syntax: CMP <Wn>, <Wm>{, <shift> #<amount>}  ==  CMP <Xn>, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     The description of SUBS (shifted register) gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_CMP_semi {ws : wsize} (wn wm : word ws) : ty_nzcv :=
+  let wmnot := wnot wm in
+  nzcv_of_aluop
+    (wn + wmnot + 1)%w
+    (wunsigned wn + wunsigned wmnot + 1)%Z
+    (wsigned wn + wsigned wmnot + 1)%Z.
+
+Definition armv8a_CMP_instr : instr_desc_t :=
+  mk_cmp_instr CMP arith_imm armv8a_CMP_semi.
+(* [C6.2.484 TST (shifted register)] ARM DDI 0487 M.a, p. 2837
+   Test (shifted register)  This instruction performs a bitwise AND operation
+   on a register value and an optionally-shifted register value. It updates the
+   condition flags based on the result, and discards the result.  This is an
+   alias of ANDS (shifted register). This means:  • The encodings in this
+   description are named to match the encodings of ANDS (shifted register). •
+   The description of ANDS (shifted register) gives the operational pseudocode,
+   any CONSTRAINED UNPREDICTABLE behavior, and any operational information for
+   this instruction.
+   Syntax: TST <Wn>, <Wm>{, <shift> #<amount>}  ==  TST <Xn>, <Xm>{, <shift> #<amount>}
+   Operation (ASL):
+     The description of ANDS (shifted register) gives the operational pseudocode for this instruction.
+*)
+Definition armv8a_TST_semi {ws : wsize} (wn wm : word ws) : ty_nzcv :=
+  nzcv_of_logop (wand wn wm).
+
+Definition armv8a_TST_instr : instr_desc_t :=
+  mk_cmp_instr TST bitmask_imm armv8a_TST_semi.
+
+(* -------------------------------------------------------------------- *)
+(* Conditional selection.
+   The condition is a first-class operand (the [CAcond] argument kind),
+   evaluated by [arm_eval_cond] on the NZCV flags and passed to the
+   semantics as a boolean. *)
+
+Definition mk_csel_instr mn (semi : word osz -> word osz -> bool -> ty_w osz)
+  : instr_desc_t :=
+  let tin := [:: lword osz; lword osz; lbool ] in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Ea 1; Ea 2; Ea 3 ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 4;
+    id_args_kinds := ak_rrr_cond;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    id_pp_asm := pp_armv8a_op mn opts;
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.138 CSEL] ARM DDI 0487 M.a, p. 2138
+   Conditional select  This instruction writes the value of the first source
+   register to the destination register if the condition is TRUE. If the
+   condition is FALSE, it writes the value of the second source register to the
+   destination register.
+   Syntax: CSEL <Xd>, <Xn>, <Xm>, <cond>
+   Operation (ASL):
+     bits(datasize) result;
+     if ConditionHolds(condition) then
+         result = X[n, datasize];
+     else
+         result = X[m, datasize];
+     X[d, datasize] = result;
+*)
+Definition armv8a_CSEL_semi {ws : wsize} (wn wm : word ws) (b : bool) : ty_w ws :=
+  if b then wn else wm.
+
+Definition armv8a_CSEL_instr := mk_csel_instr CSEL (armv8a_CSEL_semi (ws := osz)).
+
+(* -------------------------------------------------------------------- *)
+(* Loads and stores.
+   The memory access itself is performed by the framework ([eval_asm_arg]
+   reads or writes memory for address arguments); the instruction semantics
+   only sign- or zero-extends the transferred value. [LDR] and [STR] access
+   memory at the operand size; the narrow loads and stores have their
+   access width in the mnemonic. *)
+
+(* [C6.2.217 LDR (register)] ARM DDI 0487 M.a, p. 2275
+   Load register (register)  This instruction calculates an address from a base
+   register value and an offset register value, loads a word from memory, and
+   writes it to a register. The offset register value can optionally be shifted
+   and extended. For information about addressing modes, see Load/Store
+   addressing modes.
+   Syntax: LDR <Wt>, [<Xn|SP>, (<Wm>|<Xm>){, <extend> {<amount>}}]
+   Syntax: LDR <Xt>, [<Xn|SP>, (<Wm>|<Xm>){, <extend> {<amount>}}]
+   Operation (ASL):
+     constant bits(64) offset = ExtendReg(m, extend_type, shift, 64);
+     bits(64) address;
+     constant boolean privileged = PSTATE.EL != EL0;
+     constant AccessDescriptor accdesc = CreateAccDescGPR(MemOp_LOAD, nontemporal, privileged,
+                                                          tagchecked, t);
+     if n == 31 then
+         CheckSPAlignment();
+         address = SP[64];
+     else
+         address = X[n, 64];
+     address = AddressAdd(address, offset, accdesc);
+     constant bits(datasize) data = Mem[address, datasize DIV 8, accdesc];
+     X[t, regsize] = ZeroExtend(data, regsize);
+*)
+Definition armv8a_load_instr mn : instr_desc_t :=
+  let wacc :=
+    if wsize_of_narrow_load_mn mn is Some ws'
+    then ws'
+    else osz
+  in
+  let tin := [:: lword wacc ] in
+  let semi := armv8a_extend_semi (ws := wacc) (isSome (wsize_of_sload_mn mn)) osz in
+  {|
+    id_msb_flag := msbf;
+    id_tin := tin;
+    id_in := [:: Eu 1 ];
+    id_tout := [:: lword osz ];
+    id_out := [:: Ea 0 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 2;
+    id_args_kinds := ak_reg_addr;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    (* The transferred register of the zero-extending narrow loads is
+       always a W register ([LDRB <Wt>, ...]); the sign-extending loads
+       name it at the operand size ([LDRSB <Wt>|<Xt>, ...]). *)
+    id_pp_asm :=
+      pp_armv8a_op_szs mn
+        [:: (match mn with LDRB | LDRH => U32 | _ => osz end); osz ];
+    id_valid := osz_valid && (if mn is LDRSW then osz == U64 else true);
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.220 LDRB (register)] ARM DDI 0487 M.a, p. 2283
+   Load register byte (register)  This instruction calculates an address from a
+   base register value and an offset register value, loads a byte from memory,
+   zero-extends it, and writes it to a register. For information about
+   addressing modes, see Load/Store addressing modes.
+   Syntax: LDRB <Wt>, [<Xn|SP>, (<Wm>|<Xm>), <extend> {<amount>}]
+   Syntax: LDRB <Wt>, [<Xn|SP>, <Xm>{, LSL <amount>}]
+   Operation (ASL):
+     constant bits(64) offset = ExtendReg(m, extend_type, shift, 64);
+     bits(64) address;
+     constant boolean privileged = PSTATE.EL != EL0;
+     constant AccessDescriptor accdesc = CreateAccDescGPR(MemOp_LOAD, nontemporal, privileged,
+                                                          tagchecked, t);
+     if n == 31 then
+         CheckSPAlignment();
+         address = SP[64];
+     else
+         address = X[n, 64];
+     address = AddressAdd(address, offset, accdesc);
+     constant bits(8) data = Mem[address, 1, accdesc];
+     X[t, 32] = ZeroExtend(data, 32);
+*)
+
+(* [C6.2.222 LDRH (register)] ARM DDI 0487 M.a, p. 2288
+   Load register halfword (register)  This instruction calculates an address
+   from a base register value and an offset register value, loads a halfword
+   from memory, zero-extends it, and writes it to a register. For information
+   about addressing modes, see Load/Store addressing modes.
+   Syntax: LDRH <Wt>, [<Xn|SP>, (<Wm>|<Xm>){, <extend> {<amount>}}]
+   Operation (ASL):
+     constant bits(64) offset = ExtendReg(m, extend_type, shift, 64);
+     bits(64) address;
+     constant boolean privileged = PSTATE.EL != EL0;
+     constant AccessDescriptor accdesc = CreateAccDescGPR(MemOp_LOAD, nontemporal, privileged,
+                                                          tagchecked, t);
+     if n == 31 then
+         CheckSPAlignment();
+         address = SP[64];
+     else
+         address = X[n, 64];
+     address = AddressAdd(address, offset, accdesc);
+     constant bits(16) data = Mem[address, 2, accdesc];
+     X[t, 32] = ZeroExtend(data, 32);
+*)
+
+(* [C6.2.224 LDRSB (register)] ARM DDI 0487 M.a, p. 2293
+   Load register signed byte (register)  This instruction calculates an address
+   from a base register value and an offset register value, loads a byte from
+   memory, sign-extends it, and writes it to a register. For information about
+   addressing modes, see Load/Store addressing modes.
+   Syntax: LDRSB <Wt>, [<Xn|SP>, (<Wm>|<Xm>), <extend> {<amount>}]
+   Syntax: LDRSB <Wt>, [<Xn|SP>, <Xm>{, LSL <amount>}]
+   Syntax: LDRSB <Xt>, [<Xn|SP>, (<Wm>|<Xm>), <extend> {<amount>}]
+   Syntax: LDRSB <Xt>, [<Xn|SP>, <Xm>{, LSL <amount>}]
+   Operation (ASL):
+     constant bits(64) offset = ExtendReg(m, extend_type, shift, 64);
+     bits(64) address;
+     constant boolean privileged = PSTATE.EL != EL0;
+     constant AccessDescriptor accdesc = CreateAccDescGPR(MemOp_LOAD, nontemporal, privileged,
+                                                          tagchecked, t);
+     if n == 31 then
+         CheckSPAlignment();
+         address = SP[64];
+     else
+         address = X[n, 64];
+     address = AddressAdd(address, offset, accdesc);
+     constant bits(8) data = Mem[address, 1, accdesc];
+     X[t, regsize] = SignExtend(data, regsize);
+*)
+
+(* [C6.2.226 LDRSH (register)] ARM DDI 0487 M.a, p. 2298
+   Load register signed halfword (register)  This instruction calculates an
+   address from a base register value and an offset register value, loads a
+   halfword from memory, sign-extends it, and writes it to a register. For
+   information about addressing modes, see Load/Store addressing modes.
+   Syntax: LDRSH <Wt>, [<Xn|SP>, (<Wm>|<Xm>){, <extend> {<amount>}}]
+   Syntax: LDRSH <Xt>, [<Xn|SP>, (<Wm>|<Xm>){, <extend> {<amount>}}]
+   Operation (ASL):
+     constant bits(64) offset = ExtendReg(m, extend_type, shift, 64);
+     bits(64) address;
+     constant boolean privileged = PSTATE.EL != EL0;
+     constant AccessDescriptor accdesc = CreateAccDescGPR(MemOp_LOAD, nontemporal, privileged,
+                                                          tagchecked, t);
+     if n == 31 then
+         CheckSPAlignment();
+         address = SP[64];
+     else
+         address = X[n, 64];
+     address = AddressAdd(address, offset, accdesc);
+     constant bits(16) data = Mem[address, 2, accdesc];
+     X[t, regsize] = SignExtend(data, regsize);
+*)
+
+(* [C6.2.229 LDRSW (register)] ARM DDI 0487 M.a, p. 2304
+   Load register signed word (register)  This instruction calculates an address
+   from a base register value and an offset register value, loads a word from
+   memory, sign-extends it to form a 64-bit value, and writes it to a register.
+   The offset register value can be shifted left by 0 or 2 bits. For
+   information about addressing modes, see Load/Store addressing modes.
+   Syntax: LDRSW <Xt>, [<Xn|SP>, (<Wm>|<Xm>){, <extend> {<amount>}}]
+   Operation (ASL):
+     constant bits(64) offset = ExtendReg(m, extend_type, shift, 64);
+     bits(64) address;
+     constant boolean privileged = PSTATE.EL != EL0;
+     constant AccessDescriptor accdesc = CreateAccDescGPR(MemOp_LOAD, nontemporal, privileged,
+                                                          tagchecked, t);
+     if n == 31 then
+         CheckSPAlignment();
+         address = SP[64];
+     else
+         address = X[n, 64];
+     address = AddressAdd(address, offset, accdesc);
+     constant bits(32) data = Mem[address, 4, accdesc];
+     X[t, 64] = SignExtend(data, 64);
+*)
+
+(* [C6.2.415 STR (register)] ARM DDI 0487 M.a, p. 2693
+   Store register (register)  This instruction calculates an address from a
+   base register value and an offset register value, and stores a 32-bit word
+   or a 64-bit doubleword to the calculated address, from a register. For
+   information about addressing modes, see Load/Store addressing modes.  The
+   instruction uses an offset addressing mode, that calculates the address used
+   for the memory access from a base register value and an offset register
+   value. The offset can be optionally shifted and extended.
+   Syntax: STR <Wt>, [<Xn|SP>, (<Wm>|<Xm>){, <extend> {<amount>}}]
+   Syntax: STR <Xt>, [<Xn|SP>, (<Wm>|<Xm>){, <extend> {<amount>}}]
+   Operation (ASL):
+     constant bits(64) offset = ExtendReg(m, extend_type, shift, 64);
+     bits(64) address;
+     constant boolean privileged = PSTATE.EL != EL0;
+     constant AccessDescriptor accdesc = CreateAccDescGPR(MemOp_STORE, nontemporal, privileged,
+                                                          tagchecked, t);
+     if n == 31 then
+         CheckSPAlignment();
+         address = SP[64];
+     else
+         address = X[n, 64];
+     address = AddressAdd(address, offset, accdesc);
+     Mem[address, datasize DIV 8, accdesc] = X[t, datasize];
+*)
+Definition armv8a_store_instr mn : instr_desc_t :=
+  let wacc :=
+    if wsize_of_narrow_store_mn mn is Some ws'
+    then ws'
+    else osz
+  in
+  let tin := [:: lword wacc ] in
+  let semi := armv8a_extend_semi (ws := wacc) false wacc in
+  {|
+    id_msb_flag := MSB_MERGE;
+    (* The input should be an [osz] word and be zero_extended to the output
+       size, but this is implicit in Jasmin semantics. *)
+    id_tin := tin;
+    id_in := [:: Ea 0 ];
+    id_tout := [:: lword wacc ];
+    id_out := [:: Eu 1 ];
+    id_semi := sem_lprod_ok tin semi;
+    id_nargs := 2;
+    id_args_kinds := ak_reg_addr;
+    id_eq_size := refl_equal;
+    id_check_dest := refl_equal;
+    id_str_jas := armv8a_mn_str mn;
+    id_safe := [::];
+    id_doit := DOIT;
+    (* The transferred register of the narrow stores is always a W
+       register ([STRB <Wt>, ...]). *)
+    id_pp_asm :=
+      pp_armv8a_op_szs mn
+        [:: (match mn with STRB | STRH => U32 | _ => osz end); osz ];
+    id_valid := osz_valid;
+    id_safe_wf := refl_equal;
+    id_semi_errty := fun _ => sem_lprod_ok_error tin semi;
+    id_semi_safe := fun _ => sem_lprod_ok_safe tin semi;
+  |}.
+
+(* [C6.2.417 STRB (register)] ARM DDI 0487 M.a, p. 2699
+   Store register byte (register)  This instruction calculates an address from
+   a base register value and an offset register value, and stores a byte from a
+   32-bit register to the calculated address. For information about addressing
+   modes, see Load/Store addressing modes.  The instruction uses an offset
+   addressing mode, that calculates the address used for the memory access from
+   a base register value and an offset register value. The offset can be
+   optionally shifted and extended.
+   Syntax: STRB <Wt>, [<Xn|SP>, (<Wm>|<Xm>), <extend> {<amount>}]
+   Syntax: STRB <Wt>, [<Xn|SP>, <Xm>{, LSL <amount>}]
+   Operation (ASL):
+     constant bits(64) offset = ExtendReg(m, extend_type, shift, 64);
+     bits(64) address;
+     constant boolean privileged = PSTATE.EL != EL0;
+     constant AccessDescriptor accdesc = CreateAccDescGPR(MemOp_STORE, nontemporal, privileged,
+                                                          tagchecked, t);
+     if n == 31 then
+         CheckSPAlignment();
+         address = SP[64];
+     else
+         address = X[n, 64];
+     address = AddressAdd(address, offset, accdesc);
+     Mem[address, 1, accdesc] = X[t, 8];
+*)
+
+(* [C6.2.419 STRH (register)] ARM DDI 0487 M.a, p. 2704
+   Store register halfword (register)  This instruction calculates an address
+   from a base register value and an offset register value, and stores a
+   halfword from a 32-bit register to the calculated address. For information
+   about addressing modes, see Load/Store addressing modes.  The instruction
+   uses an offset addressing mode, that calculates the address used for the
+   memory access from a base register value and an offset register value. The
+   offset can be optionally shifted and extended.
+   Syntax: STRH <Wt>, [<Xn|SP>, (<Wm>|<Xm>){, <extend> {<amount>}}]
+   Operation (ASL):
+     constant bits(64) offset = ExtendReg(m, extend_type, shift, 64);
+     bits(64) address;
+     constant boolean privileged = PSTATE.EL != EL0;
+     constant AccessDescriptor accdesc = CreateAccDescGPR(MemOp_STORE, nontemporal, privileged,
+                                                          tagchecked, t);
+     if n == 31 then
+         CheckSPAlignment();
+         address = SP[64];
+     else
+         address = X[n, 64];
+     address = AddressAdd(address, offset, accdesc);
+     Mem[address, 2, accdesc] = X[t, 16];
+*)
+
+(* -------------------------------------------------------------------- *)
+(* Description of instructions. *)
+
+Definition mn_desc (mn : armv8a_mnemonic) : instr_desc_t :=
+  match mn with
+  | ADD => armv8a_ADD_instr
+  | ADDS => armv8a_ADDS_instr
+  | ADC => armv8a_ADC_instr
+  | ADCS => armv8a_ADCS_instr
+  | SUB => armv8a_SUB_instr
+  | SUBS => armv8a_SUBS_instr
+  | NEG => armv8a_NEG_instr
+  | MUL => armv8a_MUL_instr
+  | MADD => armv8a_MADD_instr
+  | MSUB => armv8a_MSUB_instr
+  | SDIV => armv8a_SDIV_instr
+  | UDIV => armv8a_UDIV_instr
+  | AND => armv8a_AND_instr
+  | ORR => armv8a_ORR_instr
+  | EOR => armv8a_EOR_instr
+  | MVN => armv8a_MVN_instr
+  | ASR => armv8a_ASR_instr
+  | LSL => armv8a_LSL_instr
+  | LSR => armv8a_LSR_instr
+  | ROR => armv8a_ROR_instr
+  | MOV => armv8a_MOV_instr
+  | MOVN => armv8a_MOVN_instr
+  | MOVZ => armv8a_MOVZ_instr
+  | MOVK => armv8a_MOVK_instr
+  | ADR => armv8a_ADR_instr
+  | SXTB => armv8a_SXTB_instr
+  | SXTH => armv8a_SXTH_instr
+  | SXTW => armv8a_SXTW_instr
+  | UXTB => armv8a_UXTB_instr
+  | UXTH => armv8a_UXTH_instr
+  | UXTW => armv8a_UXTW_instr
+  | CMP => armv8a_CMP_instr
+  | TST => armv8a_TST_instr
+  | CSEL => armv8a_CSEL_instr
+  | LDR => armv8a_load_instr LDR
+  | LDRB => armv8a_load_instr LDRB
+  | LDRH => armv8a_load_instr LDRH
+  | LDRSB => armv8a_load_instr LDRSB
+  | LDRSH => armv8a_load_instr LDRSH
+  | LDRSW => armv8a_load_instr LDRSW
+  | STR => armv8a_store_instr STR
+  | STRB => armv8a_store_instr STRB
+  | STRH => armv8a_store_instr STRH
+  end.
+
+End ARMV8A_INSTR.
+
+Definition armv8a_instr_desc (o : armv8a_asm_op) : instr_desc_t :=
+  let '(ARMv8A_op mn opts) := o in
+  mn_desc opts mn.
+
+(* Size-suffixed intrinsic parsing: [#ADD] is the X (64-bit) form and
+   [#ADD_32] the W form. Fixed-size mnemonics take no suffix. *)
+Definition armv8a_prim_sized (mn : armv8a_mnemonic) : prim_constructor armv8a_asm_op :=
+  PrimX86
+    [:: PVp U64; PVp U32 ]
+    (fun s =>
+       if s is PVp sz
+       then Some (ARMv8A_op mn (opts_at sz))
+       else None).
+
+Definition armv8a_prim_string : seq (string * prim_constructor armv8a_asm_op) :=
+  map
+    (fun mn =>
+       (string_of_armv8a_mnemonic mn,
+        if mn \in sized_mnemonics
+        then armv8a_prim_sized mn
+        else primM (ARMv8A_op mn default_opts)))
+    cenum.
+
+#[ export ]
+Instance armv8a_op_decl : asm_op_decl armv8a_asm_op :=
+  {|
+    instr_desc_op := armv8a_instr_desc;
+    prim_string := armv8a_prim_string;
+  |}.
+
+Definition armv8a_prog := @asm_prog _ _ _ _ _ _ _ armv8a_op_decl.

--- a/proofs/compiler/armv8a_lowering.v
+++ b/proofs/compiler/armv8a_lowering.v
@@ -1,0 +1,590 @@
+(* Lowering pass for ARMv8-A (AArch64): turn source-level operations into
+   architecture-specific operations.
+
+   Ported from the ARMv7-M lowering pass. The main differences follow from
+   A64 having no conditional execution: word-sized conditional expressions
+   are lowered to CSEL, and there are no conditional stores or conditional
+   immediate loads. Word operations are lowered at both register sizes:
+   64-bit (X form) and 32-bit (W form). *)
+
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssralg.
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  compiler_util
+  expr
+  lowering
+  pseudo_operator
+  shift_kind.
+Require Import
+  arch_decl
+  arch_extra.
+Require Import
+  armv8a_decl
+  armv8a_extra
+  armv8a_instr_decl
+  armv8a_params_core.
+
+Section Section.
+Context {atoI : arch_toIdent}.
+
+(* -------------------------------------------------------------------- *)
+(* Fresh variables. *)
+(* This pass is parameterized by four variable names that will be used to
+   create variables for the processor flags. *)
+
+Definition fv_NF (fv : fresh_vars) := fv "__n__"%string abool.
+Definition fv_ZF (fv : fresh_vars) := fv "__z__"%string abool.
+Definition fv_CF (fv : fresh_vars) := fv "__c__"%string abool.
+Definition fv_VF (fv : fresh_vars) := fv "__v__"%string abool.
+
+Definition all_fresh_vars (fv : fresh_vars) : seq Ident.ident :=
+  [:: fv_NF fv; fv_ZF fv; fv_CF fv; fv_VF fv ].
+
+Definition fvNF (fv : fresh_vars) : var := vbool (fv_NF fv).
+Definition fvZF (fv : fresh_vars) : var := vbool (fv_ZF fv).
+Definition fvCF (fv : fresh_vars) : var := vbool (fv_CF fv).
+Definition fvVF (fv : fresh_vars) : var := vbool (fv_VF fv).
+
+Definition fresh_flags (fv : fresh_vars) : seq var :=
+  [:: fvNF fv; fvZF fv; fvCF fv; fvVF fv ].
+
+Definition fvars (fv : fresh_vars) : Sv.t := sv_of_list id (fresh_flags fv).
+
+
+(* -------------------------------------------------------------------- *)
+
+Section ARMV8A_LOWERING.
+
+Context
+  (fv : fresh_vars).
+
+Definition low_expr : Type := option (sopn * seq pexpr).
+Definition le_skip : low_expr := None.
+Definition le_issue_sopn op es : low_expr := Some (op, es).
+Definition le_issue_extra op := le_issue_sopn (Oasm (ExtOp op)).
+Definition le_issue_aop aop := le_issue_sopn (Oasm (BaseOp (None, aop))).
+Definition le_issue_opts mn opts := le_issue_aop (ARMv8A_op mn opts).
+Definition le_issue mn ws := le_issue_opts mn (opts_at ws).
+
+Definition no_pre (ole : low_expr) : option (seq instr_r * sopn * seq pexpr) :=
+  let%opt (aop, es) := ole in Some ([::], aop, es).
+
+(* Word operations are lowered at both the X (64-bit) and W (32-bit)
+   register sizes. *)
+Definition chk_ws_reg (ws : wsize) : option unit :=
+  oassert ((ws == U64) || (ws == U32))%CMP.
+
+
+(* -------------------------------------------------------------------- *)
+(* Lowering of conditions. *)
+
+Definition flags_of_mn (mn : armv8a_mnemonic) : seq var :=
+  let ids :=
+    match mn with
+    | CMP => [:: fvNF; fvZF; fvCF; fvVF ]
+    | TST => [:: fvNF; fvZF; fvCF; fvVF ]
+    | _ => [::]
+    end
+  in
+  map (fun x => x fv) ids.
+
+Definition lflags_of_mn (vi : var_info) (mn : armv8a_mnemonic) : seq lval :=
+  [seq Lvar {| v_var := x; v_info := vi; |} | x <- flags_of_mn mn ].
+
+Definition lower_TST (e0 e1 : pexpr) : option (seq pexpr) :=
+  match e0, e1 with
+  | Papp2 (Oland _) e00 e01, Papp1 (Oword_of_int _) (Pconst 0) =>
+      Some [:: e00; e01 ]
+  | _, _ =>
+      None
+  end.
+
+Definition lower_condition_Papp2
+  (vi : var_info)
+  (op : sop2)
+  (e0 e1 : pexpr) :
+  option (armv8a_mnemonic * wsize * pexpr * seq pexpr) :=
+  let%opt (cf, ws) := cf_of_condition op in
+  let%opt _ := chk_ws_reg ws in
+  let cmp := (CMP, ws, pexpr_of_cf cf vi (fresh_flags fv), [:: e0; e1 ]) in
+  match op with
+  | Oeq (Op_w _) =>
+      let zf_var := {| v_var := fvZF fv; v_info := vi |} in
+      let eZF := Pvar (mk_lvar zf_var) in
+      Some (if lower_TST e0 e1 is Some es then (TST, ws, eZF, es) else cmp)
+  | Oneq (Op_w _)
+  | Olt (Cmp_w _ _)
+  | Ole (Cmp_w _ _)
+  | Ogt (Cmp_w _ _)
+  | Oge (Cmp_w _ _)
+      => Some cmp
+  | _ => None
+  end.
+
+Definition lower_condition_pexpr
+  (vi : var_info) (e : pexpr) : option (seq lval * sopn * seq pexpr * pexpr) :=
+  let%opt (op, e0, e1) := is_Papp2 e in
+  let%opt (mn, ws, e', es) := lower_condition_Papp2 vi op e0 e1 in
+  Some (lflags_of_mn vi mn, Oarmv8a (ARMv8A_op mn (opts_at ws)), es, e').
+
+Definition lower_condition (vi : var_info) (e : pexpr) : seq instr_r * pexpr :=
+  if lower_condition_pexpr vi e is Some (lvs, op, es, c)
+  then ([:: Copn lvs AT_none op es ], c)
+  else ([::], e).
+
+
+(* -------------------------------------------------------------------- *)
+(* Lowering of assignments. *)
+
+Definition get_arg_shift
+  (ws : wsize) (e : pexprs) : option (pexpr * shift_kind * pexpr) :=
+  if e is
+    [:: Papp2 op ((Pvar _) as v) ((Papp1 (Oword_of_int U8) (Pconst z)) as n) ]
+  then
+    let%opt sh := shift_of_sop2 ws op in
+    let%opt _ := oassert (check_shift_amount ws z) in
+    Some (v, sh, n)
+  else
+    None.
+
+Definition arg_shift
+  (mn : armv8a_mnemonic) (ws : wsize) (e : pexprs) : armv8a_asm_op * seq pexpr :=
+  let '(osh, es) :=
+    if mn \in has_shift_mnemonics
+    then
+      if get_arg_shift ws e is Some (ebase, sh, esham)
+      then
+        if shift_allowed mn sh
+        then (Some sh, [:: ebase; esham ])
+        else (None, e)
+      else (None, e)
+    else
+      (None, e)
+  in
+  let opts := {| has_shift := osh; opts_size := ws; |} in
+  (ARMv8A_op mn opts, es).
+
+(* Lower an expression of the form [v].
+   Precondition:
+   - [v] is a one of the following:
+     + a register.
+     + a stack variable. *)
+Definition lower_Pvar (ws : wsize) (v : gvar) : low_expr :=
+  let%opt _ := chk_ws_reg ws in
+  let mn := if is_var_in_memory (gv v) then LDR else MOV in
+  le_issue mn ws [:: Pvar v ].
+
+(* Lower an expression of the form [(ws)[v + e]] or [tab[ws e]]. *)
+Definition lower_load (ws : wsize) (e : pexpr) : low_expr :=
+  let%opt _ := chk_ws_reg ws in
+  le_issue LDR ws [:: e ].
+
+Definition mov_imm_op (ws : wsize) (e : pexpr) : sopn :=
+  if isSome (is_const e)
+  then Oasm (ExtOp (Oarmv8a_smart_li ws))
+  else Oarmv8a (ARMv8A_op MOV (opts_at ws)).
+
+(* Narrow zero- and sign-extending loads. *)
+Definition uload_mn (ws ws' : wsize) : option armv8a_mnemonic :=
+  match ws' with
+  | U8 => Some LDRB
+  | U16 => Some LDRH
+  | _ => None
+  end.
+
+Definition sload_mn (ws ws' : wsize) : option armv8a_mnemonic :=
+  match ws' with
+  | U8 => Some LDRSB
+  | U16 => Some LDRSH
+  | U32 => if ws == U64 then Some LDRSW else None
+  | _ => None
+  end.
+
+(* Register-to-register extensions. *)
+Definition sext_mn (ws ws' : wsize) : option armv8a_mnemonic :=
+  match ws' with
+  | U8 => Some SXTB
+  | U16 => Some SXTH
+  | U32 => if ws == U64 then Some SXTW else None
+  | _ => None
+  end.
+
+Definition uext_mn (ws ws' : wsize) : option armv8a_mnemonic :=
+  match ws' with
+  | U8 => Some UXTB
+  | U16 => Some UXTH
+  | U32 => if ws == U64 then Some UXTW else None
+  | _ => None
+  end.
+
+Definition lower_Papp1 (ws : wsize) (op : sop1) (e : pexpr) : low_expr :=
+  let%opt _ := chk_ws_reg ws in
+  match op with
+  | Oword_of_int ws' =>
+      let%opt _ := oassert (ws <= ws')%CMP in
+      let op := mov_imm_op ws e in
+      le_issue_sopn op [:: Papp1 (Oword_of_int ws) e ]
+  | Osignext ws0 ws' =>
+      let%opt _ := oassert (ws0 == ws) in
+      let%opt _ := oassert (ws' < ws)%CMP in
+      if is_load e
+      then
+        let%opt mn := sload_mn ws ws' in
+        le_issue mn ws [:: e ]
+      else
+        let%opt mn := sext_mn ws ws' in
+        le_issue mn ws [:: e ]
+  | Ozeroext ws0 ws' =>
+      let%opt _ := oassert (ws0 == ws) in
+      let%opt _ := oassert (ws' < ws)%CMP in
+      if is_load e
+      then
+        let%opt mn := uload_mn ws ws' in
+        le_issue mn ws [:: e ]
+      else
+        let%opt mn := uext_mn ws ws' in
+        le_issue mn ws [:: e ]
+  | Olnot ws0 =>
+      let%opt _ := oassert (ws0 == ws) in
+      let (op, es) := arg_shift MVN ws [:: e ] in
+      le_issue_aop op es
+  | Oneg (Op_w ws0) =>
+      let%opt _ := oassert (ws0 == ws) in
+      let (op, es) := arg_shift NEG ws [:: e ] in
+      le_issue_aop op es
+  | _ =>
+      le_skip
+  end.
+
+(* Recognize a multiplication whose product can be fused into MADD/MSUB at
+   width [ws]: any product at width at least [ws] qualifies, since only the
+   low [ws] bits of the result are kept. *)
+Definition is_mul (ws : wsize) (e : pexpr) : option (pexpr * pexpr) :=
+  if e is Papp2 (Omul (Op_w ws')) x y
+  then if (ws <= ws')%CMP then Some (x, y) else None
+  else None.
+
+(* Accept a shift amount that is either a compile-time constant already in
+   [0, wsize) or an expression explicitly masked to the operand size
+   ([a & (wsize_bits - 1)]), as on x86 and RISC-V. In the masked case the
+   mask is dropped: the A64 register shifts reduce the amount modulo the
+   operand size, which subsumes it. *)
+Definition check_shift_expr (ws : wsize) (e : pexpr) : option pexpr :=
+  if is_wconst U8 e is Some n
+  then
+    if n == wand n (wrepr U8 (wsize_bits ws - 1)) then Some e else None
+  else
+    match e with
+    | Papp2 (Oland _) a b =>
+        if is_wconst U8 b is Some n
+        then if n == wrepr U8 (wsize_bits ws - 1) then Some a else None
+        else None
+    | _ => None
+    end.
+
+Definition lower_Papp2_op
+  (ws : wsize) (op : sop2) (e0 e1 : pexpr) :
+  option (armv8a_mnemonic * pexpr * pexprs) :=
+  let%opt _ := chk_ws_reg ws in
+  match op with
+  | Oadd (Op_w _) =>
+      if is_mul ws e0 is Some (x, y)
+      then Some (MADD, x, [:: y; e1 ])
+      else if is_mul ws e1 is Some (x, y)
+      then Some (MADD, x, [:: y; e0 ])
+      else
+      Some (ADD, e0, [:: e1 ])
+  | Omul (Op_w _) =>
+      Some (MUL, e0, [:: e1 ])
+  | Osub (Op_w _) =>
+      if is_mul ws e1 is Some (x, y)
+      then Some (MSUB, x, [:: y; e0 ])
+      else
+        Some (SUB, e0, [:: e1 ])
+  | Odiv Signed (Op_w ws') =>
+      let%opt _ := oassert (ws' == ws) in
+      Some (SDIV, e0, [:: e1 ])
+  | Odiv Unsigned (Op_w ws') =>
+      let%opt _ := oassert (ws' == ws) in
+      Some (UDIV, e0, [:: e1 ])
+  | Oland _ =>
+      Some (AND, e0, [:: e1 ])
+  | Olor _ =>
+      Some (ORR, e0, [:: e1 ])
+  | Olxor _ =>
+      Some (EOR, e0, [:: e1 ])
+  (* Logical/arithmetic shifts are NOT lowered to a bare A64 shift for an
+     arbitrary amount: the register form of LSR/LSL/ASR shifts by
+     [amount mod wsize], whereas the Jasmin source shifts clamp the amount
+     to [wsize] (shifting all bits out yields 0). The two disagree once the
+     amount reaches [wsize]. As on x86 and RISC-V ([check_shift_amount]
+     there), we accept an amount that is either a compile-time constant in
+     [0, wsize) or an expression explicitly masked to the operand size
+     ([a & (wsize_bits - 1)]); the mask is subsumed by the hardware modulus
+     and is dropped. Rotates ([Oror]/[Orol]) are exempt: rotation is
+     periodic, so [mod] is already the intended semantics. *)
+  | Olsr ws' =>
+      let%opt _ := oassert (ws' == ws) in
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else
+        let%opt e1' := check_shift_expr ws e1 in
+        Some (LSR, e0, [:: e1' ])
+  | Olsl (Op_w ws') =>
+      let%opt _ := oassert (ws' == ws) in
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else
+        let%opt e1' := check_shift_expr ws e1 in
+        Some (LSL, e0, [:: e1' ])
+  | Oasr (Op_w ws') =>
+      let%opt _ := oassert (ws' == ws) in
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else
+        let%opt e1' := check_shift_expr ws e1 in
+        Some (ASR, e0, [:: e1' ])
+  | Oror ws' =>
+      let%opt _ := oassert (ws' == ws) in
+      if is_zero U8 e1 then Some (MOV, e0, [::])
+      else Some (ROR, e0, [:: e1 ])
+  | Orol ws' =>
+      let%opt _ := oassert (ws' == ws) in
+      let%opt c := is_wconst U8 e1 in
+      if c == 0%w then Some (MOV, e0, [::])
+      else Some (ROR, e0, [:: wconst (wrepr U8 (wsize_bits ws) - c)%w ])
+  | _ =>
+      None
+  end.
+
+(* Additions and subtractions of 64-bit immediates that do not fit the
+   12-bit (optionally shifted) encoding go through [Oarmv8a_add_large_imm],
+   which materializes the immediate with a MOVZ/MOVK sequence at assembly
+   generation. *)
+Definition large_arith_imm (ws : wsize) (mn : armv8a_mnemonic) (es : pexprs) : option Z :=
+  let%opt _ := oassert (ws == U64) in
+  let%opt e := if es is [:: e ] then Some e else None in
+  let%opt c := is_wconst U64 e in
+  let n := wunsigned c in
+  if is_arith_small n
+  then None
+  else
+    match mn with
+    | ADD => Some n
+    | SUB => Some (- n)%Z
+    | _ => None
+    end.
+
+(* Lower an expression of the form [a <+> b].
+   Precondition:
+   - [a] is a register.
+   - [b] is one of the following:
+     + a register.
+     + a shifted register.
+     + an immediate word. *)
+Definition lower_Papp2
+  (ws : wsize) (op : sop2) (e0 e1 : pexpr) : low_expr :=
+  let%opt (mn, e0', e1') := lower_Papp2_op ws op e0 e1 in
+  if large_arith_imm ws mn e1' is Some imm
+  then le_issue_extra Oarmv8a_add_large_imm [:: e0'; wconst (wrepr U64 imm) ]
+  else
+    let '(aop, es) := arg_shift mn ws e1' in
+    le_issue_aop aop (e0' :: es).
+
+Definition lower_pexpr_aux (ws : wsize) (e : pexpr) : low_expr :=
+  match e with
+  | Pvar v => lower_Pvar ws v
+  | Pget _ _ _ _ _
+  | Pload _ _ _ => lower_load ws e
+  | Papp1 op e => lower_Papp1 ws op e
+  | Papp2 op a b => lower_Papp2 ws op a b
+  | _ => le_skip
+  end.
+
+(* A64 has no conditional execution: conditional expressions are lowered
+   to CSEL, whose operands must be registers. *)
+Definition is_csel_arg (e : pexpr) : bool :=
+  if e is Pvar v then ~~ is_var_in_memory (gv v) else false.
+
+Definition lower_Pif
+  (vi : var_info) (ws : wsize) (c e0 e1 : pexpr) :
+  option (seq instr_r * sopn * seq pexpr) :=
+  let%opt _ := chk_ws_reg ws in
+  let%opt _ := oassert (is_csel_arg e0 && is_csel_arg e1) in
+  let '(pre, c') := lower_condition vi c in
+  Some (pre, Oarmv8a (ARMv8A_op CSEL (opts_at ws)), [:: e0; e1; c' ]).
+
+Definition lower_pexpr (vi : var_info) (ws : wsize) (e : pexpr) :
+  option (seq instr_r * sopn * seq pexpr) :=
+  if e is Pif (aword ws') c e0 e1 then
+    let%opt _ := oassert (ws == ws')%CMP in
+    lower_Pif vi ws c e0 e1
+  else
+    no_pre (lower_pexpr_aux ws e).
+
+(* Lower an assignment to memory.
+   Precondition:
+   - [lv] must be one of the following:
+     + a variable in memory.
+     + a memory location.
+   - [e] must be a register. *)
+Definition lower_store (ws : wsize) (e : pexpr) : option (armv8a_asm_op * seq pexpr) :=
+  let%opt mn := store_mn_of_wsize ws in
+  let osz := if (ws <= U16)%CMP then U64 else ws in
+  match e with
+  | Pvar _ => Some (ARMv8A_op mn (opts_at osz), [:: e ])
+  | _ => None
+  end.
+
+(* Convert an assignment into an architecture-specific operation. *)
+Definition lower_cassgn_word
+  (lv : lval) (ws : wsize) (e : pexpr) : option (seq instr_r * copn_args) :=
+  let vi := var_info_of_lval lv in
+  let%opt (pre, op, es) :=
+    if is_lval_in_memory lv
+    then
+      let%opt (aop, es) := lower_store ws e in
+      no_pre (le_issue_aop aop es)
+    else lower_pexpr vi ws e
+  in
+  Some (pre, ([:: lv ], op, es)).
+
+Definition lower_cassgn_bool (lv : lval) (tag : assgn_tag) (e : pexpr) : option (seq instr_r) :=
+  let vi := var_info_of_lval lv in
+  let%opt (lvs, op, es, c) := lower_condition_pexpr vi e in
+  Some [:: Copn lvs tag op es; Cassgn lv AT_inline abool c ].
+
+(* -------------------------------------------------------------------- *)
+(* Lowering of architecture-specific operations. *)
+
+Definition isLnone x : bool := if x is Lnone _ _ then true else false.
+
+Definition lower_add_carry
+  (lvs : seq lval) (es : seq pexpr) : option copn_args :=
+  match lvs, es with
+  | [:: cf; r ], [:: x; y; b ] =>
+      let cf_not_none := ~~ isLnone cf in
+      let%opt (mn, es') :=
+        match b with
+        | Pbool false => Some ((if cf_not_none then ADDS else ADD), [:: x; y ])
+        | Pvar _ => Some ((if cf_not_none then ADCS else ADC), es)
+        | _ => None
+        end
+      in
+      let lnoneb := Lnone dummy_var_info abool in
+      let lvs' := if cf_not_none then [:: lnoneb; lnoneb; cf; lnoneb; r ] else [:: r ] in
+      Some (lvs', Oasm (BaseOp (None, ARMv8A_op mn default_opts)), es')
+  | _, _ =>
+      None
+  end.
+
+Definition with_shift (opts : armv8a_options) sh :=
+  {| has_shift := Some sh; opts_size := opts_size opts; |}.
+
+Definition lower_base_op
+  (lvs : seq lval) (aop : armv8a_asm_op) (es : seq pexpr) : option copn_args :=
+  let: ARMv8A_op mn opts := aop in
+  let ws := opts_size opts in
+  if has_shift opts != None
+  then
+    let%opt _ := oassert (mn \in has_shift_mnemonics) in
+    Some (lvs, Oasm (BaseOp (None, ARMv8A_op mn opts)), es)
+  else
+    if mn \in [:: MVN; NEG ]
+    then
+      match es with
+      | x :: rest =>
+          if get_arg_shift ws [:: x ] is Some (ebase, sh, esham)
+          then
+            if shift_allowed mn sh
+            then Some (lvs, Oasm (BaseOp (None, ARMv8A_op mn (with_shift opts sh))), ebase :: esham :: rest)
+            else Some (lvs, Oasm (BaseOp (None, ARMv8A_op mn opts)), es)
+          else Some (lvs, Oasm (BaseOp (None, ARMv8A_op mn opts)), es)
+      | _ => None end
+    else if mn \in [:: ADD; ADDS; SUB; SUBS; AND; EOR; ORR; CMP; TST ]
+    then
+      match es with
+      | x :: y :: rest =>
+          if get_arg_shift ws [:: y ] is Some (ebase, sh, esham)
+          then
+            if shift_allowed mn sh
+            then Some (lvs, Oasm (BaseOp (None, ARMv8A_op mn (with_shift opts sh))), x :: ebase :: esham :: rest)
+            else Some (lvs, Oasm (BaseOp (None, ARMv8A_op mn opts)), es)
+          else Some (lvs, Oasm (BaseOp (None, ARMv8A_op mn opts)), es)
+      | _ => None end
+    else None.
+
+Definition lower_swap ty lvs es : option copn_args :=
+  match ty with
+  | aword sz =>
+    if (sz == U64)%CMP then
+      Some (lvs, Oasm (ExtOp (Oarmv8a_swap sz)), es)
+    else None
+  | aarr _ _ =>
+      Some (lvs, Opseudo_op (Oswap ty), es)
+  | _ => None
+  end.
+
+Definition lower_pseudo_operator
+  (lvs : seq lval) (op : pseudo_operator) (es : seq pexpr) : option copn_args :=
+  match op with
+  | Oaddcarry U64 => lower_add_carry lvs es
+  | Oswap ty => lower_swap ty lvs es
+  | _ => None
+  end.
+
+Definition lower_copn
+  (lvs : seq lval) (op : sopn) (es : seq pexpr) : option copn_args :=
+  match op with
+  | Opseudo_op pop => lower_pseudo_operator lvs pop es
+  | Oasm (BaseOp (None, aop)) => lower_base_op lvs aop es
+  | _ => None
+  end.
+
+(* -------------------------------------------------------------------- *)
+
+Fixpoint lower_i (i : instr) : cmd :=
+  let '(MkI ii ir) := i in
+  match ir with
+  | Cassgn lv tag ty e =>
+      let oirs :=
+        match ty with
+        | aword ws =>
+            let%opt (pre, (lvs, op, es)) := lower_cassgn_word lv ws e in
+            Some (pre ++ [:: Copn lvs tag op es ])
+        | abool => lower_cassgn_bool lv tag e
+        | _ => None
+        end
+      in
+      let irs := if oirs is Some irs then irs else [:: ir ] in
+      map (MkI ii) irs
+
+  | Copn lvs tag op es =>
+      let ir' :=
+        if lower_copn lvs op es is Some (lvs', op', es')
+        then Copn lvs' tag op' es'
+        else ir
+      in
+      [:: MkI ii ir' ]
+
+  | Cif e c1 c2  =>
+      let '(pre, e') := lower_condition (var_info_of_ii ii) e in
+      let c1' := List.flat_map lower_i c1 in
+      let c2' := List.flat_map lower_i c2 in
+      map (MkI ii) (pre ++ [:: Cif e' c1' c2' ])
+
+  | Cfor v r c =>
+      let c' := List.flat_map lower_i c in
+      [:: MkI ii (Cfor v r c') ]
+
+  | Cwhile a c0 e info c1 =>
+      let '(pre, e') := lower_condition (var_info_of_ii info) e in
+      let c0' := List.flat_map lower_i c0 in
+      let c1' := List.flat_map lower_i c1 in
+      [:: MkI ii (Cwhile a (c0' ++ map (MkI info) pre) e' info c1') ]
+
+  | _ =>
+      [:: i ]
+  end.
+
+End ARMV8A_LOWERING.
+
+End Section.

--- a/proofs/compiler/armv8a_lowering_proof.v
+++ b/proofs/compiler/armv8a_lowering_proof.v
@@ -1,0 +1,1889 @@
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype order ssralg.
+Import
+  Order.POrderTheory
+  Order.TotalTheory.
+From mathcomp Require Import word_ssrZ.
+
+From Coq Require Import Lia.
+
+Require Import
+  compiler_util
+  expr
+  lowering
+  lowering_lemmas
+  psem
+  utils.
+Require Import
+  arch_extra
+  sem_params_of_arch_extra.
+Require Import
+  armv8a_decl
+  armv8a_extra
+  armv8a_instr_decl
+  armv8a_lowering.
+
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
+(* On AArch64, register operations exist at both the X (64-bit) and
+   W (32-bit) widths. *)
+Lemma chk_ws_regP {A ws a} {oa : option A} :
+  (let%opt _ := chk_ws_reg ws in oa) = Some a
+  -> ((ws == U64) || (ws == U32)) /\ oa = Some a.
+Proof. by move=> /oassertP []. Qed.
+
+(* TODO_ARM: Improve. Move? *)
+Lemma nzcv_of_aluop_CF_sub ws (x y : word ws) :
+  (wunsigned (x - y) != (wunsigned x + wunsigned (wnot y) + 1)%Z)
+  = (wunsigned (x - y) == (wunsigned x - wunsigned y)%Z).
+Proof.
+  rewrite wunsigned_sub_if.
+
+  case: ZleP => _;
+    rewrite wunsigned_wnot;
+    generalize (wunsigned x) (wunsigned y);
+    clear;
+    move=> x y.
+
+  all: have h := @wbase_n0 ws.
+
+  - rewrite eqxx. apply/eqP. lia.
+
+  have -> : (wbase ws + x - y == x - y)%Z = false.
+  - apply/eqP. lia.
+
+  apply/eqP.
+  lia.
+Qed.
+
+Section PROOF.
+
+Context
+  {wsw : WithSubWord}
+  {dc : DirectCall}
+  {atoI : arch_toIdent}
+  {syscall_state : Type}
+  {sc_sem : syscall_sem syscall_state}
+  {pT : progT}
+  {sCP : semCallParams}
+  (p : prog)
+  (ev : extra_val_t)
+  (warning : instr_info -> warning_msg -> instr_info)
+  (fv : fresh_vars)
+  (fv_correct : fvars_correct (all_fresh_vars fv) (fvars fv) (p_funcs p)).
+
+Notation fvars := (fvars fv).
+Notation lower_pexpr := (lower_pexpr fv).
+Notation lower_cmd :=
+  (lower_cmd
+     (fun _ => lower_i)
+     warning
+     fv).
+Notation lower_prog :=
+  (lower_prog
+     (fun _ => lower_i)
+     warning
+     fv).
+Notation lower_i := (lower_i fv).
+Notation disj_fvars := (disj_fvars fvars).
+Notation disj_fvars_get_fundef := (disj_fvars_get_fundef fv_correct).
+
+Notation p' := (lower_prog p).
+
+(* -------------------------------------------------------------------- *)
+
+Definition eq_fv (s0 s1 : estate) : Prop :=
+  st_eq_ex fvars s0 s1.
+
+Ltac t_fvars_neq :=
+  move: fv_correct;
+  move=> /andP [] _;
+  rewrite /all_fresh_vars /=;
+  t_elim_uniq;
+  by (move=> [?]; auto).
+
+Ltac t_get_var :=
+  repeat (rewrite get_var_neq; last t_fvars_neq);
+  rewrite get_var_eq /=.
+
+Lemma fvars_NF : Sv.In (fvNF fv) fvars.
+Proof. by repeat (exact: SvD.F.add_1 || apply: SvD.F.add_2). Qed.
+
+Lemma fvars_ZF : Sv.In (fvZF fv) fvars.
+Proof. by repeat (exact: SvD.F.add_1 || apply: SvD.F.add_2). Qed.
+
+Lemma fvars_CF : Sv.In (fvCF fv) fvars.
+Proof. by repeat (exact: SvD.F.add_1 || apply: SvD.F.add_2). Qed.
+
+Lemma fvars_VF : Sv.In (fvVF fv) fvars.
+Proof. by repeat (exact: SvD.F.add_1 || apply: SvD.F.add_2). Qed.
+
+
+(* -------------------------------------------------------------------- *)
+(* Lowering of conditions. *)
+
+Definition condition_mnemonics := [:: CMP; TST ].
+
+Definition estate_of_CMP {ws : wsize} s (w0 w1 : word ws) : estate :=
+  let w1not := wnot w1 in
+  let res := (w0 + w1not + 1)%R in
+  let res_unsigned := (wunsigned w0 + wunsigned w1not + 1)%Z in
+  let res_signed := (wsigned w0 + wsigned w1not + 1)%Z in
+  let vm' :=
+    (evm s)
+      .[fvNF fv <- NF_of_word res]
+      .[fvZF fv <- ZF_of_word res]
+      .[fvCF fv <- wunsigned res != res_unsigned]
+      .[fvVF fv <- wsigned res != res_signed]
+  in
+  with_vm s vm'.
+
+(* Contrary to AArch32, TST also (re)sets VF (to false). *)
+Definition estate_of_TST {ws : wsize} s (w0 w1 : word ws) : estate :=
+  let res := wand w0 w1 in
+  let vm' :=
+    (evm s)
+      .[fvNF fv <- NF_of_word res]
+      .[fvZF fv <- ZF_of_word res]
+      .[fvCF fv <- false]
+      .[fvVF fv <- false]
+  in
+  with_vm s vm'.
+
+(* Precondition: [mn] is a condition mnemonic. *)
+Definition estate_of_condition_mn
+  (mn : armv8a_mnemonic) {ws : wsize} : estate -> word ws -> word ws -> estate :=
+  match mn with
+  | CMP => estate_of_CMP
+  | TST => estate_of_TST
+  | _ => fun s _ _ => s (* Never happens. *)
+  end.
+
+Lemma estate_of_condition_mn_eq_fv mn ws s (w0 w1 : word ws) :
+  mn \in condition_mnemonics
+  -> eq_fv s (estate_of_condition_mn mn s w0 w1).
+Proof.
+  case: mn => // _.
+  all: split => // x hx.
+  all: rewrite /=.
+  all: rewrite !Vm.setP_neq; first reflexivity.
+
+  all: apply/eqP.
+  all: move=> ?; subst x.
+  all: apply: hx.
+
+  all: by move: fvars_NF fvars_ZF fvars_CF fvars_VF.
+Qed.
+
+Lemma sem_condition_mn ii vi tag mn s es ws ws0 ws1
+    (w0 : word ws0) (w1 : word ws1) :
+  mn \in condition_mnemonics
+  -> ((ws == U64) || (ws == U32))
+  -> (ws <= ws0)%CMP
+  -> (ws <= ws1)%CMP
+  -> sem_pexprs true (p_globs p) s es = ok [:: Vword w0; Vword w1 ]
+  -> let w0' := zero_extend ws w0 in
+     let w1' := zero_extend ws w1 in
+     let aop := Oarmv8a (ARMv8A_op mn (opts_at ws)) in
+     let i := Copn (lflags_of_mn fv vi mn) tag aop es in
+     esem p' ev [:: MkI ii i ] s = ok (estate_of_condition_mn mn s w0' w1').
+Proof.
+  move=> hmn hws hws0 hws1 hsemes /=.
+  rewrite /sem_sopn /=.
+  rewrite hsemes {hsemes} /=.
+
+  case/orP: hws => /eqP ?; subst ws.
+  all: case: mn hmn => // _.
+  all: rewrite /exec_sopn /=.
+  all: by rewrite !truncate_word_le.
+Qed.
+
+Lemma lower_TST_match e0 e1 es :
+  lower_TST e0 e1 = Some es
+  -> exists ws e00 e01 ws',
+      e0 = Papp2 (Oland ws) e00 e01
+      /\ e1 = Papp1 (Oword_of_int ws') (Pconst 0).
+Proof.
+  case: e0 => // -[] // ws e00 e01.
+  case: e1 => // -[] // ws' [] // [] //.
+  move=> [?]; subst es.
+  eexists; eexists; eexists; eexists;
+    split;
+    reflexivity.
+Qed.
+
+Lemma pair_eq_dec A B
+  (A_dec : forall a1 a2 : A, { a1 = a2 } + { a1 <> a2 })
+  (B_dec : forall b1 b2 : B, { b1 = b2 } + { b1 <> b2 }) :
+  forall ab1 ab2 : A * B, { ab1 = ab2 } + {ab1 <> ab2 }.
+Proof. by decide equality. Qed.
+
+Lemma lower_condition_Papp2P vi s op e0 e1 mn ws e es v0 v1 v :
+  lower_condition_Papp2 fv vi op e0 e1 = Some (mn, ws, e, es)
+  -> sem_pexpr true (p_globs p) s e0 = ok v0
+  -> sem_pexpr true (p_globs p) s e1 = ok v1
+  -> sem_sop2 op v0 v1 = ok v
+  -> exists (ws0 ws1 : wsize) (w0 : word ws0) (w1 : word ws1),
+      let w0' := zero_extend ws w0 in
+      let w1' := zero_extend ws w1 in
+      [/\ mn \in condition_mnemonics
+        , ((ws == U64) || (ws == U32))
+        , (ws <= ws0)%CMP
+        , (ws <= ws1)%CMP
+        , sem_pexprs true (p_globs p) s es = ok [:: Vword w0; Vword w1 ]
+        & sem_pexpr true (p_globs p) (estate_of_condition_mn mn s w0' w1') e = ok v
+      ].
+Proof using atoI fv fv_correct p pT sc_sem syscall_state wsw.
+  move=> h hseme0 hseme1 hsemop.
+  move: h; rewrite /lower_condition_Papp2.
+  apply: obindP => -[cf ws'] hcf /chk_ws_regP [hws h].
+
+  (* whatever [op] is, it takes two words as arguments and returns a bool *)
+  have: exists ws0 ws1 (w0 : word ws0) (w1 : word ws1) b,
+    [/\ (ws' <= ws0)%CMP,
+        (ws' <= ws1)%CMP,
+        v0 = Vword w0,
+        v1 = Vword w1,
+        forall eq : type_of_op2 op = (aword ws', aword ws', abool),
+          ecast t (let t := t in _) eq (sem_sop2_typed op) (zero_extend ws' w0) (zero_extend ws' w1) = ok b &
+        v = Vbool b].
+  + have hty: type_of_op2 op = (aword ws', aword ws', abool).
+    + by case: (op) hcf => // -[] //= > [_ ->].
+    move: hsemop; rewrite /sem_sop2.
+    move: (sem_sop2_typed op); rewrite -> hty.
+    t_xrbindP=> /= sem _ /to_wordI' [ws0 [w0 [hcmp0 -> ->]]]
+      _ /to_wordI' [ws1 [w1 [hcmp1 -> ->]]] b ok_b <-.
+    exists ws0, ws1, w0, w1, b; split=> //.
+    move=> eq.
+    have eq_dec := pair_eq_dec (pair_eq_dec atype_eqb_OK_sumbool atype_eqb_OK_sumbool) atype_eqb_OK_sumbool.
+    by rewrite (Eqdep_dec.UIP_dec eq_dec eq erefl).
+  move=> /= [ws0 [ws1 [w0 [w1 [b [hcmp0 hcmp1 ?? {}hsemop ->]]]]]]; subst v0 v1.
+
+  (* default case: CMP *)
+  have suff hdefault: Some (CMP, ws', pexpr_of_cf cf vi (fresh_flags fv), [:: e0; e1]) = Some (mn, ws, e, es).
+  + move=> [<- <- <- <-].
+    exists ws0, ws1, w0, w1; split=> //.
+    + by rewrite /= hseme0 hseme1 /=.
+    rewrite /= /get_gvar /=; repeat t_get_var => //.
+    case: op hcf hsemop {h} => //= -[] // => [||[]|[]|[]|[]] _ [<- ->] /(_ erefl);
+      rewrite /mk_sem_sop2 /sem_opN /= /sem_combine_flags /cf_xsem /NF_of_word /ZF_of_word /=
+        1?wsub_wnot1
+        1?nzcv_of_aluop_CF_sub
+        1?wsigned_wsub_wnot1
+        ?GRing.Theory.subr_eq0
+        //
+      => -[<-].
+
+   (* Case [w0 == w1]. *)
+   - done.
+
+   (* Case [w0 != w1]. *)
+   - done.
+
+   (* Case [w0 <s w1]. *)
+   - by rewrite wltsE.
+
+   (* Case [w0 <u w1]. *)
+   - by rewrite wleuE ltzE ltNge.
+
+   (* Case [w0 <=s w1]. *)
+   - by rewrite wlesE'.
+
+   (* Case [w0 <=u w1]. *)
+   - by rewrite wleuE'.
+
+   (* Case [w0 >s w1]. *)
+   - by rewrite wlesE' ltzE ltNge.
+
+   (* Case [w0 >u w1]. *)
+   - by rewrite wleuE' ltzE ltNge.
+
+   (* Case [w0 >=s w1]. *)
+   - by rewrite wltsE lezE leNgt.
+
+   (* Case [w0 >=u w1]. *)
+   by rewrite -word.wltuE lezE leNgt.
+
+  case: op hcf hsemop h => // -[] //= _ [? ->] /(_ erefl) hsemop; subst cf.
+  case hlower: lower_TST => [es'|//].
+  (* special case: TST, [w00 & w01 == 0] *)
+  move=> [<- <- <- <-].
+  have [ws0' [e00 [e01 [ws1' [??]]]]] := lower_TST_match hlower; subst e0 e1.
+  move: hlower => /= [<-].
+  move: hseme0 hseme1; rewrite /= /sem_sop2 /sem_sop1 /=.
+  apply: rbindP => v00 hseme00.
+  apply: rbindP => v01 hseme01.
+  apply: rbindP => _ /to_wordI' [ws00 [w00 [hcmp00 ? ->]]]; subst v00.
+  apply: rbindP => _ /to_wordI' [ws01 [w01 [hcmp01 ? ->]]]; subst v01.
+  move=> /ok_inj /Vword_inj [??] /ok_inj /Vword_inj [??]; subst ws0' ws1' w0 w1.
+  move: hsemop; rewrite /mk_sem_sop2 /= wrepr0 zero_extend0 => -[<-].
+  exists ws00, ws01, w00, w01; split=> //.
+  + by apply (cmp_le_trans hcmp0 hcmp00).
+  + by apply (cmp_le_trans hcmp0 hcmp01).
+  + by rewrite hseme00 hseme01 /=.
+  rewrite /get_gvar /=; repeat t_get_var => //.
+  by rewrite /ZF_of_word /= -wand_zero_extend // !zero_extend_idem //.
+Qed.
+
+Lemma sem_lower_condition_pexpr vi tag s0 s0' ii e v lvs aop es c :
+  lower_condition_pexpr fv vi e = Some (lvs, aop, es, c)
+  -> eq_fv s0 s0'
+  -> disj_fvars (read_e e)
+  -> sem_pexpr true (p_globs p) s0 e = ok v
+  -> exists s1',
+       [/\ esem p' ev [:: MkI ii (Copn lvs tag aop es) ] s0' = ok s1'
+         , eq_fv s0 s1'
+         & sem_pexpr true (p_globs p) s1' c = ok v
+       ].
+Proof using atoI ev fv fv_correct p pT sCP sc_sem syscall_state warning wsw.
+  apply: obindP => -[[op e0] e1] /is_Papp2P ?; subst.
+  apply: obindP => -[[[mn ws] e] es'] h [????]; subst.
+
+  move=> hs00 /disj_fvars_read_e_Papp2 [hfv0 hfv1] /=.
+  t_xrbindP=> v0 hsem0 v1 hsem1 hsemop.
+
+  have hsem0' := eeq_exc_sem_pexpr hfv0 hs00 hsem0.
+  have hsem1' := eeq_exc_sem_pexpr hfv1 hs00 hsem1.
+  clear hfv0 hsem0 hsem1 hfv1.
+
+  have [ws0 [ws1 [w0 [w1 [hmn hws hws0 hws1 hsemes hseme]]]]] :=
+    lower_condition_Papp2P h hsem0' hsem1' hsemop.
+  clear h hsemop hsem0' hsem1'.
+
+  have /= hsem' := sem_condition_mn ii vi tag hmn hws hws0 hws1 hsemes.
+  clear hws0 hws1 hsemes.
+
+  eexists;
+    split;
+    first exact: hsem';
+    last exact: hseme.
+  apply: (eeq_excT hs00).
+  exact: (estate_of_condition_mn_eq_fv s0' _ _ hmn).
+Qed.
+
+Lemma sem_lower_condition vi s0 s0' ii e v pre e' :
+  lower_condition fv vi e = (pre, e')
+  -> eq_fv s0 s0'
+  -> disj_fvars (read_e e)
+  -> sem_pexpr true (p_globs p) s0 e = ok v
+  -> exists s1',
+       [/\ esem p' ev (map (MkI ii) pre) s0' = ok s1'
+         , eq_fv s0 s1'
+         & sem_pexpr true (p_globs p) s1' e' = ok v
+       ].
+Proof using atoI ev fv fv_correct p pT sCP sc_sem syscall_state warning wsw.
+  move=> h hs00 hfv hseme.
+
+  move: h.
+  rewrite /lower_condition.
+  case h: lower_condition_pexpr => [[[[lvs op] es] c]|] [? ?];
+    subst e' pre.
+
+  - exact: sem_lower_condition_pexpr h hs00 hfv hseme.
+  clear h.
+
+  exists s0'.
+  split => //.
+
+  exact: (eeq_exc_sem_pexpr hfv hs00 hseme).
+Qed.
+
+
+(* -------------------------------------------------------------------- *)
+(* Lowering of assignments. *)
+
+(* Note that the interpretation of the expression is [zero_extend ws w]
+   due to the implicit castings in [sem]. *)
+Lemma get_arg_shiftP s e ws v e' sh n :
+  get_arg_shift ws [:: e ] = Some (e', sh, n)
+  -> disj_fvars (read_e e)
+  -> sem_pexpr true (p_globs p) s e = ok v
+  -> exists ws1 (wbase : word ws1) (wsham : word U8),
+       [/\ (ws <= ws1)%CMP
+         , sem_pexpr true (p_globs p) s e' = ok (Vword wbase)
+         , sem_pexpr true (p_globs p) s n = ok (Vword wsham)
+         , to_word ws v
+           = ok (shift_op sh (zero_extend ws wbase) (wunsigned wsham))
+         & (disj_fvars (read_e e') /\ disj_fvars (read_e n))
+       ].
+Proof.
+  move=> h hfve hseme.
+
+  case: e hseme hfve h => // op.
+  move=> [] //= gx.
+  move=> [] //.
+  move=> [[]|||||||] //.
+  move=> [] // z.
+
+  rewrite /=.
+  t_xrbindP=> vbase hget hsemop.
+  move=> hfve.
+
+  apply: obindP => sh' hsh /oassertP [hchk [???]];
+    subst e' sh' n.
+
+  (* whatever [op] is, the type is the same: (aword ws, aword8, aword ws) *)
+  have hty: type_of_op2 op = (aword ws, aword U8, aword ws).
+  + move: hsh; rewrite /shift_of_sop2; apply: obindP => -[] _ /= hsh'.
+    by case: (op) hsh' => //=;
+      (try by move=> -[] //= ws'; case: (ws' =P ws) => // ->);
+      move=> ws'; case: (ws' =P ws) => // ->.
+
+  have: exists ws1 (wbase : word ws1) w,
+    [/\ (ws <= ws1)%CMP,
+        vbase = Vword wbase,
+        forall eq : type_of_op2 op = (aword ws, aword U8, aword ws),
+          ecast t (let t := t in _) eq (sem_sop2_typed op) (zero_extend ws wbase) (wrepr U8 z) = ok w &
+        v = Vword w].
+  + move: hsemop; rewrite /sem_sop2.
+    move: (sem_sop2_typed op); rewrite -> hty.
+    rewrite /= truncate_word_u.
+    t_xrbindP=> sem _ /to_wordI' [ws1 [wbase [hcmp -> ->]]] _ <- w ok_w <-.
+    exists ws1, wbase, w; split=> //.
+    move=> eq.
+    have eq_dec := pair_eq_dec (pair_eq_dec atype_eqb_OK_sumbool atype_eqb_OK_sumbool) atype_eqb_OK_sumbool.
+    by rewrite (Eqdep_dec.UIP_dec eq_dec eq erefl).
+  move=> /= [ws1 [wbase [w [hcmp ? {}hsemop ->]]]]; subst vbase.
+  exists ws1, wbase, (wrepr U8 z); split=> //=.
+  rewrite truncate_word_u.
+
+  move: hsh; rewrite /shift_of_sop2; apply: obindP => -[] _ /= hsh.
+  by case: op hty hsh hsemop {hfve} => //=;
+    (try by move=> -[] //= ws' _; case: (ws' =P ws) => // -> -[<-] /(_ erefl));
+    move=> ws' _; case: (ws' =P ws) => // -> -[<-] /(_ erefl).
+Qed.
+
+Lemma disj_fvars_read_es2 e0 e1 :
+  disj_fvars (read_e e0)
+  -> disj_fvars (read_e e1)
+  -> disj_fvars (read_es [:: e0; e1 ]).
+Proof.
+  move=> h0 h1.
+  apply: (disjoint_equal_r (read_eE _ _)).
+  exact: (union_disjoint h1 h0).
+Qed.
+
+Lemma disj_fvars_read_es2_app2 e op x y :
+  disj_fvars (read_e e)
+  -> disj_fvars (read_e (Papp2 op x y))
+  -> disj_fvars (read_es [:: x; y; e ]).
+Proof.
+  rewrite /disj_fvars {2}/read_e/= read_eE -/read_e => h0 /disjoint_union [] h1 h2.
+  rewrite /read_es /= 2!read_eE.
+  by repeat apply: union_disjoint.
+Qed.
+
+Lemma disj_fvars_read_es3 e0 e1 e2 :
+  disj_fvars (read_e e0)
+  -> disj_fvars (read_e e1)
+  -> disj_fvars (read_e e2)
+  -> disj_fvars (read_es [:: e0; e1; e2 ]).
+Proof.
+  move=> h0 h1 h2.
+  apply: (disjoint_equal_r (read_eE _ _)).
+  apply: (union_disjoint h2).
+  apply: (disjoint_equal_r (read_eE _ _)).
+  exact: (union_disjoint h1 h0).
+Qed.
+
+(* Invariant of [lower_pexpr_aux]: on AArch64 there are no conditionally
+   executed operations, so contrary to AArch32 nothing about the
+   instruction options needs to be tracked. *)
+#[ local ]
+Definition inv_lower_pexpr_aux
+  (ws : wsize) (op : sopn) (es : seq pexpr) : Prop :=
+  [/\ disj_fvars (read_es es)
+    & sopn_tout op = [:: aword ws ]
+  ].
+
+(* We prove the following for each case of [lower_pexpr_aux]. *)
+#[ local ]
+Definition ok_lower_pexpr_aux
+  (s : estate) (ws ws' : wsize) (op : sopn) (es : seq pexpr) (w : word ws') :
+  Prop :=
+  (exists2 vs,
+     sem_pexprs true (p_globs p) s es = ok vs
+     & exec_sopn op vs = ok [:: Vword (zero_extend ws w) ])
+  /\ inv_lower_pexpr_aux ws op es.
+
+#[ local ]
+Definition Plower_pexpr_aux (e : pexpr) : Prop :=
+  forall s ws ws' aop es (w : word ws'),
+    lower_pexpr_aux ws e = Some (aop, es)
+    -> (ws <= ws')%CMP
+    -> disj_fvars (read_e e)
+    -> sem_pexpr true (p_globs p) s e = ok (Vword w)
+    -> ok_lower_pexpr_aux s ws aop es w.
+
+Lemma lower_PvarP gx :
+  Plower_pexpr_aux (Pvar gx).
+Proof.
+  move=> s ws ws' aop es w.
+  move=> h hws hfvx /= hget.
+  move: h.
+  rewrite /lower_pexpr_aux /lower_Pvar /ok_lower_pexpr_aux.
+  move=> /chk_ws_regP [hws' [? ?]]; subst aop es.
+  case/orP: hws' => /eqP ?; subst ws.
+
+  all: case: is_var_in_memory.
+
+  all: split; last done.
+  all: clear hfvx.
+
+  all: rewrite /= hget {hget} /=.
+  all: eexists; first reflexivity.
+  all: rewrite /exec_sopn /=.
+  all: rewrite truncate_word_le // {hws} /=.
+  all: by rewrite ?zero_extend_u.
+Qed.
+
+Lemma lower_loadP e :
+  match e with Pload _ _ _ | Pget _ _ _ _ _ => Plower_pexpr_aux e
+  | _ => True end.
+Proof.
+  case: e => // [ al aa wsg x| al wsg] e s ws' ws'' aop es w.
+  all: rewrite /lower_pexpr_aux /lower_load.
+  all: move=> /chk_ws_regP [hwsx [??]] hws hfve; subst aop es.
+  all: have hwsx' : (ws' == U32) || (ws' == U64) by rewrite orbC.
+  all: rewrite /sem_pexpr -/(sem_pexpr _ _ s e).
+
+  - apply: on_arr_gvarP => n t hty ok_t.
+    apply: rbindP => idx.
+    apply: rbindP => ? ok_idx /to_intI ?; subst.
+    apply: rbindP => r ok_r /ok_inj /Vword_inj[] ??; subst => /=.
+    split.
+    + rewrite /= ok_t /= ok_idx /= ok_r /=.
+      eexists; first reflexivity.
+      rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hwsx' /=.
+      rewrite /semi_to_atype !computational_eq_refl /=.
+      by rewrite truncate_word_le // /= zero_extend_u.
+    done.
+
+  t_xrbindP=> woff' voff hseme hoff wres hread ? hw;
+    subst ws''.
+  move: hoff => /to_wordI [ws1 [woff [? /truncate_wordP [hws1 ?]]]];
+    subst woff' voff.
+  move: hw => [?]; subst wres.
+
+  split; last done.
+  clear hfve.
+
+  rewrite /sem_pexprs /=.
+  rewrite hseme {hseme} /=.
+  rewrite truncate_word_le // {hws1} /=.
+  rewrite hread {hread} /=.
+
+  eexists; first reflexivity.
+
+  rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hwsx' /=.
+  rewrite /semi_to_atype !computational_eq_refl /=.
+  rewrite truncate_word_le // {hws} /=.
+  by rewrite zero_extend_u.
+Qed.
+
+Lemma lower_Papp1P op e:
+  Plower_pexpr_aux (Papp1 op e).
+Proof.
+  move=> s ws ws' op' es w.
+  move=> h hws hfve.
+
+  rewrite /sem_pexpr -/(sem_pexpr _ _ s e).
+  t_xrbindP=> v hseme hw.
+
+  move: h.
+  rewrite /lower_pexpr_aux /lower_Papp1.
+  move=> /chk_ws_regP [hwsx h].
+  have hwsx' : (ws == U32) || (ws == U64) by rewrite orbC.
+  move: h.
+  case: op hw hfve => [ ws'' || ws0 ws'' | ws0 ws'' || ws0 | [] // ws0 |] // hw hfve.
+
+  (* Case: [Oword_of_int]. *)
+  - move: hw => /sem_sop1I /= [w' [?] [hw' [?] hw]].
+    move: hw => /Vword_inj [?]; subst ws'; subst.
+    move=> /= ?; subst w.
+    rewrite hws /= /mov_imm_op.
+    {
+      case: isSome => -[??]; subst op' es.
+      all: split; last by split.
+      all: eexists; first by rewrite /= hseme /= /sem_sop1 /= hw'.
+      all: rewrite /exec_sopn /sopn_sem /sopn_sem_ /= ?hwsx' /=.
+      all: rewrite /semi_to_atype ?computational_eq_refl /=.
+      all: by rewrite truncate_word_u zero_extend_wrepr.
+    }
+
+  (* Case: [Osignext]. *)
+  - move: hw => /sem_sop1I /= [w' [?] [hw' [?] hw]].
+    move: hw => /Vword_inj [?]; subst ws'.
+    move=> /= ?; subst.
+    move=> /oassertP [/eqP ? h]; subst ws0.
+    move: h => /oassertP [hlt h]; move: h.
+    case: (is_load e);
+      (apply: obindP => mn hmn [??]; subst op' es;
+       case/orP: hwsx' => /eqP ?; subst ws;
+       move: hmn; case: ws'' hlt hfve w' hw' => //= hlt hfve w' hw' [?]; subst mn;
+       (split; last by split);
+       clear hfve;
+       rewrite /= hseme {hseme} /=;
+       (eexists; first reflexivity);
+       rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hw' {hw'} /=;
+       by rewrite /armv8a_extend_semi ?zero_extend_u).
+
+  (* Case: [Ozeroext]. *)
+  - move: hw => /sem_sop1I /= [w' [?] [hw' [?] hw]].
+    move: hw => /Vword_inj [?]; subst ws'.
+    move=> /= ?; subst.
+    move=> /oassertP [/eqP ? h]; subst ws0.
+    move: h => /oassertP [hlt h]; move: h.
+    case: (is_load e);
+      (apply: obindP => mn hmn [??]; subst op' es;
+       case/orP: hwsx' => /eqP ?; subst ws;
+       move: hmn; case: ws'' hlt hfve w' hw' => //= hlt hfve w' hw' [?]; subst mn;
+       (split; last by split);
+       clear hfve;
+       rewrite /= hseme {hseme} /=;
+       (eexists; first reflexivity);
+       rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hw' {hw'} /=;
+       by rewrite /armv8a_extend_semi ?zero_extend_u).
+
+  (* Case: [Olnot]. *)
+  - move: hw => /sem_sop1I /= [w' [?] [hw' [?] hw]].
+    move: hw => /Vword_inj [?]; subst ws'.
+    move=> /= ?; subst.
+    move=> /oassertP [/eqP ? h]; subst ws0; move: h.
+
+    rewrite /arg_shift.
+    case hshift: get_arg_shift => [[[e' sh] sham]|] /=;
+      first case hallowed: (shift_allowed _ sh).
+
+    (* Recognized, allowed shift: fused. *)
+    + have [ws1 [wbase [wsham [hws1 hbase hsham hv [hfvbase hfvsham]]]]] :=
+        get_arg_shiftP hshift hfve hseme.
+      case/to_wordI': hv => wsv [] w'' []  hwsv ? hv; subst v.
+      case/truncate_wordP: hw' => hws0 ?; subst w'.
+      clear hshift hseme hfve.
+      move=> [? ?]; subst op' es.
+      have hfves := disj_fvars_read_es2 hfvbase hfvsham.
+      clear hfvbase hfvsham.
+      split; last by split.
+      clear hfves.
+      rewrite /=.
+      rewrite hbase hsham {hbase hsham} /=.
+      eexists; first reflexivity.
+      rewrite /exec_sopn /sopn_sem /sopn_sem_ /= ?hwsx' /=.
+      rewrite /semi_to_atype ?computational_eq_refl /=.
+      rewrite !truncate_word_le // {hws1} /=.
+      rewrite hallowed /=.
+      by rewrite !zero_extend_u hv.
+
+    (* Shift kind not allowed for this mnemonic: not fused. *)
+    + move=> [? ?]; subst op' es;
+      (split; last by split);
+      rewrite /= hseme /=;
+      (eexists; first reflexivity);
+      rewrite /exec_sopn /sopn_sem /sopn_sem_ /= ?hwsx' /=;
+      rewrite /semi_to_atype ?computational_eq_refl /=;
+      by rewrite hw' /= zero_extend_u.
+
+    (* No recognized shift: not fused. *)
+    move=> [? ?]; subst op' es;
+      (split; last by split);
+      rewrite /= hseme /=;
+      (eexists; first reflexivity);
+      rewrite /exec_sopn /sopn_sem /sopn_sem_ /= ?hwsx' /=;
+      rewrite /semi_to_atype ?computational_eq_refl /=;
+      by rewrite hw' /= zero_extend_u.
+
+  (* Case: [Oneg]. *)
+  move: hw => /sem_sop1I /= [w' [?] [hw' [?] hw]].
+  move: hw => /Vword_inj [?]; subst ws'.
+  move=> /= ?; subst.
+  move=> /oassertP [/eqP ? h]; subst ws0; move: h.
+
+  rewrite /arg_shift.
+  case hshift: get_arg_shift => [[[e' sh] sham]|] /=;
+    first case hallowed: (shift_allowed _ sh).
+
+  (* Recognized, allowed shift: fused. *)
+  + have [ws1 [wbase [wsham [hws1 hbase hsham hv [hfvbase hfvsham]]]]] :=
+      get_arg_shiftP hshift hfve hseme.
+    case/to_wordI': hv => wsv [] w'' []  hwsv ? hv; subst v.
+    case/truncate_wordP: hw' => hws0 ?; subst w'.
+    clear hshift hseme hfve.
+    move=> [? ?]; subst op' es.
+    have hfves := disj_fvars_read_es2 hfvbase hfvsham.
+    clear hfvbase hfvsham.
+    split; last by split.
+    clear hfves.
+    rewrite /=.
+    rewrite hbase hsham {hbase hsham} /=.
+    eexists; first reflexivity.
+    rewrite /exec_sopn /sopn_sem /sopn_sem_ /= ?hwsx' /=.
+    rewrite /semi_to_atype ?computational_eq_refl /=.
+    rewrite !truncate_word_le // {hws1} /=.
+    rewrite hallowed /=.
+    rewrite /armv8a_NEG_semi.
+    by rewrite !zero_extend_u hv add_wordE wnot1_wopp.
+
+  (* Shift kind not allowed for this mnemonic: not fused. *)
+  + move=> [? ?]; subst op' es;
+    (split; last by split);
+    rewrite /= hseme /=;
+    (eexists; first reflexivity);
+    rewrite /exec_sopn /sopn_sem /sopn_sem_ /= ?hwsx' /=;
+    rewrite /semi_to_atype ?computational_eq_refl /=;
+    rewrite hw' /= zero_extend_u /armv8a_NEG_semi;
+    by rewrite add_wordE wnot1_wopp.
+
+  (* No recognized shift: not fused. *)
+  move=> [? ?]; subst op' es;
+    (split; last by split);
+    rewrite /= hseme /=;
+    (eexists; first reflexivity);
+    rewrite /exec_sopn /sopn_sem /sopn_sem_ /= ?hwsx' /=;
+    rewrite /semi_to_atype ?computational_eq_refl /=;
+    rewrite hw' /= zero_extend_u /armv8a_NEG_semi;
+    by rewrite add_wordE wnot1_wopp.
+Qed.
+
+Lemma mk_sem_divmodP si ws op (w0 w1 : word ws) w :
+  mk_sem_divmod si op w0 w1 = ok w
+  -> [/\ (w1 <> 0%R)
+       , si <> Signed \/ (wsigned w0 <> wmin_signed ws) \/ (w1 <> (-1)%R)
+       & w = op w0 w1
+     ].
+Proof.
+  rewrite /mk_sem_divmod.
+  case: ifPn => //; rewrite negb_or => /andP [] /eqP ? h [<-]; split => //.
+  move: h; rewrite !negb_and => /or3P [] /eqP; auto.
+Qed.
+
+Section IS_MUL.
+
+Variant is_mul_spec (ws : wsize) (e: pexpr) : option (pexpr * pexpr) -> Type :=
+  | IsMulSome ws' x y :
+      (ws <= ws')%CMP
+      -> e = Papp2 (Omul (Op_w ws')) x y
+      -> is_mul_spec (Some (x, y))
+  | IsMulNone : is_mul_spec None.
+
+#[local] Hint Constructors is_mul_spec : core.
+
+Lemma is_mulP ws e : is_mul_spec ws e (is_mul ws e).
+Proof.
+  rewrite /is_mul.
+  case: e; try (move=> *; exact: IsMulNone).
+  move=> op e1 e2.
+  case: op; try (move=> *; exact: IsMulNone).
+  move=> c; case: c; try (move=> *; exact: IsMulNone).
+  move=> ws'.
+  case hle: (ws <= ws')%CMP; last exact: IsMulNone.
+  exact: (IsMulSome hle erefl).
+Qed.
+
+End IS_MUL.
+
+(* The main consequence of the lemmas in this section is lemma [lower_base_op].
+   It was moved far from it, because we also use [with_shift_binop]
+   in the proof of [lower_Papp2P]. *)
+Section WITH_SHIFT_OP.
+
+#[ local ]
+Ltac intro_opn_args :=
+  rewrite /sem_tuple /=;
+  repeat
+    match goal with
+    | [ |- forall (_ : _ * _), _ ] => move=> []
+    | [ |- forall (_ : option bool), _ ] => move=> ?
+    | [ |- forall (_ : word _), _ ] => move=> ?
+    end.
+
+#[local]
+Ltac intro_args_wrapper :=
+  intro_opn_args;
+  rewrite !truncate_word_le // => -> _ /ok_inj <-.
+
+#[local]
+Ltac destruct_args_wrapper vs :=
+  move: vs;
+  destruct_opn_args;
+  repeat (move=> ? ->).
+
+(* Rewrite result of execution. If we are under conditional execution, find
+   the condition and case on it, the case when the instruction is not
+   executiod is trivial.
+   We can't match on [sopn_sem] because of the dependent types. *)
+#[local]
+Ltac rewrite_exec :=
+  let h := fresh "h" in
+  move=> /= h ?;
+  subst;
+  move: h;
+  (move=> /ok_inj; (move=> <- || move=> [] *; subst));
+  rewrite /= !zero_extend_u.
+
+Lemma with_shift_unop mn s eb ea ts (b: word ts) (a: u8) x vs sh opts r :
+  mn \in [:: MVN; NEG ] ->
+  shift_allowed mn sh ->
+  (opts_size opts ≤ ts)%CMP ->
+  has_shift opts = None ->
+  sem_pexpr true (p_globs p) s eb = ok (Vword b) ->
+  sem_pexpr true (p_globs p) s ea = ok (Vword a) ->
+  to_word (opts_size opts) x
+    = ok (shift_op sh (zero_extend (opts_size opts) b) (wunsigned a)) ->
+  exec_sopn (Oasm (BaseOp (None, ARMv8A_op mn opts))) [:: x & vs] = ok r ->
+  exec_sopn (Oasm (BaseOp (None, ARMv8A_op mn (with_shift opts sh) ))) [:: Vword b, Vword a & vs] = ok r.
+Proof.
+  rewrite !inE.
+  case: opts => sho sz /= mn_unop hallow hts -> ok_b ok_a hx.
+  move: hallow.
+  case/orP: mn_unop => /eqP -> {mn}.
+  all: move=> /= hallow.
+  all: rewrite /exec_sopn /sopn_sem /sopn_sem_ /=.
+  all: t_xrbindP => ha hvalid hsemi z0 z1 hz1 hmatch heq.
+  all: subst ha.
+  all: move: hz1; rewrite hx => -[?]; subst z1.
+  all: move: hmatch; case: vs => //= hmatch.
+  all: move: hmatch;
+    rewrite /semi_to_atype !computational_eq_refl /= => -[?]; subst z0.
+  all: rewrite hvalid hallow /=.
+  all: rewrite (truncate_word_le _ hts) truncate_word_u /= /mk_semi1_shifted /=.
+  all: by rewrite -heq.
+Qed.
+
+Lemma with_shift_binop mn s eb ea ts (b: word ts) (a: u8) x y vs sh opts r :
+  mn \in [:: ADD; ADDS; SUB; SUBS; AND; EOR; ORR; CMP; TST] ->
+  shift_allowed mn sh ->
+  (opts_size opts ≤ ts)%CMP ->
+  has_shift opts = None ->
+  sem_pexpr true (p_globs p) s eb = ok (Vword b) ->
+  sem_pexpr true (p_globs p) s ea = ok (Vword a) ->
+  to_word (opts_size opts) y
+    = ok (shift_op sh (zero_extend (opts_size opts) b) (wunsigned a)) ->
+  exec_sopn (Oasm (BaseOp (None, ARMv8A_op mn opts))) [:: x, y & vs] = ok r ->
+  exec_sopn (Oasm (BaseOp (None, ARMv8A_op mn (with_shift opts sh) ))) [:: x, Vword b, Vword a & vs] = ok r.
+Proof.
+  rewrite !inE.
+  case: opts => sho sz /= mn_binop hallow hts -> ok_b ok_a hy.
+  move: hallow.
+  repeat case/orP: mn_binop => [ /eqP -> { mn } | mn_binop ]; last move/eqP: mn_binop => -> { mn }.
+  all: move=> /= hallow.
+  all: rewrite /exec_sopn /sopn_sem /sopn_sem_ /=.
+  all: t_xrbindP => ha hvalid hsemi z0 z1 hzx z2 hzy hmatch heq.
+  all: subst ha.
+  all: move: hzy; rewrite hy => -[?]; subst z2.
+  all: move: hmatch; case: vs => //=.
+  all: rewrite /semi_to_atype !computational_eq_refl /= => -[?]; subst z0.
+  all: rewrite hvalid hallow /=.
+  all: rewrite hzx (truncate_word_le _ hts) truncate_word_u /= /mk_semi2_2_shifted /=.
+  all: by rewrite heq.
+Qed.
+
+End WITH_SHIFT_OP.
+
+(* changing the shift component preserves the output type *)
+Lemma sopn_tout_with_shift mn opts sk :
+  id_tout (mn_desc (with_shift opts sk) mn) = id_tout (mn_desc opts mn).
+Proof.
+  case: opts => sho sz.
+  by case: sho => [sk'|]; case: mn => //=.
+Qed.
+
+(* The rotate-left-to-rotate-right amount conversion: rotating right by
+   [wsize - c] (computed on u8, where the subtraction may wrap) is rotating
+   left by [c], modulo the operand size. Wrapping is harmless because the
+   u8 base (256) is a multiple of both operand sizes (32 and 64). *)
+Lemma u8_sub_amount_mod (wb : Z) (x1 : word U8) :
+  (0 <= wb < wbase U8)%Z ->
+  (wbase U8 mod wb = 0)%Z ->
+  (wunsigned (wrepr U8 wb - x1)%R mod wb)%Z = ((wb - wunsigned x1) mod wb)%Z.
+Proof.
+  move=> hwb hdvd.
+  rewrite wunsigned_sub_if wunsigned_repr_small //.
+  case: ifP => _; first by [].
+  by rewrite -Z.add_sub_assoc Zplus_mod hdvd Z.add_0_l Zmod_mod.
+Qed.
+
+Lemma rol_ror_shift_amount ws (x1 : word U8) :
+  (ws == U64) || (ws == U32)
+  -> (wunsigned (wrepr U8 (wsize_bits ws) - x1)%w mod wsize_bits ws)%Z
+     = ((wsize_bits ws - wunsigned x1) mod wsize_bits ws)%Z.
+Proof. by case/orP => /eqP ->; rewrite sub_wordE u8_sub_amount_mod. Qed.
+
+(* TODO: factorize with x86/riscv *)
+Lemma to_word_m sz sz' a w :
+  to_word sz a = ok w ->
+  (sz' <= sz)%CMP ->
+  to_word sz' a = ok (zero_extend sz' w).
+Proof.
+  clear.
+  case/to_wordI' => n [] m [] sz_le_n ->{a} ->{w} /= sz'_le_sz.
+  by rewrite truncate_word_le ?zero_extend_idem // (cmp_le_trans sz'_le_sz sz_le_n).
+Qed.
+
+(* Masking a u8 word with [wsize_bits - 1] is reduction modulo the operand
+   size, for the two register widths. *)
+Lemma wand_mask_mod ws (x : word U8) :
+  (ws == U64) || (ws == U32)
+  -> wunsigned (wand x (wrepr U8 (wsize_bits ws - 1)))
+     = (wunsigned x mod wsize_bits ws)%Z.
+Proof.
+  by case/orP => /eqP ->; [ exact: (wand_modulo x 6) | exact: (wand_modulo x 5) ].
+Qed.
+
+(* An accepted shift amount evaluates, modulo the operand size, to the same
+   value as the original expression; and reading it needs no new variables. *)
+Lemma check_shift_exprP ws e e' s v w :
+  check_shift_expr ws e = Some e'
+  -> (ws == U64) || (ws == U32)
+  -> sem_pexpr true (p_globs p) s e = ok v
+  -> to_word U8 v = ok w
+  -> [/\ Sv.Subset (read_e e') (read_e e)
+       & exists v' (w' : word U8),
+           [/\ sem_pexpr true (p_globs p) s e' = ok v'
+             , to_word U8 v' = ok w'
+             & wunsigned w = (wunsigned w' mod wsize_bits ws)%Z ] ].
+Proof.
+  rewrite /check_shift_expr => h hws; move: h.
+  case en: is_wconst => [ n | ].
+  - case: eqP => [n_in_range|//] [<-] ok_v ok_w.
+    split; first by [].
+    exists v, w; split=> //.
+    assert (hn := is_wconstP true (p_globs p) s en).
+    move: hn; rewrite ok_v /= ok_w => -[?]; subst n.
+    by rewrite {1}n_in_range (wand_mask_mod _ hws).
+  case: {en} e => // -[] // sz' a b.
+  case en: is_wconst => [ n | ]; last by [].
+  case: eqP => [?|//]; subst n.
+  move=> [<-] /=.
+  rewrite /sem_sop2 /=.
+  t_xrbindP=> va ok_a vb ok_b wa ok_wa wb ok_wb <-{v} ok_w.
+  split.
+  - clear; rewrite {2}/read_e /= !read_eE; SvD.fsetdec.
+  assert (hb := is_wconstP true (p_globs p) s en).
+  move: hb; rewrite ok_b /= => hb.
+  exists va, (zero_extend U8 wa); split=> //.
+  - exact: (to_word_m ok_wa (wsize_le_U8 _)).
+  move: ok_w => /truncate_wordP [_ ->].
+  rewrite -wand_zero_extend; last exact: wsize_le_U8.
+  have hwb : zero_extend U8 wb = wrepr U8 (wsize_bits ws - 1).
+  - have h' := to_word_m ok_wb (wsize_le_U8 _).
+    move: h'; rewrite hb => h'.
+    exact: (esym (ok_inj h')).
+  rewrite hwb.
+  by rewrite (wand_mask_mod _ hws).
+Qed.
+
+Lemma large_arith_immP ws mn es imm :
+  large_arith_imm ws mn es = Some imm
+  -> [/\ ws = U64
+       , mn \in [:: ADD; SUB ]
+       & exists2 e, es = [:: e ]
+         & exists2 c : word U64,
+             is_wconst U64 e = Some c
+             & imm = (if mn == ADD then wunsigned c else - wunsigned c)%Z ].
+Proof.
+  rewrite /large_arith_imm.
+  move=> /oassertP [/eqP hws h]; move: h.
+  apply: obindP => e he.
+  apply: obindP => c hc.
+  case: ifP => // _.
+  case: mn => // -[<-];
+    (split=> //; exists e; first by case: es he => // ? [|//] [->]);
+    by exists c.
+Qed.
+
+Lemma lower_Papp2P op e0 e1 :
+  Plower_pexpr_aux (Papp2 op e0 e1).
+Proof.
+  move=> s ws ws' op' es w.
+  move=> h hws hfve hseme.
+
+  move: hseme.
+  rewrite /sem_pexpr -!/(sem_pexpr _ _ s _).
+  t_xrbindP=> v0 hseme0 v1 hseme1 hsemop.
+
+  move: hfve => /disj_fvars_read_e_Papp2 [hfve0 hfve1].
+
+  move: h.
+  rewrite /= /lower_Papp2.
+
+  apply: obindP => -[[mn' e0'] e1'] /chk_ws_regP [hwsx hop].
+
+  (* the default case: there is no arg shift *)
+  have hdflt:
+    let dflt_op := Oasm (BaseOp (None, ARMv8A_op mn' (opts_at ws))) in
+    ok_lower_pexpr_aux s ws dflt_op (e0' :: e1') w.
+  {
+    case: op hop hsemop => //;
+      rewrite /lower_Papp2_op /=.
+
+    all:
+      match goal with
+      | [ |- forall _ : op_kind, _ -> _ ] => move=> [|ws''] //
+      | [ |- forall (_ : cmp_kind), _ -> _ ] => move=> [|[] ws''] //
+      | [ |- forall (_ : signedness) (_ : op_kind), _ -> _ ] => move=> [] [|ws''] //
+      | [ |- forall _ : wsize, _ -> _ ] => move=> ws'' //
+      end.
+
+    (* Resolve the mnemonic: peel the [oassert (ws'' == ws)] (forcing
+       [ws'' = ws]), split the [is_mul] / [is_wconst] / [if] choices. *)
+    all: repeat first
+      [ move=> /oassertP [/eqP ?]; subst ws''
+      | match goal with
+        | [ |- context[ is_mul ] ] =>
+            case: is_mulP => [wsm ? ? hlem ?|]; subst
+        end
+      | match goal with
+        | [ |- context[ is_wconst ] ] => case hconst: is_wconst => [c|//]
+        end
+      ].
+    all: repeat (match goal with |- context[ if _ then _ else _ ] => case: ifP => hif end).
+    all: try (match goal with
+              | [ |- context[ check_shift_expr ] ] =>
+                  apply: obindP => amt hchk
+              end).
+
+    all: move=> [???] hsemop; subst mn' e0' e1'.
+    all: first
+      [ (* Plain binary ops: ADD, SUB, MUL, AND, ORR, EOR. *)
+        lazymatch goal with
+        | [ |- context[ARMv8A_op ADD _] ] => idtac
+        | [ |- context[ARMv8A_op SUB _] ] => idtac
+        | [ |- context[ARMv8A_op MUL _] ] => idtac
+        | [ |- context[ARMv8A_op AND _] ] => idtac
+        | [ |- context[ARMv8A_op ORR _] ] => idtac
+        | [ |- context[ARMv8A_op EOR _] ] => idtac
+        end;
+        move: hsemop => /sem_sop2I /= [w0' [w1' [w2 [hw0 hw1 hop hw]]]];
+        move: hw0 => /to_wordI [ws0 [w0 [? /truncate_wordP [hws0 ?]]]]; subst v0 w0';
+        move: hw1 => /to_wordI [ws1 [w1 [? /truncate_wordP [hws1 ?]]]]; subst v1 w1';
+        move: hop => [?]; subst w2;
+        move: hw => /Vword_inj [?]; subst ws'; move=> /= ?; subst w;
+        (split;
+          last (split; [ exact: (disj_fvars_read_es2 hfve0 hfve1) | by [] ]));
+        (exists [:: Vword w0; Vword w1];
+          first by rewrite /sem_pexprs /= hseme0 hseme1 /=);
+        move: (hwsx); rewrite orbC => hval;
+        rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hval /=;
+        rewrite !(truncate_word_le _ (cmp_le_trans hws _)) //;
+        rewrite /semi_to_atype !computational_eq_refl /=;
+        rewrite /armv8a_ADD_semi /armv8a_SUB_semi /armv8a_MUL_semi /armv8a_bitwise_semi /=;
+        rewrite ?add_wordE ?sub_wordE;
+        rewrite ?(wadd_zero_extend _ _ hws) ?(wsub_zero_extend _ _ hws)
+                ?(wmul_zero_extend _ _ hws)
+                -?(wand_zero_extend _ _ hws)
+                -?(wor_zero_extend _ _ hws) -?(wxor_zero_extend _ _ hws);
+        rewrite ?(wopp_zero_extend _ hws) ?(zero_extend_idem _ hws);
+        by rewrite ?(zero_extend_idem _ hws)
+      | (* Division: SDIV, UDIV (operate at [ws''= ws]). *)
+        lazymatch goal with
+        | [ |- context[ARMv8A_op SDIV _] ] => idtac
+        | [ |- context[ARMv8A_op UDIV _] ] => idtac
+        end;
+        move: hsemop => /sem_sop2I /= [w0' [w1' [w2 [hw0 hw1 hop hw]]]];
+        move: hw0 => /to_wordI [ws0 [w0 [? /truncate_wordP [hws0 ?]]]]; subst v0 w0';
+        move: hw1 => /to_wordI [ws1 [w1 [? /truncate_wordP [hws1 ?]]]]; subst v1 w1';
+        move: hop => /mk_sem_divmodP [hdiv0 hdiv1 ?]; subst w2;
+        move: hw => /Vword_inj [?]; subst ws'; move=> /= ?; subst w;
+        (split;
+          last (split; [ exact: (disj_fvars_read_es2 hfve0 hfve1) | by [] ]));
+        (exists [:: Vword w0; Vword w1];
+          first by rewrite /sem_pexprs /= hseme0 hseme1 /=);
+        move: (hwsx); rewrite orbC => hval;
+        rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hval /=;
+        rewrite !(truncate_word_le _ (cmp_le_trans hws _)) //;
+        rewrite /semi_to_atype !computational_eq_refl /=;
+        rewrite /armv8a_SDIV_semi /armv8a_UDIV_semi;
+        by rewrite zero_extend_u
+      | (* TODO(armv8a): remaining hdflt classes.
+           - MADD / MSUB (from [is_mul] rewriting of Oadd / Osub): 3-operand
+             arithmetic, need to evaluate the [is_mul] subexpressions and use
+             commutativity of [+]/[-] with the [w*w] product.
+           - MOV (degenerate shift-by-zero from Olsr/Olsl/Oasr/Oror with
+             [is_zero e1], and Orol with the rotation constant 0): identity.
+           - LSR / LSL / ASR / ROR (non-zero variable shift) and the
+             Orol-with-nonzero-constant ROR: BLOCKED by a semantic mismatch.
+             [armv8a_shift_semi] reduces the shift amount by [_ mod wsize_bits],
+             whereas Jasmin's source [wshr]/[wsar]/[wshl]/[wror] clamp it via
+             [Z.min (wsize_bits ws) _]. For a u8 shift amount >= wsize_bits the
+             two disagree (source yields 0, armv8a yields a nonzero rotate/shift
+             of [amount mod wsize_bits]). [arm_shift_semi] uses the raw amount,
+             so arm has no such gap. This must be reconciled in the instruction
+             model (clamp instead of mod, or guard the shift amount in the
+             lowering) is now provable for constant in-range amounts. *)
+        lazymatch goal with
+        | [ |- context[ARMv8A_op LSR _] ] => idtac
+        | [ |- context[ARMv8A_op LSL _] ] => idtac
+        | [ |- context[ARMv8A_op ASR _] ] => idtac
+        end;
+        move: hsemop => /sem_sop2I /= [x0 [x1 [w2 [hx0 hx1 hop hw]]]];
+        move: hop => [?]; subst w2;
+        move: hw => /Vword_inj [?]; subst ws'; move=> /= ?; subst w;
+        have [hsub [v1' [w1' [hsem1' hw1' heq]]]] :=
+          check_shift_exprP hchk hwsx hseme1 hx1;
+        (split;
+          last (split;
+            [ apply: (disj_fvars_read_es2 hfve0);
+              exact: (disjoint_w hsub hfve1)
+            | by [] ]));
+        (exists [:: v0; v1'];
+          first by rewrite /sem_pexprs /= hseme0 hsem1' /=);
+        move: (hwsx); rewrite orbC => hval;
+        rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hval /= hx0 hw1' /=;
+        rewrite /semi_to_atype !computational_eq_refl /=;
+        rewrite /armv8a_shift_semi -heq;
+        by rewrite /sem_shr /sem_shl /sem_sar /sem_shift zero_extend_u
+      | (* MOV: a shift or rotate by zero, i.e. the identity. *)
+        lazymatch goal with
+        | [ |- context[ARMv8A_op MOV _] ] => idtac
+        end;
+        move: hsemop => /sem_sop2I /= [x0 [x1 [w2 [hx0 hx1 hop hw]]]];
+        move: hop => [?]; subst w2;
+        move: hw => /Vword_inj [?]; subst ws'; move=> /= ?; subst w;
+        (* Pin the shift amount [x1] to zero. *)
+        first
+          [ assert (hwc := is_wconstP true (p_globs p) s hconst);
+            move/eqP: hif => ?; subst c;
+            move: hwc; rewrite hseme1 /= hx1 => -[?]; subst x1
+          | move/is_zeroP: hif => ?; subst e1;
+            move: hseme1; rewrite /= /sem_sop1 /= => -[?]; subst v1;
+            move: hx1; rewrite /= truncate_word_u => -[?]; subst x1
+          ];
+        (split; last (split; [ exact: hfve0 | by [] ]));
+        (exists [:: v0 ]; first by rewrite /sem_pexprs /= hseme0 /=);
+        move: (hwsx); rewrite orbC => hval;
+        rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hval /= hx0 /=;
+        rewrite /semi_to_atype !computational_eq_refl /=;
+        rewrite /armv8a_MOV_semi
+          /sem_shr /sem_shl /sem_sar /sem_ror /sem_rol /sem_shift
+          ?wrepr0 wunsigned0 ?wshr0 ?wshl0 ?wsar0 ?wror0 ?wrol0;
+        by rewrite zero_extend_u
+      | (* ROR from [Oror] (variable rotate): rotation is periodic, so the
+           [mod] in [armv8a_shift_semi] is harmless. *)
+        lazymatch goal with
+        | [ _ : sem_sop2 (Oror _) _ _ = ok _ |- context[ARMv8A_op ROR _] ] =>
+            idtac
+        end;
+        move: hsemop => /sem_sop2I /= [x0 [x1 [w2 [hx0 hx1 hop hw]]]];
+        move: hop => [?]; subst w2;
+        move: hw => /Vword_inj [?]; subst ws'; move=> /= ?; subst w;
+        (split;
+          last (split;
+            [ exact: (disj_fvars_read_es2 hfve0 hfve1) | by [] ]));
+        (exists [:: v0; v1 ];
+          first by rewrite /sem_pexprs /= hseme0 hseme1 /=);
+        move: (hwsx); rewrite orbC => hval;
+        rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hval /= hx0 hx1 /=;
+        rewrite /semi_to_atype !computational_eq_refl /=;
+        rewrite /armv8a_shift_semi /sem_ror /sem_shift zero_extend_u;
+        do 3 f_equal; apply: wror_m;
+        by rewrite Zmod_mod
+      | (* ROR from [Orol]: a rotate left by [c] is a rotate right by
+           [wsize - c]. *)
+        lazymatch goal with
+        | [ _ : sem_sop2 (Orol _) _ _ = ok _ |- context[ARMv8A_op ROR _] ] =>
+            idtac
+        end;
+        move: hsemop => /sem_sop2I /= [x0 [x1 [w2 [hx0 hx1 hop hw]]]];
+        move: hop => [?]; subst w2;
+        move: hw => /Vword_inj [?]; subst ws'; move=> /= ?; subst w;
+        assert (hwc := is_wconstP true (p_globs p) s hconst);
+        move: hwc; rewrite hseme1 /= hx1 => -[?]; subst c;
+        (split; last (split; [ exact: hfve0 | by [] ]));
+        (eexists; first by rewrite /sem_pexprs /= hseme0 /=);
+        move: (hwsx); rewrite orbC => hval;
+        rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hval /= hx0 /=;
+        rewrite truncate_word_u /=;
+        rewrite /semi_to_atype !computational_eq_refl /=;
+        rewrite /armv8a_shift_semi wrepr_unsigned /sem_rol /sem_shift
+          zero_extend_u -wror_opp;
+        do 3 f_equal; apply: wror_m;
+        rewrite Zmod_mod;
+        by apply: rol_ror_shift_amount
+      | (* MADD/MSUB: fused multiply-add/subtract from [is_mul]. *)
+        lazymatch goal with
+        | [ |- context[ARMv8A_op MADD _] ] => idtac
+        | [ |- context[ARMv8A_op MSUB _] ] => idtac
+        end;
+        (* Evaluate the [is_mul] product subexpression. *)
+        let t0 := type of hseme0 in
+        lazymatch t0 with
+        | sem_pexpr _ _ _ (Papp2 (Omul _) _ _) = _ =>
+            move: hseme0 => /=;
+            t_xrbindP=> vx hsemx vy hsemy;
+            rewrite /sem_sop2 /=;
+            t_xrbindP=> wx hwx wy hwy ?; subst v0
+        | _ =>
+            move: hseme1 => /=;
+            t_xrbindP=> vx hsemx vy hsemy;
+            rewrite /sem_sop2 /=;
+            t_xrbindP=> wx hwx wy hwy ?; subst v1
+        end;
+        move: hsemop => /sem_sop2I /= [x0 [x1 [w2 [hx0 hx1 hop hw]]]];
+        move: hop => [?]; subst w2;
+        move: hw => /Vword_inj [?]; subst ws'; move=> /= ?; subst w;
+        (* The product is at width [wsm >= ws] (from [is_mul]), the outer
+           operation at [ws'' >= ws]: only the low [ws] bits are kept, so
+           the widths need not coincide and the zero extensions distribute
+           over the operations. *)
+        (first
+          [ move: hx0; rewrite /= => /truncate_wordP [hle ?]; subst x0;
+            rename hx1 into haddend
+          | move: hx1; rewrite /= => /truncate_wordP [hle ?]; subst x1;
+            rename hx0 into haddend ]);
+        (split;
+          last (split;
+            [ first
+                [ exact: (disj_fvars_read_es2_app2 hfve1 hfve0)
+                | exact: (disj_fvars_read_es2_app2 hfve0 hfve1) ]
+            | by [] ]));
+        (eexists;
+          first by rewrite /sem_pexprs /= hsemx hsemy ?hseme0 ?hseme1 /=);
+        move: (hwsx); rewrite orbC => hval;
+        rewrite /exec_sopn /sopn_sem /sopn_sem_ /= hval /=
+          (to_word_m hwx hlem) (to_word_m hwy hlem) (to_word_m haddend hws) /=;
+        rewrite /semi_to_atype !computational_eq_refl /=;
+        rewrite /armv8a_MADD_semi /armv8a_MSUB_semi
+          ?add_wordE ?sub_wordE ?mul_wordE
+          ?(wadd_zero_extend _ _ hws) ?(wsub_zero_extend _ _ hws)
+          ?(wopp_zero_extend _ hws) ?(zero_extend_idem _ hws)
+          ?(wmul_zero_extend _ _ hlem) ?zero_extend_u;
+        first [ by [] | by rewrite GRing.addrC ] ].
+  }
+
+  case hlarge: (large_arith_imm ws mn' e1') => [imm|]; last first.
+
+  (* No large immediate: the [arg_shift] path. *)
+  - rewrite /arg_shift /=.
+    case hhas_shift: (mn' \in has_shift_mnemonics); last by move=> [<- <-].
+    case hget_arg_shift: get_arg_shift => [[[b' sh] n]|]; last by move=> [<- <-].
+    case hallowed: (shift_allowed mn' sh); last by move=> [<- <-].
+    (* special case: there is some arg shift *)
+    move=> [<- <-].
+    (* we want to use with_shift_binop, so we have to prove this *)
+    have hshift_binop:
+      mn' \in [:: ADD; ADDS; SUB; SUBS; AND; EOR; ORR; CMP; TST].
+    {
+      case: op hop hhas_shift hsemop => //;
+        rewrite /lower_Papp2_op /=.
+      all:
+        match goal with
+        | [ |- forall _ : op_kind, _ -> _ ] => move=> [|ws''] //
+        | [ |- forall (_ : cmp_kind), _ -> _ ] => move=> [|[] ws''] //
+        | [ |- forall (_ : signedness) (_ : op_kind), _ -> _ ] => move=> [] [|ws''] //
+        | [ |- forall _ : wsize, _ -> _ ] => move=> ws'' //
+        end.
+      all: repeat first
+        [ move=> /oassertP [/eqP ?]; subst ws''
+        | match goal with
+          | [ |- context[ is_mul ] ] => case: is_mulP => [? ? ? ? ?|]; subst
+          end
+        | match goal with
+          | [ |- context[ is_wconst ] ] => case hc': is_wconst => [c'|//]
+          end
+        ].
+      all: repeat (match goal with |- context[ if _ then _ else _ ] => case: ifP => _ end).
+      all: try (match goal with
+                | [ |- context[ check_shift_expr ] ] =>
+                    apply: obindP => ? ?
+                end).
+      all: by move=> [<- _ _].
+    }
+    move: hdflt => [[vs ok_vs hsopn] [hfv htout]].
+    have: exists e1'', e1' = [:: e1'' ].
+    + move: hget_arg_shift; rewrite /get_arg_shift.
+      case: (e1') => // -[] // ? [] // ? [] // [] // [] // [] // ? [] //.
+      move=> _.
+      by eexists; reflexivity.
+    move=> [e1'' ?]; subst e1'.
+    have hfve1'': disj_fvars (read_e e1'').
+    + by apply: disjoint_w hfv; clear; rewrite !read_es_cons /=; SvD.fsetdec.
+    move: ok_vs => /=.
+    t_xrbindP => v0' ok_v0' _ v1'' ok_v1'' <- ?; subst vs.
+    have [ws1 [wbase [wsham [hcmp1 hbase hsham hw1'' [hfvbase hfvsham]]]]] :=
+      get_arg_shiftP hget_arg_shift hfve1'' ok_v1''.
+    split.
+    + rewrite /= ok_v0' hbase hsham /=.
+      eexists; first by reflexivity.
+      by apply (with_shift_binop (opts := opts_at ws) hshift_binop hallowed hcmp1 erefl hbase hsham hw1'' hsopn).
+    split.
+    + apply disj_fvars_read_es3 => //.
+      by apply: disjoint_w hfv; clear; rewrite !read_es_cons /=; SvD.fsetdec.
+    by move: htout; rewrite /sopn_tout /= (sopn_tout_with_shift mn' (opts_at ws) sh).
+
+  (* Large 64-bit immediate: through [Oarmv8a_add_large_imm]. *)
+  move=> [<- <-] {hdflt}.
+  case: op hop hsemop => //;
+    rewrite /lower_Papp2_op /=.
+  all:
+    match goal with
+    | [ |- forall _ : op_kind, _ -> _ ] => move=> [|ws''] //
+    | [ |- forall (_ : cmp_kind), _ -> _ ] => move=> [|[] ws''] //
+    | [ |- forall (_ : signedness) (_ : op_kind), _ -> _ ] => move=> [] [|ws''] //
+    | [ |- forall _ : wsize, _ -> _ ] => move=> ws'' //
+    end.
+  all: repeat first
+    [ move=> /oassertP [/eqP ?]; subst ws''
+    | match goal with
+      | [ |- context[ is_mul ] ] => case: is_mulP => [? ? ? ? ?|]; subst
+      end
+    | match goal with
+      | [ |- context[ is_wconst ] ] => case hconst: is_wconst => [c'|//]
+      end
+    ].
+  all: repeat (match goal with |- context[ if _ then _ else _ ] => case: ifP => hif end).
+  all: try (match goal with
+            | [ |- context[ check_shift_expr ] ] =>
+                apply: obindP => amt hchk
+            end).
+  all: move=> [???] hsemop; subst mn' e0' e1'.
+  all: have [? hmns [e he1' [c hc himm]]] := large_arith_immP hlarge.
+  all: try (exfalso; exact: (Bool.diff_false_true hmns)).
+  all: subst ws.
+  all: move: he1' => [?]; subst e.
+  all: move: himm; rewrite /= => ?; subst imm.
+  all: move: hsemop => /sem_sop2I /= [x0 [x1 [w2 [hx0 hx1 hop2 hw]]]].
+  all: move: hop2 => [?]; subst w2.
+  all: move: hw => /Vword_inj [?]; subst ws'; move=> /= ?; subst w.
+  all: move: hx0 => /to_wordI [ws0 [w0 [? /truncate_wordP [hws0 ?]]]]; subst v0 x0.
+  all: move: hx1 => /to_wordI [ws1 [w1 [? /truncate_wordP [hws1 ?]]]]; subst v1 x1.
+  all: assert (hwc := is_wconstP true (p_globs p) s hc).
+  all: move: hwc;
+    rewrite hseme1 /= (truncate_word_le _ (cmp_le_trans hws hws1)) => -[?];
+    subst c.
+  all: split; last (split; [ exact: hfve0 | by [] ]).
+  all: eexists;
+    first by rewrite /sem_pexprs /= hseme0 /= /sem_sop1 /=.
+  all: rewrite /exec_sopn /sopn_sem /sopn_sem_ /=.
+  all: rewrite (truncate_word_le _ (cmp_le_trans hws hws0)) truncate_word_u /=.
+  all: rewrite wrepr_unsigned ?wrepr_opp wrepr_unsigned.
+  all: rewrite ?add_wordE ?sub_wordE.
+  all: rewrite ?(wadd_zero_extend _ _ hws) ?(wsub_zero_extend _ _ hws)
+               ?(zero_extend_idem _ hws).
+  all: by rewrite ?(wopp_zero_extend _ hws) ?(zero_extend_idem _ hws).
+Qed.
+
+Lemma lower_pexpr_auxP e :
+  Plower_pexpr_aux e.
+Proof.
+  move=> s ws ws' aop es w.
+  case: e => [||| gx | al aa ws0 x e || al ws0 x e | op e | op e0 e1 ||] //.
+
+  - exact: lower_PvarP.
+  - exact: (lower_loadP (Pget _ _ _ _ _)).
+  - exact: (lower_loadP (Pload _ _ _)).
+  - exact: lower_Papp1P.
+  exact: lower_Papp2P.
+Qed.
+
+Lemma sem_i_lower_pexpr_aux s0 s1 s0' ws ws' ii e op es (w : word ws') lv tag :
+  lower_pexpr_aux ws e = Some (op, es)
+  -> eq_fv s0 s0'
+  -> (ws <= ws')%CMP
+  -> disj_fvars (read_e e)
+  -> disj_fvars (vars_lval lv)
+  -> sem_pexpr true (p_globs p) s0 e = ok (Vword w)
+  -> write_lval true (p_globs p) lv (Vword (zero_extend ws w)) s0 = ok s1
+  -> exists2 s1',
+       esem_i p' ev (MkI ii (Copn [:: lv ] tag op es)) s0' = ok s1'
+       & eq_fv s1 s1'.
+Proof.
+  move=> h hs00 hws hfve hfvlv hseme hwrite.
+
+  have hseme' := eeq_exc_sem_pexpr hfve hs00 hseme.
+  clear hseme.
+
+  have [[vs hsemes hexec] _] := lower_pexpr_auxP h hws hfve hseme'.
+  clear h hws hfve hseme'.
+
+  have [s1' hwrite' hs11] := eeq_exc_write_lval hfvlv hs00 hwrite.
+  clear hfvlv hs00 hwrite.
+
+  exists s1'; last exact: hs11.
+  clear hs11.
+  rewrite /= /sem_sopn /=.
+  rewrite hsemes {hsemes} /=.
+  rewrite hexec {hexec} /=.
+  by rewrite hwrite' {hwrite'} /=.
+Qed.
+
+Lemma no_preP o pre aop es :
+  no_pre o = Some (pre, aop, es)
+  -> pre = [::] /\ o = Some (aop, es).
+Proof. case: o => //. by move=> [? ?] [<- <- <-]. Qed.
+
+Lemma sem_lower_pexpr
+  s0 s1 s0' ii vi ws ws' e pre op es (w : word ws') lv tag :
+  lower_pexpr vi ws e = Some (pre, op, es)
+  -> eq_fv s0 s0'
+  -> (ws <= ws')%CMP
+  -> disj_fvars (read_e e)
+  -> disj_fvars (vars_lval lv)
+  -> sem_pexpr true (p_globs p) s0 e = ok (Vword w)
+  -> write_lval true (p_globs p) lv (Vword (zero_extend ws w)) s0 = ok s1
+  -> exists2 s1',
+       let cmd := map (MkI ii) (pre ++ [:: Copn [:: lv ] tag op es ]) in
+       esem p' ev cmd s0' = ok s1' & eq_fv s1 s1'.
+Proof using atoI ev fv fv_correct p pT sCP sc_sem syscall_state warning wsw.
+  move=> h hs00 hws hfve hfvlv hseme hwrite.
+
+  move: s0 ws' pre op es w h hs00 hws hfve hfvlv hseme hwrite.
+  case: e =>
+    [||| gx | al aa ws0 x e || al ws0 e | op e | op e0 e1 || ty c e0 e1] //
+    s0 ws' pre aop es w h hs00 hws hfve hfvlv hseme hwrite.
+
+  1-5: move: h => /no_preP [? h]; subst pre.
+  1-5: have [s1' hsem' hs11] :=
+    sem_i_lower_pexpr_aux ii tag h hs00 hws hfve hfvlv hseme hwrite.
+  1-5: clear s0 ws w h hs00 hws hfve hfvlv hseme hwrite.
+  1-5: exists s1'; last exact: hs11.
+  1-5: by move: hsem'; rewrite /= => ->.
+
+  (* [Pif]: lowered to CSEL (A64 has no conditional execution). *)
+  clear hws.
+  move: h.
+  case: ty hfve hfvlv hseme => // ws0 hfve hfvlv hseme.
+
+  rewrite /lower_pexpr.
+  move=> /oassertP [] /eqP ?; subst ws0.
+  rewrite /lower_Pif.
+  move=> /oassertP [] hwsx h.
+  move: h => /oassertP [] hcselargs h.
+  move: h.
+  case hc: lower_condition => [pre' c'] [? ? ?]; subst pre aop es.
+  rename pre' into pre.
+
+  move: hseme.
+  rewrite /=.
+  rewrite /truncate_val /=.
+  t_xrbindP=> b vb hsemc hb v0' v0 hseme0 w0' hw0 ? v1' v1 hseme1 w1' hw1 ? hw;
+    subst v0' v1'.
+  move: hb => /to_boolI ?; subst vb.
+  move: hw0 => /to_wordI [ws0 [w0 [? /truncate_wordP [hws0 ?]]]]; subst v0 w0'.
+  move: hw1 => /to_wordI [ws1 [w1 [? /truncate_wordP [hws1 ?]]]]; subst v1 w1'.
+
+  move: hfve => /disj_fvars_read_e_Pif [hfvc hfve0 hfve1].
+
+  have [s1' [hsem01' hs10 hsemc']] := sem_lower_condition ii hc hs00 hfvc hsemc.
+  clear hc hs00 hfvc hsemc.
+
+  have [s2' hwrite12' hs21] :
+    exists2 s2',
+      write_lval true (p_globs p) lv
+        (Vword (if b then zero_extend ws w0 else zero_extend ws w1)) s1'
+        = ok s2'
+      & eq_fv s1 s2'.
+  {
+    case: b hw hsemc' => hw _.
+    all: move: hw => /Vword_inj [?]; subst ws'.
+    all: move=> /= ?; subst w.
+    all: rewrite zero_extend_u in hwrite.
+    all: have [s2' hwrite12' hs21] := eeq_exc_write_lval hfvlv hs10 hwrite.
+    all: exists s2'; last exact: hs21.
+    all: exact: hwrite12'.
+  }
+
+  exists s2'; last exact: hs21.
+Opaque esem esem_i.
+  rewrite map_cat esem_cat hsem01' /= esem1.
+Transparent esem esem_i.
+  clear hsem01'.
+  rewrite /= /sem_sopn /=.
+  rewrite (eeq_exc_sem_pexpr hfve0 hs10 hseme0) /=
+          (eeq_exc_sem_pexpr hfve1 hs10 hseme1) /=
+          hsemc' /=.
+  rewrite /exec_sopn /sopn_sem /sopn_sem_ /=.
+  move: (hwsx); rewrite orbC => hval; rewrite hval /=.
+  rewrite (truncate_word_le _ hws0) (truncate_word_le _ hws1) /=.
+  rewrite /semi_to_atype !computational_eq_refl /=.
+  rewrite /armv8a_CSEL_semi.
+  by rewrite hwrite12'.
+Qed.
+
+Lemma sem_i_lower_store s0 s1 s0' ws ws' ii e aop es (w : word ws') lv tag :
+  lower_store ws e = Some (aop, es)
+  -> eq_fv s0 s0'
+  -> (ws <= ws')%CMP
+  -> disj_fvars (read_e e)
+  -> sem_pexpr true (p_globs p) s0 e = ok (Vword w)
+  -> write_lval true (p_globs p) lv (Vword (zero_extend ws w)) s0' = ok s1
+  -> esem_i p' ev (MkI ii (Copn [:: lv ] tag (Oarmv8a aop) es)) s0' = ok s1.
+Proof.
+  move=> h hs00 hws hfv hseme hwrite.
+
+  move: h.
+  rewrite /lower_store.
+  case hmn: store_mn_of_wsize => [mn|] //.
+
+  (* On armv8a only a register can be stored: [e] is a [Pvar]. *)
+  case: e hseme hfv => [||| gx |||||||] // hseme hfv [? ?]; subst aop es.
+  rewrite /= /sem_sopn /=.
+  have /= -> := eeq_exc_sem_pexpr hfv hs00 hseme.
+  rewrite /exec_sopn /sopn_sem /sopn_sem_ /=.
+  case: ws hws hwrite hmn => // hws hwrite [?]; subst mn.
+  all: rewrite /= (truncate_word_le _ hws) /=.
+  all: rewrite /semi_to_atype ?computational_eq_refl /=.
+  all: rewrite /armv8a_extend_semi ?zero_extend_u /=.
+  all: by rewrite hwrite.
+Qed.
+
+Lemma lower_cassgn_wordP ii s0 lv tag ws e v v' s0' s1' pre lvs op es :
+  lower_cassgn_word fv lv ws e = Some (pre, (lvs, op, es))
+  -> sem_pexpr true (p_globs p) s0 e = ok v
+  -> truncate_val (cword ws) v = ok v'
+  -> write_lval true (p_globs p) lv v' s0' = ok s1'
+  -> eq_fv s0 s0'
+  -> disj_fvars (read_e e)
+  -> disj_fvars (vars_lval lv)
+  -> esem_i p' ev (MkI ii (Cassgn lv tag (aword ws) e)) s0' = ok s1'
+  -> exists2 s2',
+       esem p' ev (map (MkI ii) (pre ++ [:: Copn lvs tag op es ])) s0' = ok s2'
+       & eq_fv s1' s2'.
+Proof using atoI ev fv fv_correct p pT sCP sc_sem syscall_state warning wsw.
+  rewrite /lower_cassgn_word.
+  move=> h hseme htrunc hwrite01' hs00 hfve hfvlv hsem01'.
+
+  move: h.
+  move: htrunc.
+  rewrite /truncate_val.
+  t_xrbindP=> w' hw' ?; subst v'.
+  move: hw' => /to_wordI [ws' [w [? /truncate_wordP [hws ?]]]]; subst v w'.
+
+  case: is_lval_in_memory.
+  - case h: lower_store => [[op' es']|] // [? ? ? ?]; subst pre lvs op es.
+    exists s1'; last exact: eeq_excR.
+    rewrite esem1.
+    exact: (sem_i_lower_store ii tag h hs00 hws hfve hseme hwrite01').
+
+  case h: lower_pexpr => [[[pre' op'] es']|] // [? ? ? ?];
+    subst pre lvs op es.
+
+  have [s2 hwrite02 hs12] :=
+    eeq_exc_write_lval hfvlv (eeq_excS hs00) hwrite01'.
+  clear hwrite01'.
+
+  have /= [s3' hsem03' hs23] :=
+    sem_lower_pexpr ii tag h hs00 hws hfve hfvlv hseme hwrite02.
+  exists s3'; last exact: (eeq_excT hs12 hs23).
+  exact: hsem03'.
+Qed.
+
+Lemma lower_cassgn_boolP ii s0 lv tag e v v' s0' s1' irs :
+  lower_cassgn_bool fv lv tag e = Some irs
+  -> sem_pexpr true (p_globs p) s0 e = ok v
+  -> truncate_val cbool v = ok v'
+  -> write_lval true (p_globs p) lv v' s0' = ok s1'
+  -> eq_fv s0 s0'
+  -> disj_fvars (read_e e)
+  -> disj_fvars (vars_lval lv)
+  -> esem_i p' ev (MkI ii (Cassgn lv tag abool e)) s0' = ok s1'
+  -> exists2 s2',
+       esem p' ev (map (MkI ii) irs) s0' = ok s2'
+       & eq_fv s1' s2'.
+Proof using atoI ev fv fv_correct p pT sCP sc_sem syscall_state warning wsw.
+  rewrite /lower_cassgn_bool => h ok_v ok_v' ok_s1' hs00 hfve hfvlv hsem01'.
+  case h: lower_condition_pexpr h => [ [] [] [] lvs op es c | // ] /Some_inj <-{irs}.
+  have [ si [] hsem0i hs0i {} ok_v ] := sem_lower_condition_pexpr tag ii h hs00 hfve ok_v.
+  have hsi0' : eq_fv s0' si := eeq_excS (eeq_excT (eeq_excS hs0i) hs00).
+  have [ sj ok_sj hsj1' ] := eeq_exc_write_lval hfvlv hsi0' ok_s1'.
+  eexists.
+  - rewrite -cat1s map_cat esem_cat hsem0i /= /sem_assgn.
+    rewrite ok_v /= ok_v' /= ok_sj /=; reflexivity.
+  done.
+Qed.
+
+(* -------------------------------------------------------------------- *)
+(* Lowering of ARM-specific instructions. *)
+
+(* TODO_ARM: This lemma is similar to the one in x86_lowering, but not quite:
+   in x86 [res] is [wunsigned (wrepr (wunsigned w + wunsigned w' + Z.b2z b))].
+*)
+Lemma wunsigned_carry ws w w' b :
+  let: res := wunsigned (w + w' + wrepr ws (Z.b2z b))%R in
+  let: res' := (wunsigned w + wunsigned w' + Z.b2z b)%Z in
+  (wbase ws <=? res')%Z = (res != res')%Z.
+Proof.
+  case: b => /=; first last.
+  - rewrite Z.add_0_r wrepr0 GRing.addr0. exact: add_overflow.
+
+  rewrite wunsigned_add_if.
+  rewrite wrepr1 wunsigned1.
+  case: ZltP.
+  - rewrite wunsigned_add_if.
+    case: ZltP.
+    + move=> _.
+      move=> /Z.lt_nge /ZleP /negPf ->.
+      by symmetry; apply/negPn.
+
+    move=> h _.
+    have -> : (wbase ws <=? wunsigned w + wunsigned w' + 1)%Z.
+    + apply/ZleP. lia.
+    symmetry; apply/eqP.
+    have := wbase_pos ws.
+    lia.
+
+  rewrite wunsigned_add_if.
+  case: ZltP.
+  - move=> /Z.le_succ_l h0 /Z.le_ngt h1.
+    rewrite -(Z.le_antisymm _ _ h0 h1).
+    rewrite Z.leb_refl.
+    symmetry; apply/eqP.
+    have := wunsigned_range w.
+    lia.
+
+  move=> /Z.le_ngt h0 /Z.le_ngt h1.
+  have -> : (wbase ws <=? wunsigned w + wunsigned w' + 1)%Z.
+  - apply/ZleP. lia.
+  symmetry; apply/eqP.
+  have := wunsigned_range w.
+  lia.
+Qed.
+
+Lemma write_Lnone wdb gd x v s s' :
+  isLnone x ->
+  write_lval wdb gd x v s = ok s' ->
+  s = s'.
+Proof.
+  case: x => // ii ty _ /=.
+  by rewrite /write_none /=; t_xrbindP.
+Qed.
+
+Lemma lower_add_carryP s0 s1 ii lvs tag es lvs' op' es' :
+  esem_i p' ev (MkI ii (Copn lvs tag (sopn_addcarry U64) es)) s0 = ok s1
+  -> lower_add_carry lvs es = Some (lvs', op', es')
+  -> esem_i p' ev (MkI ii (Copn lvs' tag op' es')) s0 = ok s1.
+Proof.
+  case: lvs => [] // lv0 [] // lv1 [] //.
+  case: es => [] // e0 [] // e1 [] // e2 [] //.
+  move=> + h.
+  rewrite /= /sem_sopn /=.
+  t_xrbindP=> res _ v0 hseme0 _ v1 hseme1 _ v2 hseme2 <- <- <- + hwrite.
+  rewrite /exec_sopn /=.
+  t_xrbindP=> /= res' w0 hw0 w1 hw1 b hb hsopn ?; subst res.
+  move: hw0 => /to_wordI [ws [w [? hw0]]]; subst v0.
+  move: hw0 => /truncate_wordP [hws ?]; subst w0.
+  move: hw1 => /to_wordI [ws' [w' [? hw1]]]; subst v1.
+  move: hw1 => /truncate_wordP [hws' ?]; subst w1.
+  move: hb => /to_boolI ?; subst v2.
+  move: hsopn => [?]; subst res'.
+  move: hwrite => /=.
+  t_xrbindP=> s00 hwrite00 s01 hwrite1 ?; subst s01.
+
+  rewrite /sem_sopn /=.
+
+  move: hwrite1.
+  rewrite !wrepr_add !wrepr_unsigned.
+  move=> hwrite1.
+
+  move: h.
+  case: e2 hseme2 => [| [] || gx |||||||] //= hseme2 [???];
+    subst lvs' op' es'.
+  all: rewrite /= hseme0 hseme1 /= {hseme0 hseme1}.
+
+  2: rewrite hseme2 /= {hseme2}.
+
+  all: case no_carry: (isLnone _) => /=.
+
+  all: rewrite /exec_sopn /=.
+  all: rewrite !truncate_word_le // {hws hws'} /=.
+  all: move: hwrite00 hwrite1.
+  all: rewrite wunsigned_carry.
+
+  1, 2: move: hseme2 => [?]; subst b.
+  1, 2: rewrite /= Z.add_0_r wrepr0 GRing.addr0.
+
+  2, 4: by move=> -> /= ->.
+
+  1, 2: by move => /(write_Lnone no_carry) <- ->.
+Qed.
+
+Lemma lower_base_op s0 s1 ii lvs tag aop es lvs' op' es' :
+  disj_fvars (read_es es)
+  -> esem_i p' ev (MkI ii (Copn lvs tag (Oasm (BaseOp (None, aop))) es)) s0 = ok s1
+  -> lower_base_op lvs aop es = Some (lvs', op', es')
+  -> esem_i p' ev (MkI ii (Copn lvs' tag op' es')) s0 = ok s1.
+Proof.
+  move: aop => [mn opts].
+  move=> hfve hsemi.
+  rewrite /lower_base_op.
+  assert (default : forall lvs' op' es', Some (lvs, Oasm (BaseOp (None, ARMv8A_op mn opts)), es) = Some (lvs', op', es') ->
+                    esem_i p' ev (MkI ii (Copn lvs' tag op' es')) s0 = ok s1).
+  - move: hsemi; clear => hsemi lvs' op' es' /Some_inj[? ? ?]; subst lvs' op' es'.
+    exact: hsemi.
+  case: ifP.
+  - case: (_ \in _) => // _.
+    exact: default.
+  move/eqP => no_shift.
+  case: ifP => mn_unop.
+  - case: es hsemi hfve default => // x es hsemi hfve default.
+    case x_has_shift: get_arg_shift => [ [ [] ebase sh esham ] | ] ; last exact: default.
+    case hallowed: (shift_allowed mn sh); last exact: default.
+    case/Some_inj => <-{lvs'} <-{op'} <-{es'} /=.
+    have {} hfve : disj_fvars (read_e x).
+    + move: hfve; clear.
+      by rewrite /disj_fvars read_es_cons => /disjoint_union[].
+    move: hsemi.
+    rewrite /= /sem_sopn /=; t_xrbindP => r _ w hx ws hes <- hr hwrite.
+    have [ ts [] t [] wsham [] hts ht hwsham hw [] hfb hfa ] := get_arg_shiftP x_has_shift hfve hx.
+    rewrite ht hwsham hes /=.
+    have -> /= := with_shift_unop mn_unop hallowed hts no_shift ht hwsham hw hr.
+    exact: hwrite.
+  case: ifP => mn_binop; last by [].
+  case: es hsemi hfve default => // x [] // y es hsemi hfve default.
+  case y_has_shift: get_arg_shift => [ [ [] ebase sh esham ] | ] ; last exact: default.
+  case hallowed: (shift_allowed mn sh); last exact: default.
+  case/Some_inj => <-{lvs'} <-{op'} <-{es'} /=.
+  have {} hfve : disj_fvars (read_e y).
+  + move: hfve; clear.
+    by rewrite /disj_fvars !read_es_cons => /disjoint_union[] _ /disjoint_union[].
+  move: hsemi.
+  rewrite /= /sem_sopn /=; t_xrbindP => r _ w -> _ z hy ws hes <- <- hr hwrite.
+  have [ ts [] t [] wsham [] hts ht hwsham hw [] hfb hfa ] := get_arg_shiftP y_has_shift hfve hy.
+  rewrite ht hwsham hes /=.
+  have -> /= := with_shift_binop mn_binop hallowed hts no_shift ht hwsham hw hr.
+  exact: hwrite.
+Qed.
+
+Lemma lower_copnP s0 s1 ii lvs tag op es lvs' op' es' :
+  disj_fvars (read_es es)
+  -> esem_i p' ev (MkI ii (Copn lvs tag op es)) s0 = ok s1
+  -> lower_copn lvs op es = Some (lvs', op', es')
+  -> exists2 vm1,
+     esem_i p' ev (MkI ii (Copn lvs' tag op' es')) s0 = ok (with_vm s1 vm1) &
+     vm1 =1 evm s1.
+Proof.
+  case: op => // [pop | [[[|] aop]|//]] //; last first.
+  - (* Base op. *)
+    move=> hd hs hl; exists (evm s1) => //.
+    rewrite with_vm_same; exact: lower_base_op hd hs hl.
+  (* Pseudo operators: [Oaddcarry U64] and [Oswap]. *)
+  case: pop => //.
+  - (* Oaddcarry U64. *)
+    move=> w hd hsemi hlow.
+    move: hlow; case: w hsemi => // hsemi hlow.
+    exists (evm s1) => //.
+    rewrite with_vm_same; exact: (lower_add_carryP hsemi hlow).
+  (* Oswap. *)
+  move=> ty hd hsem hlow.
+  move: hlow; rewrite /= /lower_swap.
+  case: ty hsem => // [len ty | ws] hsem.
+  - move=> [<- <- <-].
+    by exists (evm s1) => //; rewrite with_vm_same.
+  case: ifP => // hcmp [<- <- <-].
+  by exists (evm s1) => //; rewrite with_vm_same.
+Qed.
+
+(* -------------------------------------------------------------------- *)
+
+Section IT.
+Context {E E0: Type -> Type} {wE : with_Error E E0} {rE0 : EventRels E0}.
+
+#[ local ]
+Definition Pi_ (i : instr) :=
+  disj_fvars (vars_I i) ->
+  wequiv_rec p p' ev ev eq_spec eq_fv [::i] (lower_i i) eq_fv.
+
+#[ local ]
+Definition Pi_r_ (i : instr_r) := forall ii, Pi_ (MkI ii i).
+
+#[ local ]
+Definition Pc_ (c : cmd) :=
+  disj_fvars (vars_c c) ->
+  wequiv_rec p p' ev ev eq_spec eq_fv c (lower_cmd c) eq_fv.
+
+Lemma checker_st_eq_exP_ : Checker_eq p p' checker_st_eq_ex.
+Proof. apply checker_st_eq_exP => //. Qed.
+#[local] Hint Resolve checker_st_eq_exP_ : core.
+
+Lemma it_lower_callP fn :
+  wiequiv_f p p' ev ev (rpreF (eS:= eq_spec)) fn fn (rpostF (eS:=eq_spec)).
+Proof using E E0 atoI dc ev fv fv_correct p pT rE0 sCP sc_sem syscall_state wE warning wsw.
+  apply wequiv_fun_ind => {}fn _ fs _ [<- <-] fd hget.
+  have [_ hfvres hfvc] := disj_fvars_get_fundef hget.
+  rewrite get_map_prog hget /= /lower_fd.
+  eexists; first reflexivity.
+  move=> s.
+  move=> /(eq_initialize (fd':= with_body fd (lower_cmd (f_body fd)))) -/(_ p' erefl erefl erefl erefl) hinit.
+  exists s => //; exists eq_fv, eq_fv; split => //=; last by apply st_eq_ex_finalize.
+  move: (f_body fd) hfvc. clear fn fs fd hget hfvres hinit s.
+  set sip := sip_of_asm_e.
+  apply (cmd_rect (Pr := Pi_r_) (Pi:=Pi_) (Pc:=Pc_)) => //; rewrite /Pi_r_ /Pi_ /Pc_.
+  + by move=> _; apply (wequiv_nil (sip:=sip)).
+  + move=> i c hi hc /disj_fvars_vars_c_cons [/hi{}hi /hc{}hc].
+    rewrite -cat1s.
+    by apply (wequiv_cat (sip:=sip)) with eq_fv.
+  (* Assgn *)
+  + move=> x tg ty e ii /disj_fvars_vars_I_Cassgn [hfvlv hfve].
+    apply (wequiv_assgn_esem (sip:=sip)).
+    move=> s0 s0' s1 hs00; rewrite /sem_assgn; t_xrbindP => v hseme v' htrunc hwrite.
+    have [s1' hwrite' hs11] := eeq_exc_write_lval hfvlv hs00 hwrite.
+    clear hwrite.
+    assert (hassgn : esem_i p' ev (MkI ii (Cassgn x tg ty e)) s0' = ok s1').
+    - by rewrite /= /sem_assgn (eeq_exc_sem_pexpr hfve hs00 hseme) /= htrunc /=.
+    assert (default: exists2 s1'0 : estate, esem p' ev [:: MkI ii (Cassgn x tg ty e)] s0' = ok s1'0 & eq_fv s1 s1'0).
+    - exists s1'; last exact: hs11.
+      by rewrite esem1.
+    rewrite /lower_i.
+    case: ty htrunc hassgn default => // [ | ws ] htrunc hassgn default.
+    - case h: lower_cassgn_bool => [ irs | ]; last by [].
+      have [ sj hsemj hs1j ] := lower_cassgn_boolP h hseme htrunc hwrite' hs00 hfve hfvlv hassgn.
+      exists sj => //.
+      by apply: eeq_excT hs1j.
+    case h: lower_cassgn_word => [[pre [[lvs op] es]]|]; last by [].
+    have [s2' hsem02' hs12'] :=
+      lower_cassgn_wordP h hseme htrunc hwrite' hs00 hfve hfvlv hassgn.
+    by exists s2'; last exact: (eeq_excT hs11 hs12').
+  (* Copn *)
+  + move=> lvs tag op es ii /disj_fvars_vars_I_Copn [hfvlvs hfve].
+    apply (wequiv_opn_esem (sip:=sip)) => s0 s0' s1 hs00.
+    rewrite /sem_sopn; t_xrbindP=> vs xs hsemes hexec hwrite.
+    have [s1' hwrite' hs11] := eeq_exc_write_lvals hfvlvs hs00 hwrite.
+    clear hfvlvs hwrite.
+    assert (hcopn : esem_i p' ev (MkI ii (Copn lvs tag op es)) s0' = ok s1').
+    - rewrite /= /sem_sopn /=.
+      rewrite (eeq_exc_sem_pexprs hfve hs00 hsemes) {hfve hs00 hsemes} /=.
+      rewrite hexec /=.
+      exact: hwrite'.
+Opaque esem.
+    clear hs00 hsemes hwrite' => /=.
+    case h: lower_copn => [[[lvs' op'] es']|]; last first.
+    + exists s1'; last exact: hs11.
+      by rewrite esem1.
+    have [vm hsem1 heq]:= lower_copnP hfve hcopn h.
+    exists (with_vm s1' vm); first by rewrite esem1.
+    case: hs11=> ?? hvm; split => //=.
+    by move=> z hz; rewrite heq; apply hvm.
+  (* Syscall *)
+  + move=> xs o es ii.
+    rewrite /disj_fvars vars_I_syscall => /disjoint_union [hdisjx hdisje].
+    apply (wequiv_syscall_rel_eq (sip:=sip)) with
+       checker_st_eq_ex fvars => //.
+  (* Assert *)
+  + by move=> ? ii _; apply wequiv_noassert with (ev1:=ev) (ii:=ii).
+  (* If *)
+  + move=> e c1 c2 hc1 hc2 ii /disj_fvars_vars_I_Cif [hfve /hc1{}hc1 /hc2{}hc2] /=.
+    case heq: lower_condition => [pre e'].
+    rewrite map_cat /=.
+    apply (wequiv_if_esem (sip:=sip)) with eq_fv.
+    + by move=> s t v heqfv; apply (sem_lower_condition ii heq).
+    by move=> [].
+  (* For *)
+  + move=> x dir lo hi c hc ii /= /disj_fvars_vars_I_Cfor [hfvc hfvlo hfvhi].
+    apply (wequiv_for_rel_eq (sip:=sip)) with checker_st_eq_ex fvars fvars => //.
+    + by split => //; apply disj_fvars_read_es2.
+    split => //.
+    + rewrite /vars_lvals /read_rvs /vrvs /=; apply /disjointP.
+      by move=> z hz; move/disjointP: hfvc => /(_ z); SvD.fsetdec.
+    by apply/hc/disjointP => z hz; move/disjointP: hfvc => /(_ z); SvD.fsetdec.
+  (* While *)
+  + move=> al c e ii' c' hc hc' ii /disj_fvars_vars_I_Cwhile [/hc{}hc hfve /hc'{}hc'] /=.
+    case heq: lower_condition => [pre e'].
+    apply (wequiv_while_esem (sip:=sip)) with eq_fv => //.
+    by move=> s t v heqfv; apply (sem_lower_condition ii' heq).
+  (* Call *)
+  move=> xs fn es ii /disj_fvars_vars_I_Ccall [hdisjx hdisje] /=.
+  apply (wequiv_call_rel_eq (sip:=sip)) with checker_st_eq_ex fvars => //.
+  by move=> ???; apply: (wequiv_fun_rec (spec := eq_spec)).
+Qed.
+End IT.
+
+End PROOF.

--- a/proofs/compiler/armv8a_params.v
+++ b/proofs/compiler/armv8a_params.v
@@ -1,0 +1,416 @@
+(* ARMv8-A (AArch64) architecture parameters for the compiler passes. *)
+
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype.
+From mathcomp Require Import ssralg.
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  arch_params
+  compiler_util
+  constant_prop
+  expr
+  fexpr
+  shift_kind.
+Require Import
+  lea
+  linearization
+  lowering
+  stack_alloc_params
+  stack_zeroization
+  slh_lowering.
+Require Import
+  arch_decl
+  arch_extra
+  asm_gen.
+Require Import
+  armv8a_decl
+  armv8a_extra
+  armv8a_instr_decl
+  armv8a_params_core
+  armv8a_lowering
+  armv8a_stack_zeroization.
+
+Section Section.
+Context {atoI : arch_toIdent}.
+
+(* Wrappers turning [ARMv8AFopn_core] argument triples into [fopn_args]. *)
+Definition to_opn '(d, o, e) : fopn_args := (d, Oarmv8a o, e).
+
+Definition ARMv8AFopn_mov x y   := to_opn (ARMv8AFopn_core.mov x y).
+Definition ARMv8AFopn_addi x y imm := to_opn (ARMv8AFopn_core.addi x y imm).
+Definition ARMv8AFopn_subi x y imm := to_opn (ARMv8AFopn_core.subi x y imm).
+Definition ARMv8AFopn_align x y al := to_opn (ARMv8AFopn_core.align x y al).
+
+Definition ARMv8AFopn_smart_addi x y imm :=
+  map to_opn (ARMv8AFopn_core.smart_addi x y imm).
+
+Definition ARMv8AFopn_smart_subi x y imm :=
+  map to_opn (ARMv8AFopn_core.smart_subi x y imm).
+
+Definition ARMv8AFopn_smart_addi_tmp x tmp imm :=
+  map to_opn (ARMv8AFopn_core.smart_addi_tmp x tmp imm).
+
+Definition ARMv8AFopn_smart_subi_tmp x tmp imm :=
+  map to_opn (ARMv8AFopn_core.smart_subi_tmp x tmp imm).
+
+(* ------------------------------------------------------------------------ *)
+(* Stack alloc parameters. *)
+
+Definition armv8a_mov_ofs
+  (x : lval) (tag : assgn_tag) (movk : mov_kind) (y : pexpr) (ofs : pexpr) :
+  option instr_r :=
+  let mk oa :=
+    let: (op, args) := oa in
+     Some (Copn [:: x ] tag (Oarmv8a (ARMv8A_op op default_opts)) args) in
+  match movk with
+  | MK_LEA => mk (ADR, [:: if is_zero Uptr ofs then y else add y ofs ])
+  | MK_MOV =>
+    match x with
+    | Lvar x_ =>
+      if is_Pload y then
+        if is_zero Uptr ofs then mk (LDR, [:: y ]) else None
+      else
+        match mk_lea Uptr (add y ofs) with
+        | None => None
+        | Some lea =>
+          match lea.(lea_base), lea.(lea_offset) with
+          | None, _ => None (* impossible *)
+          | Some base, None =>
+            if lea.(lea_disp) == 0%Z then mk (MOV, [:: Plvar base ])
+            else
+              (* This allows to remove constraint in register allocation *)
+              if is_arith_small lea.(lea_disp) then mk (ADD, [:: Plvar base; cast_const lea.(lea_disp) ])
+              else
+                Some (Copn [:: x ] tag (Oasm (ExtOp Oarmv8a_add_large_imm)) [:: Plvar base; cast_const lea.(lea_disp) ])
+          | Some base, Some off =>
+            if lea.(lea_disp) == 0%Z then
+              let%opt scale := Option.map Z.of_nat (shift_of_scale lea.(lea_scale)) in
+              if scale == 0%Z then
+                (* we have a special case to avoid a trivial shift of 0 *)
+                mk (ADD, [:: Plvar base; Plvar off ])
+              else
+                let opts := {| has_shift := Some SLSL; opts_size := U64 |} in
+                Some (Copn [:: x ] tag (Oarmv8a (ARMv8A_op ADD opts)) [:: Plvar base; Plvar off; eword_of_int U8 scale ])
+            else None
+          end
+        end
+    | Lmem _ _ _ _ =>
+      if is_zero Uptr ofs then mk (STR, [:: y ]) else None
+    | _ => None
+    end
+  end.
+
+Definition armv8a_immediate (x : var_i) z :=
+  Copn [:: Lvar x ] AT_none (Oasm (ExtOp (Oarmv8a_smart_li reg_size))) [:: cast_const z ].
+
+Definition armv8a_swap t (x y z w : var_i) :=
+  Copn [:: Lvar x; Lvar y] t (Oasm (ExtOp (Oarmv8a_swap reg_size))) [:: Plvar z; Plvar w].
+
+Definition armv8a_saparams : stack_alloc_params :=
+  {|
+    sap_mov_ofs := armv8a_mov_ofs;
+    sap_immediate := armv8a_immediate;
+    sap_swap := armv8a_swap;
+  |}.
+
+(* ------------------------------------------------------------------------ *)
+(* Linearization parameters. *)
+
+Section LINEARIZATION.
+
+(* X16 and X17 are the AAPCS64 intra-procedure-call scratch registers. *)
+Notation vtmpi  := (mk_var_i (to_var R16)).
+Notation vtmp2i := (mk_var_i (to_var R17)).
+
+(* --- SP 16-byte alignment invariant --------------------------------------
+
+   On AArch64 the stack pointer must be quadword (16-byte) aligned whenever it
+   is used as the base of a memory access. This is an architectural check, not
+   merely an ABI convention:
+
+     "When the SP is used as the base address of a calculation, regardless of
+      any offset applied by the instruction, if bits [3:0] of the SP are not
+      0b0000, there is a misaligned SP." (Arm ARM DDI0487M.a, D1.4.10.2 "SP
+      alignment checking", rule RRDMXG, p. D1-7135.)
+     "If SP alignment checking is enabled, then the execution of a load or store
+      using the SP with a misaligned SP generates a synchronous SP Alignment
+      exception on that load or store." (ibid., rule RTFVSM.)
+
+   The check is enabled by SCTLR_ELx.SA / SCTLR_EL1.SA0 (ibid., rule RSTDYJ) and
+   is on for EL0 on the platforms we target (e.g. Linux, Apple). See also the
+   16-byte stack-alignment requirement of the AAPCS64 (Arm IHI 0055F, "The
+   stack", "SP mod 16 = 0" at a public interface), referenced from DDI0487M.a
+   B1.2, p. B1-203.
+
+   Jasmin sizes each stack frame to the alignment of the objects it holds
+   (sao_align), which for pure 64-bit code would be only 8 bytes, so a raw
+   frame size need not be a multiple of 16. The invariant is maintained on
+   the oracle side: the stack-alloc oracle raises every function's
+   [sao_align] to at least U128 ([sp_min_align] in
+   compiler/src/arch_full.ml, applied in varalloc.ml), and frame
+   allocations are rounded up to the frame alignment
+   ([stack_frame_allocation_size], linearization.v), so every SP
+   adjustment is a multiple of 16 and export entry alignment (guaranteed
+   16-byte by the platform) is preserved across calls. The operations
+   below therefore adjust SP by exactly the size they are given, as the
+   [h_linearization_params] specification requires. *)
+
+Definition armv8a_allocate_stack_frame (rspi : var_i) (tmp : option var_i) (sz : Z) :=
+  if tmp is Some aux then
+    ARMv8AFopn_smart_subi_tmp rspi aux sz
+  else
+    [:: ARMv8AFopn_subi rspi rspi sz].
+
+Definition armv8a_free_stack_frame (rspi : var_i) (tmp : option var_i) (sz : Z) :=
+  if tmp is Some aux then
+    ARMv8AFopn_smart_addi_tmp rspi aux sz
+  else
+    [:: ARMv8AFopn_addi rspi rspi sz].
+
+Definition armv8a_set_up_sp_register
+  (rspi : var_i)
+  (sf_sz : Z)
+  (al : wsize)
+  (r : var_i)
+  (tmp : var_i) :
+  seq fopn_args :=
+  (* [al] is the frame's [sao_align], which the oracle guarantees is at
+     least U128 (16 bytes); see the SP alignment invariant above. *)
+  let load_imm := ARMv8AFopn_smart_subi tmp rspi sf_sz in
+  let i0 := ARMv8AFopn_align tmp tmp al in
+  let i1 := ARMv8AFopn_mov r rspi in
+  let i2 := ARMv8AFopn_mov rspi tmp in
+  load_imm ++ [:: i0; i1; i2 ].
+
+Definition armv8a_tmp  : Ident.ident := vname (v_var vtmpi).
+Definition armv8a_tmp2 : Ident.ident := vname (v_var vtmp2i).
+
+Definition armv8a_lmove (_ : wsize) (xd xs : var_i) :=
+  ([:: LLvar xd], Oarmv8a (ARMv8A_op MOV default_opts), [:: Rexpr (Fvar xs)]).
+
+Definition armv8a_check_ws ws := ws == reg_size.
+
+Definition armv8a_lstore (ws : wsize) (xd : var_i) (ofs : Z) (xs : var_i) :=
+  let mn := STR in
+  ([:: Store Aligned ws (faddv Uptr xd (fconst ws ofs))], Oarmv8a (ARMv8A_op mn default_opts), [:: Rexpr (Fvar xs)]).
+
+Definition armv8a_lload (ws : wsize) (xd : var_i) (xs : var_i) (ofs : Z) :=
+  let mn := LDR in
+  ([:: LLvar xd], Oarmv8a (ARMv8A_op mn default_opts), [:: Load Aligned ws (faddv Uptr xs (fconst ws ofs))]).
+
+(* Restore saved values from the stack. Unlike ARMv7 (where SP/R13 is an
+   ordinary register that LDR can target), an A64 load writes its result through
+   the general-purpose (X[]) register accessor, for which register number 31 is
+   the zero register ZR, not SP (Arm ARM DDI0487M.a, B1.2, p. B1-206; and the
+   LDR encoding takes <Xt>, never <Xt|SP>). The stack-pointer slot therefore
+   cannot be reloaded directly: the saved registers are restored first (relative
+   to the still-live SP), then the saved stack pointer is loaded into the scratch
+   register X17 and copied to SP with a MOV (which reaches SP via the SP[]
+   accessor). Large offsets are materialized into X17 as in [lloads_imm_dfl]. *)
+Definition armv8a_lloads (rspi : var_i) (to_restore : seq (var * Z)) (spofs : Z) :
+    seq fopn_args :=
+  let restore_regs :=
+    if all (fun '(_, ofs) => is_arith_small ofs) to_restore then
+      map (fun '(x, ofs) =>
+             armv8a_lload (wsize_of_atype (vtype x)) (VarI x dummy_var_info) rspi ofs)
+          to_restore
+    else
+      let ofs0 := snd (head (v_var rspi, 0%Z) to_restore) in
+      let to_restore := map (fun '(x, ofs) => (x, ofs - ofs0)%Z) to_restore in
+      ARMv8AFopn_smart_addi vtmp2i rspi ofs0
+        ++ map (fun '(x, ofs) =>
+                  armv8a_lload (wsize_of_atype (vtype x)) (VarI x dummy_var_info) vtmp2i ofs)
+               to_restore
+  in
+  let restore_sp :=
+    if is_arith_small spofs then
+      [:: armv8a_lload Uptr vtmp2i rspi spofs; armv8a_lmove Uptr rspi vtmp2i ]
+    else
+      ARMv8AFopn_smart_addi vtmp2i rspi spofs
+        ++ [:: armv8a_lload Uptr vtmp2i vtmp2i 0; armv8a_lmove Uptr rspi vtmp2i ]
+  in
+  restore_regs ++ restore_sp.
+
+Definition armv8a_liparams : linearization_params :=
+  {|
+    lip_tmp  := armv8a_tmp;
+    lip_tmp2 := armv8a_tmp2;
+    lip_not_saved_stack := [:: armv8a_tmp ];
+    lip_allocate_stack_frame := armv8a_allocate_stack_frame;
+    lip_free_stack_frame := armv8a_free_stack_frame;
+    lip_set_up_sp_register := armv8a_set_up_sp_register;
+    lip_lmove := armv8a_lmove;
+    lip_check_ws := armv8a_check_ws;
+    lip_lstore  := armv8a_lstore;
+    lip_lload := armv8a_lload;
+    lip_lstores := lstores_imm_dfl armv8a_tmp2 armv8a_lstore ARMv8AFopn_smart_addi is_arith_small;
+    lip_lloads  := armv8a_lloads;
+  |}.
+
+End LINEARIZATION.
+
+
+(* ------------------------------------------------------------------------ *)
+(* Lowering parameters. *)
+
+#[ local ]
+Definition armv8a_fvars_correct
+  (fv : fresh_vars)
+  {pT : progT}
+  (fds : seq fun_decl) :
+  bool :=
+  fvars_correct (all_fresh_vars fv) (fvars fv) fds.
+
+Definition armv8a_loparams : lowering_params :=
+  {|
+    lop_lower_i _ := lower_i;
+    lop_fvars_correct := armv8a_fvars_correct;
+  |}.
+
+
+(* ------------------------------------------------------------------------ *)
+(* Speculative execution operator lowering parameters. *)
+
+Definition armv8a_shparams : sh_params :=
+  {|
+    shp_lower := fun _ _ _ => None;
+  |}.
+
+(* ------------------------------------------------------------------------ *)
+(* Assembly generation parameters. *)
+
+Definition condt_of_rflag (r : rflag) : condt :=
+  match r with
+  | NF => MI_ct
+  | ZF => EQ_ct
+  | CF => CS_ct
+  | VF => VS_ct
+  end.
+
+Definition condt_not (c : condt) : condt :=
+  match c with
+  | EQ_ct => NE_ct
+  | NE_ct => EQ_ct
+  | CS_ct => CC_ct
+  | CC_ct => CS_ct
+  | MI_ct => PL_ct
+  | PL_ct => MI_ct
+  | VS_ct => VC_ct
+  | VC_ct => VS_ct
+  | HI_ct => LS_ct
+  | LS_ct => HI_ct
+  | GE_ct => LT_ct
+  | LT_ct => GE_ct
+  | GT_ct => LE_ct
+  | LE_ct => GT_ct
+  end.
+
+Definition condt_and (c0 c1 : condt) : option condt :=
+  match c0, c1 with
+  | CS_ct, NE_ct => Some HI_ct
+  | NE_ct, CS_ct => Some HI_ct
+  | NE_ct, GE_ct => Some GT_ct
+  | GE_ct, NE_ct => Some GT_ct
+  | _, _ => None
+  end.
+
+Definition condt_or (c0 c1 : condt) : option condt :=
+  match c0, c1 with
+  | CC_ct, EQ_ct => Some LS_ct
+  | EQ_ct, CC_ct => Some LS_ct
+  | EQ_ct, LT_ct => Some LE_ct
+  | LT_ct, EQ_ct => Some LE_ct
+  | _, _ => None
+  end.
+
+Definition is_rflags_GE (r0 r1 : rflag) : bool :=
+  match r0, r1 with
+  | NF, VF => true
+  | VF, NF => true
+  | _, _ => false
+  end.
+
+Fixpoint assemble_cond ii (e : fexpr) : cexec condt :=
+  match e with
+  | Fvar v =>
+      Let r := of_var_e ii v in ok (condt_of_rflag r)
+
+  | Fapp1 Onot e =>
+      Let c := assemble_cond ii e in ok (condt_not c)
+
+  | Fapp2 Oand e0 e1 =>
+      Let c0 := assemble_cond ii e0 in
+      Let c1 := assemble_cond ii e1 in
+      if condt_and c0 c1 is Some ct
+      then ok ct
+      else Error (E.berror ii e "Invalid condition (AND)")
+
+  | Fapp2 Oor e0 e1 =>
+      Let c0 := assemble_cond ii e0 in
+      Let c1 := assemble_cond ii e1 in
+      if condt_or c0 c1 is Some ct
+      then ok ct
+      else Error (E.berror ii e "Invalid condition (OR)")
+
+  | Fapp2 Obeq (Fvar x0) (Fvar x1) =>
+      Let r0 := of_var_e ii x0 in
+      Let r1 := of_var_e ii x1 in
+      if is_rflags_GE r0 r1
+      then ok GE_ct
+      else Error (E.berror ii e "Invalid condition (EQ).")
+
+  | _ =>
+      Error (E.berror ii e "Can't assemble condition.")
+  end.
+
+Definition is_valid_address (addr : reg_address) :=
+  match addr.(ad_disp) != 0%w, isSome addr.(ad_offset), addr.(ad_scale) != 0 with
+  | false, false, false => true
+  | true, false, false => true
+  | false, true, false => true
+  | false, true, true => true
+  | _, _, _ => false
+  end.
+
+Definition armv8a_agparams : asm_gen_params :=
+  {|
+    agp_assemble_cond := assemble_cond;
+    agp_is_valid_address := is_valid_address;
+  |}.
+
+(* ------------------------------------------------------------------------ *)
+(* Stack zeroization parameters. *)
+
+Definition armv8a_szparams : stack_zeroization_params :=
+  {|
+    szp_cmd := stack_zeroization_cmd;
+  |}.
+
+(* ------------------------------------------------------------------------ *)
+(* Shared parameters. *)
+
+Definition armv8a_is_move_op (o : asm_op_t) : bool :=
+  match o with
+  | BaseOp (None, ARMv8A_op o opts) =>
+    if o \in [:: MOV; LDR; STR; STRH; STRB ] then
+      ~~ has_shift opts
+    else false
+
+  | _ =>
+      false
+  end.
+
+Definition armv8a_params : architecture_params :=
+  {|
+    ap_sap := armv8a_saparams;
+    ap_lip := armv8a_liparams;
+    ap_plp := false;
+    ap_lop := armv8a_loparams;
+    ap_lap := {| lap_lower_address := fun _ p => ok p |};
+    ap_agp := armv8a_agparams;
+    ap_szp := armv8a_szparams;
+    ap_shp := armv8a_shparams;
+    ap_is_move_op := armv8a_is_move_op;
+  |}.
+
+End Section.

--- a/proofs/compiler/armv8a_params_common_proof.v
+++ b/proofs/compiler/armv8a_params_common_proof.v
@@ -1,0 +1,274 @@
+(* Correctness of the params-level ARMv8-A operation wrappers
+   ([ARMv8AFopn_*] in armv8a_params.v), mirroring [arm_params_common_proof.v].
+
+   These lemmas lift the core [sem_fopn_args] results of
+   [armv8a_params_core_proof.v] through the [to_opn] wrapper (which tags the
+   core op with [Oarmv8a]) to the generic linear-semantics [sem_fopn_args] and
+   [eval_instr], for the single-instruction builders used by the compiler's
+   stack handling: [mov], [addi], [subi] and [align], and for the
+   [li]-based smart combinators [smart_addi], [smart_subi] and their
+   in-place [_tmp] variants. *)
+
+From Coq Require Import Lia.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype ssralg.
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  arch_params
+  compiler_util
+  expr
+  fexpr
+  fexpr_sem
+  linear
+  linear_sem
+  linear_facts
+  psem.
+Require Import
+  arch_decl
+  arch_extra
+  sem_params_of_arch_extra.
+Require Import
+  armv8a_decl
+  armv8a_extra
+  armv8a_instr_decl
+  armv8a_params_core
+  armv8a_params_core_proof
+  armv8a_params.
+
+Ltac t_armv8a_op :=
+  rewrite /eval_instr /= /sem_sopn /= /exec_sopn /get_gvar /=;
+  t_simpl_rewrites;
+  rewrite /of_estate /= /with_vm /=;
+  repeat rewrite truncate_word_u /=;
+  rewrite ?zero_extend_u ?addn1;
+  t_simpl_rewrites.
+
+Module ARMv8AFopnP.
+
+Section WITH_PARAMS.
+
+Context
+  {atoI  : arch_toIdent}
+  {syscall_state : Type}
+  {sc_sem : syscall_sem syscall_state}
+  {call_conv : calling_convention}.
+
+#[local] Existing Instance withsubword.
+
+Let mkv xname vi :=
+  let: x := {| vname := xname; vtype := aword armv8a_reg_size; |} in
+  let: xi := {| v_var := x; v_info := vi; |} in
+  (xi, x).
+
+Lemma sem_fopn_equiv o s :
+  ARMv8AFopn_coreP.sem_fopn_args o s = sem_fopn_args (to_opn o) s.
+Proof.
+  case: o => -[xs o] es /=; case: sem_rexprs => //= >.
+  rewrite /exec_sopn /= /sopn_sem /=; case: id_valid => //=.
+  rewrite /sopn_sem_ /= /semi_to_atype.
+  move: (computational_eq _) (computational_eq _) => e1 e2.
+  rewrite <- e1, <- e2.
+  by case: app_sopn.
+Qed.
+
+Lemma sem_fopns_equiv o s :
+  ARMv8AFopn_coreP.sem_fopns_args s o = sem_fopns_args s (map to_opn o).
+Proof. by elim: o s => //= o os ih s; rewrite sem_fopn_equiv; case: sem_fopn_args. Qed.
+
+Section ARMV8A_OP.
+
+Notation next_vm_ls ls vm := (lnext_pc (lset_vm ls vm)) (only parsing).
+
+Lemma mov_sem_fopn_args {s} {xi:var_i} {y} {wy : word Uptr} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  let: vm' := (evm s).[xi <- Vword wy] in
+  sem_fopn_args (ARMv8AFopn_mov xi y) s = ok (with_vm s vm').
+Proof. by move=> hc h; rewrite -sem_fopn_equiv; apply: ARMv8AFopn_coreP.mov_sem_fopn_args. Qed.
+
+Lemma addi_sem_fopn_args {s} {xi:var_i} {y imm wy} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  let: wx' := Vword (wy + wrepr reg_size imm)in
+  let: vm' := (evm s).[xi <- wx'] in
+  sem_fopn_args (ARMv8AFopn_addi xi y imm) s = ok (with_vm s vm').
+Proof. by move=> hc h; rewrite -sem_fopn_equiv; apply: ARMv8AFopn_coreP.addi_sem_fopn_args. Qed.
+
+Lemma subi_sem_fopn_args {s} {xi:var_i} {y imm wy} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  let: wx' := Vword (wy - wrepr reg_size imm)in
+  let: vm' := (evm s).[xi <- wx'] in
+  sem_fopn_args (ARMv8AFopn_subi xi y imm) s = ok (with_vm s vm').
+Proof. by move=> hc h; rewrite -sem_fopn_equiv; apply: ARMv8AFopn_coreP.subi_sem_fopn_args. Qed.
+
+(* The alignment mask [Z_mod_lnot (wsize_size al - 1)] is the complement of
+   [wsize_size al - 1], i.e. [-wsize_size al] modulo the register base, so the
+   AND behind [align] computes exactly [align_word]. *)
+Lemma armv8a_align_mask (ws : wsize) al :
+  wrepr ws (Z_mod_lnot (wsize_size al - 1) ws) = wrepr ws (- wsize_size al).
+Proof.
+  rewrite /Z_mod_lnot wrepr_mod -wrepr_wnot wrepr_mod wrepr_wnot ZlnotE.
+  by f_equal; ring.
+Qed.
+
+Lemma align_sem_fopn_args {s} {xi:var_i} {y al} {wy : word Uptr} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  let: wx' := Vword (align_word al wy) in
+  let: vm' := (evm s).[xi <- wx'] in
+  sem_fopn_args (ARMv8AFopn_align xi y al) s = ok (with_vm s vm').
+Proof.
+  move=> hc h.
+  rewrite -sem_fopn_equiv /ARMv8AFopn_core.align /align_word -armv8a_align_mask.
+  exact: (ARMv8AFopn_coreP.andi_sem_fopn_args (imm := Z_mod_lnot (wsize_size al - 1) reg_size) hc h).
+Qed.
+
+Lemma mov_eval_instr {lp ls ii xname vi y} {wy : word Uptr} :
+  let: (xi, x) := mkv xname vi in
+  get_var true (lvm ls) (v_var y) = ok (Vword wy) ->
+  let: li := li_of_fopn_args ii (ARMv8AFopn_mov xi y) in
+  let: vm' := (lvm ls).[x <- Vword wy] in
+  eval_instr lp li ls = ok (next_vm_ls ls vm').
+Proof.
+  move=> hy.
+  have := mov_sem_fopn_args (s:=to_estate _) (xi:=(mkv xname vi).1) erefl (to_word_get_var hy).
+  by apply: sem_fopn_args_eval_instr.
+Qed.
+
+Lemma addi_eval_instr {lp ls ii xname vi y imm wy} :
+  let: (xi, x) := mkv xname vi in
+  get_var true (lvm ls) (v_var y) = ok (Vword wy) ->
+  let: li := li_of_fopn_args ii (ARMv8AFopn_addi xi y imm) in
+  let: wx' := Vword (wy + wrepr reg_size imm)in
+  let: vm' := (lvm ls).[x <- wx'] in
+  eval_instr lp li ls = ok (next_vm_ls ls vm').
+Proof.
+  move=> h1.
+  have := addi_sem_fopn_args (s:=to_estate _) (xi:=(mkv xname vi).1) (imm:=imm) erefl (to_word_get_var h1).
+  by apply: sem_fopn_args_eval_instr.
+Qed.
+
+Lemma subi_eval_instr {lp ls ii xname vi y imm wy} :
+  let: (xi, x) := mkv xname vi in
+  get_var true (lvm ls) (v_var y) = ok (Vword wy) ->
+  let: li := li_of_fopn_args ii (ARMv8AFopn_subi xi y imm) in
+  let: wx' := Vword (wy - wrepr reg_size imm)in
+  let: vm' := (lvm ls).[x <- wx'] in
+  eval_instr lp li ls = ok (next_vm_ls ls vm').
+Proof.
+  move=> h1.
+  have := subi_sem_fopn_args (s:=to_estate _) (xi:=(mkv xname vi).1) (imm:=imm) erefl (to_word_get_var h1).
+  by apply: sem_fopn_args_eval_instr.
+Qed.
+
+Lemma align_eval_instr {lp ls ii xname vi y al} {wy : word Uptr} :
+  let: (xi, x) := mkv xname vi in
+  get_var true (lvm ls) (v_var y) = ok (Vword wy) ->
+  let: li := li_of_fopn_args ii (ARMv8AFopn_align xi y al) in
+  let: wx' := Vword (align_word al wy) in
+  let: vm' := (lvm ls).[x <- wx'] in
+  eval_instr lp li ls = ok (next_vm_ls ls vm').
+Proof.
+  move=> h1.
+  have := align_sem_fopn_args (s:=to_estate _) (xi:=(mkv xname vi).1) (al:=al) erefl (to_word_get_var h1).
+  by apply: sem_fopn_args_eval_instr.
+Qed.
+
+End ARMV8A_OP.
+
+Lemma smart_addi_sem_fopn_args (xi:var_i) y imm s (w : word Uptr) :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: lc := ARMv8AFopn_smart_addi xi y imm in
+  is_arith_small imm \/ xi <> v_var y :> var ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok w ->
+  exists vm',
+    [/\ sem_fopns_args s lc = ok (with_vm s vm')
+      , vm' =[\ Sv.singleton xi ] evm s
+      & get_var true vm' xi = ok (Vword (w + wrepr reg_size imm)%R) ].
+Proof.
+  move=> hc hor hget; rewrite -sem_fopns_equiv.
+  have := [elaborate
+    ARMv8AFopn_coreP.gen_smart_opi_sem_fopn_args
+      (is_small := is_arith_small) (neutral := Some 0%Z)
+      (@ARMv8AFopn_coreP.add_sem_fopn_args _ _)
+      (@ARMv8AFopn_coreP.addi_sem_fopn_args _ _)].
+  move=> /(_ _ xi xi y imm s w) [] //.
+  + by move=> >; rewrite wrepr0 GRing.addr0.
+  move=> vm' [hsem heq heqx]; exists vm'; split => //=.
+  by apply: eq_exI heq; clear; SvD.fsetdec.
+Qed.
+
+Lemma smart_subi_sem_fopn_args (xi:var_i) y imm s (w : word Uptr) :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: lc := ARMv8AFopn_smart_subi xi y imm in
+  is_arith_small imm \/ xi <> v_var y :> var ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok w ->
+  exists vm',
+    [/\ sem_fopns_args s lc = ok (with_vm s vm')
+      , vm' =[\ Sv.singleton xi ] evm s
+      & get_var true vm' xi = ok (Vword (w - wrepr reg_size imm)%R) ].
+Proof.
+  move=> hc hor hget; rewrite -sem_fopns_equiv.
+  have := [elaborate
+    ARMv8AFopn_coreP.gen_smart_opi_sem_fopn_args
+      (is_small := is_arith_small) (neutral := Some 0%Z)
+      (@ARMv8AFopn_coreP.sub_sem_fopn_args _ _)
+      (@ARMv8AFopn_coreP.subi_sem_fopn_args _ _)].
+  move=> /(_ _ xi xi y imm s w) [] //.
+  + by move=> >; rewrite wrepr0 GRing.subr0.
+  move=> vm' [hsem heq heqx]; exists vm'; split => //=.
+  by apply: eq_exI heq; clear; SvD.fsetdec.
+Qed.
+
+Lemma smart_addi_tmp_sem_fopn_args s (tmp xi : var_i) imm (w : word Uptr) :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: lcmd := ARMv8AFopn_smart_addi_tmp xi tmp imm in
+  v_var xi <> v_var tmp ->
+  convertible (vtype tmp) (aword Uptr) ->
+  get_var true (evm s) (v_var xi) >>= to_word Uptr = ok w ->
+  exists vm',
+    [/\ sem_fopns_args s lcmd = ok (with_vm s vm')
+      , evm s =[\ Sv.add xi (Sv.singleton tmp) ] vm'
+      & get_var true vm' xi = ok (Vword (w + wrepr reg_size imm)%R) ].
+Proof.
+  move=> hc hne hty hget; rewrite -sem_fopns_equiv.
+  have := [elaborate
+    ARMv8AFopn_coreP.gen_smart_opi_sem_fopn_args
+      (is_small := is_arith_small) (neutral := Some 0%Z)
+      (@ARMv8AFopn_coreP.add_sem_fopn_args _ _)
+      (@ARMv8AFopn_coreP.addi_sem_fopn_args _ _)].
+  move=> /(_ _ tmp xi xi imm s w) [] //.
+  + by move=> >; rewrite wrepr0 GRing.addr0.
+  + by right => h; rewrite h in hne.
+  move=> vm' [hsem heq heqx]; exists vm'; split => //=.
+  by apply: eq_exS.
+Qed.
+
+Lemma smart_subi_tmp_sem_fopn_args s (tmp xi : var_i) imm (w : word Uptr) :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: lcmd := ARMv8AFopn_smart_subi_tmp xi tmp imm in
+  v_var xi <> v_var tmp ->
+  convertible (vtype tmp) (aword Uptr) ->
+  get_var true (evm s) (v_var xi) >>= to_word Uptr = ok w ->
+  exists vm',
+    [/\ sem_fopns_args s lcmd = ok (with_vm s vm')
+      , evm s =[\ Sv.add xi (Sv.singleton tmp) ] vm'
+      & get_var true vm' xi = ok (Vword (w - wrepr reg_size imm)%R) ].
+Proof.
+  move=> hc hne hty hget; rewrite -sem_fopns_equiv.
+  have := [elaborate
+    ARMv8AFopn_coreP.gen_smart_opi_sem_fopn_args
+      (is_small := is_arith_small) (neutral := Some 0%Z)
+      (@ARMv8AFopn_coreP.sub_sem_fopn_args _ _)
+      (@ARMv8AFopn_coreP.subi_sem_fopn_args _ _)].
+  move=> /(_ _ tmp xi xi imm s w) [] //.
+  + by move=> >; rewrite wrepr0 GRing.subr0.
+  + by right => h; rewrite h in hne.
+  move=> vm' [hsem heq heqx]; exists vm'; split => //=.
+  by apply: eq_exS.
+Qed.
+
+End WITH_PARAMS.
+
+End ARMv8AFopnP.

--- a/proofs/compiler/armv8a_params_core.v
+++ b/proofs/compiler/armv8a_params_core.v
@@ -1,0 +1,149 @@
+(* ARMv8-A (AArch64) core operation builders.
+
+   Sequences of base instructions used by the compiler itself (stack
+   handling, immediate materialization, ...). *)
+
+From mathcomp Require Import ssreflect ssrfun ssrbool seq eqtype.
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  compiler_util
+  expr
+  fexpr
+  linear.
+Require Import
+  arch_decl.
+Require Import
+  armv8a_decl
+  armv8a_instr_decl.
+
+(* An immediate is directly encodable in an ADD/SUB immediate instruction if
+   it is a 12-bit unsigned immediate, optionally shifted left by 12 bits
+   (ARM DDI 0487 M.a, C6.2.5 ADD (immediate)). This is the same predicate
+   the [CAimmC_armv8a_arith_imm] argument checker enforces at assembly
+   generation. *)
+Definition is_arith_small (imm : Z) : bool := is_arith_imm imm.
+
+Definition Z_mod_lnot (z : Z) (ws : wsize) : Z :=
+  let m := wbase ws in
+  (Z.lnot (z mod m) mod m)%Z.
+
+Module ARMv8AFopn_core.
+
+  #[local]
+  Open Scope Z.
+
+  Section WITH_PARAMS.
+
+  Definition opn_args := (seq lexpr * armv8a_asm_op * seq rexpr)%type.
+
+  Let op_gen mn x res : opn_args :=
+    ([:: LLvar x ], ARMv8A_op mn default_opts, res).
+  Let op_un_reg mn x y := op_gen mn x [:: rvar y ].
+  Let op_un_imm mn x imm := op_gen mn x [:: rconst reg_size imm ].
+  Let op_bin_reg mn x y z := op_gen mn x [:: rvar y; rvar z ].
+  Let op_bin_imm mn x y imm := op_gen mn x [:: rvar y; rconst reg_size imm ].
+
+  Definition mov := op_un_reg MOV.
+  Definition add := op_bin_reg ADD.
+  Definition sub := op_bin_reg SUB.
+
+  Definition movi := op_un_imm MOV.
+  Definition addi := op_bin_imm ADD.
+  Definition subi := op_bin_imm SUB.
+
+  Definition andi := op_bin_imm AND.
+
+  Let op_gen_at ws mn x res : opn_args :=
+    ([:: LLvar x ], ARMv8A_op mn (opts_at ws), res).
+
+  (* [MOVZ x, #imm, LSL #sh]: set [x] to [imm << sh], zeroing the rest. *)
+  Definition movz ws x imm sh :=
+    op_gen_at ws MOVZ x [:: rconst U16 imm; rconst U8 sh ].
+
+  (* [MOVN x, #imm, LSL #sh]: set [x] to [NOT (imm << sh)]. *)
+  Definition movn ws x imm sh :=
+    op_gen_at ws MOVN x [:: rconst U16 imm; rconst U8 sh ].
+
+  (* [MOVK x, #imm, LSL #sh]: insert [imm] at bits [sh+15:sh] of [x]. *)
+  Definition movk ws x imm sh :=
+    op_gen_at ws MOVK x [:: rvar x; rconst U16 imm; rconst U8 sh ].
+
+  Definition str x y off :=
+    let lv := lstore Aligned reg_size y off in
+    ([:: lv ], ARMv8A_op STR default_opts, [:: rvar x ]).
+
+  (* Align [y] downwards to a multiple of the alignment [al] with a
+     bitwise AND of the complement mask ([AND] accepts it as a bitmask
+     immediate since alignments are powers of two). *)
+  Definition align x y al := andi x y (Z_mod_lnot (wsize_size al - 1) reg_size).
+
+  (* Load an immediate to a register with a MOVZ/MOVK sequence.
+     A single MOVN covers the values whose upper 16-bit chunks are all
+     ones. In the general case, the low 16-bit chunk is set with MOVZ
+     (which zeroes the rest of the register) and every non-zero higher
+     chunk is inserted with MOVK. *)
+  Definition li (ws : wsize) x imm : seq opn_args :=
+    let n := imm mod (wbase ws) in
+    if n <? 2 ^ 16
+    then [:: movz ws x n 0 ]
+    else
+      if wbase ws - 2 ^ 16 <=? n
+      then [:: movn ws x (Z_mod_lnot n ws) 0 ]
+      else
+        let c0 := n mod (2 ^ 16) in
+        let c1 := (n / 2 ^ 16) mod (2 ^ 16) in
+        let c2 := (n / 2 ^ 32) mod (2 ^ 16) in
+        let c3 := (n / 2 ^ 48) mod (2 ^ 16) in
+        [:: movz ws x c0 0 ]
+          ++ (if c1 =? 0 then [::] else [:: movk ws x c1 16 ])
+          ++ (if (c2 =? 0) || (ws != U64) then [::] else [:: movk ws x c2 32 ])
+          ++ (if (c3 =? 0) || (ws != U64) then [::] else [:: movk ws x c3 48 ]).
+
+  Definition smart_mov x y :=
+    if v_var x == v_var y then [::] else [:: mov x y ].
+
+  (* Compute [R[x] := R[y] <o> imm % 2^64].
+     Precondition: if [imm] is large, [y <> tmp]. *)
+  Definition gen_smart_opi
+    (on_reg : var_i -> var_i -> var_i -> opn_args)
+    (on_imm : var_i -> var_i -> Z -> opn_args)
+    (is_small : Z -> bool)
+    (neutral : option Z)
+    (tmp x y : var_i)
+    (imm : Z) :
+    seq opn_args :=
+    let is_mov := if neutral is Some n then (imm =? n)%Z else false in
+    if is_mov
+    then smart_mov x y
+    else
+      if is_small imm
+      then [:: on_imm x y imm ]
+      else rcons (li U64 tmp imm) (on_reg x y tmp).
+
+  (* Compute [R[x] := R[y] + imm % 2^64].
+     Precondition: if [imm] is large, [x <> y]. *)
+  Definition smart_addi x y :=
+    gen_smart_opi add addi is_arith_small (Some 0%Z) x x y.
+
+  (* Compute [R[x] := R[y] - imm % 2^64].
+     Precondition: if [imm] is large, [x <> y]. *)
+  Definition smart_subi x y imm :=
+    gen_smart_opi sub subi is_arith_small (Some 0%Z) x x y imm.
+
+  (* Compute [R[x] := R[x] <o> imm % 2^64].
+     Precondition: if [imm] is large, [x <> tmp]. *)
+  Definition gen_smart_opi_tmp on_reg on_imm x tmp imm :=
+    gen_smart_opi on_reg on_imm is_arith_small (Some 0%Z) tmp x x imm.
+
+  (* Compute [R[x] := R[x] + imm % 2^64].
+     Precondition: if [imm] is large, [x <> tmp]. *)
+  Definition smart_addi_tmp x tmp imm := gen_smart_opi_tmp add addi x tmp imm.
+
+  (* Compute [R[x] := R[x] - imm % 2^64].
+     Precondition: if [imm] is large, [x <> tmp]. *)
+  Definition smart_subi_tmp x tmp imm := gen_smart_opi_tmp sub subi x tmp imm.
+
+  End WITH_PARAMS.
+
+End ARMv8AFopn_core.

--- a/proofs/compiler/armv8a_params_core_proof.v
+++ b/proofs/compiler/armv8a_params_core_proof.v
@@ -1,0 +1,722 @@
+(* Semantic correctness of the ARMv8-A core operation builders
+   ([ARMv8AFopn_core], armv8a_params_core.v), mirroring
+   [arm_params_core_proof.v].
+
+   Proven here: the [sem_fopn_args] lemmas for the single-instruction builders
+   used by the compiler's stack handling and immediate materialization —
+   [add], [addi], [sub], [subi], [mov], [andi] (the AND behind [align]),
+   [movz], [movn], [movk] — the [smart_mov] combinator, the immediate
+   materialization [li] (at register size, the form the compiler emits
+   through [gen_smart_opi]) and the [gen_smart_opi] combinator.
+
+   Unlike ARMv7-M, which materializes a 32-bit immediate with a fixed
+   MOV/MOVT pair, the AArch64 [li] emits a variable-length MOVZ/MOVN/MOVK
+   sequence over up to four 16-bit chunks of a 64-bit register. Its proof
+   goes through an invariant on the chunk chain — after inserting chunk [k],
+   the register holds [wrepr U64 (imm mod 2 ^ (16 * (k + 1)))] — so the
+   chunks skipped because they are zero preserve the invariant for free.
+   The word-level facts about the decomposition ([armv8a_MOVK_semiE] and
+   friends) are stated for any operand width, so the assembly-generation
+   proof of [Oarmv8a_smart_li] can reuse them at U32. *)
+
+From Coq Require Import Lia.
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat seq eqtype fintype ssralg.
+From mathcomp Require Import word_ssrZ.
+
+Require Import
+  arch_params
+  compiler_util
+  expr
+  fexpr
+  fexpr_sem
+  linear
+  linear_sem
+  linear_facts
+  psem.
+Require Import
+  arch_decl
+  arch_sem.
+
+Require Import
+  armv8a_decl
+  armv8a_instr_decl
+  armv8a_params_core.
+
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
+Module ARMv8AFopn_coreP.
+
+Section Section.
+
+Context
+  {syscall_state : Type}
+  {ep : EstateParams syscall_state}.
+
+#[local] Existing Instance withsubword.
+
+Definition sem_fopn_args (p : seq lexpr * armv8a_asm_op * seq rexpr) (s : estate) :=
+  let: (xs,o,es) := p in
+  Let args := sem_rexprs s es in
+  let op := instr_desc_op o in
+  Let _ := assert (id_valid op) ErrType in
+  Let t := app_sopn (map eval_ltype (id_tin op)) (id_semi op) args in
+  let res := list_ltuple t in
+  write_lexprs xs res s.
+
+Definition sem_fopns_args := foldM sem_fopn_args.
+
+Ltac t_armv8a_op :=
+  rewrite /sem_fopn_args /get_gvar /=;
+  t_simpl_rewrites;
+  rewrite /= /with_vm /=;
+  repeat rewrite truncate_word_u /=;
+  rewrite ?zero_extend_u ?addn1;
+  t_simpl_rewrites.
+
+Lemma add_sem_fopn_args {s} {xi:var_i} {y} {wy : word Uptr} {z} {wz : word Uptr} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var z) >>= to_word Uptr = ok wz ->
+  let: wx' := Vword (wy + wz)in
+  let: vm' := (evm s).[xi <- wx'] in
+  sem_fopn_args (ARMv8AFopn_core.add xi y z) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_xrbindP => *; t_armv8a_op.
+  by rewrite /= set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Lemma addi_sem_fopn_args {s} {xi:var_i} {y imm wy} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  let: wx' := Vword (wy + wrepr reg_size imm)in
+  let: vm' := (evm s).[xi <- wx'] in
+  sem_fopn_args (ARMv8AFopn_core.addi xi y imm) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_xrbindP => *; t_armv8a_op.
+  by rewrite /= set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Lemma sub_sem_fopn_args {s} {xi:var_i} {y} {wy : word Uptr} {z} {wz : word Uptr} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  get_var true (evm s) (v_var z) >>= to_word Uptr = ok wz ->
+  let: wx' := Vword (wy - wz)in
+  let: vm' := (evm s).[xi <- wx'] in
+  sem_fopn_args (ARMv8AFopn_core.sub xi y z) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_xrbindP => *; t_armv8a_op.
+  by rewrite /= /armv8a_SUB_semi sub_wordE set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Lemma subi_sem_fopn_args {s} {xi:var_i} {y imm wy} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  let: wx' := Vword (wy - wrepr reg_size imm)in
+  let: vm' := (evm s).[xi <- wx'] in
+  sem_fopn_args (ARMv8AFopn_core.subi xi y imm) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_xrbindP => *; t_armv8a_op.
+  by rewrite /= /armv8a_SUB_semi sub_wordE set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Lemma mov_sem_fopn_args {s} {xi:var_i} {y} {wy : word Uptr} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  let: vm' := (evm s).[xi <- Vword wy] in
+  sem_fopn_args (ARMv8AFopn_core.mov xi y) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_xrbindP => *; t_armv8a_op.
+  by rewrite /= /armv8a_MOV_semi set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Lemma andi_sem_fopn_args {s} {xi:var_i} {y imm wy} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy ->
+  let: wx' := Vword (wand wy (wrepr reg_size imm)) in
+  let: vm' := (evm s).[xi <- wx'] in
+  sem_fopn_args (ARMv8AFopn_core.andi xi y imm) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_xrbindP => *; t_armv8a_op.
+  by rewrite /= /armv8a_bitwise_semi set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Opaque ARMv8AFopn_core.add.
+Opaque ARMv8AFopn_core.addi.
+Opaque ARMv8AFopn_core.mov.
+Opaque ARMv8AFopn_core.sub.
+Opaque ARMv8AFopn_core.subi.
+Opaque ARMv8AFopn_core.andi.
+
+(* -------------------------------------------------------------------- *)
+(* Word-level facts about the MOVZ/MOVN/MOVK immediate decomposition.
+   Stated for any operand width [ws] (with the shift position bounded by
+   [wsize_bits ws]) so they serve both the register-size [li] below and
+   the U32 form of [Oarmv8a_smart_li] at assembly generation. *)
+
+Lemma wsize_bits_Zof ws :
+  wsize_bits ws = Z.of_nat (wsize_size_minus_1 ws).+1.
+Proof. by case: ws. Qed.
+
+Lemma wbase_pow_bits ws : wbase ws = (2 ^ wsize_bits ws)%Z.
+Proof. by rewrite wbaseE wsize_bits_Zof. Qed.
+
+Lemma wsize_bits_le_256 ws : (wsize_bits ws <= 256)%Z.
+Proof. by case: ws. Qed.
+
+(* Splitting an [n]-aligned sum bit by bit: below [n] the bits come from
+   [lbs], from [n] up they come from [hbs]. The ARMv7-M analog
+   [arm_params_core_proof.wbit_n_add] requires [2 ^ n * 2 ^ n <= wbase ws],
+   which fails for the high chunks of a 64-bit word; here the sum is only
+   required to fit the word. *)
+Lemma wbit_n_add ws (n lbs hbs : Z) (i : nat) :
+  (0 <= n)%Z ->
+  (0 <= lbs < 2 ^ n)%Z ->
+  (0 <= hbs)%Z ->
+  (2 ^ n * hbs + lbs < wbase ws)%Z ->
+  wbit_n (wrepr ws (2 ^ n * hbs + lbs)) i
+  = if (Z.of_nat i <? n)%Z
+    then wbit_n (wrepr ws lbs) i
+    else wbit_n (wrepr ws hbs) (i - Z.to_nat n).
+Proof.
+  move=> h0n hlbs hhbs hsum.
+  have h0i := Zle_0_nat i.
+  have h2n : (0 < 2 ^ n)%Z by apply: Z.pow_pos_nonneg.
+  have hmul : (0 <= 2 ^ n * hbs)%Z by nia.
+  have hrange : (0 <= 2 ^ n * hbs + lbs < wbase ws)%Z by lia.
+
+  case: ZltP => hi /=.
+
+  all: rewrite wbit_nE.
+  all: rewrite (wunsigned_repr_small hrange).
+
+  - rewrite -(Zplus_minus (Z.of_nat i) n) Z.pow_add_r; last lia; last done.
+    rewrite Z.add_comm -Z.mul_assoc Z.mul_comm Z_div_plus; first last.
+    + by apply/Z.lt_gt/Z.pow_pos_nonneg; lia.
+    rewrite Z.odd_add Z_odd_pow_2; last lia.
+    rewrite Bool.xorb_false_r wbit_nE.
+    rewrite wunsigned_repr_small; first done.
+    lia.
+
+  rewrite -(Zplus_minus n (Z.of_nat i)) (Z.pow_add_r _ _ _ h0n); last lia.
+  rewrite -Z.div_div; last lia; last lia.
+  rewrite Z.add_comm Z.mul_comm Z_div_plus; last lia.
+  rewrite (Zdiv_small _ _ hlbs) /= wbit_nE.
+  rewrite wunsigned_repr_small; first last.
+  - nia.
+  rewrite Nat2Z.n2zB; first by rewrite Z2Nat.id.
+  by apply/ZNleP; rewrite (Z2Nat.id _ h0n); apply/Z.nlt_ge.
+Qed.
+
+(* OR-ing an [n]-aligned value with a value below [2 ^ n] is addition. *)
+Lemma wor_wrepr_add ws (n lbs hbs : Z) :
+  (0 <= n)%Z ->
+  (0 <= lbs < 2 ^ n)%Z ->
+  (0 <= hbs)%Z ->
+  (2 ^ n * hbs + lbs < wbase ws)%Z ->
+  wor (wrepr ws (2 ^ n * hbs)) (wrepr ws lbs) = wrepr ws (2 ^ n * hbs + lbs).
+Proof.
+  move=> h0n hlbs hhbs hsum.
+  have h2n : (0 < 2 ^ n)%Z by apply: Z.pow_pos_nonneg.
+  have hmul : (0 <= 2 ^ n * hbs)%Z by nia.
+  apply/eqP/eq_from_wbit_n => i.
+  rewrite worE (wbit_n_add _ h0n hlbs hhbs hsum).
+  have hi_bits : (Z.of_nat i < Z.of_nat (wsize_size_minus_1 ws).+1)%Z.
+  - by apply/Nat2Z.inj_lt/ltP/ltn_ord.
+  case: ZltP => hi.
+  - rewrite (wbit_lower_bits_0 (x := hbs) (n := n)); first done.
+    + lia.
+    lia.
+  rewrite (wbit_higher_bits_0 (x := lbs) (n := n)) //; last lia.
+  rewrite orbF wbit_pow_2 //.
+  apply/andP; split.
+  - by apply/leP; lia.
+  by rewrite -ltnS ltn_ord.
+Qed.
+
+(* The MOVK mask keeps a value whose bits from [sh] up are zero: the mask
+   clears exactly bits [sh, sh + 16). *)
+Lemma wand_movk_mask_id ws (m sh : Z) :
+  (0 <= sh)%Z ->
+  (sh + 16 <= wsize_bits ws)%Z ->
+  (0 <= m < 2 ^ sh)%Z ->
+  wand (wrepr ws m) (wnot (wshl (zero_extend ws (wrepr U16 (-1))) sh))
+  = wrepr ws m.
+Proof.
+  move=> h0sh hsh hm.
+  have -> : zero_extend ws (wrepr U16 (-1)) = wrepr ws (2 ^ 16 - 1).
+  - by apply/wunsigned_inj; rewrite /zero_extend !wunsigned_repr.
+  rewrite wshl_sem // -wrepr_mul.
+  have hmask : (0 <= 2 ^ sh * (2 ^ 16 - 1) < wbase ws)%Z.
+  - split; first nia.
+    rewrite wbase_pow_bits.
+    apply: (Z.lt_le_trans _ (2 ^ (sh + 16))); last by apply: Z.pow_le_mono_r; lia.
+    rewrite Z.pow_add_r //; nia.
+  apply/eqP/eq_from_wbit_n => i.
+  rewrite wandE wnotE.
+  have hi_bits : (Z.of_nat i < Z.of_nat (wsize_size_minus_1 ws).+1)%Z.
+  - by apply/Nat2Z.inj_lt/ltP/ltn_ord.
+  case: (ZltP (Z.of_nat i) sh) => hi.
+  - rewrite (wbit_lower_bits_0 (x := 2 ^ 16 - 1) (n := sh)); first last.
+    + done.
+    + lia.
+    by rewrite andbT.
+  rewrite (wbit_higher_bits_0 (x := m) (n := sh)) //.
+  lia.
+Qed.
+
+Lemma armv8a_MOVZ_semiE ws (c : Z) :
+  (16 <= wsize_bits ws)%Z ->
+  (0 <= c < 2 ^ 16)%Z ->
+  armv8a_MOVZ_semi (ws := ws) (wrepr U16 c) (wrepr U8 0) = wrepr ws c.
+Proof.
+  move=> hws hc.
+  rewrite /armv8a_MOVZ_semi.
+  have -> : wunsigned (wrepr U8 0) = 0%Z by rewrite wunsigned_repr.
+  rewrite wshl0.
+  have hc' : (0 <= c < wbase U16)%Z by rewrite wbase_pow_bits; exact: hc.
+  by rewrite /zero_extend (wunsigned_repr_small hc').
+Qed.
+
+Lemma armv8a_MOVN_semiE ws (c : Z) :
+  (16 <= wsize_bits ws)%Z ->
+  (0 <= c < 2 ^ 16)%Z ->
+  armv8a_MOVN_semi (ws := ws) (wrepr U16 c) (wrepr U8 0)
+  = wnot (wrepr ws c).
+Proof.
+  move=> hws hc.
+  rewrite /armv8a_MOVN_semi.
+  have -> : wunsigned (wrepr U8 0) = 0%Z by rewrite wunsigned_repr.
+  rewrite wshl0.
+  have hc' : (0 <= c < wbase U16)%Z by rewrite wbase_pow_bits; exact: hc.
+  by rewrite /zero_extend (wunsigned_repr_small hc').
+Qed.
+
+(* Inserting the 16-bit chunk [c] at position [sh] of a register holding a
+   value below [2 ^ sh] recombines them by addition. *)
+Lemma armv8a_MOVK_semiE ws (m c sh : Z) :
+  (0 <= sh)%Z ->
+  (sh + 16 <= wsize_bits ws)%Z ->
+  (0 <= m < 2 ^ sh)%Z ->
+  (0 <= c < 2 ^ 16)%Z ->
+  armv8a_MOVK_semi (wrepr ws m) (wrepr U16 c) (wrepr U8 sh)
+  = wrepr ws (2 ^ sh * c + m).
+Proof.
+  move=> h0sh hsh hm hc.
+  have hbits := @wsize_bits_le_256 ws.
+  rewrite /armv8a_MOVK_semi.
+  have -> : wunsigned (wrepr U8 sh) = sh.
+  - apply: wunsigned_repr_small.
+    rewrite wbase_pow_bits /=.
+    lia.
+  rewrite (wand_movk_mask_id h0sh hsh hm).
+  have hc' : (0 <= c < wbase U16)%Z by rewrite wbase_pow_bits; exact: hc.
+  have -> : zero_extend ws (wrepr U16 c) = wrepr ws c.
+  - by rewrite /zero_extend (wunsigned_repr_small hc').
+  rewrite wshl_sem // -wrepr_mul.
+  have hsum : (2 ^ sh * c + m < wbase ws)%Z.
+  - rewrite wbase_pow_bits.
+    apply: (Z.lt_le_trans _ (2 ^ (sh + 16))); last by apply: Z.pow_le_mono_r; lia.
+    rewrite Z.pow_add_r //; nia.
+  by apply: wor_wrepr_add => //; lia.
+Qed.
+
+(* [a mod (b * c)] recombines from the chunks [a mod b] and [(a / b) mod c]. *)
+Lemma z_mod_recombine (a b c : Z) :
+  (0 < b)%Z ->
+  (0 < c)%Z ->
+  (a mod (b * c))%Z = (b * ((a / b) mod c) + a mod b)%Z.
+Proof.
+  move=> hb hc.
+  have hmodb := Z_mod_lt a b (Z.lt_gt _ _ hb).
+  have hmodc := Z_mod_lt (a / b) c (Z.lt_gt _ _ hc).
+  rewrite {1}(Z_div_mod_eq_full a b) {1}(Z_div_mod_eq_full (a / b) c).
+  set q := ((a / b) / c)%Z.
+  have -> : (b * (c * q + (a / b) mod c) + a mod b
+             = (b * ((a / b) mod c) + a mod b) + q * (b * c))%Z.
+  - ring.
+  rewrite Z_mod_plus_full Zmod_small //.
+  nia.
+Qed.
+
+(* -------------------------------------------------------------------- *)
+(* Semantics of the MOVZ/MOVN/MOVK builders at register size. *)
+
+Lemma movz_sem_fopn_args {s} {xi : var_i} {imm sh : Z} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: w := armv8a_MOVZ_semi (ws := U64) (wrepr U16 imm) (wrepr U8 sh) in
+  let: vm' := (evm s).[xi <- Vword w] in
+  sem_fopn_args (ARMv8AFopn_core.movz U64 xi imm sh) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_armv8a_op.
+  by rewrite /= set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Lemma movn_sem_fopn_args {s} {xi : var_i} {imm sh : Z} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: w := armv8a_MOVN_semi (ws := U64) (wrepr U16 imm) (wrepr U8 sh) in
+  let: vm' := (evm s).[xi <- Vword w] in
+  sem_fopn_args (ARMv8AFopn_core.movn U64 xi imm sh) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_armv8a_op.
+  by rewrite /= set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Lemma movk_sem_fopn_args {s} {xi : var_i} {imm sh : Z} {wx : word Uptr} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var xi) >>= to_word Uptr = ok wx ->
+  let: w := armv8a_MOVK_semi wx (wrepr U16 imm) (wrepr U8 sh) in
+  let: vm' := (evm s).[xi <- Vword w] in
+  sem_fopn_args (ARMv8AFopn_core.movk U64 xi imm sh) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_xrbindP => *; t_armv8a_op.
+  by rewrite /= set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Opaque ARMv8AFopn_core.movz.
+Opaque ARMv8AFopn_core.movn.
+Opaque ARMv8AFopn_core.movk.
+
+(* -------------------------------------------------------------------- *)
+(* Immediate materialization. *)
+
+Lemma li_lsem_1 s (xi : var_i) imm :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: lcmd := ARMv8AFopn_core.li U64 xi imm in
+  exists vm',
+    [/\ sem_fopns_args s lcmd = ok (with_vm s vm')
+      , vm' =[\ Sv.singleton xi ] evm s
+      & get_var true vm' xi = ok (Vword (wrepr reg_size imm)) ].
+Proof.
+  move=> hc.
+  rewrite /ARMv8AFopn_core.li.
+  set n := (imm mod wbase U64)%Z.
+  have hn : (0 <= n < wbase U64)%Z by apply/Z_mod_lt/wbase_pos.
+  have hwr : wrepr U64 n = wrepr U64 imm by rewrite /n wrepr_mod.
+
+  case: ZltP => [hsmall | /Z.nlt_ge hbig] /=.
+
+  (* Case: 16-bit immediate, single MOVZ. *)
+  - rewrite (movz_sem_fopn_args hc) /=.
+    rewrite armv8a_MOVZ_semiE //; last lia.
+    eexists; split; first reflexivity.
+    + by move=> v /Sv.singleton_spec ?; t_vm_get.
+    by t_get_var; rewrite (convertible_eval_atype hc) hwr.
+
+  case: ZleP => [hones | /Z.nle_gt hmid] /=.
+
+  (* Case: upper chunks all ones, single MOVN. *)
+  - have hl := Z.add_lnot_diag n.
+    have hlnotmod : (Z.lnot n mod wbase U64 = wbase U64 - 1 - n)%Z.
+    + have -> : Z.lnot n = ((wbase U64 - 1 - n) + (-1) * wbase U64)%Z by lia.
+      rewrite Z_mod_plus_full.
+      apply: Zmod_small; lia.
+    have hlnot : Z_mod_lnot n U64 = (wbase U64 - 1 - n)%Z.
+    + by rewrite /Z_mod_lnot (Zmod_small _ _ hn) hlnotmod.
+    rewrite (movn_sem_fopn_args hc) /=.
+    rewrite armv8a_MOVN_semiE //; last first.
+    + rewrite hlnot.
+      have hwb : wbase U64 = 18446744073709551616%Z by vm_compute.
+      lia.
+    eexists; split; first reflexivity.
+    + by move=> v /Sv.singleton_spec ?; t_vm_get.
+    by t_get_var;
+      rewrite (convertible_eval_atype hc) hlnot -hlnotmod wrepr_mod
+        wrepr_wnot Z.lnot_involutive hwr.
+
+  (* Case: general MOVZ/MOVK chain. Invariant: after treating the chunk at
+     position [sh], the register holds [wrepr U64 (n mod 2 ^ (sh + 16))]. *)
+  have hstep :
+    forall (s' : estate) (sh : Z),
+      (16 <= sh)%Z ->
+      (sh + 16 <= 64)%Z ->
+      get_var true (evm s') (v_var xi)
+        = ok (Vword (wrepr U64 (n mod 2 ^ sh))) ->
+      exists vm',
+        [/\ sem_fopns_args s'
+              (if ((n / 2 ^ sh) mod 2 ^ 16 =? 0)%Z
+               then [::]
+               else [:: ARMv8AFopn_core.movk U64 xi ((n / 2 ^ sh) mod 2 ^ 16) sh ])
+            = ok (with_vm s' vm')
+          , vm' =[\ Sv.singleton xi ] evm s'
+          & get_var true vm' xi
+            = ok (Vword (wrepr U64 (n mod 2 ^ (sh + 16)))) ].
+  - move=> s' sh hsh16 hsh64 hget.
+    have h2sh : (0 < 2 ^ sh)%Z by apply: Z.pow_pos_nonneg; lia.
+    have hchunk : (n mod 2 ^ (sh + 16) = 2 ^ sh * ((n / 2 ^ sh) mod 2 ^ 16) + n mod 2 ^ sh)%Z.
+    + by rewrite Z.pow_add_r; [ apply: z_mod_recombine | lia | lia ].
+    case: Z.eqb_spec => [hz | hnz].
+    + exists (evm s'); split.
+      * by rewrite /sem_fopns_args /= with_vm_same.
+      * done.
+      by rewrite hget hchunk hz Z.mul_0_r Z.add_0_l.
+    rewrite /sem_fopns_args /=.
+    rewrite (movk_sem_fopn_args (wx := wrepr U64 (n mod 2 ^ sh)) hc); first last.
+    + by rewrite hget /= truncate_word_u.
+    rewrite /= armv8a_MOVK_semiE //; first last.
+    + by have := Z_mod_lt (n / 2 ^ sh) (2 ^ 16); lia.
+    + by apply: Z_mod_lt; lia.
+    + lia.
+    eexists; split; first reflexivity.
+    + by move=> v /Sv.singleton_spec ?; t_vm_get.
+    by t_get_var; rewrite (convertible_eval_atype hc) /= ?hchunk.
+
+  have hc0 : (0 <= n mod 2 ^ 16 < 2 ^ 16)%Z by apply: Z_mod_lt.
+
+  (* MOVZ of the low chunk. *)
+  rewrite !orbF (movz_sem_fopn_args hc) /=.
+  rewrite armv8a_MOVZ_semiE //.
+  set s1 := with_vm s _.
+  have hget1 : get_var true (evm s1) (v_var xi)
+    = ok (Vword (wrepr U64 (n mod 2 ^ 16))).
+  - by t_get_var; rewrite (convertible_eval_atype hc).
+
+  (* Chunk at position 16. *)
+  rewrite /sem_fopns_args foldM_cat -!/sem_fopns_args.
+  have [vm2 [-> hvm2 hget2]] := hstep s1 16%Z ltac:(lia) ltac:(lia) hget1.
+  rewrite /=.
+  set s2 := with_vm s1 vm2.
+
+  (* Chunk at position 32. *)
+  rewrite /sem_fopns_args foldM_cat -!/sem_fopns_args.
+  have [vm3 [-> hvm3 hget3]] := hstep s2 32%Z ltac:(lia) ltac:(lia) hget2.
+  rewrite /=.
+  set s3 := with_vm s2 vm3.
+
+  (* Chunk at position 48. *)
+  have [vm4 [-> hvm4 hget4]] := hstep s3 48%Z ltac:(lia) ltac:(lia) hget3.
+
+  exists vm4; split.
+  - done.
+  - move=> v hv.
+    rewrite (hvm4 _ hv) /s3 /= (hvm3 _ hv) /s2 /= (hvm2 _ hv) /s1 /=.
+    have hne : v <> v_var xi.
+    + by move=> heq; apply: hv; apply/Sv.singleton_spec.
+    by t_vm_get.
+  rewrite hget4.
+  have h64 : (2 ^ (48 + 16) = wbase U64)%Z by vm_compute.
+  by rewrite h64 (Zmod_small _ _ hn) hwr.
+Qed.
+Opaque ARMv8AFopn_core.li.
+
+(* -------------------------------------------------------------------- *)
+(* Immediate materialization at W (32-bit) width, used by the
+   [Oarmv8a_smart_li U32] extra op. The destination variable still has
+   register type (a W write clears the upper bits at the assembly level);
+   at this level the varmap simply holds the 32-bit value, which the
+   [withsubword] discipline allows. *)
+
+Transparent ARMv8AFopn_core.movz.
+Transparent ARMv8AFopn_core.movn.
+Transparent ARMv8AFopn_core.movk.
+Transparent ARMv8AFopn_core.li.
+
+Lemma movz_sem_fopn_args_w32 {s} {xi : var_i} {imm sh : Z} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: w := armv8a_MOVZ_semi (ws := U32) (wrepr U16 imm) (wrepr U8 sh) in
+  let: vm' := (evm s).[xi <- Vword w] in
+  sem_fopn_args (ARMv8AFopn_core.movz U32 xi imm sh) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_armv8a_op.
+  by rewrite /= set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Lemma movn_sem_fopn_args_w32 {s} {xi : var_i} {imm sh : Z} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: w := armv8a_MOVN_semi (ws := U32) (wrepr U16 imm) (wrepr U8 sh) in
+  let: vm' := (evm s).[xi <- Vword w] in
+  sem_fopn_args (ARMv8AFopn_core.movn U32 xi imm sh) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_armv8a_op.
+  by rewrite /= set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Lemma movk_sem_fopn_args_w32 {s} {xi : var_i} {imm sh : Z} {wx : word U32} :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  get_var true (evm s) (v_var xi) >>= to_word U32 = ok wx ->
+  let: w := armv8a_MOVK_semi wx (wrepr U16 imm) (wrepr U8 sh) in
+  let: vm' := (evm s).[xi <- Vword w] in
+  sem_fopn_args (ARMv8AFopn_core.movk U32 xi imm sh) s = ok (with_vm s vm').
+Proof.
+  move=> hc.
+  rewrite /=; t_xrbindP => *; t_armv8a_op.
+  by rewrite /= set_var_truncate // (convertible_eval_atype hc).
+Qed.
+
+Opaque ARMv8AFopn_core.movz.
+Opaque ARMv8AFopn_core.movn.
+Opaque ARMv8AFopn_core.movk.
+
+Lemma li_lsem_1_w32 s (xi : var_i) imm :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: lcmd := ARMv8AFopn_core.li U32 xi imm in
+  exists vm',
+    [/\ sem_fopns_args s lcmd = ok (with_vm s vm')
+      , vm' =[\ Sv.singleton xi ] evm s
+      & get_var true vm' xi = ok (Vword (wrepr U32 imm)) ].
+Proof.
+  move=> hc.
+  rewrite /ARMv8AFopn_core.li.
+  set n := (imm mod wbase U32)%Z.
+  have hwb : wbase U32 = 4294967296%Z by vm_compute.
+  have hn : (0 <= n < wbase U32)%Z by apply/Z_mod_lt/wbase_pos.
+  have hwr : wrepr U32 n = wrepr U32 imm by rewrite /n wrepr_mod.
+
+  case: ZltP => [hsmall | /Z.nlt_ge hbig] /=.
+
+  (* Case: 16-bit immediate, single MOVZ. *)
+  - rewrite (movz_sem_fopn_args_w32 hc) /=.
+    rewrite armv8a_MOVZ_semiE //; last lia.
+    eexists; split; first reflexivity.
+    + by move=> v /Sv.singleton_spec ?; t_vm_get.
+    by t_get_var; rewrite (convertible_eval_atype hc) hwr.
+
+  case: ZleP => [hones | /Z.nle_gt hmid] /=.
+
+  (* Case: upper chunk all ones, single MOVN. *)
+  - have hl := Z.add_lnot_diag n.
+    have hlnotmod : (Z.lnot n mod wbase U32 = wbase U32 - 1 - n)%Z.
+    + have -> : Z.lnot n = ((wbase U32 - 1 - n) + (-1) * wbase U32)%Z by lia.
+      rewrite Z_mod_plus_full.
+      apply: Zmod_small; lia.
+    have hlnot : Z_mod_lnot n U32 = (wbase U32 - 1 - n)%Z.
+    + by rewrite /Z_mod_lnot (Zmod_small _ _ hn) hlnotmod.
+    rewrite (movn_sem_fopn_args_w32 hc) /=.
+    rewrite armv8a_MOVN_semiE //; last first.
+    + rewrite hlnot; lia.
+    eexists; split; first reflexivity.
+    + by move=> v /Sv.singleton_spec ?; t_vm_get.
+    by t_get_var;
+      rewrite (convertible_eval_atype hc) hlnot -hlnotmod wrepr_mod
+        wrepr_wnot Z.lnot_involutive hwr.
+
+  (* Case: MOVZ of the low chunk plus at most one MOVK. *)
+  have hc0 : (0 <= n mod 2 ^ 16 < 2 ^ 16)%Z by apply: Z_mod_lt.
+  rewrite !orbT /= cats0.
+  rewrite (movz_sem_fopn_args_w32 hc) /=.
+  rewrite armv8a_MOVZ_semiE //.
+  set s1 := with_vm s _.
+  have hget1 : get_var true (evm s1) (v_var xi)
+    = ok (Vword (wrepr U32 (n mod 2 ^ 16))).
+  - by t_get_var; rewrite (convertible_eval_atype hc).
+  have hchunk : (n mod 2 ^ (16 + 16)
+                 = 2 ^ 16 * ((n / 2 ^ 16) mod 2 ^ 16) + n mod 2 ^ 16)%Z.
+  - by rewrite Z.pow_add_r; [ apply: z_mod_recombine | lia | lia ].
+  have hmod32 : (n mod 2 ^ (16 + 16))%Z = n.
+  - have -> : (2 ^ (16 + 16) = wbase U32)%Z by vm_compute.
+    by rewrite Zmod_small.
+
+  case: Z.eqb_spec => [hz | hnz] /=.
+
+  (* Zero high chunk: the MOVZ already materialized the immediate. *)
+  - eexists; split; first reflexivity.
+    + by move=> v /Sv.singleton_spec ?; t_vm_get.
+    rewrite hget1 -hwr.
+    by rewrite -[in RHS]hmod32 hchunk hz Z.mul_0_r Z.add_0_l.
+
+  (* Nonzero high chunk: insert it with MOVK. *)
+  rewrite (movk_sem_fopn_args_w32 (wx := wrepr U32 (n mod 2 ^ 16)) hc); first last.
+  - by rewrite hget1 /= truncate_word_u.
+  have h1 : (0 <= 16)%Z by [].
+  have h2 : (16 + 16 <= wsize_bits U32)%Z by [].
+  have h3 : (0 <= (n / 2 ^ 16) mod 2 ^ 16 < 2 ^ 16)%Z by apply: Z_mod_lt.
+  rewrite /= (armv8a_MOVK_semiE h1 h2 hc0 h3).
+  eexists; split; first reflexivity.
+  - by move=> v /Sv.singleton_spec ?; t_vm_get.
+  t_get_var; rewrite (convertible_eval_atype hc) /=.
+  all: by rewrite -?hchunk ?hmod32 ?hwr.
+Qed.
+Opaque ARMv8AFopn_core.li.
+
+Lemma smart_mov_sem_fopns_args s (w : word armv8a_reg_size) (xi:var_i) y :
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: lc := ARMv8AFopn_core.smart_mov xi y in
+  get_var true (evm s) y >>= to_word Uptr = ok w ->
+  exists vm,
+    [/\ sem_fopns_args s lc = ok (with_vm s vm)
+      , vm =[\ Sv.singleton xi ] evm s
+      & get_var true vm xi >>= to_word Uptr = ok w ].
+Proof.
+  move=> hc hgety.
+  rewrite /ARMv8AFopn_core.smart_mov /=.
+  case: eqP => heq /=.
+  - case : y heq hgety=> y yi /= *; subst y.
+    rewrite -{1}(with_vm_same s); eexists; split; eauto.
+  rewrite (mov_sem_fopn_args _ hgety) //=.
+  eexists; split; first reflexivity.
+  + by move=> z /Sv.singleton_spec hz; t_vm_get.
+  by rewrite get_var_eq /= (convertible_eval_atype hc) //= truncate_word_u.
+Qed.
+
+Lemma gen_smart_opi_sem_fopn_args
+  (op : word reg_size -> word reg_size -> word reg_size)
+  (on_reg : var_i -> var_i -> var_i -> ARMv8AFopn_core.opn_args)
+  (on_imm : var_i -> var_i -> Z -> ARMv8AFopn_core.opn_args)
+  (is_small : Z -> bool)
+  (neutral : option Z)
+  (op_sem_fopn_args :
+    forall {s} {xi:var_i} {y} {wy : word Uptr} {z} {wz : word Uptr},
+      convertible xi.(vtype) (aword armv8a_reg_size) ->
+      get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy
+      -> get_var true (evm s) (v_var z) >>= to_word Uptr = ok wz
+      -> let: wx' := Vword (op wy wz)in
+      let: vm' := (evm s).[xi <- wx'] in
+      sem_fopn_args (on_reg xi y z) s = ok (with_vm s vm'))
+  (opi_sem_fopn_args :
+    forall {s} {xi:var_i} {y imm wy},
+      convertible xi.(vtype) (aword armv8a_reg_size) ->
+      get_var true (evm s) (v_var y) >>= to_word Uptr = ok wy
+      -> let: wx' := Vword (op wy (wrepr reg_size imm)) in
+     let: vm' := (evm s).[xi <- wx'] in
+     sem_fopn_args (on_imm xi y imm) s = ok (with_vm s vm'))
+  (neutral_ok : if neutral is Some z then forall w, op w (wrepr _ z) = w else true)
+  (tmp : var_i) (xi : var_i) y imm s (w : word armv8a_reg_size) :
+  convertible (vtype tmp) (aword Uptr) ->
+  convertible xi.(vtype) (aword armv8a_reg_size) ->
+  let: lc := ARMv8AFopn_core.gen_smart_opi on_reg on_imm is_small neutral tmp xi y imm in
+  is_small imm \/ v_var tmp <> v_var y ->
+  get_var true (evm s) (v_var y) >>= to_word Uptr = ok w ->
+  exists vm',
+    [/\ sem_fopns_args s lc = ok (with_vm s vm')
+      , vm' =[\ Sv.add xi (Sv.singleton tmp) ] evm s
+      & get_var true vm' xi = ok (Vword (op w (wrepr reg_size imm))) ].
+Proof.
+  move=> hc1 hc2 hcond hgety.
+  rewrite /ARMv8AFopn_core.gen_smart_opi.
+  case (neutral =P Some imm).
+  + move=> heq; move: neutral_ok; rewrite heq Z.eqb_refl => ->.
+    have [vm [-> hvm hgetx]] := smart_mov_sem_fopns_args hc2 hgety.
+    eexists; split; first reflexivity.
+    + by apply: eq_exI hvm; clear; SvD.fsetdec.
+    by apply get_var_to_word.
+  move=> hne; have -> : (if neutral is Some n then (imm =? n)%Z else false) = false.
+  + by case: (neutral) hne => // n; case: ZeqbP => [->|].
+  case: ifP hcond => [_ _ | _ [_|hxy]] //=.
+  - rewrite (opi_sem_fopn_args _ _ _ _ _ hc2 hgety) /=.
+    eexists; split; first reflexivity; last by t_get_var; rewrite (convertible_eval_atype hc2).
+    by move=> z hin; rewrite Vm.setP_neq //; apply/eqP; clear -hin; SvD.fsetdec.
+  have [vm [hsem hvm hgett]] := li_lsem_1 s (xi:=tmp) imm hc1.
+  rewrite /sem_fopns_args -cats1 foldM_cat -!/sem_fopns_args hsem /=.
+  rewrite -(get_var_eq_ex _ _ hvm) in hgety; last by move=> /=; SvD.fsetdec.
+  rewrite
+    (op_sem_fopn_args (with_vm s vm) _ _ _ _ (wrepr reg_size imm) hc2 hgety) /with_vm /=;
+    last by rewrite hgett /= truncate_word_u.
+  eexists; split; first reflexivity; last by t_get_var; rewrite (convertible_eval_atype hc2).
+  move=> z hin.
+  rewrite Vm.setP_neq; last by apply/eqP; SvD.fsetdec.
+  by rewrite hvm //; clear -hin; SvD.fsetdec.
+Qed.
+
+End Section.
+
+End ARMv8AFopn_coreP.

--- a/proofs/compiler/armv8a_params_proof.v
+++ b/proofs/compiler/armv8a_params_proof.v
@@ -1,0 +1,1125 @@
+(* Correctness of the ARMv8-A architecture parameters, mirroring
+   [arm_params_proof.v].
+
+   Proven so far: the stack-alloc hypotheses ([armv8a_hsaparams]) and the
+   complete linearization hypotheses ([armv8a_hliparams], including
+   [lloads_correct] for the custom [armv8a_lloads]), together with the
+   scratch-register facts and the (trivial) lower-addressing hypotheses.
+
+   All hypotheses are proven; the complete record is [armv8a_h_params]. *)
+From Coq Require Import Relations.
+From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat finfun.
+From mathcomp Require Import ssralg.
+From mathcomp Require Import word_ssrZ.
+
+Require Import oseq.
+
+Require Import
+  arch_params_proof
+  compiler_util
+  expr
+  fexpr
+  fexpr_sem
+  psem
+  psem_facts
+  sem_one_varmap.
+Require Import
+  lea_proof
+  linearization
+  it_linearization_proof
+  lowering
+  stack_alloc_params_proof
+  stack_zeroization_proof.
+Require
+  arch_sem.
+Require Import
+  arch_decl
+  arch_extra
+  asm_gen
+  asm_gen_proof
+  sem_params_of_arch_extra.
+Require Import
+  armv8a_decl
+  armv8a_extra
+  armv8a_instr_decl
+  armv8a
+  armv8a_lowering
+  armv8a_lowering_proof
+  armv8a_params_core
+  armv8a_params_core_proof
+  armv8a_params_common_proof
+  armv8a_stack_zeroization_proof.
+Require Export armv8a_params.
+
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
+Section Section.
+
+#[local] Existing Instance withsubword.
+#[local] Existing Instance direct_c.
+
+Context
+  {atoI  : arch_toIdent}
+  {syscall_state : Type}
+  {sc_sem : syscall_sem syscall_state}
+  {call_conv : calling_convention}.
+
+(* ------------------------------------------------------------------------ *)
+(* Stack alloc hypotheses. *)
+
+Section STACK_ALLOC.
+
+Lemma shift_of_scaleP scale shift w :
+  shift_of_scale scale = Some shift ->
+  wshl w (wunsigned (wrepr U8 (Z.of_nat shift))) = (wrepr Uptr scale * w)%R.
+Proof.
+  by case: scale => // -[|[|[|[]|]|]|] //= [<-]; rewrite wshl_sem /=.
+Qed.
+
+Lemma armv8a_mov_ofsP : mov_ofs_correct armv8a_saparams.(sap_mov_ofs).
+Proof.
+  move=> P' ev s1 e w ofs pofs x tag mk ii ins s2 P'_globs.
+  t_xrbindP=> ve ok_ve ok_w vofs ok_vofs ok_pofs.
+  rewrite /sap_mov_ofs /= /armv8a_mov_ofs.
+  case: mk.
+  + move=> [<-] hw; exists (evm s2) => //.
+    rewrite with_vm_same.
+    rewrite /sem_sopn /= P'_globs /exec_sopn.
+    case: is_zeroP.
+    + move=> hofs.
+      rewrite ok_ve /= ok_w /=.
+      move: hofs ok_vofs ok_pofs hw => -> /=.
+      rewrite /sem_sop1 /= => -[<-] /=.
+      rewrite truncate_word_u wrepr0 => -[<-].
+      by rewrite GRing.addr0 => -> /=.
+    move=> _ /=.
+    rewrite ok_ve ok_vofs /= /sem_sop2 /= ok_w ok_pofs /= truncate_word_u /=.
+    by rewrite hw.
+  case: x => //.
+  + move=> x_; set x := Lvar x_.
+    case: ifP => _.
+    + case: is_zeroP => // hofs [<-] hw; exists (evm s2) => //.
+      rewrite with_vm_same.
+      rewrite /sem_sopn /= P'_globs /exec_sopn ok_ve /= ok_w /= zero_extend_u.
+      move: hofs ok_vofs ok_pofs hw => -> /=.
+      rewrite /sem_sop1 /= => -[<-] /=.
+      rewrite truncate_word_u wrepr0 => -[<-].
+      by rewrite GRing.addr0 => -> /=.
+    case hlea: mk_lea => [[disp base scale offset]|//] /=.
+    case: base hlea => [base|//] hlea.
+    have lea_sem: sem_pexpr true [::] s1 (add e ofs) = ok (Vword (w + pofs)).
+    + by rewrite /= ok_ve ok_vofs /= /sem_sop2 /= ok_w ok_pofs /=.
+    have /(_ (cmp_le_refl _)) /(_ (cmp_le_refl _)) := mk_leaP _ _ hlea lea_sem.
+    rewrite zero_extend_u /sem_lea /=.
+    (* t_xrbindP too aggressive *)
+    apply: rbindP => wb.
+    apply: rbindP => vb ok_vb ok_wb.
+    apply: rbindP => wo ok_wo.
+    move=> /ok_inj; rewrite GRing.addrC => {}lea_sem.
+    case: offset {hlea} ok_wo => [offset|] /=.
+    + t_xrbindP=> vo ok_vo ok_wo.
+      case: eqP => // ?; subst disp.
+      case hshift: shift_of_scale => [shift|//] /=.
+      case: eqP => [heq|_].
+      + move=> [<-] hw.
+        exists (evm s2) => //.
+        rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb ok_vo /=
+          /exec_sopn /= ok_wb ok_wo /=.
+        have := shift_of_scaleP wo hshift.
+        rewrite heq wrepr0 wunsigned0 wshl_sem //= wrepr1 GRing.mul1r => ->.
+        rewrite /armv8a_ADD_semi ?add_wordE.
+        move: lea_sem; rewrite wrepr0 GRing.addr0 => ->.
+        by rewrite hw /= with_vm_same.
+      move=> [<-] hw.
+      exists (evm s2) => //.
+      rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb ok_vo /=
+        /exec_sopn /= ok_wb ok_wo truncate_word_u /=.
+      rewrite (shift_of_scaleP wo hshift).
+      rewrite /armv8a_ADD_semi ?add_wordE.
+      move: lea_sem; rewrite wrepr0 GRing.addr0 => ->.
+      by rewrite hw /= with_vm_same.
+    move=> [?]; subst wo.
+    case: eqP => [|_].
+    + move=> ?; subst disp.
+      move=> [<-] hw.
+      exists s2.(evm) => //.
+      rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb /=
+        /exec_sopn /= ok_wb /=.
+      move: lea_sem; rewrite wrepr0 GRing.mulr0 !GRing.addr0 => ->.
+      by rewrite hw /= with_vm_same.
+    case: ifP => _.
+    + move=> [<-] hw.
+      exists s2.(evm) => //.
+      rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb /=
+        /exec_sopn /= ok_wb truncate_word_u /=.
+        rewrite /armv8a_ADD_semi ?add_wordE.
+      move: lea_sem; rewrite GRing.mulr0 GRing.addr0 => ->.
+      by rewrite hw /= with_vm_same.
+    move=> [<-] hw.
+    exists s2.(evm) => //.
+    rewrite /sem_sopn P'_globs /= /get_gvar /= ok_vb /=
+      /exec_sopn /= ok_wb truncate_word_u /=.
+    rewrite /armv8a_ADD_semi ?add_wordE.
+    move: lea_sem; rewrite GRing.mulr0 GRing.addr0 => ->.
+    by rewrite hw /= with_vm_same.
+  move=> al ws_ x_ e_; move: (Lmem al ws_ x_ e_) => {al ws_ x_ e_} x.
+  case: is_zeroP => // hofs [<-] hw; exists (evm s2) => //.
+  rewrite with_vm_same.
+  rewrite /sem_sopn /= P'_globs /exec_sopn ok_ve /= ok_w /= zero_extend_u.
+  move: hofs ok_vofs ok_pofs hw => -> /=.
+  rewrite /sem_sop1 /= => -[<-] /=.
+  rewrite truncate_word_u wrepr0 => -[<-].
+  by rewrite GRing.addr0 => -> /=.
+Qed.
+
+Lemma armv8a_immediateP : immediate_correct armv8a_saparams.(sap_immediate).
+Proof.
+  move=> P' ev s ii x z hty.
+  rewrite /= /sem_sopn /= /exec_sopn /= truncate_word_u /=.
+  by rewrite /write_var set_var_eq_type ?hty.
+Qed.
+
+Lemma armv8a_swapP : swap_correct armv8a_saparams.(sap_swap).
+Proof.
+  move=> P' ev s ii tag x y z w pz pw hxty hyty hzty hwty hz hw.
+  rewrite /= /sem_sopn /= /get_gvar /= /get_var /= hz hw /=.
+  rewrite /exec_sopn /= !truncate_word_u /= /write_var /set_var /=.
+  rewrite (convertible_eval_atype hxty) (convertible_eval_atype hyty) //=.
+Qed.
+
+End STACK_ALLOC.
+
+Definition armv8a_hsaparams :
+  h_stack_alloc_params (ap_sap armv8a_params) :=
+  {|
+    mov_ofsP := armv8a_mov_ofsP;
+    sap_immediateP := armv8a_immediateP;
+    sap_swapP := armv8a_swapP;
+  |}.
+
+(* ------------------------------------------------------------------------ *)
+(* Linearization hypotheses. *)
+
+Section LINEARIZATION.
+
+Lemma convertible_rsp : convertible (aword Uptr) (aword armv8a_reg_size).
+Proof. by vm_compute. Qed.
+
+Lemma sem_fopns_args_1 s (a : fopn_args) :
+  sem_fopns_args s [:: a ] = sem_fopn_args a s.
+Proof. by rewrite /sem_fopns_args /=; case: sem_fopn_args. Qed.
+
+Lemma bind_ok_estate (s1 : estate) (f : estate -> exec estate) :
+  (Let s2 := ok s1 in f s2) = f s1.
+Proof. by []. Qed.
+
+Lemma foldM_1 (T R E : Type) (f : T -> R -> result E R) (acc : R) (a : T) :
+  foldM f acc [:: a ] = f a acc.
+Proof. by rewrite /=; case: (f a acc). Qed.
+
+Lemma armv8a_spec_lip_allocate_stack_frame :
+  allocate_stack_frame_correct armv8a_liparams.
+Proof.
+  move=> sp_rsp tmp s ts sz htmp hget /=.
+  rewrite /armv8a_allocate_stack_frame.
+  case: tmp htmp => [tmp [h1 h2]| _].
+  + have [? [-> ? /get_varP [-> _ _]]] := [elaborate
+      ARMv8AFopnP.smart_subi_tmp_sem_fopn_args
+        (xi := vid sp_rsp) sz convertible_rsp h1 h2 (to_word_get_var hget)
+    ].
+    by eexists.
+  rewrite sem_fopns_args_1
+    (ARMv8AFopnP.subi_sem_fopn_args (xi := vid sp_rsp) convertible_rsp
+       (to_word_get_var hget)).
+  eexists; split; first reflexivity.
+  + move=> z hz; rewrite Vm.setP_neq //.
+    by apply/eqP => heq; apply: hz; rewrite -heq; apply/Sv.add_spec; left.
+  by rewrite Vm.setP_eq vm_truncate_val_eq.
+Qed.
+
+Lemma armv8a_spec_lip_free_stack_frame :
+  free_stack_frame_correct armv8a_liparams.
+Proof.
+  move=> sp_rsp tmp s ts sz htmp hget /=.
+  rewrite /armv8a_free_stack_frame.
+  case: tmp htmp => [tmp [h1 h2]| _].
+  + have [? [-> ? /get_varP [-> _ _]]] := [elaborate
+      ARMv8AFopnP.smart_addi_tmp_sem_fopn_args
+        (xi := vid sp_rsp) sz convertible_rsp h1 h2 (to_word_get_var hget)
+    ].
+    by eexists.
+  rewrite sem_fopns_args_1
+    (ARMv8AFopnP.addi_sem_fopn_args (xi := vid sp_rsp) convertible_rsp
+       (to_word_get_var hget)).
+  eexists; split; first reflexivity.
+  + move=> z hz; rewrite Vm.setP_neq //.
+    by apply/eqP => heq; apply: hz; rewrite -heq; apply/Sv.add_spec; left.
+  by rewrite Vm.setP_eq vm_truncate_val_eq.
+Qed.
+
+Lemma armv8a_spec_lip_set_up_sp_register :
+  set_up_sp_register_correct armv8a_liparams.
+Proof.
+  Opaque sem_fopn_args.
+  move=> vrsp r tmp ts al sz s hget htyrsp htyr htytmp hnetr hner hnert /=.
+  rewrite /armv8a_set_up_sp_register sem_fopns_args_cat /=.
+  set ts' := align_word _ _.
+  have := ARMv8AFopnP.smart_subi_sem_fopn_args
+            (xi := tmp) (y := vrsp) (imm := sz) _ _ (to_word_get_var hget).
+  move=> [] //.
+  + by rewrite htytmp.
+  + by right.
+  move=> vm1 [] -> heq1 hget1 /=.
+  set s1 := with_vm _ _.
+  have -> /= := ARMv8AFopnP.align_sem_fopn_args
+                 (xi := tmp) (y := tmp) (al := al) (s := s1)
+                 _ (to_word_get_var hget1).
+  + set s2 := with_vm _ _.
+    have hget2 : get_var true (evm s2) vrsp = ok (Vword ts).
+    + rewrite get_var_neq; last by [].
+      rewrite (get_var_eq_ex _ _ heq1); first by [].
+      by apply: Sv_neq_not_in_singleton.
+    have -> /= := ARMv8AFopnP.mov_sem_fopn_args (xi := r) _ (to_word_get_var hget2).
+    + set s3 := with_vm _ _.
+      have hget3 : get_var true (evm s3) tmp = ok (Vword ts').
+      + by t_get_var => /=; rewrite htytmp /=.
+      have -> /= := ARMv8AFopnP.mov_sem_fopn_args (xi := vrsp) _ (to_word_get_var hget3).
+      + set s4 := with_vm _ _.
+        Transparent sem_fopn_args.
+        eexists; split => //.
+        - move=> x; t_notin_add; t_vm_get; rewrite heq1; first by t_vm_get.
+          by apply/Sv_neq_not_in_singleton/nesym.
+        - by t_get_var => /=; rewrite htyrsp /=.
+        - by t_get_var => /=; rewrite (convertible_eval_atype htyr) /=.
+        move=> x hx _.
+        move: hx => /vflagsP hxtype.
+        have [*] : [/\ v_var vrsp <> x, v_var tmp <> x & v_var r <> x].
+        - split; apply/eqP/vtype_diff; rewrite hxtype //.
+          + by rewrite htyrsp.
+          + by rewrite htytmp.
+          by apply /eqP => /= h; move: htyr; rewrite h.
+        t_vm_get; rewrite heq1 //.
+        by apply: Sv_neq_not_in_singleton.
+      by rewrite htyrsp.
+    by rewrite htyr.
+  by rewrite htytmp.
+Qed.
+
+Lemma armv8a_lmove_correct : lmove_correct armv8a_liparams.
+Proof.
+  move=> xd xs ws w s /eqP hws htxd; t_xrbindP => z hget htr; subst.
+  rewrite /armv8a_liparams /lip_lmove /armv8a_lmove /= hget /=.
+  rewrite /exec_sopn /= htr /= /set_var /=.
+  by case: vtype htxd.
+Qed.
+
+Lemma armv8a_lstore_correct : lstore_correct_aux armv8a_check_ws armv8a_lstore.
+Proof.
+  move=> xd xs ofs ws w wp s m /eqP hchk; t_xrbindP; subst ws.
+  move=> vd hgetd htrd vs hgets htrs hwr.
+  rewrite /armv8a_lstore /= hgets hgetd /= /exec_sopn /= htrs /=.
+  rewrite /sem_sop2 /= htrd /= !truncate_word_u /= truncate_word_u /=.
+  by rewrite zero_extend_u hwr.
+Qed.
+
+Lemma armv8a_smart_addi_correct : ladd_imm_correct_aux ARMv8AFopn_smart_addi.
+Proof.
+  move=> x1 x2 s w ofs hty hne hget.
+  apply: ARMv8AFopnP.smart_addi_sem_fopn_args hget => //; last by right.
+  by rewrite hty.
+Qed.
+
+Lemma armv8a_lstores_correct : lstores_correct armv8a_liparams.
+Proof.
+  apply/lstores_imm_dfl_correct.
+  + by apply armv8a_lstore_correct.
+  apply armv8a_smart_addi_correct.
+Qed.
+
+Lemma armv8a_lload_correct :
+  lload_correct_aux (lip_check_ws armv8a_liparams) armv8a_lload.
+Proof.
+  move=> xd xs ofs ws top s w vm hcheck; t_xrbindP => ? hgets hto hread hset.
+  move/eqP: hcheck => ?; subst ws.
+  rewrite /armv8a_lload /= hgets /= /sem_sop2 /= hto /= !truncate_word_u /=
+    truncate_word_u /= hread /=.
+  by rewrite /exec_sopn /= truncate_word_u /= zero_extend_u hset.
+Qed.
+
+Lemma armv8a_tmp_correct : lip_tmp armv8a_liparams <> lip_tmp2 armv8a_liparams.
+Proof. by move=> h; assert (h1 := inj_to_ident h). Qed.
+
+Lemma armv8a_check_ws_correct : lip_check_ws armv8a_liparams Uptr.
+Proof. done. Qed.
+
+(* [lloads_correct] for the custom [armv8a_lloads], which restores the
+   saved stack pointer through the scratch register X17 and a MOV, since
+   an A64 load writes through the X[] accessor for which register number
+   31 is ZR, not SP (see armv8a_params.v). *)
+
+Section LLOADS.
+
+Notation vtmp2i := (mk_var_i (to_var R17)).
+
+Let foldM_restore m1 (top' : word Uptr) :=
+  foldM (fun '(x, ofs1) (vm : Vm.t) =>
+    Let ws := if vtype x is aword ws then ok ws else Error ErrType in
+    Let _ := assert (armv8a_check_ws ws) ErrType in
+    Let w := read m1 Aligned (top' + wrepr Uptr ofs1)%R ws in
+    set_var true vm x (Vword w)).
+
+(* A restore [foldM] only modifies the variables it sets. *)
+Lemma lloads_foldM_eq_ex m1 (top' : word Uptr) (l : seq (var * Z)) vm vm' :
+  foldM_restore m1 top' vm l = ok vm' ->
+  forall z, z \notin map fst l -> vm'.[z] = vm.[z].
+Proof.
+  rewrite /foldM_restore.
+  elim: l vm => /= [ | [x ofs1] l ih] vm.
+  + by move=> [<-].
+  case heqt: vtype => [|||ws] //=; t_xrbindP => vm1 _ w _ hset /ih hex z.
+  rewrite in_cons negb_or => /andP [hzx hzl].
+  rewrite (hex _ hzl).
+  move/set_varP: hset => [_ _ ->].
+  by rewrite Vm.setP_neq // eq_sym.
+Qed.
+
+Lemma armv8a_lloads_correct : lloads_correct armv8a_liparams.
+Proof.
+  move=> rspi to_save ofs s top vm2 /= hnin hnin2 hne hget.
+  rewrite foldM_cat /=; t_xrbindP => vm_r hf.
+  case heqt: (vtype rspi) => [|||ws] //=; t_xrbindP
+    => vm2' wsx hwsx hchk w_sp hread hset heqv.
+  subst wsx vm2.
+  move/eqP: (hchk) => ?; subst ws.
+  move/set_varP: hset => [_ _ ?]; subst vm2'.
+
+  have hsetvar : forall (vm : Vm.t) (w : word Uptr),
+      set_var true vm vtmp2i (Vword w) = ok vm.[v_var vtmp2i <- Vword w].
+  - by move=> vm w; apply: set_var_eq_type.
+  have hconv2 : convertible (vtype (v_var vtmp2i)) (aword reg_size).
+  - by vm_compute.
+
+  (* The SP-restoring tail, from any varmap holding [top] in [rspi]. *)
+  have hsp : forall vmr,
+      get_var true vmr rspi >>= to_word Uptr = ok top ->
+      exists2 vm,
+        sem_fopns_args (with_vm s vmr)
+          (if is_arith_small ofs
+           then [:: armv8a_lload Uptr vtmp2i rspi ofs; armv8a_lmove Uptr rspi vtmp2i ]
+           else ARMv8AFopn_smart_addi vtmp2i rspi ofs
+                ++ [:: armv8a_lload Uptr vtmp2i vtmp2i 0%Z; armv8a_lmove Uptr rspi vtmp2i ])
+          = ok (with_vm s vm)
+        & vm =[\ Sv.singleton (v_var vtmp2i) ] vmr.[v_var rspi <- Vword w_sp].
+  - move=> vmr hget_r.
+    case: ifP => _.
+    + (* Small offset: LDR from [rspi] directly. *)
+      rewrite -cat1s sem_fopns_args_cat !sem_fopns_args_1.
+      rewrite (armv8a_lload_correct (xd := vtmp2i) (xs := rspi)
+                 (s := with_vm s vmr)
+                 armv8a_check_ws_correct hget_r hread (hsetvar _ _)).
+      rewrite /= get_var_eq /=; last by [].
+      rewrite /exec_sopn /= truncate_word_u /=.
+      rewrite set_var_eq_type /=; first last.
+      + by rewrite heqt.
+      + by [].
+      rewrite /armv8a_MOV_semi.
+      eexists; first by [].
+      move=> z /Sv.singleton_spec hz.
+      rewrite !Vm.setP; case: eqP => // _.
+      by case: eqP => // heqz; case: (hz (esym heqz)).
+    (* Large offset: materialize [rspi + ofs] into the scratch register. *)
+    rewrite /sem_fopns_args foldM_cat -!/sem_fopns_args.
+    have [vma [hsema heqa hgeta]] :=
+      ARMv8AFopnP.smart_addi_sem_fopn_args (xi := vtmp2i) (y := rspi)
+        (imm := ofs) (s := with_vm s vmr) hconv2 (or_intror hne) hget_r.
+    rewrite hsema bind_ok_estate.
+    rewrite -cat1s /sem_fopns_args foldM_cat !foldM_1 -!/sem_fopns_args.
+    have hread0 :
+      read (emem s) Aligned ((top + wrepr Uptr ofs) + wrepr Uptr 0)%R reg_size
+      = ok w_sp.
+    + by rewrite wrepr0 GRing.addr0.
+    rewrite (armv8a_lload_correct (xd := vtmp2i) (xs := vtmp2i)
+               (s := with_vm (with_vm s vmr) vma)
+               armv8a_check_ws_correct _ hread0 (hsetvar _ _)); first last.
+    + by rewrite hgeta /= truncate_word_u.
+    rewrite /= get_var_eq /=; last by [].
+    rewrite /exec_sopn /= truncate_word_u /=.
+    rewrite set_var_eq_type /=; first last.
+    + by rewrite heqt.
+    + by [].
+    rewrite /armv8a_MOV_semi.
+    eexists; first by [].
+    move=> z /Sv.singleton_spec hz.
+    rewrite !Vm.setP; case: eqP => // _.
+    case: eqP => [heqz | _]; first by case: (hz (esym heqz)).
+    by rewrite heqa //; apply/Sv.singleton_spec.
+
+  rewrite /lip_lloads /armv8a_lloads.
+  rewrite /sem_fopns_args foldM_cat -!/sem_fopns_args.
+  case hall: (all (fun '(_, ofs1) => is_arith_small ofs1) to_save).
+
+  (* All offsets small: LDR directly from [rspi]. *)
+  - have [hsem1 hget1] := lloads_aux_correct armv8a_lload_correct hnin hget hf.
+    rewrite -[X in sem_fopns_args _ X]/(lloads_aux armv8a_lload rspi to_save).
+    rewrite hsem1 bind_ok_estate.
+    have [vm -> hvm] := hsp _ hget1.
+    exists vm => //.
+    move=> z hz.
+    by rewrite (hvm _ hz).
+
+  (* Rebase through the scratch register. *)
+  rewrite -[X in sem_fopns_args _ X]/(
+    ARMv8AFopn_smart_addi vtmp2i rspi (head (v_var rspi, 0%Z) to_save).2 ++
+    lloads_aux armv8a_lload vtmp2i
+      (map (fun '(x1, ofs1) =>
+              (x1, (ofs1 - (head (v_var rspi, 0%Z) to_save).2)%Z)) to_save)).
+  move: (head _ _).2 => ofs0.
+  rewrite /sem_fopns_args foldM_cat -!/sem_fopns_args.
+  have [vma [hsema heqa hgeta]] :=
+    ARMv8AFopnP.smart_addi_sem_fopn_args (xi := vtmp2i) (y := rspi)
+      (imm := ofs0) (s := s) hconv2 (or_intror hne) hget.
+  rewrite hsema /=.
+  have hnin_reb : forall (x : var),
+      ~~ Sv.mem x (sv_of_list fst to_save) ->
+      ~~ Sv.mem x (sv_of_list fst
+                     (map (fun '(x1, ofs1) => (x1, (ofs1 - ofs0)%Z)) to_save)).
+  - move=> x /Sv_memP hx; apply/Sv_memP => /sv_of_listP; rewrite -map_comp.
+    move=> /mapP [p hin hx']; apply: hx; apply/sv_of_listP; apply/mapP.
+    by exists p => //; rewrite hx'; case: (p).
+  have [vm_r' hf' heqx] : exists2 vm_r',
+      foldM_restore (emem s) (top + wrepr Uptr ofs0)%R vma
+        (map (fun '(x1, ofs1) => (x1, (ofs1 - ofs0)%Z)) to_save) = ok vm_r'
+      & vm_r =[\ Sv.singleton (v_var vtmp2i) ] vm_r'.
+  - rewrite /foldM_restore.
+    move: heqa hf; move: (evm s) (vma) (to_save) => vm_o vma' l heqa hf.
+    elim: l vm_o vma' heqa hf => /=.
+    + by move=> vm_o vma' heqa [<-]; exists vma' => //; apply: eq_exS.
+    move=> [x ofs1] to_save' ih vm_o vma' heqa.
+    case heqtx: vtype => [|||wsx] //=; t_xrbindP.
+    move=> vm_o1 -> /= w hreadx hsetx hfx.
+    rewrite -GRing.addrA -wrepr_add.
+    have -> : (ofs0 + (ofs1 - ofs0))%Z = ofs1 by ring.
+    rewrite hreadx /= set_var_eq_type //=; last by rewrite heqtx.
+    apply: (ih _ _ _ hfx).
+    move=> z hz.
+    move/set_varP: hsetx => [_ _ ->].
+    rewrite !Vm.setP heqtx vm_truncate_val_eq //.
+    case: eqP => // _.
+    by apply: heqa.
+  have hget_r' : get_var true vm_r' rspi >>= to_word Uptr = ok top.
+  - have -> : get_var true vm_r' rspi = get_var true (evm s) rspi.
+    + rewrite /get_var (lloads_foldM_eq_ex hf'); last first.
+      * by have /Sv_memP/sv_of_listP := hnin_reb _ hnin.
+      by rewrite heqa //; apply: Sv_neq_not_in_singleton.
+    exact: hget.
+  have hgeta2 : get_var true vma (v_var vtmp2i) >>= to_word Uptr
+                = ok (top + wrepr Uptr ofs0)%R.
+  - by rewrite hgeta /= truncate_word_u.
+  have hnin2' : ~~ Sv.mem (v_var vtmp2i)
+      (sv_of_list fst (map (fun '(x1, ofs1) => (x1, (ofs1 - ofs0)%Z)) to_save)).
+  - exact: (hnin_reb _ hnin2).
+  have [hsem1 _] := lloads_aux_correct armv8a_lload_correct
+                      (rspi := vtmp2i)
+                      (to_restore := map (fun '(x1, ofs1) =>
+                                            (x1, (ofs1 - ofs0)%Z)) to_save)
+                      (s := with_vm s vma) hnin2' hgeta2 hf'.
+  rewrite -[X in sem_fopns_args _ X]/(lloads_aux armv8a_lload vtmp2i
+      (map (fun '(x1, ofs1) => (x1, (ofs1 - ofs0)%Z)) to_save)).
+  rewrite hsem1 bind_ok_estate.
+  have [vm -> hvm] := hsp _ hget_r'.
+  exists vm => //.
+  move=> z hz.
+  rewrite (hvm _ hz) !Vm.setP.
+  case: eqP => // _.
+  by apply: heqx.
+Qed.
+
+End LLOADS.
+
+End LINEARIZATION.
+
+Definition armv8a_hliparams :
+  h_linearization_params (ap_lip armv8a_params) :=
+  {|
+    spec_lip_allocate_stack_frame := armv8a_spec_lip_allocate_stack_frame;
+    spec_lip_free_stack_frame     := armv8a_spec_lip_free_stack_frame;
+    spec_lip_set_up_sp_register   := armv8a_spec_lip_set_up_sp_register;
+    spec_lip_lmove                := armv8a_lmove_correct;
+    spec_lip_lstore               := armv8a_lstore_correct;
+    spec_lip_lload                := armv8a_lload_correct;
+    spec_lip_lstores              := armv8a_lstores_correct;
+    spec_lip_lloads               := armv8a_lloads_correct;
+    spec_lip_tmp                  := armv8a_tmp_correct;
+    spec_lip_check_ws             := armv8a_check_ws_correct;
+  |}.
+
+Lemma armv8a_ok_lip_tmp :
+  exists r : reg_t, of_ident (lip_tmp (ap_lip armv8a_params)) = Some r.
+Proof. exists R16; exact: to_identK. Qed.
+
+Lemma armv8a_ok_lip_tmp2 :
+  exists r : reg_t, of_ident (lip_tmp2 (ap_lip armv8a_params)) = Some r.
+Proof. exists R17; exact: to_identK. Qed.
+
+(* ------------------------------------------------------------------------ *)
+(* Lowering hypotheses. *)
+
+Definition armv8a_hloparams : h_lowering_params (ap_lop armv8a_params).
+Proof. constructor => *; exact: it_lower_callP. Qed.
+
+(* ------------------------------------------------------------------------ *)
+(* Lowering of complex addressing mode for RISC-V.
+   It is the identity on armv8a, so the proof is trivial. *)
+
+Lemma armv8a_hlaparams : h_lower_addressing_params (ap_lap armv8a_params).
+Proof.
+  split=> /=.
+  + by move=> _ ? _ [<-].
+  + move=> _ ? _ [<-] _ fd ->; by exists fd.
+  move=> ???? _ ? _ ?? [<-]; exact: (wiequiv_f_eq (scP := sCP_stack)).
+Qed.
+
+(* ------------------------------------------------------------------------ *)
+(* Assembly generation hypotheses. *)
+
+Section ASM_GEN.
+
+Notation assemble_extra_correct :=
+  (assemble_extra_correct armv8a_agparams) (only parsing).
+
+(* FIXME: the following line fixes type inference with Coq 8.16 *)
+Local Instance the_asm : asm _ _ _ _ _ _ := _.
+
+Lemma condt_of_rflagP rf r :
+  arm_eval_cond (get_rf rf) (condt_of_rflag r) = to_bool (of_rbool (rf r)).
+Proof.
+  rewrite -get_rf_to_bool_of_rbool. by case: r.
+Qed.
+
+Lemma condt_notP rf c b :
+  arm_eval_cond rf c = ok b
+  -> arm_eval_cond rf (condt_not c) = ok (negb b).
+Proof.
+  case: c => /=.
+
+  (* Introduce booleans [b] and equalities [_ = b] and [rf _ = ok b].
+     Rewrite all equalities, simplify and case all booleans. *)
+  all: t_xrbindP=> *.
+  all: subst=> /=.
+  all:
+    repeat
+      match goal with
+      | [ H : _ _ = ok _ |- _ ] => rewrite H {H} /=
+      end.
+  all:
+    by repeat
+      match goal with
+      | [ b : bool |- _ ] => case: b
+      end.
+Qed.
+
+Lemma condt_andP rf c0 c1 c b0 b1 :
+  condt_and c0 c1 = Some c
+  -> arm_eval_cond rf c0 = ok b0
+  -> arm_eval_cond rf c1 = ok b1
+  -> arm_eval_cond rf c = ok (b0 && b1).
+Proof.
+  move: c0 c1 => [] [] //.
+  all: move=> [?]; subst c.
+  all: rewrite /arm_eval_cond /=.
+
+  all: t_xrbindP=> *.
+  all: subst=> /=.
+  all:
+    repeat
+      match goal with
+      | [ H : _ _ = ok _ |- _ ] => rewrite H {H} /=
+      end.
+  all:
+    by repeat
+      match goal with
+      | [ b : bool |- _ ] => case: b
+      end.
+Qed.
+
+Lemma condt_orP rf c0 c1 c b0 b1 :
+  condt_or c0 c1 = Some c
+  -> arm_eval_cond rf c0 = ok b0
+  -> arm_eval_cond rf c1 = ok b1
+  -> arm_eval_cond rf c = ok (b0 || b1).
+Proof.
+  move: c0 c1 => [] [] //.
+  all: move=> [?]; subst c.
+  all: rewrite /arm_eval_cond /=.
+
+  all: t_xrbindP=> *.
+  all: subst=> /=.
+  all:
+    repeat
+      match goal with
+      | [ H : _ _ = ok _ |- _ ] => rewrite H {H} /=
+      end.
+  all:
+    by repeat
+      match goal with
+      | [ b : bool |- _ ] => case: b
+      end.
+Qed.
+
+Lemma eval_assemble_cond_Pvar ii m rf x r v :
+  eqflags m rf
+  -> of_var_e ii x = ok r
+  -> get_var true (evm m) x = ok v
+  -> exists2 v',
+       value_of_bool (arm_eval_cond (get_rf rf) (condt_of_rflag r)) = ok v'
+       & value_uincl v v'.
+Proof.
+  move=> eqf hr hv.
+  have hincl := xgetflag_ex eqf hr hv.
+  clear ii x m eqf hr hv.
+
+  rewrite condt_of_rflagP.
+
+  eexists; last exact: hincl.
+  clear v hincl.
+  exact: value_of_bool_to_bool_of_rbool.
+Qed.
+
+Lemma eval_assemble_cond_Onot rf c v v0 v1 :
+  value_of_bool (arm_eval_cond (get_rf rf) c) = ok v1
+  -> value_uincl v0 v1
+  -> sem_sop1 Onot v0 = ok v
+  -> exists2 v',
+       value_of_bool (arm_eval_cond (get_rf rf) (condt_not c)) = ok v'
+       & value_uincl v v'.
+Proof.
+  move=> hv1 hincl.
+  move=> /sem_sop1I /= [b [b'] [hb [?] ? ]]; subst v b'.
+
+  have hc := value_uincl_to_bool_value_of_bool hincl hb hv1.
+  clear v0 v1 hincl hb hv1.
+
+  rewrite (condt_notP hc) {hc}.
+  by eexists.
+Qed.
+
+Lemma eval_assemble_cond_Obeq ii m rf v x0 x1 r0 r1 v0 v1 :
+  is_rflags_GE r0 r1 = true
+  -> eqflags m rf
+  -> of_var_e ii x0 = ok r0
+  -> get_var true (evm m) x0 = ok v0
+  -> of_var_e ii x1 = ok r1
+  -> get_var true (evm m) x1 = ok v1
+  -> sem_sop2 Obeq v0 v1 = ok v
+  -> exists2 v',
+       value_of_bool (arm_eval_cond (get_rf rf) GE_ct) = ok v'
+       & value_uincl v v'.
+Proof.
+  move=> hGE eqf hr0 hv0 hr1 hv1.
+
+  move=> /sem_sop2I /= [b0 [b1 [b [hb0 hb1 hb ?]]]]; subst v.
+  move: hb.
+  rewrite /mk_sem_sop2 /=.
+  move=> [?]; subst b.
+
+  have hincl0 := xgetflag_ex eqf hr0 hv0.
+  have hincl1 := xgetflag_ex eqf hr1 hv1.
+  clear ii m x0 x1 eqf hr0 hv0 hr1 hv1.
+
+  have ? := to_boolI hb0; subst v0.
+  have ? := to_boolI hb1; subst v1.
+  clear hb0 hb1.
+
+  move: r0 r1 hincl0 hincl1 hGE.
+  move=> [] [] // hincl0 hincl1 _.
+  all: rewrite 2!get_rf_to_bool_of_rbool.
+  all: rewrite (value_uinclE hincl0) {hincl0} /=.
+  all: rewrite (value_uinclE hincl1) {hincl1} /=.
+  all: by eexists.
+Qed.
+
+Lemma eval_assemble_cond_Oand rf c c0 c1 v v0 v1 v0' v1' :
+  condt_and c0 c1 = Some c
+  -> value_of_bool (arm_eval_cond (get_rf rf) c0) = ok v0'
+  -> value_uincl v0 v0'
+  -> value_of_bool (arm_eval_cond (get_rf rf) c1) = ok v1'
+  -> value_uincl v1 v1'
+  -> sem_sop2 Oand v0 v1 = ok v
+  -> exists2 v',
+       value_of_bool (arm_eval_cond (get_rf rf) c) = ok v'
+       & value_uincl v v'.
+Proof.
+  move=> hand hv0' hincl0 hv1' hincl1.
+  move=> /sem_sop2I /= [b0 [b1 [b [hb0 hb1 hb ?]]]]; subst v.
+
+  move: hb.
+  rewrite /mk_sem_sop2 /=.
+  move=> [?]; subst b.
+
+  have hc0 := value_uincl_to_bool_value_of_bool hincl0 hb0 hv0'.
+  have hc1 := value_uincl_to_bool_value_of_bool hincl1 hb1 hv1'.
+  clear hincl0 hb0 hv0' hincl1 hb1 hv1'.
+
+  rewrite (condt_andP hand hc0 hc1) {hand hc0 hc1} /=.
+  by eexists.
+Qed.
+
+Lemma eval_assemble_cond_Oor rf c c0 c1 v v0 v1 v0' v1' :
+  condt_or c0 c1 = Some c
+  -> value_of_bool (arm_eval_cond (get_rf rf) c0) = ok v0'
+  -> value_uincl v0 v0'
+  -> value_of_bool (arm_eval_cond (get_rf rf) c1) = ok v1'
+  -> value_uincl v1 v1'
+  -> sem_sop2 Oor v0 v1 = ok v
+  -> exists2 v',
+       value_of_bool (arm_eval_cond (get_rf rf) c) = ok v'
+       & value_uincl v v'.
+Proof.
+  move=> hor hv0' hincl0 hv1' hincl1.
+  move=> /sem_sop2I /= [b0 [b1 [b [hb0 hb1 hb ?]]]]; subst v.
+
+  move: hb.
+  rewrite /mk_sem_sop2 /=.
+  move=> [?]; subst b.
+
+  have hc0 := value_uincl_to_bool_value_of_bool hincl0 hb0 hv0'.
+  have hc1 := value_uincl_to_bool_value_of_bool hincl1 hb1 hv1'.
+  clear hincl0 hb0 hv0' hincl1 hb1 hv1'.
+
+  rewrite (condt_orP hor hc0 hc1) {hor hc0 hc1} /=.
+  by eexists.
+Qed.
+
+Lemma armv8a_eval_assemble_cond : assemble_cond_spec armv8a_agparams.
+Proof.
+  move=> ii m rr rf e c v; rewrite /armv8a_agparams /arm_eval_cond /get_rf /=.
+  move=> eqr eqf.
+  elim: e c v => [| x | op1 e hind | op2 e0 hind0 e1 hind1 |] //= c v.
+
+  - t_xrbindP=> r hr hc; subst c.
+    move=> hv.
+    exact: (eval_assemble_cond_Pvar eqf hr hv).
+
+  - case: op1 => //.
+    t_xrbindP=> c' hc' hc; subst c.
+    move=> v0 hv0 hsem.
+    have [v1 hv1 hincl1] := hind _ _ hc' hv0.
+    clear ii m e eqr eqf hc' hv0 hind.
+    exact: (eval_assemble_cond_Onot hv1 hincl1 hsem).
+
+  case: op2 => //.
+  - case: e0 hind0 => // x0 _.
+    case: e1 hind1 => // x1 _.
+    t_xrbindP=> r0 hr0 r1 hr1 //=.
+    case hGE: is_rflags_GE => // -[?]; subst c.
+    move=> v0 hv0 v1 hv1 hsem.
+    exact: (eval_assemble_cond_Obeq hGE eqf hr0 hv0 hr1 hv1 hsem).
+
+  - t_xrbindP=> c0 hass0 c1 hass1.
+    case hand: condt_and => [c'|] // [?]; subst c'.
+    move=> v0 hsem0 v1 hsem1 hsem.
+    have [v0' hv0' hincl0] := hind0 _ _ hass0 hsem0.
+    have [v1' hv1' hincl1] := hind1 _ _ hass1 hsem1.
+    clear eqr eqf hass0 hsem0 hind0 hass0 hsem1 hind1.
+    exact: (eval_assemble_cond_Oand hand hv0' hincl0 hv1' hincl1 hsem).
+
+  t_xrbindP=> c0 hass0 c1 hass1.
+  case hor: condt_or => [c'|] // [?]; subst c'.
+  move=> v0 hsem0 v1 hsem1 hsem.
+  have [v0' hv0' hincl0] := hind0 _ _ hass0 hsem0.
+  have [v1' hv1' hincl1] := hind1 _ _ hass1 hsem1.
+  clear eqr eqf hass0 hsem0 hind0 hass0 hsem1 hind1.
+  exact: (eval_assemble_cond_Oor hor hv0' hincl0 hv1' hincl1 hsem).
+Qed.
+
+Import arch_sem.
+
+Lemma sem_sopns_fopns_args s lc :
+  sem_sopns s [seq (None, o, d, e) | '(d, o, e) <- lc] =
+  sem_fopns_args s (map to_opn lc).
+Proof.
+  elim: lc s => //= -[[xs o] es ] lc ih s.
+  rewrite /sem_fopn_args /sem_sopn_t /=; case: sem_rexprs => //= >.
+  by rewrite /exec_sopn /= /sopn_sem /Oarmv8a; case: i_valid => //=;
+    case : app_sopn => //= >; case write_lexprs.
+Qed.
+
+Lemma assemble_swap_correct ws : assemble_extra_correct (Oarmv8a_swap ws).
+Proof.
+  move=> rip ii lvs args m xs ys m' s ops ops' /=.
+  case: eqP => // -> {ws}.
+  case: lvs => // -[] // x [] // -[] // y [] //.
+  case: args => // -[] // [] // z [] // [] // [] // w [] //=.
+  t_xrbindP => vz hz _ vw hw <- <-.
+  rewrite /exec_sopn /= /sopn_sem /sopn_sem_ /= /swap_semi.
+  t_xrbindP => /= _ wz hvz ww hvw <- <- /=.
+  t_xrbindP => _ vm1 /set_varP [_ htrx ->] <- _ vm2 /set_varP [_ htry ->] <- <-
+    /eqP hxw /eqP hyx /and4P [hxt hyt hzt hwt] <-.
+  move=> hmap hlom.
+  have h := (assemble_opsP armv8a_eval_assemble_cond hmap erefl _ hlom).
+  set m1 := (with_vm m (((evm m).[x <- Vword (wxor wz ww)])
+               .[y <- Vword (wxor (wxor wz ww) ww)])
+               .[x <- Vword (wxor (wxor wz ww) (wxor (wxor wz ww) ww))]).
+  case: (h m1) => {h}.
+  + rewrite /= hz /= hw /= /exec_sopn /= hvz hvw /=.
+    rewrite set_var_truncate //= !get_var_eq //= (convertible_eval_atype hxt) /=.
+    rewrite get_var_neq // hw /= truncate_word_u /= hvw /=.
+    rewrite set_var_truncate //= !get_var_eq //= (convertible_eval_atype hyt) /=.
+    rewrite get_var_neq // get_var_eq //= (convertible_eval_atype hxt) /=
+      !truncate_word_u /=.
+    rewrite set_var_truncate //= !with_vm_idem.
+  move=> s' hfold hlom'; exists s' => //; apply: lom_eqv_ext hlom'.
+  move=> i /=; rewrite !Vm.setP; case: eqP => [<- | ?].
+  + by move/eqP/negbTE: hyx => -> /=; rewrite (convertible_eval_atype hxt) /=
+      wxorA wxor_xx wxor0.
+  by case: eqP => // _; rewrite -wxorA wxor_xx wxorC wxor0.
+Qed.
+
+Lemma assemble_add_large_imm_correct :
+  assemble_extra_correct Oarmv8a_add_large_imm.
+Proof.
+  move=> rip ii lvs args m xs ys m' s ops ops' /=.
+  case: lvs => // -[] // [[xt xn] xii] [] //.
+  set xi := {| v_var := _ |}.
+  case: args => // -[] // [] // y [] // [] // [] // [] // w [] // imm [] //=.
+  t_xrbindP => vy hvy <-.
+  rewrite /exec_sopn /= /sopn_sem /sopn_sem_ /=; t_xrbindP
+    => /= n w1 hw1 w2 hw2 ? <- /=; subst n.
+  t_xrbindP => ? vm1 hsetx <- <- /= /eqP hne.
+  move=> /andP [] hxtty /andP [] hyty _ <- hmap hlom.
+  move/to_wordI: hw1 => [ws [w' [?]]] /truncate_wordP [hle1 ?]; subst vy w1.
+  move/get_varP: (hvy) => [_ _ /compat_valE] /=;
+    rewrite (convertible_eval_atype hyty) => -[_ [] <- hle2].
+  have ? := cmp_le_antisym hle1 hle2; subst ws => {hle1 hle2}.
+  have := ARMv8AFopnP.smart_addi_sem_fopn_args (xi := xi) (y := y) (imm := imm)
+            hxtty (or_intror _ hne) (to_word_get_var hvy).
+  move=> [vm []]; rewrite -sem_sopns_fopns_args => hsem heqex /get_varP [hvmx _ _].
+  have [] := (assemble_opsP armv8a_eval_assemble_cond hmap _ hsem hlom).
+  + by rewrite all_map; apply/allT => -[[]].
+  move=> s' -> hlo; exists s' => //.
+  apply: lom_eqv_ext hlo => z /=.
+  move/get_varP: hvy => -[hvmy _ _].
+  move: hsetx; rewrite set_var_eq_type //;
+    last by rewrite (convertible_eval_atype hxtty).
+  move=> -[<-].
+  rewrite Vm.setP.
+  case: eqP => heqx.
+  + rewrite (convertible_eval_atype hxtty) -heqx -hvmx zero_extend_u /=.
+    move: hw2 => /truncate_wordP [? ].
+    by rewrite zero_extend_wrepr // => ->.
+  by apply heqex; move=> /=; clear -heqx; SvD.fsetdec.
+Qed.
+
+Lemma uncons_LLvarP ii les x les' :
+  uncons_LLvar ii les = ok (x, les') ->
+  les = LLvar x :: les'.
+Proof. by case: les => [// | [// | ?] ?] [-> ->]. Qed.
+
+Lemma uncons_wconstP ii les imm les' :
+  uncons_wconst ii les = ok (imm, les') ->
+  exists ws, les = rconst ws imm :: les'.
+Proof.
+  case: les => [// | [//|]] [] // [] // ? [] // ?? [-> ->]. by eexists.
+Qed.
+
+Lemma smart_li_argsP ii ws les res x imm res' :
+  smart_li_args ii ws les res = ok (x, imm, res') ->
+  [/\ (ws == U64) || (ws == U32)
+    , les = [:: LLvar x ]
+    , convertible (vtype (v_var x)) (aword reg_size)
+    & exists ws', res = rconst ws' imm :: res'
+  ].
+Proof.
+  rewrite /smart_li_args.
+  t_xrbindP=> -> -[??] /uncons_LLvarP ->.
+  t_xrbindP=> ? /nilP -> [??] /uncons_wconstP [? ->].
+  t_xrbindP=> ???; subst.
+  split=> //=.
+  by eexists.
+Qed.
+
+Lemma assemble_smart_li_correct ws : assemble_extra_correct (Oarmv8a_smart_li ws).
+Proof.
+  move=> rip ii lvs args m xs ys m' s ops ops'.
+  move=> hsemargs hexec hwrite.
+  rewrite /= /assemble_smart_li.
+  t_xrbindP=> -[[x imm] ?] /smart_li_argsP [hws ? hty [ws' ?]] [?] hops heq;
+    subst lvs args ops.
+  case/orP: hws => /eqP ?; subst ws.
+  (* U64 *)
+  - have [vm []] := ARMv8AFopn_coreP.li_lsem_1 m imm hty.
+    move=> hsem hvm hgetx.
+    have [] :=
+      assemble_opsP (m' := with_vm m vm) armv8a_eval_assemble_cond hops _ _ heq.
+    - by rewrite all_map; apply/allT => -[[]].
+    - move: hsem.
+      by rewrite ARMv8AFopnP.sem_fopns_equiv -sem_sopns_fopns_args /= => ->.
+    move=> s' -> heq'.
+    exists s' => //.
+    move: hsemargs hexec hwrite => /=.
+    t_xrbindP => vs _ ?; subst xs.
+    rewrite /exec_sopn /= /sopn_sem /=.
+    t_xrbindP=> w w' /truncate_wordP [hws' ?]; subst w'.
+    case: vs => // -[?] ?; subst w ys.
+    t_xrbindP=> m0 vm0 hsetx ??; subst m0 m'.
+    apply: (lom_eqv_ext _ heq').
+    move=> y.
+    move/get_varP: hgetx => -[/= hx _ _].
+    move: hsetx.
+    rewrite set_var_eq_type //; last by rewrite (convertible_eval_atype hty).
+    move=> [<-].
+    rewrite Vm.setP.
+    case: eqP => [? | hne].
+    - subst y.
+      by rewrite (convertible_eval_atype hty) /= zero_extend_wrepr.
+    rewrite hvm //.
+    by apply/Sv.singleton_spec/nesym.
+  (* U32: a W write stores the 32-bit value in the register-typed variable
+     (allowed by the [withsubword] discipline); the assembly level clears
+     the upper bits, which [value_uincl] absorbs. *)
+  have [vm []] := ARMv8AFopn_coreP.li_lsem_1_w32 m imm hty.
+  move=> hsem hvm hgetx.
+  have [] :=
+    assemble_opsP (m' := with_vm m vm) armv8a_eval_assemble_cond hops _ _ heq.
+  - by rewrite all_map; apply/allT => -[[]].
+  - move: hsem.
+    by rewrite ARMv8AFopnP.sem_fopns_equiv -sem_sopns_fopns_args /= => ->.
+  move=> s' -> heq'.
+  exists s' => //.
+  move: hsemargs hexec hwrite => /=.
+  t_xrbindP => vs _ ?; subst xs.
+  rewrite /exec_sopn /= /sopn_sem /=.
+  t_xrbindP=> w w' /truncate_wordP [hws' ?]; subst w'.
+  case: vs => // -[?] ?; subst w ys.
+  t_xrbindP=> m0 vm0 hsetx ??; subst m0 m'.
+  apply: (lom_eqv_ext _ heq').
+  move=> y.
+  move/get_varP: hgetx => -[/= hx _ _].
+  move/set_varP: hsetx => [_ _ ->].
+  rewrite Vm.setP.
+  case: eqP => [? | hne].
+  - subst y.
+    by rewrite (convertible_eval_atype hty) /= zero_extend_wrepr.
+  rewrite hvm //.
+  by apply/Sv.singleton_spec/nesym.
+Qed.
+
+Lemma armv8a_assemble_extra_op op : assemble_extra_correct op.
+Proof.
+  case: op.
+  + exact: assemble_swap_correct.
+  + exact: assemble_add_large_imm_correct.
+  exact: assemble_smart_li_correct.
+Qed.
+
+Lemma armv8a_assemble_extra_sz ii op lvs args ops :
+   to_asm ii op lvs args = ok ops -> ssrnat.leq 1 (size ops).
+Proof.
+  rewrite /to_asm /= /assemble_extra /=.
+  case: op.
+  + move=> w; case: eqP => // _.
+    case: lvs => // -[] // ? [] // -[] // ? [] //.
+    case: args => // -[] // [] // ? [] // [] // [] // ? [] //.
+    by t_xrbindP => _ _ _ <-.
+  + case: lvs => // -[] // ? [] //.
+    case: args => // -[] // [] // ? [] // [] // [] // [] // ? [] // ? [] //.
+    t_xrbindP => /negPf hne _ <-.
+    rewrite /asm_args_of_opn_args /= /ARMv8AFopn_core.smart_addi /=.
+    rewrite /ARMv8AFopn_core.gen_smart_opi /ARMv8AFopn_core.smart_mov.
+    case: ifP => //.
+    + by rewrite hne.
+    case: ifP => //.
+    by rewrite size_map size_rcons.
+  move=> w. rewrite /assemble_smart_li /= /smart_li_args.
+  t_xrbindP => ?? -[] ???.
+  t_xrbindP => ?? -[] ??? [<-] [<-].
+  rewrite /asm_args_of_opn_args /= /ARMv8AFopn_core.li.
+  case: ifP => //; case: ifP => //.
+Qed.
+
+Definition armv8a_hagparams : h_asm_gen_params (ap_agp armv8a_params) :=
+  {|
+    hagp_eval_assemble_cond := armv8a_eval_assemble_cond;
+    hagp_assemble_extra_op := armv8a_assemble_extra_op;
+    hagp_assemble_extra_sz := armv8a_assemble_extra_sz;
+  |}.
+
+End ASM_GEN.
+
+(* ------------------------------------------------------------------------ *)
+(* Speculative execution. *)
+
+Lemma armv8a_hshp : slh_lowering_proof.h_sh_params (ap_shp armv8a_params).
+Proof. by constructor; move=> ???? []. Qed.
+
+(* ------------------------------------------------------------------------ *)
+(* Stack zeroization. *)
+
+Section STACK_ZEROIZATION.
+
+Lemma armv8a_hszparams : h_stack_zeroization_params (ap_szp armv8a_params).
+Proof.
+  split.
+  + exact: armv8a_stack_zero_cmd_not_ext_lbl.
+  exact: armv8a_stack_zero_cmdP.
+Qed.
+
+End STACK_ZEROIZATION.
+
+(* ------------------------------------------------------------------------ *)
+(* Shared hypotheses. *)
+
+Definition armv8a_is_move_opP op vx v :
+  ap_is_move_op armv8a_params op
+  -> exec_sopn (Oasm op) [:: vx ] = ok v
+  -> values_uincl v [:: vx ].
+Proof.
+  case: op => // -[[] // [mn opt]] /=.
+  case: ifP => // hmn /negPf hs.
+  case: opt hmn hs => sho sz hmn /= hs.
+  case: sho hs => [sk | ] hs; first by [].
+  rewrite /exec_sopn /sopn_sem /sopn_sem_ /=.
+  rewrite /semi_to_atype.
+  move: (computational_eq _) (computational_eq _) => e1 e2.
+  rewrite <- e1, <- e2.
+  clear e1 e2.
+  (* To avoid duplication, we prove that [mn] returns [to_word ws vx] for
+     some [ws]. *)
+  have ->:
+    Let semi := assert (id_valid (mn_desc {| has_shift := None; opts_size := sz |} mn)) ErrType >>
+                ok (id_semi (mn_desc {| has_shift := None; opts_size := sz |} mn)) in
+    (Let t := app_sopn (map eval_ltype (id_tin (mn_desc {| has_shift := None; opts_size := sz |} mn))) semi [:: vx] in
+    ok (list_ltuple t)) =
+      Let _ := assert (id_valid (mn_desc {| has_shift := None; opts_size := sz |} mn)) ErrType in
+      Let ws := if head lbool (id_tout (mn_desc {| has_shift := None; opts_size := sz |} mn)) is lword ws
+                then ok ws else type_error in
+      Let wx := to_word ws vx in
+      ok [:: Vword wx].
+  + by case: mn hmn => //= _;
+      case: sz => //=;
+      case: to_word => //= ?;
+      rewrite /armv8a_MOV_semi ?zero_extend_u.
+  t_xrbindP=> _ ws0 _ w0 hw0 hv.
+  move/to_wordI: hw0 => [ws [w [? htr]]]; subst vx.
+  rewrite -hv.
+  constructor=> //=.
+  by apply (truncate_word_uincl htr).
+Qed.
+
+(* ------------------------------------------------------------------------ *)
+
+Definition armv8a_h_params : h_architecture_params armv8a_params :=
+  {|
+    hap_hsap        := armv8a_hsaparams;
+    hap_hlip        := armv8a_hliparams;
+    ok_lip_tmp      := armv8a_ok_lip_tmp;
+    ok_lip_tmp2     := armv8a_ok_lip_tmp2;
+    hap_hlop        := armv8a_hloparams;
+    hap_hlap        := armv8a_hlaparams;
+    hap_hagp        := armv8a_hagparams;
+    hap_hshp        := armv8a_hshp;
+    hap_hszp        := armv8a_hszparams;
+    hap_is_move_opP := armv8a_is_move_opP;
+  |}.
+
+End Section.

--- a/proofs/compiler/armv8a_stack_zeroization.v
+++ b/proofs/compiler/armv8a_stack_zeroization.v
@@ -1,0 +1,169 @@
+(* Stack zeroization for ARMv8-A (AArch64). *)
+
+From mathcomp Require Import ssreflect.
+
+Require Import
+  expr
+  fexpr
+  label
+  linear
+  stack_zero_strategy
+  arch_decl
+  arch_extra
+  armv8a_decl
+  armv8a_extra
+  armv8a_instr_decl
+  armv8a_params_core.
+Require Import compiler_util.
+
+Section STACK_ZEROIZATION.
+
+Context {atoI : arch_toIdent}.
+
+(* Wrappers turning [ARMv8AFopn_core] argument triples into [fopn_args]. *)
+Definition to_opn '(d, o, e) : fopn_args := (d, Oarmv8a o, e).
+
+Definition fopn_mov x y := to_opn (ARMv8AFopn_core.mov x y).
+Definition fopn_sub x y z := to_opn (ARMv8AFopn_core.sub x y z).
+Definition fopn_movi x imm := to_opn (ARMv8AFopn_core.movi x imm).
+Definition fopn_align x y al := to_opn (ARMv8AFopn_core.align x y al).
+
+(* Load an immediate to a register (kept as a single pseudo-instruction,
+   expanded to a MOVZ/MOVK sequence at assembly generation). *)
+Definition fopn_li (x : var_i) (imm : Z) : fopn_args :=
+  let op := Oasm (ExtOp (Oarmv8a_smart_li reg_size)) in
+  ([:: LLvar x ], op, [:: rconst reg_size imm ]).
+
+Section RSP.
+
+Context
+  (vrsp : var_i)
+  (lbl : label)
+  (alignment ws : wsize)
+  (stk_max : Z)
+.
+
+Let vsaved_sp := mk_var_i (to_var R2).
+Let voff := mk_var_i (to_var R3).
+Let vzero := mk_var_i (to_var R12).
+Let vzf := mk_var_i (to_var ZF).
+Let vflags := [seq mk_var_i (to_var f) | f <- rflags ].
+Let leflags := [seq LLvar f | f <- vflags ].
+
+(* For both strategies we need to initialize:
+   - [saved_sp] to save [SP]
+   - [off] to offset from [SP] to already zeroized region
+   - [SP] to align and point to the end of the region to zeroize
+   - [zero] to zero
+   Since we can't align [SP] directly, we use [zero] as a scratch register.
+   This is the implementation:
+    saved_sp = sp
+    off = stk_max
+    zero = saved_sp & - (wsize_size alignment)
+    sp = zero
+    sp -= off
+    zero = 0
+*)
+Definition sz_init : lcmd :=
+  let args :=
+    fopn_mov vsaved_sp vrsp
+    :: fopn_li voff stk_max
+    :: fopn_align vzero vsaved_sp alignment
+    :: fopn_mov vrsp vzero
+    :: fopn_sub vrsp vrsp voff
+    :: [:: fopn_movi vzero 0 ]
+  in
+  map (li_of_fopn_args dummy_instr_info) args.
+
+Definition store_zero (off : fexpr) : linstr_r :=
+  if store_mn_of_wsize ws is Some mn
+    then
+      let current := Store Aligned ws (faddv Uptr vrsp off) in
+      (* A 32-bit clear step needs the W form of STR; the narrow stores
+         (STRB, STRH) store the low bits of the X register. *)
+      let op := ARMv8A_op mn (opts_at (match ws with U32 => U32 | _ => U64 end)) in
+      Lopn [:: current ] (Oarmv8a op) [:: rvar vzero ]
+    else Lalign. (* Absurd case. *)
+
+(* Implementation:
+l1:
+    ?{zf}, off = #SUBS(off, wsize_size ws)
+    (ws)[rsp + off] = zero
+    IF (!zf) GOTO l1
+*)
+Definition sz_loop : lcmd :=
+  let dec_off :=
+    let op := ARMv8A_op SUBS default_opts in
+    let dec := rconst reg_size (wsize_size ws) in
+    Lopn (leflags ++ [:: LLvar voff ]) (Oarmv8a op) [:: rvar voff; dec ]
+  in
+  let irs :=
+    [:: Llabel InternalLabel lbl
+      ; dec_off
+      ; store_zero (Fvar voff)
+      ; Lcond (Fapp1 Onot (Fvar vzf)) lbl
+    ]
+  in
+  map (MkLI dummy_instr_info) irs.
+
+Definition restore_sp :=
+  [:: li_of_fopn_args dummy_instr_info (fopn_mov vrsp vsaved_sp) ].
+
+Definition stack_zero_loop : lcmd := sz_init ++ sz_loop ++ restore_sp.
+
+Definition stack_zero_loop_vars :=
+  sv_of_list v_var [:: vsaved_sp, voff, vzero & vflags].
+
+
+(* Implementation:
+    (ws)[rsp + (stk_max / wsize_size ws - 1) * wsize_size ws] = zero
+    ...
+    (ws)[rsp + wsize_size ws] = zero
+    (ws)[rsp + 0] = zero
+*)
+Definition sz_unrolled : lcmd :=
+  let rn := rev (ziota 0 (stk_max / wsize_size ws)) in
+  [seq MkLI dummy_instr_info (store_zero (fconst reg_size (off * wsize_size ws))) | off <- rn ].
+
+Definition stack_zero_unrolled : lcmd := sz_init ++ sz_unrolled ++ restore_sp.
+
+(* [voff] is used, because it is set by [sz_init], even though it is not used in
+   the for loop. *)
+Definition stack_zero_unrolled_vars :=
+  sv_of_list v_var [:: vsaved_sp, voff, vzero & vflags].
+
+End RSP.
+
+Definition stack_zeroization_cmd
+  (szs : stack_zero_strategy)
+  (rspn : Ident.ident)
+  (lbl : label)
+  (ws_align ws : wsize)
+  (stk_max : Z) :
+  cexec (lcmd * Sv.t) :=
+  let err msg :=
+    {|
+      pel_msg := compiler_util.pp_s msg;
+      pel_fn := None;
+      pel_fi := None;
+      pel_ii := None;
+      pel_vi := None;
+      pel_pass := Some "stack zeroization"%string;
+      pel_internal := false;
+  |}
+  in
+  let err_size :=
+    err "Stack zeroization size not supported in ARMv8-A"%string in
+  Let _ := assert (ws <= U64)%CMP err_size in
+  let rsp := vid rspn in
+  match szs with
+  | SZSloop =>
+    ok (stack_zero_loop rsp lbl ws_align ws stk_max, stack_zero_loop_vars)
+  | SZSloopSCT =>
+    let err_sct := err "Strategy ""loop with SCT"" is not supported in ARMv8-A"%string in
+    Error err_sct
+  | SZSunrolled =>
+    ok (stack_zero_unrolled rsp ws_align ws stk_max, stack_zero_unrolled_vars)
+  end.
+
+End STACK_ZEROIZATION.

--- a/proofs/compiler/armv8a_stack_zeroization_proof.v
+++ b/proofs/compiler/armv8a_stack_zeroization_proof.v
@@ -1,0 +1,811 @@
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype ssralg.
+From mathcomp Require Import word_ssrZ.
+From Coq Require Import Lia.
+
+Require Import
+  expr
+  fexpr
+  fexpr_sem
+  linear
+  linear_sem
+  linear_facts
+  psem
+  psem_facts
+  low_memory.
+Require stack_zeroization_proof.
+Require Import
+  arch_decl
+  arch_extra
+  sem_params_of_arch_extra.
+Require Import
+  armv8a_decl
+  armv8a_extra
+  armv8a_instr_decl
+  armv8a_params_core_proof
+  armv8a_params_common_proof.
+Require Export armv8a_stack_zeroization.
+Import seq_extra.
+
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
+#[local] Existing Instance withsubword.
+
+Section STACK_ZEROIZATION.
+
+Context {atoI : arch_toIdent} {syscall_state : Type} {sc_sem : syscall_sem syscall_state}.
+Context {call_conv : calling_convention}.
+
+Section RSP.
+
+Context (rspn : Ident.ident).
+Let rspi := vid rspn.
+
+Let vsaved_sp := mk_var_i (to_var R2).
+Let voff := mk_var_i (to_var R3).
+Let vzero := mk_var_i (to_var R12).
+Let vzf := mk_var_i (to_var ZF).
+Let vflags := [seq mk_var_i (to_var f) | f <- rflags ].
+Let leflags := [seq LLvar f | f <- vflags ].
+
+Lemma store_zero_eval_instr lp ii ws e (ls:lstate) (w1 w2 : word Uptr) m' :
+  (ws <= U64)%CMP ->
+  get_var true (lvm ls) vzero = ok (@Vword Uptr 0) ->
+  get_var true (lvm ls) rspi = ok (Vword w1) ->
+  sem_fexpr (lvm ls) e >>= to_word Uptr = ok w2 ->
+  write (lmem ls) Aligned (w1 + w2)%R (sz:=ws) 0 = ok m' ->
+  let i := MkLI ii (store_zero rspi ws e) in
+  eval_instr lp i ls = ok (lnext_pc (lset_mem ls m')).
+Proof.
+  move=> ws_small hvzero hrsp.
+  t_xrbindP=> ? he hto hm'.
+  have h0 : forall wsx, (wsx <= U64)%CMP ->
+    truncate_word wsx (0%R : word Uptr) = ok (0%R : word wsx).
+  + by move=> wsx hle; rewrite (truncate_word_le _ hle) zero_extend0.
+  rewrite /eval_instr /= /store_zero.
+  case: ws ws_small hm' => //= _ hm'.
+  all: rewrite hvzero /= /exec_sopn /= ?h0 //=.
+  all: rewrite hrsp /= /sem_sop2 /= (truncate_word_u w1) /= he /= hto /=.
+  all: rewrite truncate_word_u /= ?truncate_word_u ?h0 //= ?zero_extend0 /=.
+  all: rewrite ?add_wordE ?(h0 U8 erefl) ?(h0 U16 erefl) ?(h0 U32 erefl) /=.
+  all: by rewrite hm' /=.
+Qed.
+
+(* [eval_instr] lemmas for the wrappers of armv8a_stack_zeroization.v that
+   have no ARMv8AFopnP counterpart ([fopn_li] is the [Oarmv8a_smart_li]
+   pseudo-instruction, whose sopn semantics is the identity; its expansion
+   is proven at assembly generation). *)
+
+Lemma fopn_li_eval_instr {lp0 ls ii} {xi : var_i} {imm : Z} :
+  convertible (vtype xi) (aword armv8a_reg_size) ->
+  let: li := li_of_fopn_args ii (fopn_li xi imm) in
+  let: vm' := (lvm ls).[v_var xi <- Vword (wrepr Uptr imm)] in
+  eval_instr lp0 li ls = ok (lnext_pc (lset_vm ls vm')).
+Proof.
+  move=> hc.
+  rewrite /eval_instr /= /sem_sopn /= /exec_sopn /= truncate_word_u /=.
+  by rewrite /write_var set_var_truncate // (convertible_eval_atype hc) /= ?addn1.
+Qed.
+
+Lemma fopn_movi_eval_instr {lp0 ls ii} {xi : var_i} {imm : Z} :
+  convertible (vtype xi) (aword armv8a_reg_size) ->
+  let: li := li_of_fopn_args ii (fopn_movi xi imm) in
+  let: vm' := (lvm ls).[v_var xi <- Vword (wrepr Uptr imm)] in
+  eval_instr lp0 li ls = ok (lnext_pc (lset_vm ls vm')).
+Proof.
+  move=> hc.
+  rewrite /eval_instr /= /sem_sopn /= /exec_sopn /= truncate_word_u /=.
+  rewrite /armv8a_MOV_semi /=.
+  by rewrite /write_var set_var_truncate // (convertible_eval_atype hc) /= ?addn1.
+Qed.
+
+Lemma fopn_sub_eval_instr {lp0 ls ii} {xi y z : var_i} {wy wz : word Uptr} :
+  convertible (vtype xi) (aword armv8a_reg_size) ->
+  get_var true (lvm ls) (v_var y) = ok (Vword wy) ->
+  get_var true (lvm ls) (v_var z) = ok (Vword wz) ->
+  let: li := li_of_fopn_args ii (fopn_sub xi y z) in
+  let: vm' := (lvm ls).[v_var xi <- Vword (wy - wz)] in
+  eval_instr lp0 li ls = ok (lnext_pc (lset_vm ls vm')).
+Proof.
+  move=> hc hy hz.
+  have := ARMv8AFopn_coreP.sub_sem_fopn_args (s := to_estate ls) hc
+            (to_word_get_var hy) (to_word_get_var hz).
+  rewrite ARMv8AFopnP.sem_fopn_equiv.
+  by apply: sem_fopn_args_eval_instr.
+Qed.
+
+Context (lp : lprog) (fn : funname).
+Context (ws_align : wsize) (ws : wsize) (stk_max : Z).
+Context (lt_0_stk_max : (0 < stk_max)%Z).
+Context (halign : is_align stk_max ws).
+Context (le_ws_ws_align : (ws <= ws_align)%CMP).
+Context (ptr : pointer).
+Context (hstack : (stk_max <= wunsigned (align_word ws_align ptr))%Z).
+Let top := (align_word ws_align ptr - wrepr Uptr stk_max)%R.
+
+#[local]
+Lemma top_aligned : is_align top ws.
+Proof using halign le_ws_ws_align ptr stk_max top ws ws_align.
+  rewrite /top.
+  apply is_align_add.
+  + apply (is_align_m le_ws_ws_align).
+    by apply do_align_is_align.
+  move: halign; rewrite -WArray.arr_is_align => /is_align_addE <-.
+  by rewrite GRing.addrN.
+Qed.
+
+Record state_rel_unrolled vars s1 s2 n (p:word Uptr) := {
+  sr_scs : s1.(escs) = s2.(escs);
+  sr_mem : mem_equiv s1.(emem) s2.(emem);
+  sr_mem_valid : forall p, between top stk_max p U8 -> validw s2.(emem) Aligned p U8;
+  sr_disjoint :
+    forall p, disjoint_zrange top stk_max p (wsize_size U8) ->
+      read s1.(emem) Aligned p U8 = read s2.(emem) Aligned p U8;
+  sr_zero : forall p,
+    between (top + wrepr _ n) (stk_max - n) p U8 -> read s2.(emem) Aligned p U8 = ok 0%R;
+  sr_vm : s1.(evm) =[\ Sv.add rspi vars] s2.(evm) ;
+  sr_vsaved : s2.(evm).[vsaved_sp] = Vword ptr;
+  sr_rsp : s2.(evm).[rspi] = Vword p;
+  sr_vzero : s2.(evm).[vzero] = @Vword Uptr 0; (* contrary to x86, not ws but U32 *)
+  sr_aligned : is_align n ws;
+  sr_bound : (0 <= n <= stk_max)%Z;
+}.
+
+Record state_rel_loop vars s1 s2 n p := {
+  srl_off : s2.(evm).[voff] = Vword (wrepr Uptr n);
+  srl_srs :> state_rel_unrolled vars s1 s2 n p
+}.
+
+Lemma state_rel_unrolledI vars1 vars2 s1 s2 n p :
+  Sv.Subset vars1 vars2 ->
+  state_rel_unrolled vars1 s1 s2 n p ->
+  state_rel_unrolled vars2 s1 s2 n p.
+Proof.
+  move=> hsubset hsr.
+  case: hsr => hscs hmem hvalid hdisj hzero hvm hsaved hrsp hvzero haligned hbound.
+  split=> //.
+  apply: eq_exI hvm.
+  by apply (SvD.F.add_s_m erefl hsubset).
+Qed.
+
+Lemma state_rel_loopI vars1 vars2 s1 s2 n p :
+  Sv.Subset vars1 vars2 ->
+  state_rel_loop vars1 s1 s2 n p ->
+  state_rel_loop vars2 s1 s2 n p.
+Proof.
+  move=> hsubset hsr.
+  case: hsr => hoff hsr.
+  split=> //.
+  by apply (state_rel_unrolledI hsubset hsr).
+Qed.
+
+Section INIT.
+
+Definition sz_init_vars :=
+  sv_of_list v_var [:: vsaved_sp; voff; vzero].
+
+Context (pre pos : seq linstr).
+Context (hbody : is_linear_of lp fn (pre ++ sz_init rspi ws_align stk_max ++ pos)).
+Context (rsp_nin : ~ Sv.In rspi sz_init_vars).
+
+Lemma sz_initP (s1 : estate) :
+  valid_between (emem s1) top stk_max ->
+  s1.(evm).[rspi] = Vword ptr ->
+  exists s2,
+    lsem_n lp (endpc lp fn) (of_estate s1 fn (size pre)) (of_estate s2 fn (size pre + size (sz_init rspi ws_align stk_max))) /\
+    state_rel_loop sz_init_vars s1 s2 stk_max top.
+Proof using atoI call_conv fn halign hbody leflags lp lt_0_stk_max pos pre ptr rsp_nin rspi rspn sc_sem stk_max syscall_state top vflags voff vsaved_sp vzero vzf ws ws_align.
+  move=> hvalid hrsp.
+  move: hbody => /=.
+  set isave_sp := li_of_fopn_args _ (fopn_mov _ _).
+  set iload_off := li_of_fopn_args _ (fopn_li _ _).
+  set ialign := li_of_fopn_args _ (fopn_align _ _ _).
+  set istore_sp := li_of_fopn_args _ (fopn_mov _ _).
+  set isub_sp := li_of_fopn_args _ (fopn_sub _ _ _).
+  set izero := li_of_fopn_args _ (fopn_movi _ _).
+  move=> hbody'.
+
+  eexists (Estate _ _ _); split=> /=.
+  apply: (lsem_n_eval_lin (n:=0) hbody') => //=.
+  + by rewrite addn0.
+  + apply: ARMv8AFopnP.mov_eval_instr.
+    by rewrite /get_var hrsp /=.
+  rewrite /lnext_pc /=; apply: (lsem_n_eval_lin (n:=1) hbody');
+   [ done | by rewrite addnC | done | | ].
+  + by apply: fopn_li_eval_instr.
+  rewrite /lnext_pc /=; apply: (lsem_n_eval_lin (n:=2) hbody') => //=; first by rewrite addnC.
+  + apply: ARMv8AFopnP.align_eval_instr.
+    rewrite /= get_var_neq; last by move=> /esym /(@inj_to_var _ _ _ _ _ _).
+    by rewrite get_var_eq.
+  rewrite /lnext_pc /=; apply: (lsem_n_eval_lin (n:=3) hbody') => //=; first by rewrite addnC.
+  + apply: ARMv8AFopnP.mov_eval_instr.
+    by rewrite get_var_eq.
+  rewrite /lnext_pc /=; apply: (lsem_n_eval_lin (n:=4) hbody') => //=; first by rewrite addnC.
+  + apply: fopn_sub_eval_instr => /=.
+    * by vm_compute.
+    * rewrite get_var_eq /=; last by []. reflexivity.
+    rewrite get_var_neq;
+      last by move=> h; apply /rsp_nin /sv_of_listP;
+      rewrite !in_cons /= -h eqxx /= ?orbT.
+    rewrite get_var_neq; last by move=> /esym /(@inj_to_var _ _ _ _ _ _).
+    by rewrite get_var_eq.
+  rewrite /lnext_pc /=; apply: (lsem_n_eval_lin (n:=5) hbody');
+   [ done | by rewrite addnC | done | | ].
+  + by apply: fopn_movi_eval_instr.
+  rewrite /lnext_pc /= addnC; apply lsem_n_0.
+  split=> /=.
+  + do 4 (rewrite Vm.setP_neq;
+      last by [
+        apply /eqP => /esym /(@inj_to_var _ _ _ _ _ _) |
+        apply /eqP => h; apply /rsp_nin /sv_of_listP;
+          rewrite !in_cons /= -h eqxx /= ?orbT]).
+    by rewrite Vm.setP_eq.
+
+  split=> //=.
+  + move=> p.
+    by rewrite Z.sub_diag /between (negbTE (not_zbetween_neg _ _ _ _)).
+  + do 4 (rewrite (eq_ex_set_l _ (eq_ex_refl _));
+      last by case; apply Sv.add_spec; (left; reflexivity) ||
+      right; apply /sv_of_listP; rewrite !in_cons /= eqxx /= ?orbT).
+    apply: eq_ex_set_r.
+    by do 3 (move=> /Sv.add_spec /Decidable.not_or [] ?).
+    rewrite (eq_ex_set_l _ (eq_ex_refl _));
+      last by case; by repeat (apply/Sv.add_spec; ((by left) || right)).
+    done.
+  + do 4 (rewrite Vm.setP_neq;
+      last by [
+        apply /eqP => /esym /(@inj_to_var _ _ _ _ _ _) |
+        apply /eqP => h; apply /rsp_nin /sv_of_listP;
+          rewrite !in_cons /= -h eqxx /= ?orbT]).
+    rewrite Vm.setP_neq; first by rewrite Vm.setP_eq.
+    by apply/eqP => /esym /(@inj_to_var _ _ _ _ _ _).
+  + rewrite Vm.setP_neq;
+      last by apply /eqP => h; apply /rsp_nin /sv_of_listP;
+      rewrite !in_cons /= -h eqxx /= ?orbT.
+    by rewrite Vm.setP_eq.
+  + rewrite Vm.setP_eq /=.
+    by rewrite wrepr0.
+  by lia.
+Qed.
+
+End INIT.
+
+Section LOOP.
+
+Definition sz_loop_vars :=
+  sv_of_list v_var [:: voff & vflags].
+
+Context (hsmall : (ws <= U64)%CMP).
+Context (lbl : label.label) (pre pos : seq linstr).
+Context (hbody : is_linear_of lp fn (pre ++ sz_loop rspi lbl ws ++ pos)).
+Context (rsp_nin : ~ Sv.In rspi sz_loop_vars).
+Context (hlabel : ~~ has (is_label lbl) pre).
+
+Lemma loop_bodyP vars s1 s2 n :
+  Sv.Subset sz_loop_vars vars ->
+  state_rel_loop vars s1 s2 n top ->
+  (0 < n)%Z ->
+  exists s3,
+    [/\ lsem_n lp (endpc lp fn) (of_estate s2 fn (size pre + 1))
+                (of_estate s3 fn (size pre + 3)),
+        s3.(evm).[vzf] = Vbool (ZF_of_word (wrepr U64 n - wrepr U64 (wsize_size ws)))
+      & state_rel_loop vars s1 s3 (n - wsize_size ws) top].
+Proof using atoI call_conv fn halign hbody hsmall hstack lbl le_ws_ws_align leflags lp lt_0_stk_max pos pre ptr rsp_nin rspi rspn sc_sem stk_max syscall_state top vflags voff vsaved_sp vzero vzf ws ws_align.
+  move=> hsubset hsr hlt.
+  have hn: (0 < wsize_size ws <= n)%Z.
+  + split=> //.
+    have := hsr.(sr_aligned).
+    rewrite is_alignE WArray.p_to_zE.
+    move=> /eqP /Z.mod_divide [//|m ?].
+    have ? := wsize_size_pos ws.
+    have: (0 < m)%Z; nia.
+  have: validw (emem s2) Aligned (top + (wrepr Uptr n - wrepr Uptr (wsize_size ws)))%R ws.
+  + apply /validwP; split.
+    + rewrite /= (is_align_addE top_aligned).
+      have /is_align_addE <- := [elaborate (is_align_mul ws 1)].
+      rewrite Z.mul_1_r GRing.addrC GRing.subrK.
+      rewrite WArray.arr_is_align.
+      by apply hsr.(sr_aligned).
+    move=> k hk.
+    apply hsr.(sr_mem_valid).
+    rewrite /between /zbetween wsize8 !zify addE /top.
+    rewrite -wrepr_sub -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
+    have hbound := hsr.(sr_bound).
+    have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
+    by rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
+  move=> /(writeV 0) [m' hm'].
+  eexists (Estate _ _ _); split=> /=.
+  + apply: (lsem_n_eval_lin (n:=1) hbody) => //=.
+    + rewrite /eval_instr /=
+        /get_var hsr.(srl_off) /= /exec_sopn /= !truncate_word_u /= add_wordE wsub_wnot1
+        /of_estate /= /lnext_pc /= -addnS.
+      reflexivity.
+    apply: (lsem_n_eval_lin (n:=2) hbody) => //=.
+    + apply: store_zero_eval_instr => //=.
+      + do 5 (rewrite (@get_var_neq _ _ _ vzero);
+          last by [|move=> /(@inj_to_var _ _ _ _ _ _)]).
+        by rewrite /get_var hsr.(sr_vzero).
+      + do 5 (rewrite (@get_var_neq _ _ _ rspi);
+          last by [|move=> /= h; apply /rsp_nin /sv_of_listP;
+          rewrite !in_cons /= -h eqxx /= ?orbT]).
+        by rewrite /get_var hsr.(sr_rsp); reflexivity.
+      + rewrite get_var_eq //= truncate_word_u; reflexivity.
+      exact: hm'.
+    by rewrite /lnext_pc /= -!addnS; apply lsem_n_0.
+  + do 3 (rewrite Vm.setP_neq;
+      last by [|apply /eqP => /(@inj_to_var _ _ _ _ _ _)]).
+    by rewrite Vm.setP_eq.
+  case: hsr => hoff [hscs hmem hvalid hdisj hzero hvm hsaved hrsp hvzero haligned hbound].
+  split=> /=.
+  + rewrite Vm.setP_eq /=.
+    by rewrite wrepr_sub.
+  split=> //=.
+  + apply (mem_equiv_trans hmem).
+    split.
+    + by apply (Memory.write_mem_stable hm').
+    by move=> ??; symmetry; apply (write_validw_eq hm').
+  + move=> p hb.
+    rewrite (write_validw_eq hm').
+    by apply hvalid.
+  + move=> p hp.
+    rewrite (writeP_neq _ hm'); first by apply hdisj.
+    apply: disjoint_range_alt.
+    apply: disjoint_zrange_incl_l hp.
+    rewrite /top /zbetween !zify -wrepr_sub.
+    assert (h := wunsigned_range (align_word ws_align ptr)).
+    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+  + move=> p hb.
+    rewrite (write_read8 hm') subE /=.
+    case: ifPn => [_|h].
+    + by rewrite LE.read0.
+    apply hzero.
+    move: h hb; rewrite /between /zbetween wsize8 !zify /top.
+    change armv8a_reg_size with Uptr.
+    rewrite -wrepr_sub -wrepr_opp -!GRing.addrA -!wrepr_add.
+    have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
+    rewrite wunsigned_sub_if.
+    rewrite wunsigned_add; last by lia.
+    rewrite wunsigned_add; last by lia.
+    case: ZleP; lia.
+  + by do 5 (rewrite (eq_ex_set_l _ (eq_ex_refl _));
+      last by case; apply Sv.add_spec; right;
+      apply /hsubset /sv_of_listP; rewrite !in_cons /= eqxx /= ?orbT).
+  + rewrite Vm.setP_neq; last by apply /eqP => /(@inj_to_var _ _ _ _ _ _).
+    by rewrite !Vm.setP_neq.
+  + rewrite Vm.setP_neq;
+      last by apply /eqP => h; apply /rsp_nin /sv_of_listP;
+      rewrite !in_cons /= -h eqxx /= ?orbT.
+    by do 4 rewrite Vm.setP_neq //.
+  + by do 5 (rewrite Vm.setP_neq;
+      last by [|apply /eqP => /(@inj_to_var _ _ _ _ _ _)]).
+  + rewrite -WArray.arr_is_align wrepr_sub.
+    have /is_align_addE <- := [elaborate (is_align_mul ws 1)].
+    rewrite Z.mul_1_r GRing.addrC GRing.subrK.
+    by rewrite WArray.arr_is_align.
+  by lia.
+Qed.
+
+Lemma loopP vars s1 s2 n :
+  Sv.Subset sz_loop_vars vars ->
+  state_rel_loop vars s1 s2 n top ->
+  (0 < n)%Z ->
+  exists s3,
+    [/\ lsem_n lp (endpc lp fn) (of_estate s2 fn (size pre + 1))
+                (of_estate s3 fn (size pre + 4))
+      & state_rel_loop vars s1 s3 0 top].
+Proof using atoI call_conv fn halign hbody hlabel hsmall hstack lbl le_ws_ws_align leflags lp lt_0_stk_max pos pre ptr rsp_nin rspi rspn sc_sem stk_max syscall_state top vflags voff vsaved_sp vzero vzf ws ws_align.
+  move=> hsubset hsr hlt.
+  have [k hn]: (exists k, n = Z.of_nat k * wsize_size ws)%Z.
+  + have := hsr.(sr_aligned).
+    rewrite is_alignE WArray.p_to_zE.
+    move=> /eqP /Z.mod_divide [//|m ?].
+    exists (Z.to_nat m).
+    rewrite Z2Nat.id //.
+    have := wsize_size_pos ws.
+    by lia.
+  elim: k n s2 hsr hlt hn => [|k ih] n s2 hsr hlt hn.
+  + move: hn; rewrite Z.mul_0_l.
+    by lia.
+  have [s3 [hsem3 hzf3 hsr3]] := loop_bodyP hsubset hsr hlt.
+  have: (k = 0 \/ 0 < k)%coq_nat by lia.
+  case=> hk.
+  + subst k.
+    move: hn; rewrite Z.mul_1_l => ?; subst n.
+    exists s3; split.
+    + apply: (lsem_n_step_end hsem3).
+      by rewrite /step (find_instr_skip' hbody (n := 3)) // /= /eval_instr /=
+         /get_var /= hzf3 /= GRing.addrN /ZF_of_word /= /setpc /=
+         /lnext_pc /= -addnS.
+    by move: hsr3; rewrite Z.sub_diag.
+  have hlt3: (0 < n - wsize_size ws)%Z by nia.
+  have hn3: (n - wsize_size ws)%Z = (Z.of_nat k * wsize_size ws)%Z by lia.
+  have [s4 [hsem4 hsr4]] := ih _ _ hsr3 hlt3 hn3.
+  exists s4; split=> //.
+  apply: (lsem_n_trans hsem3).
+  apply: (lsem_n_eval_lin (n:=3) hbody) => //=; last by apply hsem4.
+  rewrite /eval_instr /=.
+  rewrite /get_var /= hzf3 /=.
+  have ->: ~~ ZF_of_word (wrepr U64 n - wrepr U64 (wsize_size ws)).
+  + rewrite /ZF_of_word; apply /eqP => /(f_equal wunsigned).
+    rewrite wunsigned0 -wrepr_sub wunsigned_repr_small; first by lia.
+    change U64 with Uptr.
+    have := hsr.(sr_bound).
+    have! := (wunsigned_range (align_word ws_align ptr)).
+    have := wsize_size_pos ws.
+    by lia.
+  have [lfd -> -> /=] := hbody.
+  rewrite (find_label_cat_hd (sip := sip_of_asm_e) _ hlabel).
+  rewrite (find_labelE (sip := sip_of_asm_e)) /=.
+  rewrite /is_label /= eqxx /=.
+  rewrite /setcpc /=.
+  by rewrite -addnS.
+Qed.
+
+Lemma sz_loopP vars s1 s2 n :
+  Sv.Subset sz_loop_vars vars ->
+  state_rel_loop vars s1 s2 n top ->
+  (0 < n)%Z ->
+  exists s3,
+    [/\ lsem_n lp (endpc lp fn) (of_estate s2 fn (size pre))
+                (of_estate s3 fn (size pre + size (sz_loop rspi lbl ws)))
+      & state_rel_loop vars s1 s3 0 top].
+Proof using atoI call_conv fn halign hbody hlabel hsmall hstack lbl le_ws_ws_align leflags lp lt_0_stk_max pos pre ptr rsp_nin rspi rspn sc_sem stk_max syscall_state top vflags voff vsaved_sp vzero vzf ws ws_align.
+  move=> hsubset hsr hlt.
+  have [s3 [hsem3 hsr3]] := loopP hsubset hsr hlt.
+  exists s3; split=> //.
+  apply: (lsem_n_eval_lin (n:=0) hbody) => //=.
+  + by rewrite addn0.
+  rewrite /lnext_pc -addn1; apply hsem3.
+Qed.
+
+End LOOP.
+
+Section RESTORE.
+
+(* We write to [rspi], so we assume that it is different from the variables
+   occurring in the invariant predicate. *)
+Definition restore_sp_vars :=
+  sv_of_list v_var [:: voff; vzero].
+
+Context (pre pos : seq linstr).
+Context (hbody : is_linear_of lp fn (pre ++ restore_sp rspi ++ pos)).
+Context (rsp_nin : ~ Sv.In rspi restore_sp_vars).
+
+Lemma restore_spP vars (s1 s2 : estate) :
+  state_rel_unrolled vars s1 s2 0 top ->
+  exists s3,
+    lsem_n lp (endpc lp fn)
+      (of_estate s2 fn (size pre))
+      (of_estate s3 fn (size pre + size (restore_sp rspi))) /\
+    state_rel_unrolled vars s1 s3 0 ptr.
+Proof using atoI call_conv fn hbody leflags lp pos pre ptr rsp_nin rspi rspn sc_sem stk_max syscall_state top vflags voff vsaved_sp vzero vzf ws ws_align.
+  move=> hsr.
+  eexists (Estate _ _ _); split=> /=.
+  + apply: (lsem_n_eval_lin1 (n:=0) hbody) => //=; first by rewrite addn0.
+    rewrite addn1; apply: ARMv8AFopnP.mov_eval_instr.
+    by rewrite /get_var /= hsr.(sr_vsaved) /=; reflexivity.
+  case: hsr => hscs hmem hvalid hdisj hzero hvm hsaved hrsp hvzero haligned hbound.
+  split=> //=.
+  + by rewrite (eq_ex_set_l _ (eq_ex_refl _));
+      last by case; apply Sv.add_spec; left; reflexivity.
+  + rewrite Vm.setP /=.
+    by case: eq_op.
+  + by rewrite Vm.setP_eq.
+  + by rewrite Vm.setP_neq;
+      last by apply /eqP => h; apply /rsp_nin /sv_of_listP;
+      rewrite !in_cons /= -h eqxx /= ?orbT.
+Qed.
+
+End RESTORE.
+
+Section UNROLLED.
+
+Context (hsmall : (ws <= U64)%CMP).
+Context (pre pos : seq linstr).
+Context (hbody : is_linear_of lp fn (pre ++ sz_unrolled rspi ws stk_max ++ pos)).
+
+Lemma unrolled_bodyP vars s1 s2 n :
+  state_rel_unrolled vars s1 s2 (stk_max - Z.of_nat n * wsize_size ws) top ->
+  (Z.of_nat n < stk_max / wsize_size ws)%Z ->
+  exists s3,
+    [/\ lsem_n lp (endpc lp fn) (of_estate s2 fn (size pre + n))
+                (of_estate s3 fn (size pre + n.+1))
+      & state_rel_unrolled vars s1 s3 (stk_max - Z.of_nat n.+1 * wsize_size ws) top].
+Proof using atoI call_conv fn halign hbody hsmall hstack le_ws_ws_align leflags lp lt_0_stk_max pos pre ptr rspi rspn sc_sem stk_max syscall_state top vflags voff vsaved_sp vzero vzf ws ws_align.
+Local Opaque wsize_size Z.of_nat.
+  move=> hsr hlt.
+  have hlt': (0 < Z.of_nat n.+1 * wsize_size ws <= stk_max)%Z.
+  + split; first by have := wsize_size_pos ws; lia.
+    etransitivity; last by apply (Z.mul_div_le _ (wsize_size ws)).
+    rewrite Z.mul_comm; apply Z.mul_le_mono_nonneg_l => //.
+    rewrite Nat2Z.inj_succ.
+    by apply Z.le_succ_l.
+  have: validw (emem s2) Aligned (top + (wrepr Uptr (stk_max - Z.of_nat n.+1 * wsize_size ws)))%R ws.
+  + apply /validwP; split.
+    + rewrite /= (is_align_addE top_aligned).
+      have /is_align_addE <- := [elaborate (is_align_mul ws (Z.of_nat n.+1))].
+      rewrite Z.mul_comm wrepr_sub GRing.addrC GRing.subrK.
+      by rewrite WArray.arr_is_align.
+    move=> k hk.
+    apply hsr.(sr_mem_valid).
+    rewrite /between /zbetween wsize8 !zify addE /top.
+    rewrite -GRing.addrA -[(_ + wrepr _ k)%R]wrepr_add.
+    have hbound := hsr.(sr_bound).
+    have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
+    by rewrite [_ (_ + _ + _)%R]wunsigned_add; last rewrite wunsigned_sub; lia.
+  move=> /(writeV 0) [m' hm'].
+  eexists (Estate _ _ _); split.
+  + apply: (lsem_n_eval_lin1 (n:= n) hbody) => //.
+    + rewrite oseq.onth_cat !size_map size_rev size_ziota.
+      have hlt'': n < Z.to_nat (stk_max / wsize_size ws) by apply /ltP; lia.
+      rewrite hlt''.
+      rewrite onth_map.
+      rewrite oseq.onth_nth (nth_map 0%Z); last by rewrite size_rev size_ziota.
+      have -> //:
+        (nth 0 (rev (ziota 0 (stk_max / wsize_size ws))) n * wsize_size ws =
+          stk_max - Z.of_nat n.+1 * wsize_size ws)%Z.
+      rewrite nth_rev; last by rewrite size_ziota.
+      rewrite nth_ziota /=; last first.
+      + by rewrite size_ziota -minusE; apply /ltP; lia.
+      rewrite size_ziota.
+      rewrite Nat2Z.n2zB //.
+      rewrite Z2Nat.id; last by lia.
+      rewrite Z.mul_sub_distr_r.
+      rewrite Z.mul_comm -(proj2 (Z.div_exact _ _ _)) //.
+      by move: halign; rewrite is_alignE WArray.p_to_zE => /eqP.
+    rewrite addnS.
+    apply: store_zero_eval_instr => //=.
+    + by rewrite /get_var hsr.(sr_vzero).
+    + by rewrite /get_var hsr.(sr_rsp); reflexivity.
+    + by rewrite truncate_word_u; reflexivity.
+    by apply hm'.
+  case: hsr => hscs hmem hvalid hdisj hzero hvm hsaved hrsp hvzero haligned hbound.
+  split=> //=.
+  + apply (mem_equiv_trans hmem).
+    split.
+    + by apply (Memory.write_mem_stable hm').
+    by move=> ??; symmetry; apply (write_validw_eq hm').
+  + move=> p hb.
+    rewrite (write_validw_eq hm').
+    by apply hvalid.
+  + move=> p hp.
+    rewrite (writeP_neq _ hm'); first by apply hdisj.
+    apply: disjoint_range_alt.
+    apply: disjoint_zrange_incl_l hp.
+    rewrite /top /zbetween !zify.
+    assert (h := wunsigned_range (align_word ws_align ptr)).
+    by rewrite wunsigned_add; last rewrite wunsigned_sub; lia.
+  + move=> p hb.
+    rewrite (write_read8 hm') subE /=.
+    case: ifPn => [_|h].
+    + by rewrite LE.read0.
+    apply hzero.
+    move: h hb; rewrite /between /zbetween wsize8 !zify /top.
+    change armv8a_reg_size with Uptr.
+    rewrite -wrepr_opp -!GRing.addrA -!wrepr_add.
+    have ? := [elaborate (wunsigned_range (align_word ws_align ptr))].
+    rewrite wunsigned_sub_if.
+    rewrite wunsigned_add; last by lia.
+    rewrite wunsigned_add; last by lia.
+    case: ZleP; lia.
+  + rewrite -WArray.arr_is_align.
+    have /is_align_addE <- := [elaborate (is_align_mul ws (Z.of_nat n.+1))].
+    rewrite Z.mul_comm wrepr_sub GRing.addrC GRing.subrK.
+    by rewrite WArray.arr_is_align.
+  by lia.
+Local Transparent wsize_size Z.of_nat.
+Qed.
+
+Lemma sz_unrolledP vars s1 s2 :
+  state_rel_unrolled vars s1 s2 stk_max top ->
+  exists s3,
+    [/\ lsem_n lp (endpc lp fn) (of_estate s2 fn (size pre))
+                (of_estate s3 fn (size pre + size (sz_unrolled rspi ws stk_max)))
+      & state_rel_unrolled vars s1 s3 0 top].
+Proof using atoI call_conv fn halign hbody hsmall hstack le_ws_ws_align leflags lp lt_0_stk_max pos pre ptr rspi rspn sc_sem stk_max syscall_state top vflags voff vsaved_sp vzero vzf ws ws_align.
+  move=> hsr.
+  rewrite /sz_unrolled size_map size_rev size_ziota.
+  have [k [hmax hbound]]:
+    exists k, (stk_max = Z.of_nat k * wsize_size ws)%Z
+           /\ k <= Z.to_nat (stk_max / wsize_size ws).
+  + have := halign.
+    rewrite is_alignE WArray.p_to_zE.
+    move=> /eqP /Z.mod_divide [//|m h].
+    exists (Z.to_nat m).
+    split.
+    + rewrite Z2Nat.id //.
+      by have := wsize_size_pos ws; lia.
+    by rewrite h Z.div_mul.
+  rewrite -(Z.sub_diag stk_max).
+  rewrite {1 3}hmax {hmax}.
+  rewrite Z.div_mul // Nat2Z.id.
+  elim: k s2 hbound hsr => [|k ih] s2 hbound hsr.
+  + rewrite /= addn0 Z.sub_0_r.
+    by exists s2; split=> //; apply lsem_n_0.
+  have [s3 [hsem3 hsr3]] := ih _ (ltnW hbound) hsr.
+  have hbound': (Z.of_nat k < stk_max / wsize_size ws)%Z.
+  + by move/leP: hbound; lia.
+  have [s4 [hsem4 hsr4]] := unrolled_bodyP hsr3 hbound'.
+  exists s4; split=> //.
+  by apply (lsem_n_trans hsem3).
+Qed.
+
+End UNROLLED.
+
+Section STACK_ZERO_LOOP.
+
+Context (hsmall : (ws <= U64)%CMP).
+Context (lbl : label.label) (pre pos : seq linstr).
+Context (hbody : is_linear_of lp fn (pre ++ stack_zero_loop rspi lbl ws_align ws stk_max ++ pos)).
+Context (rsp_nin : ~ Sv.In rspi stack_zero_loop_vars).
+Context (hlabel : ~~ has (is_label lbl) pre).
+
+Lemma sz_init_no_lbl : ~~ has (is_label lbl) (sz_init rspi ws_align stk_max).
+Proof. done. Qed.
+
+Lemma stack_zero_loopP (s1 : estate) :
+  valid_between (emem s1) top stk_max ->
+  (evm s1).[rspi] = Vword ptr ->
+  exists s2,
+    [/\ lsem_n lp (endpc lp fn) (of_estate s1 fn (size pre))
+                (of_estate s2 fn (size pre + size (stack_zero_loop rspi lbl ws_align ws stk_max)))
+      & state_rel_unrolled stack_zero_loop_vars s1 s2 0 ptr].
+Proof using atoI call_conv fn halign hbody hlabel hsmall hstack lbl le_ws_ws_align leflags lp lt_0_stk_max pos pre ptr rsp_nin rspi rspn sc_sem stk_max syscall_state top vflags voff vsaved_sp vzero vzf ws ws_align.
+  move=> hvalid hrsp.
+  move: hbody; rewrite /stack_zero_loop -!catA => hbody'.
+  have hsubset_init: Sv.Subset sz_init_vars stack_zero_loop_vars.
+  + move=> x /sv_of_listP hin.
+    apply /sv_of_listP.
+    move: hin; apply: allP.
+    by rewrite /= !eqxx ?orbT /=.
+  have rsp_nin_init: ~ Sv.In rspi sz_init_vars.
+  + by move=> /hsubset_init.
+  have [s2 [hsem2 hsr2]] := sz_initP hbody' rsp_nin_init hvalid hrsp.
+  move: hbody'; rewrite catA => hbody'.
+  have hsubset_loop: Sv.Subset sz_loop_vars stack_zero_loop_vars.
+  + move=> x /sv_of_listP hin.
+    apply /sv_of_listP.
+    move: hin; apply: allP.
+    by rewrite /= !eqxx ?orbT /=.
+  have rsp_nin_loop: ~ Sv.In rspi sz_loop_vars.
+  + by move=> /hsubset_loop.
+  have hlabel_loop: ~~ has (is_label lbl) (pre ++ sz_init rspi ws_align stk_max).
+  + by rewrite has_cat negb_or hlabel sz_init_no_lbl.
+  have hsr2' := state_rel_loopI hsubset_init hsr2.
+  have [s3 [hsem3 hsr3]] :=
+    sz_loopP hsmall hbody' rsp_nin_loop hlabel_loop hsubset_loop hsr2' lt_0_stk_max.
+  move: hbody'; rewrite catA => hbody'.
+  have hsubset_restore: Sv.Subset restore_sp_vars stack_zero_loop_vars.
+  + move=> x /sv_of_listP hin.
+    apply /sv_of_listP.
+    move: hin; apply: allP.
+    by rewrite /= !eqxx ?orbT /=.
+  have rsp_nin_restore: ~ Sv.In rspi restore_sp_vars.
+  + by move=> /hsubset_restore.
+  have [s4 [hsem4 hsr4]] := restore_spP hbody' rsp_nin_restore hsr3.
+
+  exists s4; split=> //.
+  apply (lsem_n_trans hsem2).
+  rewrite -size_cat.
+  apply (lsem_n_trans hsem3).
+  rewrite -!size_cat !catA (size_cat _ (restore_sp _)).
+  exact: hsem4.
+Qed.
+
+End STACK_ZERO_LOOP.
+
+Section STACK_ZERO_UNROLLED.
+
+Context (hsmall : (ws <= U64)%CMP).
+Context (pre pos : seq linstr).
+Context (hbody : is_linear_of lp fn (pre ++ stack_zero_unrolled rspi ws_align ws stk_max ++ pos)).
+Context (rsp_nin : ~ Sv.In rspi stack_zero_unrolled_vars).
+
+Lemma stack_zero_unrolledP (s1 : estate) :
+  valid_between (emem s1) top stk_max ->
+  (evm s1).[rspi] = Vword ptr ->
+  exists s2,
+    [/\ lsem_n lp (endpc lp fn) (of_estate s1 fn (size pre))
+                (of_estate s2 fn (size pre + size (stack_zero_unrolled rspi ws_align ws stk_max)))
+      & state_rel_unrolled stack_zero_unrolled_vars s1 s2 0 ptr].
+Proof using atoI call_conv fn halign hbody hsmall hstack le_ws_ws_align leflags lp lt_0_stk_max pos pre ptr rsp_nin rspi rspn sc_sem stk_max syscall_state top vflags voff vsaved_sp vzero vzf ws ws_align.
+  move=> hvalid hrsp.
+  move: hbody; rewrite /stack_zero_loop -!catA => hbody'.
+  have hsubset_init: Sv.Subset sz_init_vars stack_zero_unrolled_vars.
+  + move=> x /sv_of_listP hin.
+    apply /sv_of_listP.
+    move: hin; apply: allP.
+    by rewrite /= !eqxx ?orbT /=.
+  have rsp_nin_init: ~ Sv.In rspi sz_init_vars.
+  + by move=> /hsubset_init.
+  have [s2 [hsem2 hsr2]] := sz_initP hbody' rsp_nin_init hvalid hrsp.
+  move: hbody'; rewrite catA => hbody'.
+  have hsr2' := state_rel_unrolledI hsubset_init hsr2.
+  have [s3 [hsem3 hsr3]] := sz_unrolledP hsmall hbody' hsr2'.
+  move: hbody'; rewrite catA => hbody'.
+  have hsubset_restore: Sv.Subset restore_sp_vars stack_zero_loop_vars.
+  + move=> x /sv_of_listP hin.
+    apply /sv_of_listP.
+    move: hin; apply: allP.
+    by rewrite /= !eqxx ?orbT /=.
+  have rsp_nin_restore: ~ Sv.In rspi restore_sp_vars.
+  + by move=> /hsubset_restore.
+  have [s4 [hsem4 hsr4]] := restore_spP hbody' rsp_nin_restore hsr3.
+
+  exists s4; split=> //.
+  apply (lsem_n_trans hsem2).
+  rewrite -size_cat.
+  apply (lsem_n_trans hsem3).
+  rewrite -!size_cat !catA (size_cat _ (restore_sp _)).
+  exact: hsem4.
+Qed.
+
+End STACK_ZERO_UNROLLED.
+
+End RSP.
+
+Lemma sz_init_no_ext_lbl rsp ws_align stk_max :
+  label_in_lcmd (sz_init rsp ws_align stk_max) = [::].
+Proof. done. Qed.
+
+Lemma store_zero_no_ext_lbl ii rsp ws off :
+  get_label (MkLI ii (store_zero rsp ws off)) = None.
+Proof. by rewrite /store_zero; case: store_mn_of_wsize. Qed.
+
+Lemma armv8a_stack_zero_cmd_not_ext_lbl szs rspn lbl ws_align ws stk_max cmd vars :
+  stack_zeroization_cmd szs rspn lbl ws_align ws stk_max = ok (cmd, vars) ->
+  label_in_lcmd cmd = [::].
+Proof.
+  rewrite /stack_zeroization_cmd.
+  t_xrbindP=> _.
+  case: szs => //.
+  + move=> [<- _].
+    rewrite /stack_zero_loop !label_in_lcmd_cat sz_init_no_ext_lbl.
+    by rewrite /= store_zero_no_ext_lbl.
+  + move=> [<- _].
+    rewrite /stack_zero_unrolled !label_in_lcmd_cat sz_init_no_ext_lbl.
+    rewrite /= cats0.
+    rewrite /sz_unrolled.
+    by elim: rev => [//|?? ih] /=; rewrite store_zero_no_ext_lbl.
+Qed.
+
+Lemma armv8a_stack_zero_cmdP szs rspn lbl ws_align ws stk_max cmd vars :
+  stack_zeroization_cmd szs rspn lbl ws_align ws stk_max = ok (cmd, vars) ->
+  stack_zeroization_proof.sz_cmd_spec rspn lbl ws_align ws stk_max cmd vars.
+Proof.
+   move=> hcmd rsp_nin lt_0_stk_max halign le_ws_ws_align lp fn lc
+    /negP hlabel hbody ls ptr hfn hpc hstack hrsp top hvalid.
+  have [s2 [hsem hsr]]: [elaborate
+    exists s2,
+      lsem_n lp (endpc lp fn) ls (of_estate s2 fn (size lc + size cmd))
+      /\ state_rel_unrolled
+          rspn ws_align ws stk_max ptr vars (to_estate ls) s2 0 ptr].
+  + move: hcmd; rewrite /stack_zeroization_cmd.
+    t_xrbindP=> ws_small.
+    case: szs => //.
+    + move=> [??]; subst cmd vars.
+      rewrite -(cats0 (stack_zero_loop _ _ _ _ _)) in hbody.
+      have := stack_zero_loopP
+          lt_0_stk_max halign le_ws_ws_align hstack ws_small hbody rsp_nin
+          hlabel (s1 := to_estate _) hvalid hrsp.
+      by rewrite -hfn -hpc of_estate_to_estate.
+    move=> [??]; subst cmd vars.
+    rewrite -(cats0 (stack_zero_unrolled _ _ _ _)) in hbody.
+    have := stack_zero_unrolledP
+        lt_0_stk_max halign le_ws_ws_align hstack ws_small hbody rsp_nin
+        (s1 := to_estate _) hvalid hrsp.
+    by rewrite -hfn -hpc of_estate_to_estate.
+
+  exists (emem s2), (evm s2); split=> //.
+  + by rewrite -{2}hfn /of_estate -hsr.(sr_scs) in hsem.
+  + move=> x hin.
+    case: (x =P vid rspn) => [->|hneq].
+    + by rewrite hsr.(sr_rsp).
+    apply hsr.(sr_vm).
+    by case/Sv.add_spec.
+  + by apply hsr.(sr_mem).
+  + have := hsr.(sr_zero).
+    by rewrite wrepr0 GRing.addr0 Z.sub_0_r.
+  exact: hsr.(sr_disjoint).
+Qed.
+
+End STACK_ZEROIZATION.

--- a/proofs/compiler/it_merge_varmaps_proof.v
+++ b/proofs/compiler/it_merge_varmaps_proof.v
@@ -1155,7 +1155,7 @@ Proof using ok_p.
   set results := sv_of_list v_var (f_res fd).
   set params := sv_of_list v_var (f_params fd).
   move => checked_body hdisj checked_params RSP_not_result preserved_magic checked_save_stack tmp_call_magic.
-  t_xrbindP => to_save_not_result ok_callee_saved ok_params.
+  t_xrbindP => to_save_not_result ok_callee_saved ok_call_ra ok_params.
   have /merge_varmaps_funP hsem : preF fn fn fs t.
   + rewrite /preF ok_fd; split => //.
     exists args'; split => //.

--- a/proofs/compiler/jasmin_compiler.v
+++ b/proofs/compiler/jasmin_compiler.v
@@ -4,5 +4,6 @@ Require psem_defs.
 Require arm_params.
 Require x86_params.
 Require riscv_params.
+Require armv8a_params.
 Require sem_params_of_arch_extra.
 Require wint_int.

--- a/proofs/compiler/merge_varmaps.v
+++ b/proofs/compiler/merge_varmaps.v
@@ -263,6 +263,11 @@ Section CHECK.
                     (E.gen_error true None (pp_s "the function returns a callee-saved register")) in
         Let _ := assert (Sv.subset (Sv.inter callee_saved W') to_save)
                     (E.gen_error true None (pp_s "the function kills some callee-saved registers")) in
+        (* The return-address register is not callee-saved, but the return of
+           an export function jumps to the address it held at function entry,
+           so it must be saved and restored if the body kills it. *)
+        Let _ := assert (Sv.subset (Sv.inter call_ra W') to_save)
+                    (E.gen_error true None (pp_s "the function kills the return-address register")) in
         assert (all (λ x : var_i, if vtype x is aword _ then true else false ) (f_params fd))
             (E.gen_error true None (pp_s "the export function has non-word arguments"))
     end.

--- a/proofs/compiler/riscv_decl.v
+++ b/proofs/compiler/riscv_decl.v
@@ -193,7 +193,8 @@ Definition riscv_linux_call_conv : calling_convention :=
  ; call_xreg_args := [::]
  ; call_reg_ret   := [:: X10; X11]
  ; call_xreg_ret  := [::]
- ; call_reg_ret_uniq := erefl true;
+ ; call_reg_ret_uniq := erefl true
+ ; call_reg_ra    := Some RA
 |}.
 
 

--- a/proofs/compiler/x86_decl.v
+++ b/proofs/compiler/x86_decl.v
@@ -318,7 +318,8 @@ Definition x86_linux_call_conv : calling_convention :=
    ; call_xreg_args := [:: XMM0; XMM1; XMM2; XMM3; XMM4; XMM5; XMM6; XMM7 ]
    ; call_reg_ret   := [:: RAX; RDX ]
    ; call_xreg_ret  := [:: XMM0; XMM1 ]
-   ; call_reg_ret_uniq := erefl true;
+   ; call_reg_ret_uniq := erefl true
+   ; call_reg_ra    := None
   |}.
 
 Definition x86_windows_call_conv : calling_convention :=
@@ -330,7 +331,8 @@ Definition x86_windows_call_conv : calling_convention :=
    ; call_xreg_args := [:: XMM0; XMM1; XMM2; XMM3 ]
    ; call_reg_ret   := [:: RAX ]
    ; call_xreg_ret  := [:: XMM0 ]
-   ; call_reg_ret_uniq := erefl true;
+   ; call_reg_ret_uniq := erefl true
+   ; call_reg_ra    := None
   |}.
 
 Definition x86_internal_call_conv : internal_calling_convention :=

--- a/proofs/lang/extraction.v
+++ b/proofs/lang/extraction.v
@@ -82,5 +82,9 @@ Separate Extraction
   riscv_instr_decl
   riscv_extra
   riscv_params
+  armv8a_decl
+  armv8a_instr_decl
+  armv8a_extra
+  armv8a_params
   compiler
   wint_int.

--- a/proofs/lang/one_varmap.v
+++ b/proofs/lang/one_varmap.v
@@ -8,10 +8,15 @@ From mathcomp Require Import ssreflect ssrfun ssrbool.
 Record ovm_syscall_sig_t := 
   { scs_vin : seq var; scs_vout : seq var }.
 
-Class one_varmap_info := { 
+Class one_varmap_info := {
   syscall_sig  : syscall_t -> ovm_syscall_sig_t;
   all_vars     : Sv.t;
   callee_saved : Sv.t;
+  (* Register in which export functions receive the return address, if it is
+     not passed on the stack. It is not callee-saved, but export functions
+     must nonetheless preserve it so that the final (unmodelled) return jump
+     goes back to the caller. *)
+  call_ra      : Sv.t;
   vflags       : Sv.t;
   vflagsP      : forall x, Sv.In x vflags -> vtype x = abool
 }.

--- a/proofs/lang/shift_kind.v
+++ b/proofs/lang/shift_kind.v
@@ -13,6 +13,22 @@ Variant shift_kind :=
 
 HB.instance Definition _ := hasDecEq.Build shift_kind shift_kind_eqb_OK.
 
+(* Inclusive bounds on the immediate shift amount of an AArch32 (A32/T32)
+   shifted-register operand. Unlike AArch64 (see [check_shift_amount] in
+   armv8a_decl.v, where the range is [0, datasize) for every shift type), the
+   AArch32 range depends on the shift type, because the 5-bit immediate field
+   is decoded differently per type.
+
+   Source: [DecodeImmShift(srtype, imm5)] (Arm ARM DDI0487M.a, J1.2.3.7, p.
+   J1-16079):
+     - '00' LSL: shift_n = UInt(imm5)                         -> 0..31
+     - '01' LSR: shift_n = if imm5 == 0 then 32 else UInt(imm5) -> 1..32
+     - '10' ASR: shift_n = if imm5 == 0 then 32 else UInt(imm5) -> 1..32
+     - '11' ROR: if imm5 == 0 then RRX (a distinct operation), else
+                 shift_n = UInt(imm5)                          -> 1..31
+   i.e. LSR/ASR encode a shift of 32 as imm5 = 0, and ROR #0 is RRX, so only
+   LSL admits an amount of 0. This is why the AArch32 immediate checker
+   [CAimmC_arm_shift_amout] (arch_decl.v) is keyed on the [shift_kind]. *)
 Definition shift_amount_bounds sk :=
   match sk with
   | SLSL => (0, 31)%Z


### PR DESCRIPTION
**This PR is a proposal**, following up on the review discussion of #1541 ([this comment](https://github.com/jasmin-lang/jasmin/pull/1541) asked why the saving of X30 around export functions is done by the assembly printer rather than by register allocation / linearization). It is **based on #1541 and can only land after it**; until #1541 is merged, the diff shown here includes its commits — only the last four commits belong to this PR.

## What it does

On architectures where the caller passes the return address of an export function in a register (X30 on arm64, `ra` on RISC-V), that register is now saved and restored through the same verified mechanism as killed callee-saved registers — a slot in the stack frame, written and read by the to-save machinery of linearization — instead of by unverified glue emitted by the assembly printers around the function body. The printers now only emit the final return jump (`ret`), which puts them in the exact same position as the x86 printer and its `ret`.

- `calling_convention` gains a `call_reg_ra : option reg_t` field recording this register, and `one_varmap_info` derives the corresponding variable set.
- The one-varmap checker (`merge_varmaps`) enforces the new invariant for export functions: if the body kills the return-address register, it must be in `sf_to_save`. The write-set `W'` already accounts for that register at every call (`ra_vm`) and system call (`syscall_kill`), so the check integrates with the existing analysis; a single line of `it_merge_varmaps_proof` needed adaptation.
- The register-allocation oracle spills the return-address register like a killed callee-saved register, and it is removed from the general allocatable pool on these architectures: it now carries a live value across the whole body of export functions, and using it as a scratch register would needlessly consume a spill slot (it was only free under the old save-everything glue).

## Consequences

- Export functions that do not kill the return-address register (e.g. leaf functions) no longer touch the stack at all to save it; e.g. on arm64 an exported increment is now just `add w0, w0, #1` / `ret`.
- The `callee_saved = n` annotation must account for the return-address register when the function kills it (documented in the manual).

## Scope and limitations

- **arm-m4 keeps the printer glue** (`push {lr}` / `pop {pc}`). There, LR is also the linearization scratch register (`lip_tmp2`): the prologue of an export function kills it before any store into the frame is possible, and this is structural on T32 (SP cannot be aligned in place, and R0-R3 carry arguments), so `call_reg_ra` is `None` for arm-m4, with a comment explaining why.
- The final return jump itself remains a single unverified printer instruction on all architectures (as `ret` already is on x86): the semantic contract of export calls (`lsem_exportcall` / `asmsem_exportcall`) ends when the program counter reaches the end of the body, and modelling the jump back to an external caller would require changing those contracts. This is left as future work; this PR reduces the unverified surface to that single instruction and makes the restoration of the return-address register part of the checked, verified pipeline.

## Validation

- Coq proofs, extraction and OCaml build all green.
- Full test suite: 1066/1066 across all categories (x86-64 ATT/Intel/nolea, arm-m4, armv8a, risc-v, all stack-zeroization variants, CCT/CCT-DOIT/SCT); `dune runtest` green (one legitimate golden update: a RISC-V temporary formerly allocated to `ra` now goes to `x5`).
- Native execution of exported leaf/calling functions on AArch64.
- The formosa-mldsa ML-DSA AArch64 port (parameter sets 44, 65 and 87) passes its complete KAT suites when compiled with this branch.
