### PR TITLE
CI: EasyCrypt 2026.09 & Z3 4.16.0

### DIFF
--- a/scripts/easycrypt.nix
+++ b/scripts/easycrypt.nix
@@ -20,13 +20,13 @@ with {
   };
 
   "release" = rec {
-    version = "2026.07";
+    version = "2026.09";
     rev = "r${version}";
     src = fetchFromGitHub {
       owner = "easycrypt";
       repo = "easycrypt";
       inherit rev;
-      hash = "sha256-ZJRvMdIv75BcU9r8kJdOF7XtTL5dFNycDMSnZjuSp3I=";
+      hash = "sha256-7ZnGZOZyV5znDGzg0c3XSsliQyOFOwJp2iyAzJtDNwk=";
     };
     extraBuildInputs = [];
   };

--- a/scripts/z3.nix
+++ b/scripts/z3.nix
@@ -1,11 +1,11 @@
 { z3, fetchFromGitHub }:
 
 z3.overrideAttrs (_: rec {
-  version = "4.13.4";
+  version = "4.16.0";
   src = fetchFromGitHub {
     owner = "Z3Prover";
     repo = "z3";
     tag = "z3-${version}";
-    hash = "sha256-8hWXCr6IuNVKkOegEmWooo5jkdmln9nU7wI8T882BSE=";
+    hash = "sha256-DnhX3kxggnFmyYwXEPBsBA1rh4oor1oIJR5TMJk/jvc=";
   };
 })


### PR DESCRIPTION
Follows the recent EasyCrypt release:
https://github.com/EasyCrypt/easycrypt/releases/tag/r2026.09