### PR TITLE
Add jobs param to opam build config

### DIFF
--- a/opam
+++ b/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/jasmin-lang/jasmin/issues"
 dev-repo: "git+https://github.com/jasmin-lang/jasmin.git"
 
 build: [
-  make "build"
+  make "build" "-j%{jobs}%"
 ]
 install: [
   make "PREFIX=%{prefix}%" "install"


### PR DESCRIPTION
# Description

Add a "jobs" flag to the `opam` file's `build` section. I believe this will help make installing Jasmin with the Rocq dependencies via `opam pin add` a little quicker.

<!-- if this is your first contribution - [ ] Add your name to `AUTHORS` -->
