### PR TITLE
add coq-lsp in devTools

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation {
          angstrom
          batteries
          menhir menhirLib zarith apron yojson ]))
-    ++ optionals devTools (with oP; [ merlin ocaml-lsp ])
+    ++ optionals devTools ([ coqPackages.coq-lsp ] ++ (with oP; [ merlin ocaml-lsp ]))
     ++ optionals ecDeps [ easycrypt z3.out ]
     ++ optionals opamDeps [ rsync git pkg-config perl ppl mpfr opam ]
     ;


### PR DESCRIPTION
# Description
`nix develop` with `devTools` now provides `coq-lsp` alongside `merlin` and
`ocaml-lsp`, so that editors can use the Coq LSP server on the proofs.

Fixes # (issue) <!-- if applicable -->

# Checklist

<!-- if this is your first contribution - [ ] Add your name to `AUTHORS` -->
